### PR TITLE
docs: add Cursor installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ In [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run:
 /plugin install wix@wix
 ```
 
+### Cursor
+
+Install from the [Cursor Marketplace](https://cursor.com/marketplace) or in Cursor go to **Settings > Rules > New Rule > Add from Github** with `https://github.com/wix/skills.git`.
+
 ### Skills
 
 Install these skills using [skills](https://github.com/vercel-labs/add-skill):


### PR DESCRIPTION
## Summary
- Adds a Cursor installation section to the README with links to the Cursor Marketplace and manual setup via Settings > Rules > New Rule > Add from Github

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Verify Cursor Marketplace link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)