### PR TITLE
fix(wix-cli-service-plugin): correct type errors in additional fees SPI

### DIFF
--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -54,7 +54,7 @@ src/backend/service-plugins/
 | File | Purpose |
 | --- | --- |
 | `plugin.ts` | Contains the service plugin handler logic with `provideHandlers()` - this is where you implement your custom business logic |
-| `extensions.ts` | Contains the service plugin builder configuration with id (GUID), name, description, and source path |
+| `extensions.ts` | Contains the service plugin builder configuration with id (GUID), name, source path, and builder-specific optional fields |
 
 ## Implementation Requirements
 
@@ -208,10 +208,9 @@ The `id` must be a unique, static UUID v4 string. Generate a fresh UUID for each
 | --- | --- | --- |
 | `id` | string | Service plugin ID as a GUID. Must be unique across all extensions in the project. |
 | `name` | string | The service plugin name (visible in app dashboard when developing an app). |
-| `description` | string | A short description of what the service plugin does. |
 | `source` | string | Path to the service plugin handler file that contains the plugin logic. |
 
-Additional fields may be required or optional depending on the specific service plugin type.
+Additional fields vary by builder method. For example, `ecomShippingRates()` accepts optional `description`, `learnMoreUrl`, `dashboardUrl`, `fallbackDefinitionMandatory`, and `thumbnailUrl`. Check TypeScript types for the specific builder method you are using.
 
 **Builder methods by SPI type:**
 

--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -190,11 +190,10 @@ Each service plugin requires an `extensions.ts` file in its folder with the appr
 ```typescript
 import { extensions } from "@wix/astro/builders";
 
-export const ecomshippingratesMyShipping = extensions.ecomShippingRates({
+export const ecomadditionalfeesMyFees = extensions.ecomAdditionalFees({
   id: "{{GENERATE_UUID}}",
-  name: "My Shipping Rates",
-  description: "Calculates custom shipping rates based on order weight",
-  source: "./backend/service-plugins/ecom-shipping-rates/my-shipping/plugin.ts",
+  name: "My Additional Fees",
+  source: "./backend/service-plugins/ecom-additional-fees/my-fees/plugin.ts",
 });
 ```
 
@@ -204,24 +203,26 @@ The `id` must be a unique, static UUID v4 string. Generate a fresh UUID for each
 
 ### Builder Configuration Fields
 
+All builder methods accept these three fields:
+
 | Field | Type | Description |
 | --- | --- | --- |
 | `id` | string | Service plugin ID as a GUID. Must be unique across all extensions in the project. |
 | `name` | string | The service plugin name (visible in app dashboard when developing an app). |
 | `source` | string | Path to the service plugin handler file that contains the plugin logic. |
 
-Additional fields vary by builder method. For example, `ecomShippingRates()` accepts optional `description`, `learnMoreUrl`, `dashboardUrl`, `fallbackDefinitionMandatory`, and `thumbnailUrl`. Check TypeScript types for the specific builder method you are using.
+**Builder methods by SPI type and their accepted fields:**
 
-**Builder methods by SPI type:**
+| SPI Type          | Builder Method           | Accepted Fields |
+| ----------------- | ------------------------ | --------------- |
+| Shipping Rates    | `ecomShippingRates()`    | `id`, `name`, `source`, `description`, `learnMoreUrl`, `dashboardUrl`, `fallbackDefinitionMandatory`, `thumbnailUrl` |
+| Additional Fees   | `ecomAdditionalFees()`   | `id`, `name`, `source` |
+| Validations       | `ecomValidations()`      | `id`, `name`, `source`, `validateInCart` |
+| Discount Triggers | `ecomDiscountTriggers()` | `id`, `name`, `source` |
+| Gift Cards        | `ecomGiftCards()`        | `id`, `name`, `source` |
+| Payment Settings  | `ecomPaymentSettings()`  | `id`, `name`, `source`, `fallbackValueForRequires3dSecure` |
 
-| SPI Type          | Builder Method           |
-| ----------------- | ------------------------ |
-| Shipping Rates    | `ecomShippingRates()`    |
-| Additional Fees   | `ecomAdditionalFees()`   |
-| Validations       | `ecomValidations()`      |
-| Discount Triggers | `ecomDiscountTriggers()` |
-| Gift Cards        | `ecomGiftCards()`        |
-| Payment Settings  | `ecomPaymentSettings()`  |
+Only `ecomShippingRates()` accepts `description`. Passing unsupported fields to other builders causes TypeScript errors.
 
 ### Step 2: Register in Main Extensions File
 

