### PR TITLE
feat(wds-docs): add cheat sheets to cut tool calls by ~75%

### DIFF
--- a/skills/wds-docs/SKILL.md
+++ b/skills/wds-docs/SKILL.md
@@ -6,33 +6,46 @@ compatibility: Requires @wix/design-system package installed in the project.
 
 # WDS Documentation Navigator
 
-**Docs path:** `node_modules/@wix/design-system/dist/docs/`
+## FAST PATH: Cheat Sheets First (1 Read covers 90% of cases)
 
-## CRITICAL: Never Read Entire Files
+Before using the staged docs lookup, check the **pre-built references** in this skill's `references/` folder.
 
-Files are 200-900+ lines. Follow the staged discovery flow below.
+### Step 1: Read the cheat sheet
+
+Read **one file** that covers your needs:
+
+| Need | File | Covers |
+|------|------|--------|
+| Component props & snippets | `references/COMMON_COMPONENTS.md` | Top ~20 components with correct types, snippets, deprecation warnings, and gotchas |
+| Dashboard page patterns | `references/RECIPES.md` | CRUD table, form modal, delete confirm, settings card, selection, empty state |
+| Icon names | `references/ICONS.md` | ~100 most-used icons organized by category, naming conventions |
+
+**For most tasks, reading `COMMON_COMPONENTS.md` + `ICONS.md` is sufficient (2 Reads total).**
+
+### Step 2: Only fall back to full docs if needed
+
+If a component is NOT in the cheat sheet, use the staged lookup below.
 
 ---
 
-## Stage 1: Find Component
+## SLOW PATH: Full Docs Lookup (for uncommon components)
 
-**Goal:** Search for component by feature/keyword
+**Docs path:** `node_modules/@wix/design-system/dist/docs/`
+
+### CRITICAL: Never Read Entire Files
+
+Files are 200-900+ lines. Follow the staged discovery flow below.
+
+### Stage 1: Find Component
 
 ```bash
 Grep: "table" in components.md
 Grep: "form\|input\|validation" in components.md
-Grep: "modal\|dialog\|popup" in components.md
 ```
 
-**Output:** Component name + description + do/don'ts
+**Output:** Component name + description + do/don'ts → Go to Stage 2
 
-**Next:** Go to Stage 2 with component name
-
----
-
-## Stage 2: Get Props + Example List
-
-**Goal:** Get props AND discover available examples
+### Stage 2: Get Props + Example List
 
 ```bash
 # 2a. Get props (small files OK to read, large files grep)
@@ -43,37 +56,15 @@ Grep: "### disabled" in components/BoxProps.md -A 3  # Box is huge
 Grep: "^### " in components/ButtonExamples.md -n
 ```
 
-**Output from 2b:**
-```
-5:### Size
-17:### Skin
-71:### Affix
-123:### Disabled
-183:### Loading state
-```
-
-**Next:** Pick example(s) from list, go to Stage 3
-
----
-
-## Stage 3: Fetch Specific Example
-
-**Goal:** Read only the example you need (~30-50 lines)
+### Stage 3: Fetch Specific Example
 
 ```bash
-# Option A: Read with offset (line number from Stage 2)
 Read: components/ButtonExamples.md offset=183 limit=40
-
-# Option B: Grep with context
-Grep: "### Loading state" in components/ButtonExamples.md -A 40
 ```
 
-**Output:** JSX code example for that specific feature
+### Stage 4: Icons (when needed)
 
----
-
-## Stage 4: Icons (when needed)
-
+Prefer `references/ICONS.md` first. Fall back to:
 ```bash
 Grep: "Add\|Edit\|Delete\|Search" in icons.md
 ```
@@ -83,92 +74,19 @@ Grep: "Add\|Edit\|Delete\|Search" in icons.md
 ## Flow Summary
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│ Stage 1: Grep components.md for keyword                 │
-│          → finds: Button, Card, Table...                │
-└────────────────────┬────────────────────────────────────┘
-                     ↓
-┌─────────────────────────────────────────────────────────┐
-│ Stage 2a: Read/Grep {Component}Props.md                 │
-│           → gets: props with types & descriptions       │
-│                                                         │
-│ Stage 2b: Grep "^### " in {Component}Examples.md        │
-│           → gets: example names + line numbers          │
-│           "5:### Size, 71:### Affix, 183:### Loading"   │
-└────────────────────┬────────────────────────────────────┘
-                     ↓
-┌─────────────────────────────────────────────────────────┐
-│ Stage 3: Read offset=183 limit=40                       │
-│          → gets: specific example JSX code              │
-└────────────────────────────────────────────────────────┘
-```
-
----
-
-## Example Session: Product Page
-
-```bash
-# Stage 1: Find components
-Grep: "image\|card\|price" in components.md
-→ Image, Card, Text found
-
-# Stage 2a: Get Card props
-Read: components/CardProps.md
-
-# Stage 2b: List Card examples
-Grep: "^### " in components/CardExamples.md -n
-→ 5:### Basic, 25:### With media, 60:### Clickable
-
-# Stage 3: Fetch "With media" example
-Read: components/CardExamples.md offset=25 limit=35
-→ Gets Card with Image example code
-
-# Repeat Stage 2-3 for other components as needed
-```
-
-**Result:** ~80 lines read instead of 1500+
-
----
-
-## Quick Reference
-
-| Stage | Command | Output |
-|-------|---------|--------|
-| 1. Find | `Grep: "keyword" in components.md` | Component name |
-| 2a. Props | `Read: {Name}Props.md` | Props list |
-| 2b. Examples | `Grep: "^### " in {Name}Examples.md` | Example names + lines |
-| 3. Fetch | `Read: offset=N limit=40` | Example code |
-| 4. Icons | `Grep: "IconName" in icons.md` | Icon exists |
-
----
-
-## File Sizes
-
-| File | Lines | Strategy |
-|------|-------|----------|
-| components.md | ~970 | Grep, never read fully |
-| icons.md | ~400 | Grep for specific icon |
-| Most Props.md | 30-100 | Read fully OK |
-| BoxProps.md | 8000+ | Grep only! |
-| Most Examples.md | 100-600 | Grep → offset read |
-| PageExamples.md | 940 | Grep → offset read |
-
----
-
-## Grep Patterns by Use Case
-
-```bash
-# Forms
-Grep: "form\|input\|validation" in components.md
-
-# Layout
-Grep: "layout\|page\|card\|box" in components.md
-
-# Data display
-Grep: "table\|list\|badge" in components.md
-
-# Feedback
-Grep: "notification\|toast\|loader" in components.md
+┌────────────────────────────────────────────────────────────┐
+│ FAST: Read references/COMMON_COMPONENTS.md (1 tool call)   │
+│       + references/ICONS.md if icons needed                │
+│       + references/RECIPES.md for page patterns            │
+│                                                            │
+│       → Covers ~90% of components. STOP HERE if covered.   │
+└─────────────────────────┬──────────────────────────────────┘
+                          ↓ component NOT in cheat sheet
+┌────────────────────────────────────────────────────────────┐
+│ SLOW Stage 1: Grep components.md for keyword               │
+│ SLOW Stage 2: Read {Name}Props.md + Grep Examples headings │
+│ SLOW Stage 3: Read specific example with offset            │
+└────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -180,15 +98,18 @@ Grep: "notification\|toast\|loader" in components.md
 | Rectangle/container | `<Box>` | Layout wrapper |
 | Text button | `<TextButton>` | Secondary actions |
 | Input with label | `<FormField>` + `<Input>` | Wrap inputs |
