### PR TITLE
feat(wix-cli-backend-api): add Wix Secrets Manager guidance for secure API key handling

### DIFF
--- a/skills/wix-cli-backend-api/SKILL.md
+++ b/skills/wix-cli-backend-api/SKILL.md
@@ -26,6 +26,20 @@ Use HTTP endpoints when you need to:
 - Serve dynamic content (images, RSS feeds, personalized data)
 - Access runtime data or server-side databases
 
+## Secrets Management
+
+When backend endpoints need API keys or credentials for third-party services, use the Wix Secrets Manager. See [Wix Secrets Reference](references/WIX_SECRETS.md) for complete documentation.
+
+**Key rule:** NEVER hardcode API keys, tokens, or credentials. Always retrieve them at runtime:
+
+```typescript
+import { secrets } from "@wix/secrets";
+
+const apiKey = await secrets.getSecret("MY_API_KEY");
+```
+
+Always include a manual action item telling the site owner to store required secrets in the Wix Secrets Manager dashboard.
+
 ## File Structure and Naming
 
 ### Basic Endpoint

--- a/skills/wix-cli-backend-api/SKILL.md
+++ b/skills/wix-cli-backend-api/SKILL.md
@@ -35,7 +35,7 @@ When backend endpoints need API keys or credentials for third-party services, us
 ```typescript
 import { secrets } from "@wix/secrets";
 
-const apiKey = await secrets.getSecret("MY_API_KEY");
+const { value: apiKey } = await secrets.getSecretValue("MY_API_KEY");
 ```
 
 Always include a manual action item telling the site owner to store required secrets in the Wix Secrets Manager dashboard.

--- a/skills/wix-cli-backend-api/SKILL.md
+++ b/skills/wix-cli-backend-api/SKILL.md
@@ -30,15 +30,7 @@ Use HTTP endpoints when you need to:
 
 When backend endpoints need API keys or credentials for third-party services, use the Wix Secrets Manager. See [Wix Secrets Reference](references/WIX_SECRETS.md) for complete documentation.
 
-**Key rule:** NEVER hardcode API keys, tokens, or credentials. Always retrieve them at runtime:
-
-```typescript
-import { secrets } from "@wix/secrets";
-
-const { value: apiKey } = await secrets.getSecretValue("MY_API_KEY");
-```
-
-Always include a manual action item telling the site owner to store required secrets in the Wix Secrets Manager dashboard.
+**Key rule:** NEVER hardcode API keys, tokens, or credentials. Always retrieve them at runtime using `@wix/secrets`.
 
 ## File Structure and Naming
 

--- a/skills/wix-cli-backend-api/references/WIX_SECRETS.md
+++ b/skills/wix-cli-backend-api/references/WIX_SECRETS.md
@@ -12,10 +12,10 @@ npm install @wix/secrets
 
 ## SDK Methods
 
-| Method Call | Import | TypeScript Signature | Description |
-| --- | --- | --- | --- |
-| `secrets.getSecretValue()` | `import { secrets } from '@wix/secrets'` | `(name: string) => Promise<{ value: string }>` | Retrieve a secret value by name |
-| `secrets.listSecretInfo()` | `import { secrets } from '@wix/secrets'` | `() => Promise<{ secrets: Secret[] }>` | List metadata about all secrets (names only, not values) |
+| Method Call | Import | TypeScript Signature | Description | Required Scope |
+| --- | --- | --- | --- | --- |
+| `secrets.getSecretValue()` | `import { secrets } from '@wix/secrets'` | `(name: string) => Promise<{ value: string }>` | Retrieve a secret value by name | `SCOPE.VELO.MANAGE_SECRETS` |
+| `secrets.listSecretInfo()` | `import { secrets } from '@wix/secrets'` | `() => Promise<{ secrets: Secret[] }>` | List metadata about all secrets (names only, not values) | `SCOPE.VELO.MANAGE_SECRETS` |
 
 ## Usage Example
 
@@ -26,20 +26,16 @@ import type { APIRoute } from "astro";
 import { secrets } from "@wix/secrets";
 
 export const POST: APIRoute = async ({ request }) => {
-  const { prompt } = await request.json();
+  const { value: apiKey } = await secrets.getSecretValue("MY_API_KEY");
 
-  const { value: apiKey } = await secrets.getSecretValue("OPENAI_API_KEY");
-
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+  // Use apiKey to call your third-party service
+  const response = await fetch("https://api.example.com/endpoint", {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      model: "gpt-4",
-      messages: [{ role: "user", content: prompt }],
-    }),
+    body: JSON.stringify(await request.json()),
   });
 
   const data = await response.json();
