### PR TITLE
docs(wix-cli-site-component): update wix-cli-site-component skill with installation config and type naming

### DIFF
--- a/wix-cli/skills/wix-cli-site-component/SKILL.md
+++ b/wix-cli/skills/wix-cli-site-component/SKILL.md
@@ -59,6 +59,26 @@ Strict type definitions:
 
 The manifest defines the editor contract using these key sections:
 
+### installation (Initial Placement)
+
+```json
+{
+  "installation": {
+    "staticContainer": "HOMEPAGE",
+    "initialSize": {
+      "width": { "sizingType": "pixels", "pixels": 400 },
+      "height": { "sizingType": "pixels", "pixels": 300 }
+    }
+  }
+}
+```
+
+- **staticContainer**: Use `"HOMEPAGE"` for automatic installation on Harmony editor
+- **initialSize**: Defines initial dimensions with `sizingType` options:
+  - `"content"` - Auto-size based on content
+  - `"stretched"` - Fill available space
+  - `"pixels"` - Fixed pixel dimension (requires `pixels` property)
+
 ### editorElement (Root Configuration)
 
 ```json
@@ -391,13 +411,13 @@ Each site component requires an `extensions.ts` file in its folder:
 
 ```typescript
 import { extensions } from "@wix/astro/builders";