+| Number input | `<NumberInput>` | Prefer over `<Input type="number">` |
+| Textarea | `<InputArea>` | Multiline text |
 | Toggle | `<ToggleSwitch>` | On/off settings |
 | Modal | `<Modal>` + `<CustomModalLayout>` | Use together |
-| Grid | `<Layout>` + `<Cell>` | Responsive |
+| Confirm dialog | `<Modal>` + `<MessageModalLayout>` | Short messages |
+| Grid | `<Layout>` + `<Cell>` | Responsive grid |
+| Select/dropdown | `<Dropdown>` | Single select |
+| Search | `<Search>` | With optional dropdown |
 
 ---
 
 ## Spacing (px → SP conversion)
-
-When designer specifies pixels, convert to the nearest SP token:
 
 | Token | Classic | Studio |
 |-------|---------|--------|
@@ -199,11 +120,7 @@ When designer specifies pixels, convert to the nearest SP token:
 | `SP5` | 30px | 20px |
 | `SP6` | 36px | 24px |
 
-```tsx
-<Box gap="SP2" padding="SP3">
-```
-
-Only use SP tokens for `gap`, `padding`, `margin` - not for width/height.
+Only use SP tokens for `gap`, `padding`, `margin` — not for width/height.
 
 ---
 
@@ -213,3 +130,16 @@ Only use SP tokens for `gap`, `padding`, `margin` - not for width/height.
 import { Button, Card, Image } from '@wix/design-system';
 import { Add, Edit, Delete } from '@wix/wix-ui-icons-common';
 ```
+
+---
+
+## File Sizes (for full docs lookup)
+
+| File | Lines | Strategy |
+|------|-------|----------|
+| components.md | ~970 | Grep, never read fully |
+| icons.md | ~400 | Grep, or use references/ICONS.md |
+| Most Props.md | 30-100 | Read fully OK |
+| BoxProps.md | 8000+ | Grep only! |
+| Most Examples.md | 100-600 | Grep → offset read |
+| PageExamples.md | 940 | Grep → offset read |

--- a/skills/wds-docs/references/COMMON_COMPONENTS.md
+++ b/skills/wds-docs/references/COMMON_COMPONENTS.md
@@ -1,0 +1,669 @@
+# WDS Common Components Cheat Sheet
+
+Quick-reference for the ~20 most-used components. Use this **first** before falling back to the full docs.
+
+All imports: `import { ComponentName } from '@wix/design-system';`
+All icons: `import { IconName } from '@wix/wix-ui-icons-common';`
+
+---
+
+## Page
+
+Compound: `<Page.Header>`, `<Page.Content>`, `<Page.Tail>`, `<Page.Section>`, `<Page.Footer>`
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `height` | string | Use `"100vh"` or `"calc(100vh - 48px)"` for BM pages |
+| `maxWidth` | number | Default 1248. Excludes padding. |
+| `minWidth` | number | Default 864. |
+| `sidePadding` | number | Default 48px. |
+
+`<Page.Header>` key props: `title` (string), `subtitle` (string), `actionsBar` (ReactNode — put buttons here), `breadcrumbs` (ReactNode).
+
+```tsx
+<Page height="calc(100vh - 48px)">
+  <Page.Header title="Products" actionsBar={<Button prefixIcon={<Add />}>Add Product</Button>} />
+  <Page.Content>
+    {/* content here */}
+  </Page.Content>
+</Page>
+```
+
+---
+
+## Button
+
+| Prop | Type | Values |
+|------|------|--------|
+| `skin` | ButtonSkin | `'standard'` \| `'destructive'` \| `'premium'` \| `'light'` \| `'transparent'` \| `'inverted'` \| `'ai'` |
+| `priority` | ButtonPriority | `'primary'` \| `'secondary'` |
+| `size` | ButtonSize | `'tiny'` \| `'small'` \| `'medium'` \| `'large'` |
+| `prefixIcon` | IconElement | `<Add />` etc. |
+| `suffixIcon` | IconElement | |
+| `fullWidth` | boolean | 100% parent width |
+| `disabled` | boolean | |
+| `as` | string \| Component | Render as `'a'`, `'div'`, etc. |
+
+```tsx
+<Button skin="destructive" priority="secondary" prefixIcon={<Delete />}>
+  Remove
+</Button>
+```
+
+---
+
+## Box
+
+Layout wrapper with flex support. **Use SP tokens for gap/padding/margin.**
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `direction` | `'horizontal'` \| `'vertical'` | Default: `'horizontal'` |
+| `align` | `'left'` \| `'center'` \| `'right'` \| `'space-between'` | X-axis |
+| `verticalAlign` | `'top'` \| `'middle'` \| `'bottom'` \| `'space-between'` | Y-axis |
+| `gap` | BoxCssSizingProperty | Use `"SP1"`–`"SP6"` |
+| `padding` | BoxCssSizingProperty | Use `"SP1"`–`"SP6"` |
+| `margin` | BoxCssSizingProperty | Use `"SP1"`–`"SP6"` |
+| `width` | BoxCssSizingProperty | |
+| `height` | BoxCssSizingProperty | |
+| `backgroundColor` | string | Color palette key or hex |
+
+SP tokens: SP1=6px, SP2=12px, SP3=18px, SP4=24px, SP5=30px, SP6=36px
+
+```tsx
+<Box direction="vertical" gap="SP4" padding="SP3">
+  <Box align="space-between" verticalAlign="middle">
+    <Text>Left</Text>
+    <Button>Right</Button>
+  </Box>
+</Box>
+```
+
+---
+
+## Text
+
+| Prop | Type | Values |
+|------|------|--------|
+| `size` | TextSize | `'tiny'` \| `'small'` \| `'medium'` |
+| `weight` | TextWeight | `'thin'` \| `'normal'` \| `'bold'` |
+| `skin` | TextSkin | `'standard'` \| `'error'` \| `'success'` \| `'premium'` \| `'disabled'` |
+| `secondary` | boolean | Lighter font color |
+| `light` | boolean | For dark backgrounds |
+| `ellipsis` | boolean | Truncate with tooltip |
+| `maxLines` | number | Multi-line truncation |
+| `tagName` | string | Render as `'span'`, `'p'`, `'div'`, etc. |
+
+```tsx
+<Text size="small" weight="bold" skin="error">Required field</Text>
+```
+
+---
+
+## Heading
+
+| Prop | Type | Values |
+|------|------|--------|
+| `size` | Size | `'extraLarge'` \| `'large'` \| `'medium'` \| `'small'` \| `'extraSmall'` \| `'tiny'` |
+| `as` | string | HTML tag: `'h1'`–`'h6'`, `'div'`, etc. |
+| `light` | boolean | For dark backgrounds |
+| `ellipsis` | boolean | Truncate with tooltip |
+
+> **Deprecated:** `appearance` prop — use `size` instead.
+
+```tsx
+<Heading size="medium" as="h2">Section Title</Heading>
+```
+
+---
+
+## Card
+
+Compound: `<Card.Header>`, `<Card.Subheader>`, `<Card.Content>`, `<Card.Divider>`
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `controls` | ReactNode | Top-right controls (e.g., CloseButton) |
+| `stretchVertically` | boolean | Fill container height |
+| `showShadow` | boolean | Drop shadow |
+| `hideOverflow` | boolean | Clip overflow |
+
+`<Card.Header>` props: `title` (string), `subtitle` (string), `suffix` (ReactNode).
+
+```tsx
+<Card>
+  <Card.Header title="Details" suffix={<TextButton>Edit</TextButton>} />
+  <Card.Divider />
+  <Card.Content>
+    <Box direction="vertical" gap="SP3">
+      {/* form fields */}
+    </Box>
+  </Card.Content>
+</Card>
+```
+
+---
+
+## Table
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `data` | array | Each item needs `id` (used as React key) |
+| `columns` | array | `{ title, render: (row) => ReactNode }` — see below |
+| `onRowClick` | func | Enables row hover effect |
+| `onSortClick` | func | `(column, sortDescending) => void` |
+| `showSelection` | boolean | Checkbox column |
+| `selectedIds` | array \| `'ALL'` | Selected row IDs |
+| `onSelectionChanged` | func | `(type, change?) => void` |
+| `skin` | enum | `'standard'` \| `'neutral'` |
+| `rowVerticalPadding` | enum | `'large'` \| `'medium'` \| `'small'` \| `'tiny'` |
+| `showHeaderWhenEmpty` | boolean | Show titlebar with no data |
+| `horizontalScroll` | boolean | |
+
+Column object: `{ title: string, render: (row) => ReactNode, width?: string, align?: string, sortable?: boolean, sortDescending?: boolean, stickyActionCell?: boolean }`
+
+Compound: `<Table.Content />` (required), `<Table.Titlebar />`, `<Table.SubToolbar>`
+
+```tsx
+<Table data={items} columns={columns} onSortClick={handleSort}>
+  <TableToolbar>
+    <TableToolbar.ItemGroup position="start">
+      <TableToolbar.Item>
+        <TableToolbar.Title>Products</TableToolbar.Title>
+      </TableToolbar.Item>
+    </TableToolbar.ItemGroup>
+    <TableToolbar.ItemGroup position="end">
+      <TableToolbar.Item>
+        <Search value={search} onChange={e => setSearch(e.target.value)} />
+      </TableToolbar.Item>
+    </TableToolbar.ItemGroup>
+  </TableToolbar>
+  <Table.Content />
+</Table>
+```
+
+---
+
+## TableToolbar
+
+Compound: `<TableToolbar.ItemGroup>`, `<TableToolbar.Item>`, `<TableToolbar.Title>`, `<TableToolbar.Label>`, `<TableToolbar.Divider>`, `<TableToolbar.SelectedCount>`
+
+`<TableToolbar.ItemGroup>` prop: `position` — `'start'` | `'end'`
+
+```tsx
+<TableToolbar>
+  <TableToolbar.ItemGroup position="start">
+    <TableToolbar.Item><TableToolbar.Title>Items</TableToolbar.Title></TableToolbar.Item>
+  </TableToolbar.ItemGroup>
+  <TableToolbar.ItemGroup position="end">
+    <TableToolbar.Item><Search /></TableToolbar.Item>
+  </TableToolbar.ItemGroup>
+</TableToolbar>
+```
+
+---
+
+## TableActionCell
+
+**IMPORTANT:** `secondaryActions` require an `icon` prop (ReactNode). This is **required**, not optional.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `primaryAction` | object \| array | `{ text, onClick?, visibility?, prefixIcon?, suffixIcon?, skin? }` |
+| `secondaryActions` | array | `{ text, icon, onClick, skin?, disabled? }` — **icon is required** |
+| `numOfVisibleSecondaryActions` | number | Show N as icon buttons outside menu |
+| `alwaysShowSecondaryActions` | boolean | Visible without hover |
+| `moreActionsTooltipText` | string | Tooltip for "..." button. Recommended: `"More actions"` |
+| `size` | enum | `'medium'` \| `'small'` |
+
+Secondary actions use **Small** icon variants in the popover menu.
+
+```tsx
+<TableActionCell
+  primaryAction={{ text: 'Edit', onClick: () => handleEdit(row) }}
+  secondaryActions={[
+    { text: 'Duplicate', icon: <DuplicateSmall />, onClick: () => handleDuplicate(row) },
+    { text: 'Delete', icon: <DeleteSmall />, onClick: () => handleDelete(row), skin: 'destructive' },
+  ]}
+  numOfVisibleSecondaryActions={0}
+  moreActionsTooltipText="More actions"
+/>
+```
+
+---
+
+## Modal + CustomModalLayout
+
+**Always use together.** `<Modal>` is the overlay; `<CustomModalLayout>` is the content.
+
+### Modal
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `isOpen` | boolean | **Required.** Controls visibility |
+| `onRequestClose` | func | Called on overlay click / Escape |
+| `shouldCloseOnOverlayClick` | boolean | Default: true |
+| `screen` | enum | `'full'` \| `'desktop'` \| `'mobile'` |
+
+### CustomModalLayout
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `title` | string \| ReactNode | **Required** |
+| `content` | ReactNode | **Required** (children also work) |
+| `primaryButtonText` | string \| ReactNode | |
+| `primaryButtonOnClick` | func | |
+| `primaryButtonProps` | ButtonProps | Use `{ disabled: true }` to disable |
+| `secondaryButtonText` | string \| ReactNode | |
+| `secondaryButtonOnClick` | func | |
+| `secondaryButtonProps` | ButtonProps | |
+| `closeButtonProps` | `{ onClick }` | **Preferred** — see deprecated below |
+| `width` | string \| number | Min: 510px, max: 1254px |
+| `maxHeight` | string \| number | |
+| `removeContentPadding` | boolean | For Table/Page inside modal |
+| `sideActions` | ReactNode | Footer start (e.g., checkbox) |
+| `footnote` | ReactNode | Bottom text |
+| `theme` | enum | `'standard'` \| `'premium'` \| `'destructive'` |
+| `showHeaderDivider` | enum | `'auto'` \| `true` \| `false` |
+| `showFooterDivider` | enum | `'auto'` \| `true` \| `false` |
+
+> **Deprecated:** `onCloseButtonClick` — use `closeButtonProps={{ onClick: handler }}` instead.
+> **Deprecated:** `onHelpButtonClick` — use `helpButtonProps={{ onClick: handler }}` instead.
+> **NOT a prop:** `disablePrimaryButton` — use `primaryButtonProps={{ disabled: true }}` instead.
+
+```tsx
+<Modal isOpen={isOpen} onRequestClose={onClose} shouldCloseOnOverlayClick>
+  <CustomModalLayout
+    title="Add Item"
+    primaryButtonText="Save"
+    primaryButtonOnClick={handleSave}
+    primaryButtonProps={{ disabled: !isValid }}
+    secondaryButtonText="Cancel"
+    secondaryButtonOnClick={onClose}
+    closeButtonProps={{ onClick: onClose }}
+    content={
+      <Box direction="vertical" gap="SP4">
+        <FormField label="Name" required>
+          <Input value={name} onChange={e => setName(e.target.value)} />
+        </FormField>
+      </Box>
+    }
+  />
+</Modal>
+```
+
+---
+
+## MessageModalLayout
+
+For short confirmation/warning messages. Same deprecated props as CustomModalLayout.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `title` | ReactNode | |
+| `content` | ReactNode | Short message |
+| `illustration` | ReactNode | 120x120 image/icon |
+| `primaryButtonText` | ReactNode | |
+| `primaryButtonOnClick` | func | |
+| `primaryButtonProps` | ButtonProps | |
+| `secondaryButtonText` | ReactNode | |
+| `secondaryButtonOnClick` | func | |
+| `closeButtonProps` | object | **Preferred over deprecated `onCloseButtonClick`** |
+| `skin` | enum | `'standard'` \| `'premium'` \| `'destructive'` |
+
+> **Deprecated:** `onCloseButtonClick` — use `closeButtonProps={{ onClick: handler }}`.
+> **Deprecated:** `onHelpButtonClick` — use `helpButtonProps={{ onClick: handler }}`.
+
+```tsx
+<Modal isOpen={showConfirm} onRequestClose={onClose}>
+  <MessageModalLayout
+    title="Delete item?"
+    content="This action cannot be undone."
+    primaryButtonText="Delete"
+    primaryButtonOnClick={handleDelete}
+    secondaryButtonText="Cancel"
+    secondaryButtonOnClick={onClose}
+    closeButtonProps={{ onClick: onClose }}
+    skin="destructive"
+  />
+</Modal>
+```
+
+---
+
+## Input
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `value` | string \| number | |
+| `onChange` | ChangeEventHandler | Standard React onChange |
+| `placeholder` | string | |
+| `disabled` | boolean | |
+| `readOnly` | boolean | |
+| `status` | InputStatus | `'error'` \| `'warning'` \| `'loading'` |
+| `statusMessage` | ReactNode | Tooltip on status icon |
+| `size` | InputSize | `'small'` \| `'medium'` \| `'large'` |
+| `prefix` | ReactNode | Before input |
+| `suffix` | ReactNode | After input |
+| `clearButton` | boolean | Show X |
+| `onClear` | func | |
+| `type` | string | `'text'` \| `'password'` \| `'number'` etc. |
+| `min` | **number** | **NOT string — use `min={0}` not `min="0"`** |
+| `max` | **number** | **NOT string** |
+| `step` | **number** | **NOT string** |
+| `maxLength` | number | |
+| `border` | enum | `'standard'` \| `'round'` \| `'bottomLine'` \| `'none'` |
+
+```tsx
+<Input
+  value={email}
+  onChange={e => setEmail(e.target.value)}
+  placeholder="Enter email"
+  status={error ? 'error' : undefined}
+  statusMessage={error}
+/>
+```
+
+---
+
+## NumberInput
+
+**Prefer over `<Input type="number">`** for numeric values.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `value` | number | |
+| `onChange` | `(value: number, stringValue: string) => void` | **Different from Input!** |
+| `min` | **number** | |
+| `max` | **number** | |
+| `step` | number \| number[] | |
+| `placeholder` | string | |
+| `disabled` | boolean | |
+| `hideStepper` | boolean | Hide +/- buttons |
+| `prefix` | ReactNode | |
+| `suffix` | ReactNode | |
+| `status` | InputStatus | `'error'` \| `'warning'` \| `'loading'` |
+| `statusMessage` | ReactNode | |
+| `strict` | boolean | |
+
+```tsx
+<NumberInput
+  value={price}
+  onChange={(val) => setPrice(val)}
+  min={0}
+  step={0.01}
+  prefix={<Input.Affix>$</Input.Affix>}
+/>
+```
+
+---
+
+## InputArea (Textarea)
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `value` | string | |
+| `onChange` | ChangeEventHandler | |
+| `placeholder` | string | |
+| `rows` | number | Initial visible rows |
+| `maxLength` | number | |
+| `hasCounter` | boolean | Show char count |
+| `resizable` | boolean | |
+| `autoGrow` | boolean | |
+| `minRowsAutoGrow` | number | |
+| `maxRowsAutoGrow` | number | |
+| `status` | InputStatus | |
+| `statusMessage` | ReactNode | |
+| `disabled` | boolean | |
+
+```tsx
+<InputArea
+  value={description}
+  onChange={e => setDescription(e.target.value)}
+  placeholder="Enter description"
+  rows={3}
+  maxLength={500}
+  hasCounter
+  resizable
+/>
+```
+
+---
+
+## FormField
+
+Wrapper for form inputs. Provides label, status, and char count.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `label` | ReactNode | |
+| `required` | boolean | Shows asterisk |
+| `status` | StatusType | `'error'` \| `'warning'` |
+| `statusMessage` | ReactNode | Below input |
+| `infoContent` | ReactNode | Tooltip on info icon |
+| `charCount` | number | Max length counter |
+| `id` | string | Connects label to input via `for` |
+| `labelPlacement` | enum | `'top'` \| `'right'` \| `'left'` |
+| `stretchContent` | boolean | Child fills available space |
+
+```tsx
+<FormField label="Email" required status={error ? 'error' : undefined} statusMessage={error}>
+  <Input value={email} onChange={e => setEmail(e.target.value)} />
+</FormField>
+```
+
+---
+
+## Dropdown
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `options` | array | `{ id, value }` — id is required and unique |
+| `selectedId` | string \| number | Controlled |
+| `initialSelectedId` | string \| number | Uncontrolled |
+| `onSelect` | func | `(option) => void` |
+| `placeholder` | string | |
+| `disabled` | boolean | |
+| `status` | enum | `'error'` \| `'warning'` \| `'loading'` |
+| `statusMessage` | ReactNode | |
+| `size` | enum | `'small'` \| `'medium'` \| `'large'` |
+| `clearButton` | boolean | |
+
+```tsx
+<Dropdown
+  options={[
+    { id: '1', value: 'Option A' },
+    { id: '2', value: 'Option B' },
+  ]}
+  selectedId={selected}
+  onSelect={opt => setSelected(opt.id)}
+  placeholder="Choose..."
+/>
+```
+
+---
+
+## Search
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `value` | string | |
+| `onChange` | func | Standard input onChange |
+| `onClear` | func | |
+| `placeholder` | string | Default varies |
+| `debounceMs` | number | Debounce onChange |
+| `options` | array | Dropdown suggestions (same as Dropdown) |
+| `expandable` | boolean | Collapse to icon, expand on click |
+| `expandWidth` | string \| number | Width when expanded |
+| `size` | enum | `'small'` \| `'medium'` \| `'large'` |
+
+```tsx
+<Search
+  value={searchTerm}
+  onChange={e => setSearchTerm(e.target.value)}
+  onClear={() => setSearchTerm('')}
+  placeholder="Search..."
+/>
+```
+
+---
+
+## Badge
+
+| Prop | Type | Values |
+|------|------|--------|
+| `skin` | BadgeSkin | `'general'` \| `'standard'` \| `'danger'` \| `'success'` \| `'neutral'` \| `'neutralLight'` \| `'warning'` \| `'warningLight'` \| `'urgent'` \| `'neutralStandard'` \| `'neutralSuccess'` \| `'neutralDanger'` \| `'premium'` \| `'ai'` |
+| `type` | BadgeType | `'solid'` \| `'outlined'` \| `'transparent'` |
+| `size` | BadgeSize | `'tiny'` \| `'small'` \| `'medium'` |
+| `prefixIcon` | IconElement | |
+| `suffixIcon` | IconElement | |
+| `uppercase` | boolean | |
+
+```tsx
+<Badge skin="success" size="small">Active</Badge>
+<Badge skin="danger" type="outlined">Out of Stock</Badge>
+```
+
+---
+
+## EmptyState
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `title` | ReactNode | |
+| `subtitle` | ReactNode | |
+| `image` | string \| ReactNode | URL or component |
+| `children` | ReactNode | Below subtitle (buttons etc.) |
+| `align` | enum | `'start'` \| `'center'` |
+| `skin` | enum | `'page'` \| `'section'` |
+
+```tsx
+<EmptyState
+  title="No items yet"
+  subtitle="Create your first item to get started."
+>
+  <TextButton prefixIcon={<Add />}>Add Item</TextButton>
+</EmptyState>
+```
+
+---
+
+## Layout + Cell
+
+Grid layout system.
+
+| Layout Prop | Type | Notes |
+|-------------|------|-------|
+| `cols` | number | Grid columns (default: 12) |
+| `gap` | CSS gap | Default: 24px |
+| `justifyItems` | CSS justifyItems | |
+| `alignItems` | CSS alignItems | |
+
+| Cell Prop | Type | Notes |
+|-----------|------|-------|
+| `span` | number | Columns to span (default: 12) |
+
+```tsx
+<Layout cols={12} gap="24px">
+  <Cell span={6}>
+    <FormField label="First Name"><Input /></FormField>
+  </Cell>
+  <Cell span={6}>
+    <FormField label="Last Name"><Input /></FormField>
+  </Cell>
+  <Cell span={12}>
+    <FormField label="Email"><Input /></FormField>
+  </Cell>
+</Layout>
+```
+
+---
+
+## ToggleSwitch
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `checked` | boolean | |
+| `onChange` | func | |
+| `disabled` | boolean | |
+| `size` | enum | `'small'` \| `'medium'` \| `'large'` |
+| `skin` | enum | `'standard'` \| `'success'` \| `'error'` |
+
+```tsx
+<ToggleSwitch checked={enabled} onChange={() => setEnabled(!enabled)} size="small" />
+```
+
+---
+
+## Tooltip
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `content` | ReactNode | Tooltip text |
+| `children` | ReactNode | Trigger element |
+| `placement` | Placement | `'top'` \| `'bottom'` \| `'left'` \| `'right'` etc. |
+| `enterDelay` | number | ms before show |
+| `exitDelay` | number | ms before hide |
+| `maxWidth` | string \| number | |
+| `appendTo` | AppendTo | `'window'` \| `'scrollParent'` \| `'viewport'` \| `'parent'` |
+| `disabled` | boolean | |
+
+```tsx
+<Tooltip content="Delete this item" placement="top">
+  <IconButton><Delete /></IconButton>
+</Tooltip>
+```
+
+---
+
+## Loader
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `size` | LoaderSize | `'tiny'` \| `'small'` \| `'medium'` \| `'large'` |
+| `color` | LoaderColor | `'blue'` \| `'white'` |
+| `text` | ReactNode | Message below loader |
+| `status` | LoaderStatus | `'loading'` \| `'success'` \| `'error'` |
+| `statusMessage` | string | Tooltip on hover |
+
+```tsx
+<Loader size="small" />
+<Loader size="medium" text="Loading data..." />
+```
+
+---
+
+## TextButton
+
+For secondary/inline actions.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `size` | enum | `'tiny'` \| `'small'` \| `'medium'` |
+| `weight` | enum | `'thin'` \| `'normal'` |
+| `skin` | enum | `'standard'` \| `'light'` \| `'premium'` \| `'destructive'` \| `'dark'` |
+| `prefixIcon` | IconElement | |
+| `suffixIcon` | IconElement | |
+| `underline` | enum | `'none'` \| `'onHover'` \| `'always'` |
+| `as` | string \| Component | |
+| `disabled` | boolean | |
+
+```tsx
+<TextButton size="small" prefixIcon={<Edit />}>Edit</TextButton>
+```
+
+---
+
+## IconButton
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `size` | enum | `'tiny'` \| `'small'` \| `'medium'` \| `'large'` |
+| `skin` | enum | `'standard'` \| `'inverted'` \| `'light'` \| `'transparent'` \| `'premium'` |
+| `priority` | enum | `'primary'` \| `'secondary'` |
+| `disabled` | boolean | |
+| `children` | ReactNode | Icon component |
+
+```tsx
+<IconButton size="small" priority="secondary"><MoreSmall /></IconButton>
+```

--- a/skills/wds-docs/references/ICONS.md
+++ b/skills/wds-docs/references/ICONS.md
@@ -1,0 +1,146 @@
+# WDS Common Icons
+
+Import: `import { IconName } from '@wix/wix-ui-icons-common';`
+
+Props: `size?: string | number` + all SVG attributes.
+
+## Naming Convention
+
+- **Resizable icons** have two variants: `IconName` (24px default) and `IconNameSmall` (18px)
+- **Filled variants:** `IconNameFilled` / `IconNameFilledSmall`
+- Use **Small** variants inside `TableActionCell` secondary actions and compact UI
+- Use standard (non-Small) variants for buttons, page headers, and general UI
+
+---
+
+## Most-Used Icons by Category
+
+### CRUD Actions
+| Icon | Usage |
+|------|-------|
+| `Add` / `AddSmall` | Create/add new item |
+| `Edit` / `EditSmall` | Edit item |
+| `Delete` / `DeleteSmall` | Delete/remove item |
+| `Duplicate` / `DuplicateSmall` | Duplicate/copy item |
+| `Confirm` / `ConfirmSmall` | Confirm/approve action |
+| `Dismiss` / `DismissSmall` | Cancel/dismiss |
+
+### Navigation & Views
+| Icon | Usage |
+|------|-------|
+| `ChevronDown` / `ChevronDownSmall` | Expand, dropdown |
+| `ChevronRight` / `ChevronRightSmall` | Navigate forward, drill-in |
+| `ChevronLeft` / `ChevronLeftSmall` | Navigate back |
+| `ChevronUp` / `ChevronUpSmall` | Collapse |
+| `ArrowRight` / `ArrowRightSmall` | Direction |
+| `ExternalLink` / `ExternalLinkSmall` | Open in new tab |
+| `More` / `MoreSmall` | More options (horizontal dots) |
+| `VerticalMenu` / `VerticalMenuSmall` | More options (vertical dots) |
+
+### Content & Data
+| Icon | Usage |
+|------|-------|
+| `Search` / `SearchSmall` | Search |
+| `Filters` / `FiltersSmall` | Filter content |
+| `SortAscending` / `SortAscendingSmall` | Sort ascending |
+| `SortDescending` / `SortDescendingSmall` | Sort descending |
+| `DownloadImport` / `DownloadImportSmall` | Download/import |
+| `UploadExport` / `UploadExportSmall` | Upload/export |
+| `Print` / `PrintSmall` | Print |
+| `Refresh` / `RefreshSmall` | Refresh/reload |
+
+### Status & Feedback
+| Icon | Usage |
+|------|-------|
+| `StatusComplete` / `StatusCompleteSmall` | Success/done |
+| `StatusAlert` / `StatusAlertSmall` | Error/alert |
+| `StatusWarning` / `StatusWarningSmall` | Warning |
+| `Info` / `InfoSmall` | Information |
+| `Help` / `HelpSmall` | Help |
+| `Visible` / `VisibleSmall` | Show/visible |
+| `Hidden` / `HiddenSmall` | Hide/hidden |
+
+### Communication
+| Icon | Usage |
+|------|-------|
+| `Email` / `EmailSmall` | Email |
+| `EmailSend` / `EmailSendSmall` | Send email |
+| `Chat` / `ChatSmall` | Chat/message |
+| `Phone` / `PhoneSmall` | Phone |
+| `Send` / `SendSmall` | Send |
+
+### Users & People
+| Icon | Usage |
+|------|-------|
+| `User` / `UserSmall` | Single user |
+| `Users` / `UsersSmall` | Multiple users |
+| `UserAdd` / `UserAddSmall` | Add user |
+| `UserRemove` / `UserRemoveSmall` | Remove user |
+
+### Commerce
+| Icon | Usage |
+|------|-------|
+| `Cart` / `CartSmall` | Shopping cart |
+| `CreditCard` / `CreditCardSmall` | Payment |
+| `Shipping` / `ShippingSmall` | Shipping/delivery |
+| `Tag` / `TagSmall` | Tag/label |
+| `Discount` / `DiscountSmall` | Discount/coupon |
+| `Receipt` / `ReceiptSmall` | Receipt/invoice |
+| `Package` / `PackageSmall` | Package |
+
+### Settings & Config
+| Icon | Usage |
+|------|-------|
+| `Settings` / `SettingsSmall` | Settings |
+| `LockLocked` / `LockLockedSmall` | Locked/secure |
+| `LockUnlocked` / `LockUnlockedSmall` | Unlocked |
+| `Globe` / `GlobeSmall` | Global/international |
+| `Languages` / `LanguagesSmall` | Multi-language |
+
+### Media
+| Icon | Usage |
+|------|-------|
+| `Image` / `ImageSmall` | Image |
+| `PhotoCamera` / `PhotoCameraSmall` | Camera/photo |
+| `VideoCamera` / `VideoCameraSmall` | Video |
+| `Document` / `DocumentSmall` | Document/file |
+| `Attachment` / `AttachmentSmall` | Attach file |
+
+### Misc
+| Icon | Usage |
+|------|-------|
+| `Star` / `StarFilled` | Rating/favorite |
+| `Favorite` / `FavoriteFilled` | Heart/like |
+| `FavoriteSmall` / `FavoriteFilledSmall` | Heart small |
+| `Pin` / `PinSmall` | Pin/location |
+| `Location` / `LocationSmall` | Location |
+| `Date` / `DateSmall` | Calendar/date |
+| `Time` / `TimeSmall` | Clock/time |
+| `Link` / `LinkSmall` | Link |
+| `Unlink` / `UnlinkSmall` | Remove link |
+| `Copy` | Copy to clipboard |
+| `Share` / `ShareSmall` | Share |
+| `Flag` / `FlagSmall` | Flag/report |
+| `Bookmark` / `BookmarkSmall` | Bookmark/save |
+
+---
+
+## Usage Examples
+
+```tsx
+import { Add, Delete, Edit, Search } from '@wix/wix-ui-icons-common';
+
+<Button prefixIcon={<Add />}>Add Item</Button>
+<IconButton><Delete /></IconButton>
+<TableActionCell secondaryActions={[
+  { text: 'Edit', icon: <EditSmall />, onClick: handleEdit },
+  { text: 'Delete', icon: <DeleteSmall />, onClick: handleDelete },
+]} />
+```
+
+## Icon Size Override
+
+```tsx
+<Add size={20} />
+<DeleteSmall size={16} />
+```

--- a/skills/wds-docs/references/RECIPES.md
+++ b/skills/wds-docs/references/RECIPES.md
@@ -1,0 +1,362 @@
+# WDS Dashboard Recipes
+
+Copy-and-adapt patterns for common dashboard layouts. All imports from `@wix/design-system`.
+
+---
+
+## 1. CRUD Table Page
+
+Full dashboard page with toolbar, search, table with actions, and empty state.
+
+```tsx
+import {
+  Page, Table, TableToolbar, TableActionCell,
+  Card, Search, Button, Box, Text, Badge, EmptyState, TextButton, Loader,
+} from '@wix/design-system';
+import { Add, DeleteSmall, EditSmall, DuplicateSmall } from '@wix/wix-ui-icons-common';
+
+function ProductsPage() {
+  const [items, setItems] = useState([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const columns = [
+    { title: 'Name', render: (row) => <Text weight="bold">{row.name}</Text>, width: '40%' },
+    { title: 'Status', render: (row) => (
+      <Badge skin={row.active ? 'success' : 'neutral'} size="small">
+        {row.active ? 'Active' : 'Inactive'}
+      </Badge>
+    )},
+    { title: 'Price', render: (row) => `$${row.price.toFixed(2)}`, align: 'right' },
+    {
+      title: '',
+      render: (row) => (
+        <TableActionCell
+          primaryAction={{ text: 'Edit', onClick: () => handleEdit(row) }}
+          secondaryActions={[
+            { text: 'Duplicate', icon: <DuplicateSmall />, onClick: () => handleDuplicate(row) },
+            { text: 'Delete', icon: <DeleteSmall />, onClick: () => handleDelete(row), skin: 'destructive' },
+          ]}
+          numOfVisibleSecondaryActions={0}
+          moreActionsTooltipText="More actions"
+        />
+      ),
+      stickyActionCell: true,
+      width: '72px',
+    },
+  ];
+
+  const filtered = items.filter(item =>
+    item.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <Page height="calc(100vh - 48px)">
+        <Page.Header title="Products" />
+        <Page.Content>
+          <Box align="center" verticalAlign="middle" height="300px">
+            <Loader size="medium" />
+          </Box>
+        </Page.Content>
+      </Page>
+    );
+  }
+
+  return (
+    <Page height="calc(100vh - 48px)">
+      <Page.Header
+        title="Products"
+        actionsBar={<Button prefixIcon={<Add />}>Add Product</Button>}
+      />
+      <Page.Content>
+        <Card hideOverflow>
+          <Table data={filtered} columns={columns}>
+            <TableToolbar>
+              <TableToolbar.ItemGroup position="start">
+                <TableToolbar.Item>
+                  <TableToolbar.Title>All Products</TableToolbar.Title>
+                </TableToolbar.Item>
+              </TableToolbar.ItemGroup>
+              <TableToolbar.ItemGroup position="end">
+                <TableToolbar.Item>
+                  <Search
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    onClear={() => setSearch('')}
+                    placeholder="Search products..."
+                  />
+                </TableToolbar.Item>
+              </TableToolbar.ItemGroup>
+            </TableToolbar>
+            {filtered.length === 0 ? (
+              <Table.EmptyState>
+                <EmptyState
+                  title="No products found"
+                  subtitle="Try a different search or add a new product."
+                >
+                  <TextButton prefixIcon={<Add />}>Add Product</TextButton>
+                </EmptyState>
+              </Table.EmptyState>
+            ) : (
+              <Table.Content />
+            )}
+          </Table>
+        </Card>
+      </Page.Content>
+    </Page>
+  );
+}
+```
+
+---
+
+## 2. Form Modal (Add/Edit)
+
+Modal with form fields, validation, and save/cancel.
+
+```tsx
+import {
+  Modal, CustomModalLayout, Box, FormField, Input, NumberInput,
+  InputArea, Dropdown, ToggleSwitch, Text, Layout, Cell,
+} from '@wix/design-system';
+
+function ItemFormModal({ isOpen, onClose, onSave, item }) {
+  const [name, setName] = useState(item?.name ?? '');
+  const [price, setPrice] = useState(item?.price ?? 0);
+  const [description, setDescription] = useState(item?.description ?? '');
+  const [category, setCategory] = useState(item?.categoryId ?? '');
+  const [active, setActive] = useState(item?.active ?? true);
+  const [errors, setErrors] = useState({});
+
+  const validate = () => {
+    const newErrors = {};
+    if (!name.trim()) newErrors.name = 'Name is required';
+    if (price < 0) newErrors.price = 'Price must be positive';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSave = () => {
+    if (!validate()) return;
+    onSave({ name, price, description, categoryId: category, active });
+  };
+
+  return (
+    <Modal isOpen={isOpen} onRequestClose={onClose} shouldCloseOnOverlayClick>
+      <CustomModalLayout
+        title={item ? 'Edit Item' : 'Add Item'}
+        primaryButtonText="Save"
+        primaryButtonOnClick={handleSave}
+        secondaryButtonText="Cancel"
+        secondaryButtonOnClick={onClose}
+        closeButtonProps={{ onClick: onClose }}
+        content={
+          <Box direction="vertical" gap="SP4">
+            <Layout cols={12} gap="24px">
+              <Cell span={8}>
+                <FormField label="Name" required status={errors.name ? 'error' : undefined} statusMessage={errors.name}>
+                  <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Item name" />
+                </FormField>
+              </Cell>
+              <Cell span={4}>
+                <FormField label="Price" required status={errors.price ? 'error' : undefined} statusMessage={errors.price}>
+                  <NumberInput
+                    value={price}
+                    onChange={(val) => setPrice(val)}
+                    min={0}
+                    step={0.01}
+                    prefix={<Input.Affix>$</Input.Affix>}
+                  />
+                </FormField>
+              </Cell>
+            </Layout>
+            <FormField label="Category">
+              <Dropdown
+                options={[
+                  { id: 'electronics', value: 'Electronics' },
+                  { id: 'clothing', value: 'Clothing' },
+                  { id: 'food', value: 'Food' },
+                ]}
+                selectedId={category}
+                onSelect={(opt) => setCategory(opt.id)}
+                placeholder="Select category"
+              />
+            </FormField>
+            <FormField label="Description">
+              <InputArea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Enter description"
+                rows={3}
+                maxLength={500}
+                hasCounter
+              />
+            </FormField>
+            <Box verticalAlign="middle" gap="SP2">
+              <ToggleSwitch checked={active} onChange={() => setActive(!active)} size="small" />
+              <Text size="small">{active ? 'Active' : 'Inactive'}</Text>
+            </Box>
+          </Box>
+        }
+      />
+    </Modal>
+  );
+}
+```
+
+---
+
+## 3. Delete Confirmation Modal
+
+```tsx
+import { Modal, MessageModalLayout } from '@wix/design-system';
+
+function DeleteConfirmModal({ isOpen, onClose, onConfirm, itemName }) {
+  return (
+    <Modal isOpen={isOpen} onRequestClose={onClose} shouldCloseOnOverlayClick>
+      <MessageModalLayout
+        title={`Delete ${itemName}?`}
+        content="This action cannot be undone. The item and all its data will be permanently removed."
+        primaryButtonText="Delete"
+        primaryButtonOnClick={onConfirm}
+        secondaryButtonText="Cancel"
+        secondaryButtonOnClick={onClose}
+        closeButtonProps={{ onClick: onClose }}
+        skin="destructive"
+      />
+    </Modal>
+  );
+}
+```
+
+---
+
+## 4. Settings Card with Form
+
+```tsx
+import { Card, Box, FormField, Input, ToggleSwitch, Text, Button } from '@wix/design-system';
+
+function SettingsCard() {
+  return (
+    <Card>
+      <Card.Header title="Notification Settings" subtitle="Configure how you receive alerts" />
+      <Card.Divider />
+      <Card.Content>
+        <Box direction="vertical" gap="SP4">
+          <FormField label="Email Address" required>
+            <Input value={email} onChange={e => setEmail(e.target.value)} placeholder="you@example.com" />
+          </FormField>
+          <Box align="space-between" verticalAlign="middle">
+            <Box direction="vertical">
+              <Text weight="bold">Email Notifications</Text>
+              <Text size="small" secondary>Receive alerts via email</Text>
+            </Box>
+            <ToggleSwitch checked={emailEnabled} onChange={() => setEmailEnabled(!emailEnabled)} />
+          </Box>
+          <Box align="space-between" verticalAlign="middle">
+            <Box direction="vertical">
+              <Text weight="bold">SMS Notifications</Text>
+              <Text size="small" secondary>Receive alerts via text message</Text>
+            </Box>
+            <ToggleSwitch checked={smsEnabled} onChange={() => setSmsEnabled(!smsEnabled)} />
+          </Box>
+          <Box align="right">
+            <Button>Save Changes</Button>
+          </Box>
+        </Box>
+      </Card.Content>
+    </Card>
+  );
+}
+```
+
+---
+
+## 5. Table with Selection and Bulk Actions
+
+```tsx
+import {
+  Table, TableToolbar, Card, Button, Box, Text,
+} from '@wix/design-system';
+import { Delete } from '@wix/wix-ui-icons-common';
+
+function SelectableTable({ items }) {
+  const [selectedIds, setSelectedIds] = useState([]);
+
+  const mainToolbar = () => (
+    <TableToolbar>
+      <TableToolbar.ItemGroup position="start">
+        <TableToolbar.Item>
+          <TableToolbar.Title>Items ({items.length})</TableToolbar.Title>
+        </TableToolbar.Item>
+      </TableToolbar.ItemGroup>
+    </TableToolbar>
+  );
+
+  const selectionToolbar = () => (
+    <TableToolbar>
+      <TableToolbar.ItemGroup position="start">
+        <TableToolbar.Item>
+          <TableToolbar.SelectedCount>{`${selectedIds.length} selected`}</TableToolbar.SelectedCount>
+        </TableToolbar.Item>
+      </TableToolbar.ItemGroup>
+      <TableToolbar.ItemGroup position="end">
+        <TableToolbar.Item layout="button">
+          <Button skin="destructive" priority="secondary" prefixIcon={<Delete />}>
+            Delete Selected
+          </Button>
+        </TableToolbar.Item>
+      </TableToolbar.ItemGroup>
+    </TableToolbar>
+  );
+
+  return (
+    <Card hideOverflow>
+      <Table
+        data={items}
+        columns={columns}
+        showSelection
+        selectedIds={selectedIds}
+        onSelectionChanged={(type, change) => {
+          if (type === 'ALL') setSelectedIds(items.map(i => i.id));
+          else if (type === 'NONE') setSelectedIds([]);
+          else if (type === 'SINGLE_TOGGLE') {
+            setSelectedIds(prev =>
+              change.value ? [...prev, change.id] : prev.filter(id => id !== change.id)
+            );
+          }
+        }}
+      >
+        {selectedIds.length > 0 ? selectionToolbar() : mainToolbar()}
+        <Table.Content />
+      </Table>
+    </Card>
+  );
+}
+```
+
+---
+
+## 6. Empty Page State
+
+```tsx
+import { Page, EmptyState, Button } from '@wix/design-system';
+import { Add } from '@wix/wix-ui-icons-common';
+
+function EmptyPage() {
+  return (
+    <Page height="calc(100vh - 48px)">
+      <Page.Header title="Orders" />
+      <Page.Content>
+        <EmptyState
+          title="No orders yet"
+          subtitle="Once customers place orders, they'll appear here."
+        >
+          <Button prefixIcon={<Add />}>Create Order</Button>
+        </EmptyState>
+      </Page.Content>
+    </Page>
+  );
+}
+```


### PR DESCRIPTION
## Summary

- **Add 3 pre-built reference files** (`COMMON_COMPONENTS.md`, `ICONS.md`, `RECIPES.md`) that cover ~90% of WDS lookups in 1-2 Reads instead of 4+ tool calls per component
- **Restructure SKILL.md** to use cheat-sheet-first flow: read references first, fall back to staged docs only for uncommon components
- **Embed deprecation warnings and type gotchas** directly in cheat sheets to prevent known issues (e.g., `onCloseButtonClick` deprecated, `min` must be number not string, `icon` required on `TableActionCell` secondary actions)

## Problem

Every component lookup required 4+ tool calls at runtime (grep components.md → read Props.md → grep Examples.md headings → read specific example). For a dashboard page using 6 components, that's ~24 tool calls just for WDS docs. In a real codegen run (ShipRateManager app), a WDS docs failure cascade wasted ~62s (18% of total time) and 15+ steps searching for icon names in node_modules.

## What Changed

| File | Purpose |
|------|---------|
| `references/COMMON_COMPONENTS.md` (670 lines) | Top ~20 components with correct prop types, JSX snippets, deprecation warnings |
| `references/ICONS.md` (147 lines) | ~100 most-used icons by category with naming conventions (standard vs Small vs Filled) |
| `references/RECIPES.md` (363 lines) | 6 ready-to-adapt dashboard patterns (CRUD table, form modal, delete confirm, settings card, bulk selection, empty state) |
| `SKILL.md` (146 lines, was 216) | Restructured: FAST PATH (read cheat sheets) → SLOW PATH (staged docs lookup for uncommon components) |

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Tool calls for 6-component page | ~24 | ~2 |
| Icon lookup steps | ~15 (searching node_modules) | 1 Read |
| Deprecated prop errors | Frequent | Prevented inline |
| Pattern assembly | From scratch each time | Copy-adapt from recipes |

## Test plan

- [ ] Copy updated skill to `~/.agents/skills/wds-docs/` and run opencode in a generated-app to verify skill loads and references are found
- [ ] Run `yarn preview` in codegen and generate a dashboard page — verify fewer WDS-related tool calls in codegen.log
- [ ] Verify uncommon components (not in cheat sheet) still work via the fallback staged lookup

Made with [Cursor](https://cursor.com)