### PR TITLE
fix(wix-cli-service-plugin): replace static type definitions with MCP…

### DIFF
--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -14,7 +14,7 @@ When you implement a service plugin, Wix calls your custom functions during spec
 
 Follow these steps in order when creating a service plugin:
 
-1. [ ] **Read the reference doc** for your SPI type (REQUIRED before implementation)
+1. [ ] **Read the reference doc** for your SPI type, then **use `ReadFullDocsMethodSchema`** to get the exact request/response types (REQUIRED before implementation)
 2. [ ] Create plugin folder: `src/extensions/backend/service-plugins/<service-type>/<plugin-name>/`
 3. [ ] Create `plugin.ts` with correct imports and `provideHandlers()` call
 4. [ ] Implement all required handler functions with complete business logic

--- a/skills/wix-cli-service-plugin/references/ADDITIONAL-FEES.md
+++ b/skills/wix-cli-service-plugin/references/ADDITIONAL-FEES.md
@@ -16,39 +16,6 @@ import { additionalFees } from '@wix/ecom/service-plugins';
 | --- | --- |
 | `calculateAdditionalFees` | Calculate and return additional fees to apply to the order |
 
-## Request Structure
-
-The `calculateAdditionalFees` handler receives `{ request, metadata }`. Key fields on `request`:
-
-```typescript
-{
-  lineItems: Array<{
-    id: string;                      // Line item GUID
-    quantity: number;                // Quantity of item
-    productName: string;             // Item name
-    price: string;                   // Price for a single item as a STRING (e.g., "25.00"), NOT an object
-    catalogReference?: {
-      catalogItemId: string;         // Item GUID within its catalog
-      appId: string;                 // Catalog app GUID
-      options?: Record<string, any>; // Additional item details
-    };
-    physicalProperties?: {
-      weight: number;                // Item weight
-      sku: string;                   // Stock-keeping unit
-      shippable: boolean;            // Whether item is shippable
-    };
-  }>;
-  shippingAddress?: {                // Shipping address (if provided)
-    country: string;                 // ISO-3166 alpha-2 country code
-    subdivision?: string;            // State/province code
-    city?: string;
-    postalCode?: string;
-  };
-  buyerDetails?: { ... };           // Buyer contact info
-  subtotal: string;                  // Pre-calculated total: sum of (price × quantity) for all line items, as a STRING
-}
-```
-
 ## Example: Global Additional Fee from Database Configuration
 
 This example queries a CMS collection to retrieve a configurable global fee that applies to all orders.
@@ -124,25 +91,17 @@ additionalFees.provideHandlers({
 });
 ```
 
-## Response Structure
+## Request and Response Schema
 
-The `calculateAdditionalFees` handler must return:
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
 
-```typescript
-{
-  additionalFees: Array<{
-    code: string;           // Unique identifier for the fee
-    name: string;           // Display name
-    translatedName?: string; // Optional translated name
-    price: string;          // Fee amount as string
-    taxDetails?: {
-      taxable: boolean;     // Whether fee is taxable
-    };
-    lineItemIds?: string[]; // Optional: specific items (omit for cart-wide)
-  }>;
-  currency: string;         // Currency code (e.g., "USD")
-}
-```
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
+
+| Handler | Docs URL |
+| --- | --- |
+| `calculateAdditionalFees` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/additional-fees/additional-fees-service-plugin/calculate-additional-fees?apiView=SDK |
 
 ## Key Implementation Notes
 

--- a/skills/wix-cli-service-plugin/references/BOOKINGS-STAFF-SORTING.md
+++ b/skills/wix-cli-service-plugin/references/BOOKINGS-STAFF-SORTING.md
@@ -18,29 +18,17 @@ import { staffSorting } from "@wix/bookings/service-plugins";
 | --- | --- |
 | `sortStaffMembers` | Sort available staff members by priority for a given booking slot |
 
-## Request Fields
+## Request and Response Schema
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `policyId` | string | The ID of the sorting policy being applied |
-| `slot` | object | The booking slot details |
-| `slot.startDate` | string | Slot start date/time |
-| `slot.endDate` | string | Slot end date/time |
-| `slot.serviceId` | string | The booked service ID |
-| `slot.locationId` | string | The booking location ID |
-| `slot.timeZone` | string | Time zone of the slot |
-| `availableResourceIds` | string[] | IDs of staff members available for this slot |
-| `extendedFields` | object | Additional custom fields |
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
 
-## Response Structure
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
 
-```typescript
-{
-  staff: Array<{
-    resourceId: string;  // Staff member resource ID
-  }>;
-}
-```
+| Handler | Docs URL |
+| --- | --- |
+| `sortStaffMembers` | https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-sorting-service-plugin/sort-staff-members?apiView=SDK |
 
 **Important constraints:**
 - You must return the **exact same IDs** from `availableResourceIds`, reordered by priority

--- a/skills/wix-cli-service-plugin/references/DISCOUNT-TRIGGERS.md
+++ b/skills/wix-cli-service-plugin/references/DISCOUNT-TRIGGERS.md
@@ -66,29 +66,18 @@ customTriggers.provideHandlers({
 });
 ```
 