-import manifest from "./site/components/my-component/manifest.json";
+import manifest from "./manifest.json";
 
 export const sitecomponentMyComponent = extensions.siteComponent({
   ...manifest,
   id: "{{GENERATE_UUID}}",
   description: "My Component",
-  type: "platform.builder.{{GENERATE_UUID}}",
+  type: "platform.MyComponent",
   resources: {
     client: {
       component: "./site/components/my-component/component.tsx",
@@ -407,7 +427,14 @@ export const sitecomponentMyComponent = extensions.siteComponent({
 });
 ```
 
-**Note:** The `id` and `type` should use the same UUID.
+**CRITICAL: Type Naming Convention**
+
+The `type` field uses the format `platform.{PascalCaseFolderName}`:
+- Folder `my-component` → `type: "platform.MyComponent"`
+- Folder `product-card` → `type: "platform.ProductCard"`
+- Folder `hero-section` → `type: "platform.HeroSection"`
+
+The folder name is converted to PascalCase (hyphens removed, each word capitalized).
 
 **CRITICAL: UUID Generation**
 

--- a/wix-cli/skills/wix-cli-site-component/references/EXAMPLE.md
+++ b/wix-cli/skills/wix-cli-site-component/references/EXAMPLE.md
@@ -40,6 +40,13 @@ src/site/components/perfect-example/
 
 ```json
 {
+  "installation": {
+    "staticContainer": "HOMEPAGE",
+    "initialSize": {
+      "width": { "sizingType": "pixels", "pixels": 400 },
+      "height": { "sizingType": "pixels", "pixels": 400 }
+    }
+  },
   "editorElement": {
     "selector": ".perfect-example",
     "displayName": "Perfect Example",
@@ -988,32 +995,47 @@ export const SocialLinks: React.FC<SocialLinksComponentProps> = ({
 
 ## Key Patterns Demonstrated
 
-### 1. Manifest-to-React Alignment
+### 1. Installation Configuration
+
+```json
+"installation": {
+  "staticContainer": "HOMEPAGE",
+  "initialSize": {
+    "width": { "sizingType": "pixels", "pixels": 400 },
+    "height": { "sizingType": "pixels", "pixels": 400 }
+  }
+}
+```
+
+- `staticContainer: "HOMEPAGE"` ensures automatic installation on Harmony editor
+- `initialSize` defines the component's default dimensions when added to a page
+
+### 2. Manifest-to-React Alignment
 
 - Each manifest element key (`badge`, `title`, etc.) matches the React removal state check
 - CSS selectors match manifest selectors exactly (`.perfect-example__badge`)
 - Data types in manifest match TypeScript types (`text` → `Text`, `number` → `NumberType`)
 
-### 2. Sub-Component Architecture
+### 3. Sub-Component Architecture
 
 - Each visual element is a separate sub-component
 - Sub-components receive `className` prop for CSS styling
 - Props spread pattern: `{...elementProps?.badge}`
 
-### 3. Removal State Handling
+### 4. Removal State Handling
 
 ```tsx
 const rm = wix?.elementsRemovalState || {};
 {!rm['badge'] && <Badge ... />}
 ```
 
-### 4. CSS Variable Integration
+### 5. CSS Variable Integration
 
 - Root element uses CSS variables for dynamic styling
 - `display` property configurable via manifest
 - All selectors declared once with `box-sizing: border-box`
 
-### 5. Accessibility
+### 6. Accessibility
 
 - Proper `aria-disabled` on buttons
 - `loading="lazy"` on images

--- a/wix-cli/skills/wix-cli-site-component/references/MANIFEST_GUIDELINES.md
+++ b/wix-cli/skills/wix-cli-site-component/references/MANIFEST_GUIDELINES.md
@@ -6,6 +6,13 @@ The manifest defines the contract between your React component and the Wix ecosy
 
 ```json
 {
+  "installation": {
+    "staticContainer": "HOMEPAGE",
+    "initialSize": {
+      "width": { "sizingType": "pixels", "pixels": 400 },
+      "height": { "sizingType": "pixels", "pixels": 300 }
+    }
+  },
   "editorElement": {
     "selector": ".component-name",
     "displayName": "Component Name",
@@ -17,6 +24,84 @@ The manifest defines the contract between your React component and the Wix ecosy
   }
 }
 ```
+
+## Installation Configuration
+
+The `installation` property defines how the component is initially placed and sized when added to a page.
+
+### Installation Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `staticContainer` | string | Automatic installation location. Use `"HOMEPAGE"` to auto-install on homepage |
+| `initialSize` | object | Initial dimensions when the component is added |
+
+### Initial Size Configuration
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `width` | InitialSizeSetting | Width configuration |
+| `height` | InitialSizeSetting | Height configuration |
+
+### InitialSizeSetting
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `sizingType` | string | One of: `"content"`, `"stretched"`, `"pixels"` |
+| `pixels` | number | Required when sizingType is `"pixels"` |
+
+### Sizing Type Values
+
+| Value | Description |
+|-------|-------------|
+| `content` | Component auto-sizes based on its content |
+| `stretched` | Component stretches to fill available space |
+| `pixels` | Component has a fixed pixel dimension (requires `pixels` property) |
+
+### Installation Examples
+
+```json
+// Fixed dimensions (most common)
+{
+  "installation": {
+    "staticContainer": "HOMEPAGE",
+    "initialSize": {
+      "width": { "sizingType": "pixels", "pixels": 400 },
+      "height": { "sizingType": "pixels", "pixels": 300 }
+    }
+  }
+}
+
+// Content-based height
+{
+  "installation": {
+    "staticContainer": "HOMEPAGE",
+    "initialSize": {
+      "width": { "sizingType": "pixels", "pixels": 600 },
+      "height": { "sizingType": "content" }
+    }
+  }
+}
+
+// Stretched width
+{
+  "installation": {
+    "staticContainer": "HOMEPAGE",
+    "initialSize": {
+      "width": { "sizingType": "stretched" },
+      "height": { "sizingType": "pixels", "pixels": 400 }
+    }
+  }
+}
+```
+
+### Installation Guidelines
+
+- **Always include** `"staticContainer": "HOMEPAGE"` for automatic installation on Harmony editor
+- **Default initial size** is 400px width, 300px height (matches Wix Harmony defaults)
+- Use `"content"` for height when the component should auto-size based on its content
+- Use `"stretched"` when the component should fill available space
+- Use `"pixels"` for fixed dimensions
 
 ## Data Types
 


### PR DESCRIPTION
## Summary

- Updated extension registration documentation to reflect the new `type` field naming convention (`platform.{PascalCaseFolderName}` instead of UUID-based)
- Added comprehensive `installation` configuration documentation for manifest files
- Updated example manifest to include installation block