--- a/skills/wix-cli-service-plugin/references/ADDITIONAL-FEES.md
+++ b/skills/wix-cli-service-plugin/references/ADDITIONAL-FEES.md
@@ -16,6 +16,39 @@ import { additionalFees } from '@wix/ecom/service-plugins';
 | --- | --- |
 | `calculateAdditionalFees` | Calculate and return additional fees to apply to the order |
 
+## Request Structure
+
+The `calculateAdditionalFees` handler receives `{ request, metadata }`. Key fields on `request`:
+
+```typescript
+{
+  lineItems: Array<{
+    id: string;                      // Line item GUID
+    quantity: number;                // Quantity of item
+    productName: string;             // Item name
+    price: string;                   // Price for a single item as a STRING (e.g., "25.00"), NOT an object
+    catalogReference?: {
+      catalogItemId: string;         // Item GUID within its catalog
+      appId: string;                 // Catalog app GUID
+      options?: Record<string, any>; // Additional item details
+    };
+    physicalProperties?: {
+      weight: number;                // Item weight
+      sku: string;                   // Stock-keeping unit
+      shippable: boolean;            // Whether item is shippable
+    };
+  }>;
+  shippingAddress?: {                // Shipping address (if provided)
+    country: string;                 // ISO-3166 alpha-2 country code
+    subdivision?: string;            // State/province code
+    city?: string;
+    postalCode?: string;
+  };
+  buyerDetails?: { ... };           // Buyer contact info
+  subtotal: string;                  // Pre-calculated total: sum of (price × quantity) for all line items, as a STRING
+}
+```
+
 ## Example: Global Additional Fee from Database Configuration
 
 This example queries a CMS collection to retrieve a configurable global fee that applies to all orders.


### PR DESCRIPTION
## Summary

- Add request structure to `ADDITIONAL-FEES.md` documenting that `lineItem.price` is a plain `string` (not `{amount: string}`) and that `subtotal` is pre-calculated
- Remove `description` from generic builder config table — only `ecomShippingRates()` accepts it
- Change extension example from `ecomShippingRates()` to `ecomAdditionalFees()` to prevent models from copying `description` into unsupported builders
- Add per-builder accepted fields table showing exactly which fields each method accepts

## Eval Results

Ran 15 eval runs total (5 per configuration) with the prompt:
> "make an additional fees app. it should be configurable and free from some amount the user configures. add a fomo widget to the stage that shows how much i need to spend to elimante the shipping fee"

### Old skill (baseline) — 5 runs

| Assertion | Pass Rate |
|-----------|-----------|
| no-description-bug (final code) | 5/5 (all self-corrected) |
| no-price-amount-bug (final code) | 5/5 (all self-corrected) |
| tsc first-try pass | **0/5** |

- All 5 runs initially hit **both** bugs (`description` on `ecomAdditionalFees()` and `lineItem.price.amount`)
- All self-corrected after tsc errors
- Avg: **351s**, **84.5k tokens**

### New skill (iteration 1 — price fix only) — 5 runs

| Assertion | Pass Rate |
|-----------|-----------|
| no-description-bug (final code) | 5/5 (all self-corrected) |
| no-price-amount-bug (final code) | 5/5 (**never introduced**) |
| tsc first-try pass | **0/5** |

- `price.amount` bug fully eliminated — 0/5 introduced it vs 5/5 baseline
- `description` bug persisted — still present in all runs
- Avg: **294s**, **71.9k tokens** (~16% improvement)

### New skill (iteration 2 — both fixes) — 5 runs

| Assertion | Pass Rate |
|-----------|-----------|
| no-description-bug (final code) | 5/5 (**never introduced**) |
| no-price-amount-bug (final code) | 5/5 (**never introduced**) |
| tsc first-try pass | **4/5** |

- Both bugs fully eliminated
- 4/5 runs passed tsc on first attempt (1 failure was unrelated `cart` vs `currentCart` import)
- Avg: **294s**, **65.9k tokens** (~22% fewer tokens vs baseline)

## Test plan

- [x] Verify `npx tsc --noEmit` passes on 4/5 runs with new skill (vs 0/5 baseline)
- [x] Verify `description` bug eliminated (0/5 vs 5/5 baseline)
- [x] Verify `price.amount` bug eliminated (0/5 vs 5/5 baseline)
- [x] Review generated code quality in eval outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)