### PR TITLE
fix: consolidate validation to orchestrator only

### DIFF
--- a/skills/wix-cli-backend-api/SKILL.md
+++ b/skills/wix-cli-backend-api/SKILL.md
@@ -240,7 +240,3 @@ src/pages/api/
 - Validate input parameters and request bodies
 - Use async/await for asynchronous operations
 - No `@ts-ignore` comments
-
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.

--- a/skills/wix-cli-backend-event/SKILL.md
+++ b/skills/wix-cli-backend-event/SKILL.md
@@ -118,7 +118,3 @@ onContactCreated(async (event) => {
 
 1. **Release** a version with your changes.
 2. **Trigger** the event by taking an action.
-
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript, build, and preview.

--- a/skills/wix-cli-dashboard-menu-plugin/SKILL.md
+++ b/skills/wix-cli-dashboard-menu-plugin/SKILL.md
@@ -169,7 +169,3 @@ Identify which Wix app the user is targeting, then read **only** the correspondi
 
 - Only output files that are directly required for the task
 - Do NOT add README.md or documentation files unless explicitly requested
-
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.

--- a/skills/wix-cli-dashboard-modal/SKILL.md
+++ b/skills/wix-cli-dashboard-modal/SKILL.md
@@ -286,7 +286,3 @@ export default function ItemEditModal() {
   );
 }
 ```
-
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.

--- a/skills/wix-cli-dashboard-page/SKILL.md
+++ b/skills/wix-cli-dashboard-page/SKILL.md
@@ -291,10 +291,6 @@ Do NOT copy field names from embedded script or other extension registrations. D
 - Separate types/interfaces into dedicated type files
 - Keep each component/function focused (~50-100 lines max)
 
-## Verification
-
-After implementation completes, the **wix-cli-orchestrator** will run validation using [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md).
-
 ## API Spec Support
 
 When an API specification is provided, you can make API calls to those endpoints. See [API Spec Reference](references/API_SPEC.md) for details on how to use API specs in dashboard pages.

--- a/skills/wix-cli-dashboard-plugin/SKILL.md
+++ b/skills/wix-cli-dashboard-plugin/SKILL.md
@@ -220,7 +220,3 @@ Each dashboard plugin requires an `<plugin-name>.extension.ts` file in its folde
 - If making a large file (>300 lines), split it into multiple smaller files with imports
 - Only output files that are directly required for the task
 - Do NOT add README.md or documentation files unless explicitly requested
-
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.

--- a/skills/wix-cli-data-collection/SKILL.md
+++ b/skills/wix-cli-data-collection/SKILL.md
@@ -446,10 +446,6 @@ Both collections are defined in the same `src/extensions/data/extensions.ts` fil
 
 **Note:** For owner tracking, create a custom collection for users rather than referencing Wix Members directly.
 
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.
-
 ## Reference Documentation
 
 - [extension-template.ts](assets/extension-template.ts) - Template for `src/extensions/data/extensions.ts`

--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -236,7 +236,3 @@ To test your service plugin extension:
 
 1. **Release a version** with your changes - new service plugins or changes to existing ones won't take effect until you've built and released your project
 2. **Trigger the call** to your service plugin by performing the relevant action (e.g., add items to cart and view cart to test Additional Fees)
-
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.

--- a/skills/wix-cli-site-component/SKILL.md
+++ b/skills/wix-cli-site-component/SKILL.md
@@ -496,10 +496,6 @@ The `id` must be a unique, static UUID v4 string. Generate a fresh UUID for each
 - NEVER use mocks, placeholders, or TODOs in any code
 - ALWAYS implement complete, production-ready functionality
 
-## Verification
-
-After implementation, use [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md) to validate TypeScript compilation, build, preview, and runtime behavior.
-
 ## Reference Documentation
 
 - [Complete Example](references/EXAMPLE.md) - Full production-ready site component example with all patterns

--- a/skills/wix-cli-site-widget/SKILL.md
+++ b/skills/wix-cli-site-widget/SKILL.md
@@ -593,7 +593,3 @@ The `id` must be a unique, static UUID v4 string. Generate a fresh UUID for each
 - Inline styles only (no CSS imports)
 - Handle Wix Editor environment when using Wix Data API
 - Consistent prop naming (camelCase in widget, kebab-case in panel)
-
-## Verification
-
-After implementation completes, the **wix-cli-orchestrator** will run validation using [wix-cli-app-validation](../wix-cli-app-validation/SKILL.md).


### PR DESCRIPTION
## Summary
- Removed `## Verification` section (referencing `wix-cli-app-validation`) from 10 individual skills
- Validation is now only triggered by the orchestrator at Step 5, eliminating duplicate validation runs by sub-agents

## Eval Results

### Prompt 1: Dashboard page + data collection (shift management)
| Metric | Baseline | After | Delta |
|--------|----------|-------|-------|
| Duration | 287.9s | 229.0s | **-20.5%** |
| Tokens | 81,887 | 70,925 | **-13.4%** |
| Cost | $0.057 | $0.049 | **-14.0%** |
| TSC | FAIL | PASS | **Fixed** |
| Build | PASS | PASS | — |

### Prompt 2: Countdown custom element widget
| Metric | Baseline | After | Delta |
|--------|----------|-------|-------|
| Duration | 253.4s | 209.3s | **-17.4%** |
| Tokens | 53,802 | 44,572 | **-17.2%** |
| Cost | $0.037 | $0.031 | **-16.2%** |
| TSC | PASS | PASS | — |
| Build | PASS | PASS | — |

### Prompt 3: Additional Fees SPI + data collection + dashboard
| Metric | Baseline | After | Delta |
|--------|----------|-------|-------|
| Duration | 505.9s | 277.4s | **-45.2%** |
| Tokens | 104,977 | 70,393 | **-32.9%** |
| Cost | $0.073 | $0.049 | **-32.9%** |
| TSC | PASS | PASS | — |
| Build | PASS | PASS | — |

### Average across all prompts
| Metric | Baseline | After | Delta |
|--------|----------|-------|-------|
| Duration | 349.1s | 238.6s | **-27.7%** |
| Tokens | 80,222 | 61,963 | **-21.2%** |
| Cost | $0.056 | $0.043 | **-21.0%** |
| Correctness | 1.67/3 | 2.0/3 | **+0.33** |

## Root Cause
Individual skills had `## Verification` sections telling the agent to invoke `wix-cli-app-validation`.
Sub-agents would read this and run validation independently, then the orchestrator would run it again —
resulting in duplicate install → tsc → build → preview cycles.

## Files Changed
10 skill SKILL.md files — removed 4 lines each (the `## Verification` section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)