### PR TITLE
fix(wix-manage): remove incorrect DUPLICATE_NAME error from restaurants recipe

### DIFF
--- a/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+++ b/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
@@ -327,7 +327,6 @@ Common dietary labels:
 | `MENU_NOT_FOUND` | Invalid menu ID | Verify menu exists |
 | `ITEM_NOT_FOUND` | Invalid item ID | Verify item exists |
 | `INVALID_PRICE` | Negative price | Use positive amounts |
-| `DUPLICATE_NAME` | Section/item name exists | Use unique names |
 
 ## Related Documentation
 


### PR DESCRIPTION
.