### PR TITLE
feat(vscode): add VS Code agent plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ In [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run:
 /plugin install wix@wix
 ```
 
+### VS Code Plugin
+
+In VS Code, open the Command Palette (`CMD+SHIFT+P`), select **Chat: Install Plugin From Source**, and enter `https://github.com/wix/skills`.
+
 ### Cursor Plugin
 
 Go to **Settings > Rules > New Rule > Add from Github** with `https://github.com/wix/skills.git`.

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "wix",
+  "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Wix",
+    "url": "https://dev.wix.com"
+  },
+  "repository": "https://github.com/wix/skills",
+  "license": "MIT",
+  "keywords": ["wix", "wix-cli", "wix-mcp", "ecommerce", "cms", "wix-apps"]
+}


### PR DESCRIPTION
## Summary

- Add root-level `plugin.json` for VS Code Copilot Chat plugin installation
- Add VS Code installation instructions to README

## Install

In VS Code, open the Command Palette (`CMD+SHIFT+P`), select **Chat: Install Plugin From Source**, and enter `https://github.com/wix/skills`.

## Test plan

- [ ] Open VS Code with GitHub Copilot Chat enabled
- [ ] Run **Chat: Install Plugin From Source** and enter the repo URL
- [ ] Verify skills and MCP server are loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)