### PR TITLE
feat(wix-cli-orchestrator): aggregate manual action items from sub-agents

### DIFF
--- a/wix-cli/skills/wix-cli-orchestrator/SKILL.md
+++ b/wix-cli/skills/wix-cli-orchestrator/SKILL.md
@@ -44,7 +44,7 @@ Helps select the appropriate Wix CLI extension type based on use case and requir
 
 ## Your Role
 
-You are a **decision-maker and orchestrator**, not an implementer. **Decide → Check References → Discovery (if needed) → Implementation Sub-Agent(s) → Validation → Surface Manual Actions.** Ask clarifying questions if unclear; recommend extension type; check reference files first, spawn discovery only for missing APIs; spawn implementation sub-agents; run validation; aggregate and present all manual action items at the end.
+You are a **decision-maker and orchestrator**, not an implementer. **Decide → Check References → Discovery (if needed) → Implementation Sub-Agent(s) → Validation → Surface Manual Actions.** Ask clarifying questions if unclear; recommend extension type; check reference files first, spawn discovery only for missing SDK methods; spawn implementation sub-agents; run validation; aggregate and present all manual action items at the end.
 
 ---
 
@@ -218,7 +218,14 @@ Return ONLY a concise summary in this format:
 Include any gotchas or constraints discovered.
 
 ## Manual Action Items
-List any manual steps the user must perform (e.g., enable API permissions, configure dashboard settings). Write "None" if there are no manual steps.
+List any manual steps the user must perform (e.g., configure dashboard settings, enable permissions). Write "None" if there are no manual steps.
+
+**Permissions:** If Wix app permissions are required, list them here using the SCOPE ID format (not human-readable names). Examples:
+- `@wix/data` read operations (query, get) require "SCOPE.DC-DATA.READ"
+- `@wix/data` write operations (insert, update, remove) require "SCOPE.DC-DATA.WRITE"
+- Embedded scripts require "SCOPE.DC-APPS.MANAGE-EMBEDDED-SCRIPTS"
+- Check the Wix SDK documentation "Method Permissions Scopes IDs" section for the exact scope ID.
+- IMPORTANT: Use scope IDs like "SCOPE.DC-DATA.READ", NOT human-readable names like "Read Data Items".
 ```
 
 **If discovery is spawned, wait for it to complete before proceeding to Step 4.**
@@ -266,7 +273,7 @@ Constraints:
 
 ⚠️ MANDATORY when using Data Collections: Use EXACT collection ID from `idSuffix` (case-sensitive). Example: If `idSuffix` is "product-recommendations", use "<app-namespace>/product-recommendations" NOT "productRecommendations".
 
-⚠️ MANDATORY: At the END of your response, include a section titled "## Manual Action Items" listing ANY steps the user must perform manually (e.g., configuring settings in the Wix dashboard, adding API keys, enabling permissions, setting up external services, etc.). If there are no manual steps, write "None". This section MUST always be present in your final response.
+⚠️ MANDATORY: At the END of your response, include a section titled "## Manual Action Items" listing ANY steps the user must perform manually (e.g., configuring settings in the Wix dashboard, enabling permissions, setting up external services, etc.). If there are no manual steps, write "None". This section MUST always be present in your final response.
 
 Implement this extension following the skill guidelines.
 ```
@@ -344,7 +351,7 @@ Only after validation passes, provide a **concise summary section** at the top o
 
 ⚠️ **BLOCKING REQUIREMENT** ⚠️
 
-**Sub-agents often report manual steps the user must take (e.g., configure permissions in the Wix dashboard, set up API keys, enable specific features, etc.). These MUST NOT get lost.**
+**Sub-agents often report manual steps the user must take (e.g., configure permissions in the Wix dashboard, enable specific features, etc.). These MUST NOT get lost.**
 
 After ALL sub-agents complete, you MUST:
 

--- a/wix-cli/skills/wix-cli-orchestrator/SKILL.md
+++ b/wix-cli/skills/wix-cli-orchestrator/SKILL.md
@@ -262,7 +262,9 @@ SDK Context:
 Constraints:
 [Any gotchas or limitations from discovery]
 
-⚠️ MANDATORY when using WDS: Before using @wix/design-system components, invoke the wds-docs skill FIRST to get correct imports (icons are from @wix/wix-ui-icons-common, NOT @wix/design-system/icons).
+⚠️ MANDATORY when using WDS: Invoke the wds-docs skill FIRST to get correct imports (icons are from @wix/wix-ui-icons-common, NOT @wix/design-system/icons).
+
+⚠️ MANDATORY when using Data Collections: Use EXACT collection ID from `idSuffix` (case-sensitive). Example: If `idSuffix` is "product-recommendations", use "<app-namespace>/product-recommendations" NOT "productRecommendations".
 
 ⚠️ MANDATORY: At the END of your response, include a section titled "## Manual Action Items" listing ANY steps the user must perform manually (e.g., configuring settings in the Wix dashboard, adding API keys, enabling permissions, setting up external services, etc.). If there are no manual steps, write "None". This section MUST always be present in your final response.
 