-## Response Structure
+## Request and Response Schema
 
-### getEligibleTriggers Response
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
 
-```typescript
-{
-  eligibleTriggers: Array<{
-    customTriggerId: string;  // ID matching one from listTriggers
-    identifier: string;       // Unique identifier for this trigger instance
-  }>;
-}
-```
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
 
-### listTriggers Response
-
-```typescript
-{
-  customTriggers: Array<{
-    _id: string;    // Unique trigger ID
-    name: string;   // Display name shown in Wix dashboard
-  }>;
-}
-```
+| Handler | Docs URL |
+| --- | --- |
+| `getEligibleTriggers` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/custom-discount-triggers-integration-service-plugin/get-eligible-triggers?apiView=SDK |
+| `listTriggers` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/custom-discount-triggers-integration-service-plugin/list-triggers?apiView=SDK |
 
 ## Key Implementation Notes
 

--- a/skills/wix-cli-service-plugin/references/GIFT-CARDS.md
+++ b/skills/wix-cli-service-plugin/references/GIFT-CARDS.md
@@ -63,35 +63,19 @@ giftVouchersProvider.provideHandlers({
 });
 ```
 
-## Response Structure
+## Request and Response Schema
 
-### redeem Response
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
 
-```typescript
-{
-  remainingBalance: number;   // Balance after redemption
-  currencyCode: string;       // Currency code (e.g., "USD", "ILS")
-  transactionId: string;      // Unique ID for this redemption transaction
-}
-```
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
 
-### _void Response
-
-```typescript
-{
-  remainingBalance: number;   // Balance after voiding (restored amount)
-  currencyCode: string;       // Currency code
-}
-```
-
-### getBalance Response
-
-```typescript
-{
-  balance: number;            // Current gift card balance
-  currencyCode: string;       // Currency code
-}
-```
+| Handler | Docs URL |
+| --- | --- |
+| `redeem` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/payments/gift-cards/gift-cards-service-plugin/redeem?apiView=SDK |
+| `getBalance` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/payments/gift-cards/gift-cards-service-plugin/get-balance?apiView=SDK |
+| `_void` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/payments/gift-cards/gift-cards-service-plugin/void?apiView=SDK |
 
 ## Key Implementation Notes
 

--- a/skills/wix-cli-service-plugin/references/SHIPPING-RATES.md
+++ b/skills/wix-cli-service-plugin/references/SHIPPING-RATES.md
@@ -58,34 +58,17 @@ shippingRates.provideHandlers({
 });
 ```
 
-## Response Structure
+## Request and Response Schema
 
