### PR TITLE
docs(wix-cli): use CODE_IDENTIFIER for site component type prefix and extract app identifiers to reference

### DIFF
--- a/skills/wix-cli-orchestrator/SKILL.md
+++ b/skills/wix-cli-orchestrator/SKILL.md
@@ -158,25 +158,10 @@ Follow the checklist; steps below add detail.
 Only ask for configuration values when **absolutely necessary** for the implementation to proceed — i.e., the sub-agent literally cannot generate working code without it. If a value can be configured later or added as a manual step, don't block on it.
 
 **App Namespace Requirement:**
-When creating a Data Collection, you MUST ask the user for their app namespace from Wix Dev Center. This is a required parameter that must be obtained from the user's Dev Center dashboard and cannot be recommended or guessed.
+When creating a Data Collection, you MUST ask the user for their app namespace. If not provided, read [APP_IDENTIFIERS.md](references/APP_IDENTIFIERS.md) and give the user the instructions to obtain it.
 
-**Instructions to give the user:**
-
-**If you don't have an app namespace yet:**
-1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
-2. Select your app
-3. In the left menu, select **Develop > Extensions**
-4. Click **+ Create Extension** and find the **Data Collections** extension
-5. Click **+ Create**
-6. You will be prompted to create an app namespace - follow the prompts to set it up
-
-**If you already have an app namespace:**
-1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
-2. Open your app dashboard
-3. Click the three dots (...) menu button in the top-right corner (next to "Test App" button)
-4. Select "View ID & keys" from the dropdown menu
-5. In the modal that opens, scroll to the bottom to find the "Namespace" field
-6. Copy the Namespace value
+**Code Identifier Requirement:**
+When creating a Site Component, you need the user's Code Identifier. If not provided, read [APP_IDENTIFIERS.md](references/APP_IDENTIFIERS.md) and give the user the instructions to obtain it.
 
 If unclear on approach (placement, visibility, configuration, integration), ask clarifying questions. If the answer could change the extension type, wait for the response before proceeding. Otherwise, proceed with the best-fit extension type.
 

--- a/skills/wix-cli-orchestrator/references/APP_IDENTIFIERS.md
+++ b/skills/wix-cli-orchestrator/references/APP_IDENTIFIERS.md
@@ -1,0 +1,35 @@
+# App Identifiers
+
+How to obtain required app identifiers from Wix Dev Center.
+
+## App Namespace
+
+Required when creating **Data Collections**. Scopes collection IDs to prevent conflicts between apps.
+
+### First, check if you already have an app namespace:
+1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
+2. Open your app dashboard
+3. Click the three dots (...) menu button in the top-right corner (next to "Test App" button)
+4. Select "View ID & keys" from the dropdown menu
+5. In the modal that opens, scroll to the bottom to find the "Namespace" field
+6. If you see a Namespace value, copy it
+
+### If there is no app namespace, create one:
+1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
+2. Select your app
+3. In the left menu, select **Develop > Extensions**
+4. Click **+ Create Extension** and find the **Data Collections** extension
+5. Click **+ Create**
+6. You will be prompted to create an app namespace - follow the prompts to set it up
+
+## Code Identifier
+
+Required when creating **Site Components**. Used as the type prefix for site component extensions (e.g. `type: '<CODE_IDENTIFIER>.ComponentName'`). Every Wix app has one automatically — there is no need to create it.
+
+### How to get the Code Identifier:
+1. Go to [Wix Dev Center](https://manage.wix.com/studio/custom-apps/)
+2. Open your app dashboard
+3. Click the three dots (...) menu button in the top-right corner (next to "Test App" button)
+4. Select "View ID & keys" from the dropdown menu
+5. In the modal that opens, find the "Code Identifier" field
+6. Copy the Code Identifier value

--- a/skills/wix-cli-site-component/SKILL.md
+++ b/skills/wix-cli-site-component/SKILL.md
@@ -418,7 +418,7 @@ export const sitecomponentMyComponent = extensions.siteComponent({
   ...manifest,
   id: "{{GENERATE_UUID}}",
   description: "My Component",
-  type: "platform.MyComponent",
+  type: "<CODE_IDENTIFIER>.MyComponent",
   resources: {
     client: {
       component: "./extensions/site/components/my-component/component.tsx",
@@ -430,12 +430,22 @@ export const sitecomponentMyComponent = extensions.siteComponent({
 
 **CRITICAL: Type Naming Convention**
 
-The `type` field uses the format `platform.{PascalCaseFolderName}`:
-- Folder `my-component` → `type: "platform.MyComponent"`
-- Folder `product-card` → `type: "platform.ProductCard"`
-- Folder `hero-section` → `type: "platform.HeroSection"`
+The `type` field uses the format `{CODE_IDENTIFIER}.{PascalCaseFolderName}`:
+- Folder `my-component` → `type: "<CODE_IDENTIFIER>.MyComponent"`
+- Folder `product-card` → `type: "<CODE_IDENTIFIER>.ProductCard"`
+- Folder `hero-section` → `type: "<CODE_IDENTIFIER>.HeroSection"`
 
 The folder name is converted to PascalCase (hyphens removed, each word capitalized).
+
+**CODE_IDENTIFIER Requirement:**
+The Code Identifier is a required value that cannot be guessed. Every Wix app has one automatically.
+
+**If Code Identifier is provided in the prompt:**
+- Use it as the type prefix: `<actual-code-identifier>.ComponentName`
+
+**If Code Identifier is NOT provided:**
+- Use the placeholder `<CODE_IDENTIFIER>` in the type field: `<CODE_IDENTIFIER>.ComponentName`
+- Add to Manual Action Items: "Replace `<CODE_IDENTIFIER>` with your actual Code Identifier from Wix Dev Center"
 
 **CRITICAL: UUID Generation**
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `platform.` type prefix with `{CODE_IDENTIFIER}.{PascalCaseFolderName}` in site component extensions, aligning with how `prompt-utils.ts` already uses `CODE_IDENTIFIER`
- Extract app namespace and code identifier instructions into a shared `references/APP_IDENTIFIERS.md` file to reduce token usage in the orchestrator skill
- Add CODE_IDENTIFIER provided/not-provided handling to site-component skill (matching data-collection's namespace pattern)
- Reorder app namespace instructions to check existing first, then create if missing

## Test plan
- Deploy preview with App Builder
- Tested locally with skills on new cli app
<img width="697" height="261" alt="image" src="https://github.com/user-attachments/assets/97bafab5-3a6f-4250-b577-da2f53a302f2" />