--- a/wix-cli/skills/wix-cli-orchestrator/SKILL.md
+++ b/wix-cli/skills/wix-cli-orchestrator/SKILL.md
@@ -126,6 +126,32 @@ Follow the checklist; steps below add detail.
 
 ### Step 1: Ask Clarifying Questions (if needed)
 
+#### A. Required Configuration Values
+
+**BEFORE spawning implementation sub-agents**, check if any of these required values are needed and ASK THE USER if not already provided:
+
+| Extension Type | Required Configuration | Question to Ask |
+|----------------|------------------------|-----------------|
+| Data Collection | App namespace | "What is your app namespace? (e.g., `@company/app-name`). This is required to create the data collection. If you haven't set one yet, I'll include steps to configure it in the manual steps section." |
+| Backend API | API authentication method | "How should this API be authenticated? (e.g., OAuth, API keys, session-based, etc.)" |
+| Service Plugin | SPI implementation details | "Which specific SPI endpoint are you implementing? (e.g., ecom.v1.TaxCalculator)" |
+| Third-party Integration | API keys/credentials | "Do you have API keys for [service]? If not, I'll include steps to obtain them in the manual steps section." |
+| Embedded Script | External service configuration | "Do you need to configure any external services (analytics, tracking, etc.)? If yes, provide the configuration details or I'll include setup steps." |
+
+**When to ask:**
+- If the value is REQUIRED for the extension to function correctly
+- If missing the value would result in incomplete implementation or avoidable manual steps
+- If the user needs to provide site-specific or app-specific configuration
+
+**When NOT to ask:**
+- If the value can be configured later without affecting implementation
+- If the user already provided it in their request
+- If it's a standard convention that doesn't need user input (e.g., default port numbers, standard file paths)
+
+**Important:** For Data Collections, ALWAYS check if the user has provided their app namespace. If not provided, ask for it OR note that you'll include configuration steps in the manual actions section.
+
+#### B. Clarifying Questions for Approach
+
 If unclear: placement, visibility, configuration, integration. Wait if the answer changes extension type; otherwise proceed and say you can add optional extension later.
 
 ### Step 2: Make Your Recommendation
@@ -285,11 +311,35 @@ If validation fails:
 
 ### Step 6: Report Completion
 
-Only after validation passes, report to the user:
+Only after validation passes, provide a **concise summary section** at the top of your response that includes:
 
-- What was created
-- How to test it (preview commands)
-- Any next steps
+**Required format:**
+
+```markdown
+## ✅ Implementation Complete
+
+[1-2 sentence description of what was built]
+
+**Extensions Created:**
+- [Extension 1 Name] - [Brief purpose]
+- [Extension 2 Name] - [Brief purpose]
+- [Extension 3 Name] - [Brief purpose]
+
+**Build Status:**
+- ✅ Dependencies: [Installed / status message]
+- ✅ TypeScript: [No compilation errors / status]
+- ✅ Build: [Completed successfully / status]
+- ✅/⚠️ Preview: [Running at URL / Failed - reason]
+
+**⚠️ IMPORTANT: [X] manual step(s) required to complete setup** (see "Manual Steps Required" section below)
+```
+
+**Critical rules:**
+- The summary MUST explicitly state how many manual steps are required
+- The summary MUST reference where to find the manual steps ("see Manual Steps Required section below")
+- If there are NO manual steps, state: "✅ No manual steps required — you're ready to go!"
+- Keep the summary concise (under 200 words)
+- Present build status clearly with ✅ or ⚠️ indicators
 
 ### Step 7: Surface Manual Action Items
 
@@ -301,27 +351,51 @@ After ALL sub-agents complete, you MUST:
 
 1. **Review every sub-agent's output** for any "Manual Action Items" section or any mention of steps the user needs to perform manually
 2. **Aggregate ALL manual action items** from every sub-agent into a single, deduplicated list
-3. **Present them prominently** at the very end of your final message to the user, under a clear heading
+3. **Reference them in the summary section** (Step 6) by stating how many manual steps exist
+4. **Present them prominently** at the very end of your final message to the user, under a clear heading
 
-**Format for the final message:**
+**Complete workflow for manual steps:**
 
-```
+1. **In the summary (Step 6):** Include the line `**⚠️ IMPORTANT: [X] manual step(s) required to complete setup** (see "Manual Steps Required" section below)`
+2. **At the end of your response:** Present the full detailed manual steps section
+
+**Format for the manual steps section:**
+
+```markdown
 ## 🔧 Manual Steps Required
 
 The following actions need to be done manually by you:
 
