### PR TITLE
feat(gemini-extension): add Gemini CLI extension manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Go to **Settings > Rules > New Rule > Add from Github** with `https://github.com
 Install using [Gemini CLI](https://geminicli.com):
 
 ```bash
-gemini extensions install github:wix/skills
+gemini extensions install https://github.com/wix/skills
 ```
 
 ### Skills CLI

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ In [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run:
 
 Go to **Settings > Rules > New Rule > Add from Github** with `https://github.com/wix/skills.git`.
 
+### Gemini CLI
+
+Install using [Gemini CLI](https://geminicli.com):
+
+```bash
+gemini extensions install github:wix/skills
+```
+
 ### Skills CLI
 
 Install using [skills CLI](https://github.com/vercel-labs/skills):
@@ -60,6 +68,7 @@ These skills work with any agent that supports the [Agent Skills specification](
 
 - Cursor
 - Claude Code
+- Gemini CLI
 - Codex
 - GitHub Copilot
 - Windsurf

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,11 @@
+{
+  "name": "wix",
+  "version": "1.0.0",
+  "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
+  "mcpServers": {
+    "wix-mcp": {
+      "command": "npx",
+      "args": ["-y", "@wix/mcp-remote@latest", "https://mcp.wix.com/mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `gemini-extension.json` manifest to support [Gemini CLI](https://geminicli.com) as a new AI coding assistant
- Configures the Wix MCP server (`@wix/mcp-remote`) inline, as required by the Gemini extension format
- Agent skills are auto-discovered from the existing `skills/` directory via `SKILL.md` files — no explicit list needed

## Install

```
gemini extensions install github:wix/skills
```

Or link locally for development:

```
gemini extensions link /path/to/skills
```

## Test plan

- [ ] Run `gemini extensions link .` from the repo root and verify the extension loads
- [ ] Confirm Wix MCP server connects (`wix-mcp` appears in available tools)
- [ ] Confirm skills are discovered from `skills/` subdirectories
- [ ] Run `gemini extensions install github:wix/skills` after merge to test public install

🤖 Generated with [Claude Code](https://claude.com/claude-code)