### PR TITLE
feat(wix-cli-service-plugin): add Bookings Staff Sorting Provider SPI

### DIFF
--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -89,8 +89,6 @@ The handler file (`plugin.ts`) contains the service plugin logic. It must:
 3. Each handler function receives a payload with `request` and `metadata`
 4. Return the expected response structure for that SPI type
 
-**eCommerce example (Shipping Rates):**
-
 ```typescript
 import { shippingRates } from "@wix/ecom/service-plugins";
 
@@ -116,27 +114,6 @@ shippingRates.provideHandlers({
           },
         },
       ],
-    };
-  },
-});
-```
-
-**Bookings example (Staff Sorting):**
-
-```typescript
-import { staffSorting } from "@wix/bookings/service-plugins";
-
-staffSorting.provideHandlers({
-  sortStaffMembers: async (payload) => {
-    const { request } = payload;
-
-    // Implement custom staff sorting logic
-    // - request contains availableResourceIds, slot details, etc.
-
-    return {
-      staff: request.availableResourceIds.map((resourceId) => ({
-        resourceId,
-      })),
     };
   },
 });

--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-cli-service-plugin
-description: Use when implementing service plugin extensions that inject custom backend logic into existing Wix business solution flows or introduce new flows to Wix sites. Triggers include SPI, service plugin, backend flow, business logic, custom shipping rates, additional fees, tax calculation, checkout validation, discount triggers, gift cards, eCommerce customization.
+description: Use when implementing service plugin extensions that inject custom backend logic into existing Wix business solution flows or introduce new flows to Wix sites (eCommerce, Bookings, etc.). Triggers include SPI, service plugin, backend flow, business logic, custom shipping rates, additional fees, tax calculation, checkout validation, discount triggers, gift cards, eCommerce customization, bookings staff sorting.
 compatibility: Requires Wix CLI development environment.
 ---
 
@@ -8,7 +8,7 @@ compatibility: Requires Wix CLI development environment.
 
 Creates service plugin extensions for Wix CLI applications. Service plugins are a set of APIs defined by Wix that you can use to inject custom logic into the existing backend flows of Wix business solutions or to introduce entirely new flows to Wix sites.
 
-When you implement a service plugin, Wix calls your custom functions during specific flows. Common use cases include eCommerce customization (shipping, fees, taxes, validations), but service plugins can extend any Wix business solution that exposes SPIs.
+When you implement a service plugin, Wix calls your custom functions during specific flows. Common use cases include eCommerce customization (shipping, fees, taxes, validations) and Bookings customization (staff sorting), but service plugins can extend any Wix business solution that exposes SPIs.
 
 ## Quick Start Checklist
 
@@ -36,6 +36,7 @@ Follow these steps in order when creating a service plugin:
 | Shipping Rates | [SHIPPING-RATES.md](./references/SHIPPING-RATES.md) |
 | Tax Calculation | [TAX-CALCULATION.md](./references/TAX-CALCULATION.md) |
 | Validations | [VALIDATIONS.md](./references/VALIDATIONS.md) |
+| Bookings Staff Sorting | [BOOKINGS-STAFF-SORTING.md](./references/BOOKINGS-STAFF-SORTING.md) |
 
 ## Output Structure
 
@@ -83,10 +84,12 @@ All service plugins must include comprehensive data validation:
 
 The handler file (`plugin.ts`) contains the service plugin logic. It must:
 
-1. Import the relevant service plugin from `@wix/ecom/service-plugins`
+1. Import the relevant service plugin from the appropriate package (e.g., `@wix/ecom/service-plugins` for eCommerce, `@wix/bookings/service-plugins` for Bookings)
 2. Call `provideHandlers()` with an object containing handler functions
 3. Each handler function receives a payload with `request` and `metadata`
 4. Return the expected response structure for that SPI type
+
+**eCommerce example (Shipping Rates):**
 
 ```typescript
 import { shippingRates } from "@wix/ecom/service-plugins";
@@ -113,6 +116,27 @@ shippingRates.provideHandlers({
           },
         },
       ],
+    };
+  },
+});
+```
+
+**Bookings example (Staff Sorting):**
+
+```typescript
+import { staffSorting } from "@wix/bookings/service-plugins";
+
+staffSorting.provideHandlers({
+  sortStaffMembers: async (payload) => {
+    const { request } = payload;
+
+    // Implement custom staff sorting logic
+    // - request contains availableResourceIds, slot details, etc.
+
+    return {
+      staff: request.availableResourceIds.map((resourceId) => ({
+        resourceId,
+      })),
     };
   },
 });
@@ -221,8 +245,9 @@ All builder methods accept these three fields:
 | Discount Triggers | `ecomDiscountTriggers()` | `id`, `name`, `source` |
 | Gift Cards        | `ecomGiftCards()`        | `id`, `name`, `source` |
 | Payment Settings  | `ecomPaymentSettings()`  | `id`, `name`, `source`, `fallbackValueForRequires3dSecure` |
+| Bookings Staff Sorting | `bookingsStaffSortingProvider()` | `id`, `name`, `source`, `methodName`, `methodDescription`, `dashboardPluginId` |
 
-Only `ecomShippingRates()` accepts `description`. Passing unsupported fields to other builders causes TypeScript errors.
+Only `ecomShippingRates()` accepts `description`. Passing unsupported fields to other builders causes TypeScript errors. `bookingsStaffSortingProvider()` requires `methodName` and `methodDescription` fields, and optionally accepts `dashboardPluginId`.
 
 ### Step 2: Register in Main Extensions File
 