-1. [Action item from sub-agent A]
-2. [Action item from sub-agent B]
-3. ...
+### 1. [Action Category/Title]
+[Detailed description with specific instructions]
+- Step-by-step if needed
+- Include where to find things in the UI
+- Provide example values if helpful
 
-If no manual steps are needed, state: "No manual steps required — you're all set!"
+### 2. [Action Category/Title]
+[Detailed description]
+
+### 3. [Action Category/Title]
+[Detailed description]
+
+[Continue for all manual steps...]
+```
+
+**If no manual steps are needed:**
+```markdown
+## 🔧 Manual Steps Required
+
+No manual steps required — you're all set! Your implementation is complete and ready to use.
 ```
 
 **Rules:**
-- This section MUST be the **last thing** in your final response to the user
+- The summary section (Step 6) MUST reference the manual steps
+- This detailed manual steps section MUST be the **last thing** in your final response to the user
 - Even if you think the items were mentioned earlier in the conversation, **repeat them here** — assume the user only reads the final summary
-- Include context for each item (e.g., "In the Wix dashboard, go to Settings > Permissions and enable X" rather than just "enable X")
+- Include full context for each item (e.g., "In the Wix dashboard, go to Settings > Permissions and enable X" rather than just "enable X")
+- Group related steps together under category headings for clarity
 - If a sub-agent didn't include a "Manual Action Items" section, review its full output for any implicit manual steps (phrases like "you'll need to", "make sure to", "don't forget to", "manually", "go to the dashboard", etc.)
+- Number the main categories/sections (1, 2, 3...) for easy reference
 
 **Summary:** Discovery = business domain SDK only (Stores, Bookings, etc.) — skip for extension SDK and data collections. Implementation = load extension skill; invoke `wds-docs` FIRST when using WDS (for correct imports). Validation = `wix-cli-app-validation`. Manual actions = always aggregated and surfaced at the end.
 

--- a/wix-cli/skills/wix-cli-orchestrator/SKILL.md
+++ b/wix-cli/skills/wix-cli-orchestrator/SKILL.md
@@ -126,33 +126,11 @@ Follow the checklist; steps below add detail.
 
 ### Step 1: Ask Clarifying Questions (if needed)
 
-#### A. Required Configuration Values
+Only ask for configuration values when **absolutely necessary** for the implementation to proceed — i.e., the sub-agent literally cannot generate working code without it. If a value can be configured later or added as a manual step, don't block on it.
 
-**BEFORE spawning implementation sub-agents**, check if any of these required values are needed and ASK THE USER if not already provided:
+**Always ask:** Data Collection app namespace (required to create the collection — ask if not provided).
 
-| Extension Type | Required Configuration | Question to Ask |
-|----------------|------------------------|-----------------|
-| Data Collection | App namespace | "What is your app namespace? (e.g., `@company/app-name`). This is required to create the data collection. If you haven't set one yet, I'll include steps to configure it in the manual steps section." |
-| Backend API | API authentication method | "How should this API be authenticated? (e.g., OAuth, API keys, session-based, etc.)" |
-| Service Plugin | SPI implementation details | "Which specific SPI endpoint are you implementing? (e.g., ecom.v1.TaxCalculator)" |
-| Third-party Integration | API keys/credentials | "Do you have API keys for [service]? If not, I'll include steps to obtain them in the manual steps section." |
-| Embedded Script | External service configuration | "Do you need to configure any external services (analytics, tracking, etc.)? If yes, provide the configuration details or I'll include setup steps." |
-
-**When to ask:**
-- If the value is REQUIRED for the extension to function correctly
-- If missing the value would result in incomplete implementation or avoidable manual steps
-- If the user needs to provide site-specific or app-specific configuration
-
-**When NOT to ask:**
-- If the value can be configured later without affecting implementation
-- If the user already provided it in their request
-- If it's a standard convention that doesn't need user input (e.g., default port numbers, standard file paths)
-
-**Important:** For Data Collections, ALWAYS check if the user has provided their app namespace. If not provided, ask for it OR note that you'll include configuration steps in the manual actions section.
-
-#### B. Clarifying Questions for Approach
-
-If unclear: placement, visibility, configuration, integration. Wait if the answer changes extension type; otherwise proceed and say you can add optional extension later.
+If unclear on approach (placement, visibility, configuration, integration), ask. If the answer could change the extension type, wait for the response before proceeding. Otherwise, proceed with the best-fit extension type.
 
 ### Step 2: Make Your Recommendation
 

--- a/wix-cli/skills/wix-cli-orchestrator/SKILL.md
+++ b/wix-cli/skills/wix-cli-orchestrator/SKILL.md
@@ -128,9 +128,12 @@ Follow the checklist; steps below add detail.
 
 Only ask for configuration values when **absolutely necessary** for the implementation to proceed — i.e., the sub-agent literally cannot generate working code without it. If a value can be configured later or added as a manual step, don't block on it.
 
-**Always ask:** Data Collection app namespace (required to create the collection — ask if not provided).
+**App Namespace Requirement:**
+When creating a Data Collection, you MUST ask the user for their app namespace from Wix Dev Center. This is a required parameter that must be obtained from the user's Dev Center settings and cannot be recommended or guessed.
+- Inform the user that you need their app namespace from Wix Dev Center
+- Wait for the user to provide the namespace value before proceeding to implementation
 
-If unclear on approach (placement, visibility, configuration, integration), ask. If the answer could change the extension type, wait for the response before proceeding. Otherwise, proceed with the best-fit extension type.
+If unclear on approach (placement, visibility, configuration, integration), ask clarifying questions. If the answer could change the extension type, wait for the response before proceeding. Otherwise, proceed with the best-fit extension type.
 
 ### Step 2: Make Your Recommendation
 

--- a/wix-cli/skills/wix-cli-orchestrator/SKILL.md
+++ b/wix-cli/skills/wix-cli-orchestrator/SKILL.md
@@ -129,9 +129,25 @@ Follow the checklist; steps below add detail.
 Only ask for configuration values when **absolutely necessary** for the implementation to proceed — i.e., the sub-agent literally cannot generate working code without it. If a value can be configured later or added as a manual step, don't block on it.
 
 **App Namespace Requirement:**
-When creating a Data Collection, you MUST ask the user for their app namespace from Wix Dev Center. This is a required parameter that must be obtained from the user's Dev Center settings and cannot be recommended or guessed.
-- Inform the user that you need their app namespace from Wix Dev Center
-- Wait for the user to provide the namespace value before proceeding to implementation
+When creating a Data Collection, you MUST ask the user for their app namespace from Wix Dev Center. This is a required parameter that must be obtained from the user's Dev Center dashboard and cannot be recommended or guessed.
+
+**Instructions to give the user:**
+
+**If you don't have an app namespace yet:**
+1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
+2. Select your app
+3. In the left menu, select **Develop > Extensions**
+4. Click **+ Create Extension** and find the **Data Collections** extension
+5. Click **+ Create**
+6. You will be prompted to create an app namespace - follow the prompts to set it up
+
+**If you already have an app namespace:**
+1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
+2. Open your app dashboard
+3. Click the three dots (...) menu button in the top-right corner (next to "Test App" button)
+4. Select "View ID & keys" from the dropdown menu
+5. In the modal that opens, scroll to the bottom to find the "Namespace" field
+6. Copy the Namespace value
 
 If unclear on approach (placement, visibility, configuration, integration), ask clarifying questions. If the answer could change the extension type, wait for the response before proceeding. Otherwise, proceed with the best-fit extension type.
 


### PR DESCRIPTION
## Summary

- **Problem:** Sub-agents frequently report manual steps the user needs to take (e.g., configure dashboard settings, enable API permissions, add API keys), but these get buried in the middle of long conversations and are easily missed.
- **Solution:** Updated the orchestrator to require every sub-agent (discovery + implementation) to include a structured `## Manual Action Items` section in their responses. The orchestrator then aggregates all items and presents them in a single, deduplicated list at the very end of the conversation.
- **Additional improvements:**
  - Added detailed step-by-step instructions for users to find or create their app namespace in the Wix Dev Center dashboard (covers both new and existing namespace flows)
  - Simplified Step 1 to only block on values that are absolutely necessary for code generation
  - Added a structured completion report format (Step 6) with build status indicators and manual step count
  - Added a dedicated Step 7 for surfacing manual action items with a clear format template

## Changes

- Added Step 8 to the mandatory checklist for manual action item collection
- New Step 7 workflow section with detailed aggregation rules and output format
- Updated sub-agent prompt templates to require `## Manual Action Items` section
- Added anti-pattern rule for buried manual steps
- Updated role description to include the new workflow stage
- Expanded Step 1 with app namespace lookup instructions (Dev Center flows)
- Restructured Step 6 with a required completion summary format

## Test plan

- [x] Run a feature build that involves manual steps (e.g., one requiring dashboard permissions or API keys) and verify the orchestrator surfaces them at the end
- [x] Run a feature build with no manual steps and verify the "No manual steps required" message appears
- [x] Run a multi-extension build (parallel sub-agents) and verify manual items from all sub-agents are aggregated
- [x] Run a data collection build and verify the app namespace prompt includes detailed Dev Center instructions