-```typescript
-{
-  shippingRates: Array<{
-    code: string;             // Unique identifier for this shipping option
-    title: string;            // Display name shown to customer
-    logistics: {
-      deliveryTime: string;   // Estimated delivery time (e.g., "2-5 days")
-    };
-    cost: {
-      price: string;          // Base shipping price as string
-      currency: string;       // Currency code (e.g., "USD")
-      additionalCharges?: Array<{
-        price: string;        // Additional charge amount
-        type: ChargeType;     // Type of charge (HANDLING_FEE, etc.)
-        details?: string;     // Description of the charge
-      }>;
-    };
-  }>;
-}
-```
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
 
-## ChargeType Values
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
 
-| Type | Description |
+| Handler | Docs URL |
 | --- | --- |
-| `ChargeType.HANDLING_FEE` | Additional handling fee |
+| `getShippingRates` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/shipping-rates/shipping-rates-integration-service-plugin/get-shipping-rates?apiView=SDK |
 
 ## Key Implementation Notes
 

--- a/skills/wix-cli-service-plugin/references/TAX-CALCULATION.md
+++ b/skills/wix-cli-service-plugin/references/TAX-CALCULATION.md
@@ -60,23 +60,17 @@ taxCalculationProvider.provideHandlers({
 });
 ```
 
-## Response Structure
+## Request and Response Schema
 
-```typescript
-{
-  lineItemTaxes: Array<{
-    lineItemId: string;           // ID of the line item
-    taxBreakdown: Array<{
-      name: string;               // Tax name (e.g., "State Sales Tax")
-      rate: string;               // Tax rate as string (e.g., "7.25")
-      amount: {
-        amount: string;           // Tax amount as string
-        currency: string;         // Currency code (e.g., "USD")
-      };
-    }>;
-  }>;
-}
-```
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
+
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
+
+| Handler | Docs URL |
+| --- | --- |
+| `calculateTax` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/tax/tax-calculation-integration-service-plugin/calculate-tax?apiView=SDK |
 
 ## Key Implementation Notes
 

--- a/skills/wix-cli-service-plugin/references/VALIDATIONS.md
+++ b/skills/wix-cli-service-plugin/references/VALIDATIONS.md
@@ -47,39 +47,17 @@ validations.provideHandlers({
 });
 ```
 
-## Response Structure
+## Request and Response Schema
 
-```typescript
-{
-  violations: Array<{
-    description: string;                    // Message shown to customer
-    severity: validations.Severity;         // ERROR or WARNING
-    target: {
-      other: {
-        name: validations.NameInOther;      // Target type
-      };
-    } | {
-      lineItem: {
-        _id: string;                        // Specific line item ID
-      };
-    };
-  }>;
-}
-```
+**IMPORTANT: Before implementing, use the MCP tools below to read the full request and response types for each handler.**
 
-## Severity Levels
+**MCP Tools to use:**
+- `ReadFullDocsMethodSchema` - Full request/response schema with field names, types, and descriptions
+- `ReadFullDocsArticle` - Full documentation with code examples (use if schema needs more context)
 
-| Severity | Description |
+| Handler | Docs URL |
 | --- | --- |
-| `validations.Severity.ERROR` | Blocks checkout - customer cannot proceed |
-| `validations.Severity.WARNING` | Shows warning but allows checkout to continue |
-
-## Target Types
-
-| Target | Description |
-| --- | --- |
-| `validations.NameInOther.OTHER_DEFAULT` | General cart/order level validation |
-| `lineItem._id` | Validation targeting a specific item |
+| `getValidationViolations` | https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/validations/validations-integration-service-plugin/get-validation-violations?apiView=SDK |
 
 ## Key Implementation Notes
 


### PR DESCRIPTION
… doc lookups

Static request/response type definitions in SPI reference docs were prone to becoming outdated. Replace them with links to ReadFullDocsMethodSchema and ReadFullDocsArticle MCP tools so implementations always use the latest types.