--- a/skills/wix-cli-service-plugin/references/BOOKINGS-STAFF-SORTING.md
+++ b/skills/wix-cli-service-plugin/references/BOOKINGS-STAFF-SORTING.md
@@ -1,0 +1,130 @@
+# Bookings Staff Sorting Provider Service Plugin Reference
+
+## Overview
+
+The Staff Sorting Provider SPI allows you to implement custom staff assignment algorithms for Wix Bookings. When a booking slot has multiple available staff members, Wix calls your plugin to determine the priority order for staff assignment.
+
+**FQDN**: `wix.interfaces.resources.sorting.v1.staff_sorting_provider`
+
+## Import
+
+```typescript
+import { staffSorting } from "@wix/bookings/service-plugins";
+```
+
+## Handler
+
+| Handler | Description |
+| --- | --- |
+| `sortStaffMembers` | Sort available staff members by priority for a given booking slot |
+
+## Request Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `policyId` | string | The ID of the sorting policy being applied |
+| `slot` | object | The booking slot details |
+| `slot.startDate` | string | Slot start date/time |
+| `slot.endDate` | string | Slot end date/time |
+| `slot.serviceId` | string | The booked service ID |
+| `slot.locationId` | string | The booking location ID |
+| `slot.timeZone` | string | Time zone of the slot |
+| `availableResourceIds` | string[] | IDs of staff members available for this slot |
+| `extendedFields` | object | Additional custom fields |
+
+## Response Structure
+
+```typescript
+{
+  staff: Array<{
+    resourceId: string;  // Staff member resource ID
+  }>;
+}
+```
+
+**Important constraints:**
+- You must return the **exact same IDs** from `availableResourceIds`, reordered by priority
+- Do not add or remove any IDs
+- If your response is invalid, Wix falls back to random assignment
+
+## Performance Requirements
+
+- **Hard limit**: Response must be returned within **5 seconds**
+- **Recommended**: Keep response time under **500ms** for optimal user experience
+
+## Example: Workload Balancing
+
+This example sorts staff members to balance workload by prioritizing those with fewer recent bookings.
+
+```typescript
+import { staffSorting } from "@wix/bookings/service-plugins";
+import { auth } from "@wix/essentials";
+import { bookings } from "@wix/bookings";
+
+staffSorting.provideHandlers({
+  sortStaffMembers: async (payload) => {
+    const { request } = payload;
+    const { availableResourceIds, slot } = request;
+
+    // Query recent bookings for each available staff member
+    const elevatedQuery = auth.elevate(bookings.queryBookings);
+    const recentBookings = await elevatedQuery()
+      .eq("resource.id", availableResourceIds)
+      .ge("start.timestamp", new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
+      .find();
+
+    // Count bookings per staff member
+    const bookingCounts = new Map<string, number>();
+    for (const id of availableResourceIds) {
+      bookingCounts.set(id, 0);
+    }
+    for (const booking of recentBookings.items) {
+      const resourceId = booking.resource?.id;
+      if (resourceId && bookingCounts.has(resourceId)) {
+        bookingCounts.set(resourceId, (bookingCounts.get(resourceId) ?? 0) + 1);
+      }
+    }
+
+    // Sort by fewest bookings first (balance workload)
+    const sorted = [...availableResourceIds].sort(
+      (a, b) => (bookingCounts.get(a) ?? 0) - (bookingCounts.get(b) ?? 0)
+    );
+
+    return {
+      staff: sorted.map((resourceId) => ({ resourceId })),
+    };
+  },
+});
+```
+
+## Extension Registration
+
+Register the staff sorting provider using the `bookingsStaffSortingProvider()` builder. This builder requires additional fields beyond the standard ones:
+
+```typescript
+import { extensions } from "@wix/astro/builders";
+
+export const staffSorting = extensions.bookingsStaffSortingProvider({
+  id: "{{GENERATE_UUID}}",
+  name: "Workload Balanced Staff Assignment",
+  source: "./backend/service-plugins/bookings-staff-sorting/workload-balancer/plugin.ts",
+  methodName: "Workload Balancer",
+  methodDescription: "Assigns staff members based on their recent booking count to balance workload evenly",
+});
+```
+
+### Additional Builder Fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `methodName` | string | Yes | Display name for the sorting method |
+| `methodDescription` | string | Yes | Description of the sorting algorithm |
+| `dashboardPluginId` | string | No | Optional dashboard plugin ID for configuration UI |
+
+## Key Implementation Notes
+
+1. **Return all IDs** - You must return every ID from `availableResourceIds`, just reordered
+2. **Performance matters** - Keep logic fast; the booking flow waits for your response
+3. **Elevate permissions** - Use `auth.elevate` when querying Wix APIs from the handler
+4. **Deterministic sorting** - Use a tiebreaker (e.g., resource ID) when priorities are equal
+5. **Graceful degradation** - If your external data source is unavailable, return the original order rather than failing


### PR DESCRIPTION
## Summary

- Add `BOOKINGS-STAFF-SORTING.md` reference doc for the Bookings Staff Sorting Provider SPI (`wix.interfaces.resources.sorting.v1.staff_sorting_provider`)
- Update `SKILL.md` to include Bookings Staff Sorting in the references table, builder methods table, description, and implementation examples
- Add `bookingsStaffSortingProvider()` builder method documentation with its specific fields (`methodName`, `methodDescription`, `dashboardPluginId`)

## Changes

### New file
- `skills/wix-cli-service-plugin/references/BOOKINGS-STAFF-SORTING.md` — Full reference with handler signature, request/response fields, performance requirements, workload-balancing example, and extension registration

### Modified file
- `skills/wix-cli-service-plugin/SKILL.md` — Updated description, references table, implementation pattern section (added Bookings example), and builder methods table

## Source
Ported from `yanivef/bookings-staff-sorting-provider` branch on `wix-private/ditto`.