### PR TITLE
docs(readme): add notice that skills are for the new Wix CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Agent skills for building Wix applications with AI coding assistants.
 
+> **Note**: These skills are designed for the **new Wix CLI**. See [About the Wix CLI](https://dev.wix.com/docs/wix-cli/guides/about-the-wix-cli) to learn more.
+
 ## Installation
 
 ### Claude Code Plugin


### PR DESCRIPTION
## Summary
- Adds a note below the description linking to the [About the Wix CLI](https://dev.wix.com/docs/wix-cli/guides/about-the-wix-cli) page to clarify these skills target the new Wix CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)