@@ -61,26 +57,11 @@ export const POST: APIRoute = async ({ request }) => {
 When generating code that uses secrets, ALWAYS include this manual action item:
 
 > **Store API secrets in the Wix Secrets Manager:**
-> 1. In your Wix dashboard, go to Settings > Secrets Manager
+> 1. In your Wix dashboard, go to [Developer Tools > Secrets Manager](https://www.wix.com/my-account/site-selector/?buttonText=Select%20Site&title=Select%20a%20Site&autoSelectOnSingleSite=true&actionUrl=https:%2F%2Fwww.wix.com%2Fdashboard%2F%7B%7BmetaSiteId%7D%7D%2Fdeveloper-tools/secrets-manager)
 > 2. Click "Store a New Secret"
-> 3. Set the secret name to exactly: `SECRET_NAME_HERE`
+> 3. Set the secret name to exactly: `SECRET_NAME_HERE` _(use the exact name from the generated code, e.g. `MY_API_KEY`)_
 > 4. Paste your API key/token as the value
 > 5. Click "Save"
 >
 > The app will not function until this secret is stored.
 
-## Secrets vs Dynamic Parameters
-
-| Data Type | Use | Reason |
-| --- | --- | --- |
-| API keys, auth tokens, passwords | `@wix/secrets` | Sensitive, must not be exposed client-side |
-| Tracking IDs (Google Analytics, Pixel) | Dynamic parameters | Non-sensitive, needed client-side |
-| Public app IDs (Intercom, chat widgets) | Dynamic parameters | Non-sensitive, needed client-side |
-| Webhook URLs | Dynamic parameters or secrets | Depends on sensitivity |
-| Database connection strings | `@wix/secrets` | Sensitive credentials |
-
-## Permissions
-
-| Operation | Required Scope |
-| --- | --- |
-| `getSecretValue`, `listSecretInfo` | `SCOPE.VELO.MANAGE_SECRETS` |

--- a/skills/wix-cli-backend-api/references/WIX_SECRETS.md
+++ b/skills/wix-cli-backend-api/references/WIX_SECRETS.md
@@ -57,7 +57,7 @@ export const POST: APIRoute = async ({ request }) => {
 When generating code that uses secrets, ALWAYS include this manual action item:
 
 > **Store API secrets in the Wix Secrets Manager:**
-> 1. In your Wix dashboard, go to [Developer Tools > Secrets Manager](https://www.wix.com/my-account/site-selector/?buttonText=Select%20Site&title=Select%20a%20Site&autoSelectOnSingleSite=true&actionUrl=https:%2F%2Fwww.wix.com%2Fdashboard%2F%7B%7BmetaSiteId%7D%7D%2Fdeveloper-tools/secrets-manager)
+> 1. In your Wix dashboard, go to [Developer Tools > Secrets Manager](https://dev.wix.com/docs/develop-websites/articles/workspace-tools/developer-tools/secrets-manager/manage-secrets-in-the-secrets-manager)
 > 2. Click "Store a New Secret"
 > 3. Set the secret name to exactly: `SECRET_NAME_HERE` _(use the exact name from the generated code, e.g. `MY_API_KEY`)_
 > 4. Paste your API key/token as the value

--- a/skills/wix-cli-backend-api/references/WIX_SECRETS.md
+++ b/skills/wix-cli-backend-api/references/WIX_SECRETS.md
@@ -14,8 +14,8 @@ npm install @wix/secrets
 
 | Method Call | Import | TypeScript Signature | Description |
 | --- | --- | --- | --- |
-| `secrets.getSecret()` | `import { secrets } from '@wix/secrets'` | `(name: string) => Promise<string>` | Retrieve a secret value by name |
-| `secrets.listSecretInfo()` | `import { secrets } from '@wix/secrets'` | `() => Promise<ListSecretInfoResponse>` | List metadata about all secrets (names only, not values) |
+| `secrets.getSecretValue()` | `import { secrets } from '@wix/secrets'` | `(name: string) => Promise<{ value: string }>` | Retrieve a secret value by name |
+| `secrets.listSecretInfo()` | `import { secrets } from '@wix/secrets'` | `() => Promise<{ secrets: Secret[] }>` | List metadata about all secrets (names only, not values) |
 
 ## Usage Example
 
@@ -28,7 +28,7 @@ import { secrets } from "@wix/secrets";
 export const POST: APIRoute = async ({ request }) => {
   const { prompt } = await request.json();
 
-  const apiKey = await secrets.getSecret("OPENAI_API_KEY");
+  const { value: apiKey } = await secrets.getSecretValue("OPENAI_API_KEY");
 
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
@@ -83,4 +83,4 @@ When generating code that uses secrets, ALWAYS include this manual action item:
 
 | Operation | Required Scope |
 | --- | --- |
-| `getSecret`, `listSecretInfo` | `SCOPE.DC-APPS.MANAGE-SECRETS` |
+| `getSecretValue`, `listSecretInfo` | `SCOPE.VELO.MANAGE_SECRETS` |

--- a/skills/wix-cli-backend-api/references/WIX_SECRETS.md
+++ b/skills/wix-cli-backend-api/references/WIX_SECRETS.md
@@ -1,0 +1,86 @@
+# Wix Secrets Manager SDK Reference
+
+Complete reference for securely storing and retrieving API keys, tokens, and credentials.
+
+## Installation
+
+**IMPORTANT**: The `@wix/secrets` package must be installed as a dependency before use.
+
+```bash
+npm install @wix/secrets
+```
+
+## SDK Methods
+
+| Method Call | Import | TypeScript Signature | Description |
+| --- | --- | --- | --- |
+| `secrets.getSecret()` | `import { secrets } from '@wix/secrets'` | `(name: string) => Promise<string>` | Retrieve a secret value by name |
+| `secrets.listSecretInfo()` | `import { secrets } from '@wix/secrets'` | `() => Promise<ListSecretInfoResponse>` | List metadata about all secrets (names only, not values) |
+
+## Usage Example
+
+Astro API endpoint that retrieves a secret and calls a third-party API:
+
+```typescript
+import type { APIRoute } from "astro";
+import { secrets } from "@wix/secrets";
+
+export const POST: APIRoute = async ({ request }) => {
+  const { prompt } = await request.json();
+
+  const apiKey = await secrets.getSecret("OPENAI_API_KEY");
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4",
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  const data = await response.json();
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+## CRITICAL RULES
+
+1. **NEVER hardcode API keys, tokens, or credentials in any generated code.**
+2. **Secrets can ONLY be accessed in backend code** (server-side endpoints, service plugins, backend events) — NOT in frontend code, site widgets, or embedded scripts.
+3. **Site owners must manually store secrets** via the Secrets Manager dashboard before the app functions.
+
+## Manual Action Item Template
+
+When generating code that uses secrets, ALWAYS include this manual action item:
+
+> **Store API secrets in the Wix Secrets Manager:**
+> 1. In your Wix dashboard, go to Settings > Secrets Manager
+> 2. Click "Store a New Secret"
+> 3. Set the secret name to exactly: `SECRET_NAME_HERE`
+> 4. Paste your API key/token as the value
+> 5. Click "Save"
+>
+> The app will not function until this secret is stored.
+
+## Secrets vs Dynamic Parameters
+
+| Data Type | Use | Reason |
+| --- | --- | --- |
+| API keys, auth tokens, passwords | `@wix/secrets` | Sensitive, must not be exposed client-side |
+| Tracking IDs (Google Analytics, Pixel) | Dynamic parameters | Non-sensitive, needed client-side |
+| Public app IDs (Intercom, chat widgets) | Dynamic parameters | Non-sensitive, needed client-side |
+| Webhook URLs | Dynamic parameters or secrets | Depends on sensitivity |
+| Database connection strings | `@wix/secrets` | Sensitive credentials |
+
+## Permissions
+
+| Operation | Required Scope |
+| --- | --- |
+| `getSecret`, `listSecretInfo` | `SCOPE.DC-APPS.MANAGE-SECRETS` |

--- a/skills/wix-cli-backend-event/SKILL.md
+++ b/skills/wix-cli-backend-event/SKILL.md
@@ -10,6 +10,10 @@ Creates event extensions for Wix CLI applications. Events are triggered when spe
 
 Common use cases: run logic when a contact is created, an order is placed, a booking is confirmed, or a blog post is published.
 
+## Secrets Management
+
+When event handlers need API keys or credentials for third-party services, use `@wix/secrets` to retrieve them at runtime. See [Wix Secrets Reference](../wix-cli-backend-api/references/WIX_SECRETS.md) for complete documentation.
+
 ## Quick Start Checklist
 
 Follow these steps in order when creating an event extension.

--- a/skills/wix-cli-embedded-script/SKILL.md
+++ b/skills/wix-cli-embedded-script/SKILL.md
@@ -216,7 +216,7 @@ Every embedded script should have at minimum an **enable/disable toggle** parame
 | Parameter    | Type      | Purpose                              |
 | ------------ | --------- | ------------------------------------ |
 | `enabled`    | `BOOLEAN` | Allow site owner to activate/disable |
-| `apiKey`     | `TEXT`    | Third-party service credentials      |
+| `apiKey`     | `TEXT`    | Non-sensitive public identifiers only (e.g., tracking IDs, public app IDs). For sensitive API keys, use `@wix/secrets` in a Backend API endpoint instead |
 | `trackingId` | `TEXT`    | Analytics/pixel identifiers          |
 | `headline`   | `TEXT`    | Customizable display text            |
 | `color`      | `COLOR`   | UI customization                     |
@@ -349,6 +349,7 @@ Do NOT apply embedded script field names to dashboard page registrations.
 - **API calls:** Only create fetch() calls to /api/\* endpoints that exist in the API spec
 - **Scoping:** Prefix CSS classes and IDs to avoid conflicts with site styles
 - **Cleanup:** Remove event listeners and intervals when appropriate
+- **Secrets vs Dynamic Parameters:** Dynamic parameters are visible in client-side HTML. NEVER use them for sensitive credentials (API keys, auth tokens). Use `@wix/secrets` in a backend endpoint instead. Dynamic parameters are appropriate for non-sensitive configuration like tracking IDs, pixel IDs, and public app identifiers.
 
 ## Complete Example: Coupon Popup
 

--- a/skills/wix-cli-embedded-script/SKILL.md
+++ b/skills/wix-cli-embedded-script/SKILL.md
@@ -351,6 +351,14 @@ Do NOT apply embedded script field names to dashboard page registrations.
 - **Cleanup:** Remove event listeners and intervals when appropriate
 - **Secrets vs Dynamic Parameters:** Dynamic parameters are visible in client-side HTML. NEVER use them for sensitive credentials (API keys, auth tokens). Use `@wix/secrets` in a backend endpoint instead. Dynamic parameters are appropriate for non-sensitive configuration like tracking IDs, pixel IDs, and public app identifiers.
 
+  | Data Type | Use | Reason |
+  | --- | --- | --- |
+  | API keys, auth tokens, passwords | `@wix/secrets` in a Backend API endpoint | Sensitive, must not be exposed client-side |
+  | Tracking IDs (Google Analytics, Pixel) | Dynamic parameters | Non-sensitive, needed client-side |
+  | Public app IDs (Intercom, chat widgets) | Dynamic parameters | Non-sensitive, needed client-side |
+  | Webhook URLs | Dynamic parameters or secrets | Depends on sensitivity |
+  | Database connection strings | `@wix/secrets` in a Backend API endpoint | Sensitive credentials |
+
 ## Complete Example: Coupon Popup
 
 ### 1. Define Parameters

--- a/skills/wix-cli-service-plugin/SKILL.md
+++ b/skills/wix-cli-service-plugin/SKILL.md
@@ -10,6 +10,10 @@ Creates service plugin extensions for Wix CLI applications. Service plugins are 
 
 When you implement a service plugin, Wix calls your custom functions during specific flows. Common use cases include eCommerce customization (shipping, fees, taxes, validations) and Bookings customization (staff sorting), but service plugins can extend any Wix business solution that exposes SPIs.
 
+## Secrets Management
+
+When service plugins need API keys or credentials for third-party services, use `@wix/secrets` to retrieve them at runtime. See [Wix Secrets Reference](../wix-cli-backend-api/references/WIX_SECRETS.md) for complete documentation.
+
 ## Quick Start Checklist
 
 Follow these steps in order when creating a service plugin:


### PR DESCRIPTION
## Summary

- **New reference file:** Created `skills/wix-cli-backend-api/references/WIX_SECRETS.md` with complete Wix Secrets Manager SDK documentation including installation, SDK methods, usage examples, critical rules, manual action item template, secrets vs dynamic parameters decision table, and permissions
- **Updated `wix-cli-backend-api/SKILL.md`:** Added a "Secrets Management" section after "Use Cases" that directs to the reference file and establishes the key rule to never hardcode credentials
- **Updated `wix-cli-embedded-script/SKILL.md`:** Clarified that the `apiKey` dynamic parameter is for non-sensitive public identifiers only, and added a "Secrets vs Dynamic Parameters" best practice explaining when to use `@wix/secrets` vs dynamic parameters

## Context

Part of CODEAI-397 — ensures code generation skills guide LLMs to use Wix Secrets Manager for sensitive credentials instead of hardcoding API keys or exposing them through client-side dynamic parameters.

## Test plan

- [ ] Verify `WIX_SECRETS.md` follows the same format as the existing `WIX_DATA.md` reference
- [ ] Verify the "Secrets Management" section in `wix-cli-backend-api/SKILL.md` appears between "Use Cases" and "File Structure and Naming"
- [ ] Verify the `apiKey` parameter description in `wix-cli-embedded-script/SKILL.md` clarifies it is for non-sensitive identifiers only
- [ ] Verify the new best practice bullet in `wix-cli-embedded-script/SKILL.md` appears in the "Best Practices" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)