### PR TITLE
feat(plugin-config): add explicit skills array to plugin configurations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,25 @@
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": ["wix", "wix-cli", "wix-mcp", "ecommerce", "cms", "wix-apps"],
-  "skills": ["./skills/"],
+  "skills": [
+    "./skills/wds-docs",
+    "./skills/wix-cli-app-validation",
+    "./skills/wix-cli-backend-api",
+    "./skills/wix-cli-backend-event",
+    "./skills/wix-cli-context-provider",
+    "./skills/wix-cli-dashboard-menu-plugin",
+    "./skills/wix-cli-dashboard-modal",
+    "./skills/wix-cli-dashboard-page",
+    "./skills/wix-cli-dashboard-plugin",
+    "./skills/wix-cli-data-collection",
+    "./skills/wix-cli-embedded-script",
+    "./skills/wix-cli-extension-registration",
+    "./skills/wix-cli-orchestrator",
+    "./skills/wix-cli-service-plugin",
+    "./skills/wix-cli-site-component",
+    "./skills/wix-cli-site-plugin",
+    "./skills/wix-cli-site-widget",
+    "./skills/wix-stores-versioning"
+  ],
   "mcpServers": "./.mcp.json"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,5 +10,6 @@
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": ["wix", "wix-cli", "wix-mcp", "ecommerce", "cms", "wix-apps"],
+  "skills": ["./skills/"],
   "mcpServers": "./.mcp.json"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -10,6 +10,7 @@
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": ["wix", "wix-cli", "mcp", "ecommerce", "cms", "backend-api"],
+  "skills": ["./skills/"],
   "mcpServers": "./.mcp.json",
   "logo": "assets/logo.svg"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -10,7 +10,6 @@
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": ["wix", "wix-cli", "mcp", "ecommerce", "cms", "backend-api"],
-  "skills": ["./skills/"],
   "mcpServers": "./.mcp.json",
   "logo": "assets/logo.svg"
 }


### PR DESCRIPTION
## Summary
- Add `"skills": ["./skills/"]` to `.claude-plugin/plugin.json` (per Claude Code plugin spec)
- Add `"skills": ["./skills/"]` to `.cursor-plugin/plugin.json` (per Cursor plugin spec)

This makes the skills directory explicit in both plugin configurations rather than relying on implicit auto-discovery.

## Test plan
- [ ] Verify both `plugin.json` files are valid JSON
- [ ] Confirm skills are still discovered correctly when installing the plugin in Claude Code
- [ ] Confirm skills are still discovered correctly when installing the plugin in Cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)