### PR TITLE
add wix-manage skills including all existing skills and docs yamls

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,8 @@
   "keywords": ["wix", "wix-cli", "wix-mcp", "ecommerce", "cms", "wix-apps"],
   "skills": [
     "./skills/wds-docs",
-    "./skills/wix-app"
+    "./skills/wix-app",
+    "./skills/wix-manage"
   ],
   "mcpServers": "./.mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Agent skills for building Wix applications with AI coding assistants.
 ## Installation
 
 ### Claude Code Plugin
+
 In [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run:
 
 ```bash
@@ -46,10 +47,11 @@ npx skills add wix/skills -g
 
 ## Available Skills
 
-| Skill | Purpose | When to Use |
-|-------|---------|-------------|
-| [wix-app](skills/wix-app/SKILL.md) | Build Wix app extensions | Adding any extension — dashboard pages, site widgets, backend events, service plugins, embedded scripts, data collections, and more |
-| [wds-docs](skills/wds-docs/SKILL.md) | Wix Design System reference | Looking up WDS component props, examples, icons |
+| Skill                                    | Purpose                          | When to Use                                                                                                                         |
+| ---------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [wix-app](skills/wix-app/SKILL.md)       | Build Wix app extensions         | Adding any extension — dashboard pages, site widgets, backend events, service plugins, embedded scripts, data collections, and more |
+| [wds-docs](skills/wds-docs/SKILL.md)     | Wix Design System reference      | Looking up WDS component props, examples, icons                                                                                     |
+| [wix-manage](skills/wix-manage/SKILL.md) | Wix business solution management | REST API operations for configuring and managing Wix business solutions                                                             |
 
 ## Supported Agents
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: wix-manage
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, events, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, site-properties, ecommerce."
+compatibility: Requires Wix REST API access (API key or OAuth).
+---
+
+# Management Recipes Index
+
+## What Are Management Recipes?
+
+**Management recipes are for REST API operations** that configure, set up, and manage Wix business entities on your site. These recipes use REST API calls and are designed for:
+
+- **Site setup and configuration** — Initial setup of stores, bookings, payments, and other business apps
+- **Entity management** — Creating, updating, and deleting products, services, staff members, pricing plans
+- **Administrative operations** — Bulk updates, contact labeling, data migrations
+- **Backend integrations** — Server-to-server automations, webhooks, data synchronization
+
+These recipes do NOT cover frontend development or SDK usage for displaying data to users.
+
+---
+
+## App Installation
+
+### [Install Wix Apps](references/app-installation/install-wix-apps.md)
+**Technical:** Installs Wix apps on a site using Apps Installer API. Covers enabling Velo (Wix Code), app installation, and common app definition IDs.
+
+### [List Installed Apps](references/app-installation/list-installed-apps.md)
+**Technical:** Lists all apps installed on a site using Apps Installer API. Useful for verifying app installations before making API calls and diagnosing authorization errors.
+
+---
+
+## Blog
+
+### [How to Create Blog Posts](references/blog/how-to-create-blog-posts.md)
+**Technical:** Creates and publishes blog posts using Blog Posts API. Covers Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
+
+---
+
+## Bookings
+
+### [Booking Service Policy Setup](references/bookings/booking-service-policy-setup.md)
+**Technical:** Sets up booking policies, cancellation rules, and waitlist configuration using the Services API policy fields. Covers bookingPolicy, cancellationPolicy, and waitlist settings.
+
+### [Booking System Integration Gaps](references/bookings/booking-system-integration-gaps.md)
+**Technical:** Documents undocumented API patterns for booking payments. Covers Bookings→Ecommerce integration, booking ID transformation to catalog items, and async payment confirmation flows.
+
+### [Bookings Staff Setup](references/bookings/bookings-staff-setup.md)
+**Technical:** Creates staff members and configures custom working hours using Staff API + Calendar Events API. Critical two-step process: create staff → assign schedule → create working hours events.
+
+### [Create and Update Booking Services](references/bookings/create-and-update-booking-services.md)
+**Technical:** Full CRUD operations for Wix Bookings services using Services API. Covers service types (APPOINTMENT, CLASS, COURSE), pricing configuration, location setup, and schedule management.
+
+### [End-to-End Booking Flow](references/bookings/end-to-end-booking-flow.md)
+**Technical:** Complete booking flow from service discovery to payment. Query services, check availability with Time Slots V2, create bookings, and process payment via eCommerce checkout.
+
+### [External Calendar Integration](references/bookings/external-calendar-integration.md)
+**Technical:** OAuth-based integration with Google Calendar, Microsoft Outlook, and Apple Calendar. Covers authentication flows, sync configuration, and bidirectional event management.
+
+### [Multi-Resource Service Creation](references/bookings/multi-resource-service-creation.md)
+**Technical:** Creates resource types and individual resources using Resources API. Enables services that require multiple resources (rooms + equipment + staff) with automatic allocation.
+
+---
+
+## Calendar
+
+### [Configure Default Business Hours](references/calendar/configure-default-business-hours.md)
+**Technical:** Uses Calendar Events API to create WORKING_HOURS events on the business schedule. Covers the critical distinction between Calendar Events API (correct) vs Site Properties API (incorrect) for setting base availability.
+
+---
+
+## CMS
+
+### [CMS Data Items CRUD](references/cms/cms-data-items-crud.md)
+**Technical:** Add, query, update, and delete items in CMS collections. Use this to insert content, bulk insert/update/patch/delete items, query with filters, and manage collection data. Key endpoints: /wix-data/v2/items, /wix-data/v2/bulk/items/*.
+
+### [CMS Data Operations Extended](references/cms/cms-data-operations-extended.md)
+**Technical:** Additional CMS data operations including count, upsert (bulk save), and update by filter patterns.
+
+### [CMS eCommerce Catalog Integration](references/cms/cms-ecommerce-catalog-integration.md)
+**Technical:** The recommended way to sell existing CMS collection items (tickets, bookings, memberships) through Wix checkout. Add the CATALOG plugin to convert any CMS collection into purchasable products with cart and payment integration.
+
+### [CMS References & Relationships](references/cms/cms-references-and-relationships.md)
+**Technical:** Add, replace, or remove items from MULTI_REFERENCE fields. Use insert-references, replace-references, remove-references endpoints. Required for managing multi-reference relationships - these CANNOT be set via regular insert/update/patch operations. Also covers single references and querying with expanded references.
+
+### [CMS Schema Management](references/cms/cms-schema-management.md)
+**Technical:** Create and modify CMS collection structures. Covers listing collections, creating collections with fields, adding/removing fields, and updating collection settings.
+
+---
+
+## Contacts
+
+### [Bulk Delete Contacts](references/contacts/bulk-delete-contacts.md)
+**Technical:** Deletes multiple contacts using filter-based bulk delete. Covers safe deletion patterns, GDPR compliance, soft delete alternatives, and batch processing strategies.
+
+### [Bulk Label and Unlabel Contacts](references/contacts/bulk-label-and-unlabel-contacts.md)
+**Technical:** Adds/removes labels from multiple contacts using Contacts API bulk operations. Covers label creation, contact filtering, batch processing, and rate limit handling.
+
+---
+
+## Domains
+
+### [Domain Search and Purchase](references/domains/domain-search-and-purchase.md)
+**Technical:** Search for available domains, get domain suggestions, and generate purchase links using Domain Search V2 API. Covers availability checks, TLD filtering, and connecting domains to Wix sites.
+
+---
+
+## eCommerce
+
+### [Setup Store Pickup Location](references/ecommerce/setup-store-pickup-location.md)
+**Technical:** Configures a pickup option for an online store so customers can choose in-store pickup at checkout. Uses the Delivery Profiles API to discover the Pickup carrier, add a delivery region, and attach the carrier with a free pickup rate.
+
+---
+
+## Events
+
+### [List Events](references/events/list-events.md)
+**Technical:** Queries events from Wix Events using Events API. Covers field sets (DETAILS, URLS, REGISTRATION), filtering by status/date, and pagination.
+
+---
+
+## Forms
+
+### [Create Form](references/forms/create-form.md)
+**Technical:** Creates a form with fields (name, email, etc.) using the Form Schemas API. Covers field configuration, layout, and post-submission triggers.
+
+---
+
+## Get Paid
+
+### [Create Payment Links](references/get-paid/create-payment-links.md)
+**Technical:** Creates payment links for collecting payments without a checkout flow. Covers store products (catalog items), custom line items, variants, due dates, and sending links via email.
+
+### [How to Setup Wix Payments](references/get-paid/how-to-setup-wix-payments.md)
+**Technical:** Configures Wix Payments as the payment provider. Covers eligibility checking, business verification, bank account setup, and payment method configuration (cards, PayPal, Apple Pay).
+
+### [Payment Links for Bookings](references/get-paid/payment-links-for-bookings.md)
+**Technical:** Creates payment links for unpaid bookings using Payment Links API. Links booking IDs to payment requests with proper redirect handling.
+
+---
+
+## Media
+
+### [Upload Media to Wix](references/media/upload-media-to-wix.md)
+**Technical:** Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
+
+---
+
+## Pricing Plans
+
+### [Create and Update Pricing Plans](references/pricing-plans/create-and-update-pricing-plans.md)
+**Technical:** Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, and plan visibility.
+
+### [Pricing Plans Bookings Integration](references/pricing-plans/pricing-plans-bookings-integration.md)
+**Technical:** Links Pricing Plans to Bookings services using the Benefit Programs API. Enables package deals and memberships that grant booking access.
+
+---
+
+## Restaurants
+
+### [Wix Restaurants Setup](references/restaurants/wix-restaurants-setup.md)
+**Technical:** Configures restaurant menus, sections, and items using Menus API. Covers menu structure (Menu → Section → Item), modifiers, pricing, availability schedules, and ordering settings.
+
+---
+
+## Rich Content
+
+### [Ricos Converter Service](references/rich-content/ricos-converter-service.md)
+**Technical:** Validates and converts content between Ricos documents and HTML/Markdown/plain text using the Ricos Documents API. Covers plugin configuration, format conversion in both directions, and document validation.
+
+---
+
+## Site Properties
+
+### [Change Payment Currency](references/site-properties/change-payment-currency-site-properties.md)
+**Technical:** Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask.
+
+---
+
+## Sites
+
+### [Create Site from Template](references/sites/create-site-from-template.md)
+**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless site setup, OAuth app creation, and publishing.
+
+### [Query Sites](references/sites/query-sites.md)
+**Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
+
+---
+
+## Stores
+
+### [Add Store Pages to Site](references/stores/add-store-pages-to-site.md)
+**Technical:** Adds missing checkout and cart pages to a site when Stores app is installed. Used when store pages are missing after migration or setup issues.
+
+### [Bulk Create Products with Options](references/stores/bulk-create-products-with-options.md)
+**Technical:** Uses bulk products endpoint to create multiple products with inventory in a single request. Handles variant generation from options, media format requirements, and error handling for partial failures.
+
+### [Create Product (Catalog V1)](references/stores/create-product-catalog-v1.md)
+**Technical:** Create products using the Catalog V1 Products API. Use this recipe when the site's catalog version is CATALOG_V1. Covers simple product creation, product with options, and key V1 request structure differences from V3.
+
+### [Create Product with Options (Catalog V3)](references/stores/create-product-with-options-catalog-v3.md)
+**Technical:** Single product creation with options using Catalog V3 Products API. Covers option types (TEXT_CHOICES, SWATCH_CHOICES), choice configuration, and automatic variant generation.
+
+### [Query Products](references/stores/query-products.md)
+**Technical:** Query and list products from a Wix Store using Catalog V3 Query Products endpoint. Covers correct fields enum values, filtering, sorting, and paging.
+
+### [Query Products (Catalog V1)](references/stores/query-products-catalog-v1.md)
+**Technical:** Query and list products from a Wix Store using the Catalog V1 Query Products endpoint. Use this recipe when the site's catalog version is CATALOG_V1. Covers basic queries, filtering, sorting, and paging.
+
+### [Setup Online Store (Catalog V3)](references/stores/setup-online-store-catalog-v3.md)
+**Technical:** Initializes a Stores catalog with Catalog V3 Products API, bulk products endpoint, and Categories API. Covers product creation, option configuration, variant management, and category assignment.
+
+### [Update Product Pre-Order](references/stores/update-product-pre-order.md)
+**Technical:** Manages pre-order settings for product variants using V3 Inventory API. Covers enabling/disabling pre-orders, setting messages, configuring limits, and handling trackQuantity requirements.
+
+### [Update Product with Options](references/stores/update-product-with-options.md)
+**Technical:** Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, variant-specific pricing, and revision-based updates to prevent conflicts.

--- a/skills/wix-manage/references/app-installation/install-wix-apps.md
+++ b/skills/wix-manage/references/app-installation/install-wix-apps.md
@@ -1,0 +1,113 @@
+---
+name: "Install Wix Apps"
+description: Installs Wix apps on a site using Apps Installer API. Covers enabling Velo (Wix Code), app installation, and common app definition IDs.
+---
+# Install Wix Apps on a Site
+
+This recipe guides you through installing Wix apps on a site using the Apps Installer REST API, including enabling Velo (Wix Code) when needed.
+
+## Prerequisites
+
+- Site ID where apps will be installed
+- Knowledge of which app to install (see [Apps Created by Wix](https://dev.wix.com/docs/rest/articles/get-started/apps-created-by-wix))
+
+## Required APIs
+
+- **Apps Installer API**: [REST](https://dev.wix.com/docs/rest/business-management/app-installation/install-app)
+
+---
+
+## Step 1: Enable Velo (Wix Code) if Needed
+
+If you receive the error `WDE0110: Wix Code not enabled`, you must first enable Velo on the site.
+
+**Endpoint**: `POST https://www.wixapis.com/mcp-serverless/v1/velo/provision`
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/mcp-serverless/v1/velo/provision/' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+**Response**: Empty body on success.
+
+### IMPORTANT NOTES:
+- Only call this endpoint if you receive the `WDE0110` error
+- This is a one-time operation per site
+
+---
+
+## Step 2: Install the Wix App
+
+Use the Apps Installer API to install any Wix app on a site.
+
+**Endpoint**: `POST https://www.wixapis.com/apps-installer-service/v1/app-instance/install`
+
+**Request Body**:
+```json
+{
+  "tenant": {
+    "tenantType": "SITE",
+    "id": "<SITE_ID>"
+  },
+  "appInstance": {
+    "appDefId": "<APP_DEF_ID>"
+  }
+}
+```
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instance/install' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tenant": {
+      "tenantType": "SITE",
+      "id": "<SITE_ID>"
+    },
+    "appInstance": {
+      "appDefId": "<APP_DEF_ID>"
+    }
+  }'
+```
+
+### Common App Definition IDs
+
+Before installing, refer to the [Apps Created by Wix](https://dev.wix.com/docs/rest/articles/get-started/apps-created-by-wix) documentation to find the correct `appDefId` for the app you want to install.
+
+Some common apps:
+| App | appDefId |
+|-----|----------|
+| Wix Stores | `215238eb-22a5-4c36-9e7b-e7c08025e04e` |
+| Wix Bookings | `13d21c63-b5ec-5912-8397-c3a5ddb27a97` |
+| Wix Blog | `14bcded7-0066-7c35-14d7-466cb3f09103` |
+| Wix Events | `140603ad-af8d-84a5-2c80-a0f60cb47351` |
+| Wix Pricing Plans | `1522827f-c56c-a5c9-2ac9-00f9e6ae12d3` |
+
+### IMPORTANT NOTES:
+- I MUST NEVER guess the `appDefId` - always refer to the official documentation
+- The `tenantType` MUST be `SITE`
+- The `id` in tenant is the site's metaSiteId
+
+---
+
+## Error Handling
+
+### App Not Installed Error
+If you receive an error indicating a required app is not installed, use this recipe to install it before proceeding.
+
+### WDE0110: Wix Code not enabled
+Call the Velo provision endpoint (Step 1) first, then retry the original operation.
+
+---
+
+## Next Steps
+
+After installing an app:
+- Configure the app's settings using its specific APIs
+- Set up any required app-specific data (products for Stores, services for Bookings, etc.)

--- a/skills/wix-manage/references/app-installation/list-installed-apps.md
+++ b/skills/wix-manage/references/app-installation/list-installed-apps.md
@@ -1,0 +1,124 @@
+---
+name: "List Installed Apps"
+description: Lists all apps installed on a site using Apps Installer API. Useful for verifying app installations before making API calls and diagnosing authorization errors.
+---
+# List Installed Apps on a Site
+
+This recipe guides you through listing all installed apps on a Wix site using the Apps Installer REST API. This is useful for verifying app installations before making API calls that require specific apps.
+
+## Prerequisites
+
+- Site ID for the site you want to check
+
+## Required APIs
+
+- **Apps Installer API**: [Get Installed Apps](https://dev.wix.com/docs/rest/business-management/app-installation/get-installed-apps)
+
+---
+
+## Step 1: Query Installed Apps
+
+Use the Get Installed Apps endpoint to retrieve all apps installed on a site.
+
+**Endpoint**: `GET https://www.wixapis.com/apps-installer-service/v1/app-instances`
+
+**Request**:
+```bash
+curl -X GET \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instances' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json'
+```
+
+**Response**:
+```json
+{
+  "appInstances": [
+    {
+      "id": "instance-id-1",
+      "appDefId": "1380b703-ce81-ff05-f115-39571d94dfcd",
+      "version": "^0.0.0",
+      "enabled": true,
+      "status": "UNKNOWN"
+    },
+    {
+      "id": "instance-id-2",
+      "appDefId": "13d21c63-b5ec-5912-8397-c3a5ddb27a97",
+      "enabled": true,
+      "status": "UNKNOWN"
+    }
+  ]
+}
+```
+
+---
+
+## Step 2: Identify Apps by Definition ID
+
+Match the `appDefId` values from the response against known Wix app IDs.
+
+### Common Wix App Definition IDs
+
+| App | appDefId |
+|-----|----------|
+| Wix Stores | `1380b703-ce81-ff05-f115-39571d94dfcd` |
+| Wix Bookings | `13d21c63-b5ec-5912-8397-c3a5ddb27a97` |
+| Wix Blog | `14bcded7-0066-7c35-14d7-466cb3f09103` |
+| Wix Events | `140603ad-af8d-84a5-2c80-a0f60cb47351` |
+| Wix Pricing Plans | `1522827f-c56c-a5c9-2ac9-00f9e6ae12d3` |
+| Wix Restaurants | `13e8d036-5516-6f75-e025-2aca3b5d7930` |
+
+For a complete list, see [Apps Created by Wix](https://dev.wix.com/docs/rest/articles/get-started/apps-created-by-wix).
+
+---
+
+## Use Cases
+
+### Verify App Before API Calls
+
+Before calling APIs that require specific apps (e.g., Bookings, Stores), check if the app is installed:
+
+```javascript
+// Pseudocode example
+const installedApps = await getInstalledApps(siteId);
+const bookingsAppId = "13d21c63-b5ec-5912-8397-c3a5ddb27a97";
+
+const hasBookings = installedApps.appInstances.some(
+  app => app.appDefId === bookingsAppId
+);
+
+if (!hasBookings) {
+  // Install Bookings app first
+  // See: Install Wix Apps recipe
+}
+```
+
+### Diagnose Authorization Errors
+
+If you receive `401 Unauthorized` or `403 Forbidden` errors from Wix APIs:
+
+1. **List installed apps** using this recipe
+2. **Check if the required app** is in the response
+3. **If missing**: Install the app using the [Install Wix Apps](install-wix-apps.md) recipe
+4. **Retry the original API call**
+
+---
+
+## Error Handling
+
+### 401 Unauthorized
+- Verify your authentication token is valid
+- Check that the token has `APP-MARKET.VIEW-INSTALLED-APP` permission
+
+### Empty Response
+- The site may have no additional apps installed beyond core Wix functionality
+- This is normal for new or minimal sites
+
+---
+
+## Next Steps
+
+After checking installed apps:
+- **If app is missing**: Use the [Install Wix Apps](install-wix-apps.md) recipe to install required apps
+- **If app is installed but API fails**: Check API permissions and authentication
+- **For Bookings APIs**: See [Bookings recipes](../../SKILL.md) for service setup

--- a/skills/wix-manage/references/blog/how-to-create-blog-posts.md
+++ b/skills/wix-manage/references/blog/how-to-create-blog-posts.md
@@ -1,0 +1,226 @@
+---
+name: "How to Create Blog Posts"
+description: Creates and publishes blog posts using Blog Posts API. Covers Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
+---
+
+**Article: Create and Publish Blog Posts with Rich Content and Images**
+
+---
+
+## Description
+
+This article demonstrates how to create and immediately publish blog posts using Wix Blog REST API, including handling external images, rich content formatting, and proper media management workflow.
+
+### Part 0: Get an Author/Member ID (Required for 3rd-Party Apps)
+
+**IMPORTANT**: When calling the Blog API as a 3rd-party app (not as the site owner), `draftPost.memberId` is **required**. The API will reject requests with "Missing post owner information" if omitted.
+
+1. Query site members to get a valid member ID using [List Members](https://dev.wix.com/docs/rest/crm/members-contacts/members/member-management/members/list-members):
+
+   ```bash
+   curl -X GET "https://www.wixapis.com/members/v1/members?fieldsets=PUBLIC&paging.limit=1" \
+     -H "Authorization: <AUTH>"
+   ```
+
+2. Use the `id` field from the response as `draftPost.memberId` when creating the blog post. This member will be the post author.
+
+   > **Note**: The member ID must belong to an existing site member or collaborator. If the members query returns no results, you may need to create a member first or use the site owner's member ID.
+
+### Part 1: Import External Images to Wix Media Manager
+
+1. Identify external image URLs from user input for cover images and embedded content images.
+
+2. Import each external image using [Import File](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file). This converts external URLs to Wix Media IDs required for blog posts.
+
+   ```bash
+   curl -X POST "https://www.wixapis.com/site-media/v1/files/import" \
+     -H "Authorization: <AUTH>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "url": "https://example.com/image.jpg",
+       "mediaType": "IMAGE",
+       "displayName": "Cover Image.jpg"
+     }'
+   ```
+
+   The response will include a `file.id` field. Use this ID in blog post creation. Images with `operationStatus: "PENDING"` can be used immediately.
+
+3. Store the returned file IDs for use in blog post creation.
+
+### Part 2: Create Blog Post with Rich Content
+
+1. Create blog post using [Create Draft Post](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post) for single posts, or [Bulk Create Draft Posts](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/bulk-create-draft-posts) for multiple posts.
+
+   ```bash
+   curl -X POST "https://www.wixapis.com/blog/v3/draft-posts" \
+     -H "Authorization: <AUTH>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "draftPost": {
+         "title": "My Blog Post",
+         "memberId": "author-member-id",
+         "richContent": {
+           "nodes": [
+             {
+               "type": "PARAGRAPH",
+               "nodes": [{
+                 "type": "TEXT",
+                 "textData": {
+                   "text": "This is a paragraph with some content.",
+                   "decorations": []
+                 }
+               }],
+               "paragraphData": {}
+             }
+           ]
+         },
+         "media": {
+           "wixMedia": {
+             "image": { "id": "mediaId" }
+           },
+           "displayed": true,
+           "custom": true
+         }
+       },
+       "publish": true
+     }'
+   ```
+
+2. Structure rich content using Ricos JSON format. Reference [Ricos documentation](https://dev.wix.com/docs/rest/assets/rich-content/ricos-documents/introduction) for complete node structure. Common node types:
+   - `PARAGRAPH` for text content
+   - `HEADING` for section headers
+   - `IMAGE` for embedded images (requires Wix Media ID)
+   - `ORDERED_LIST` and `BULLETED_LIST` for lists
+   - `BLOCKQUOTE` for quoted text
+   - `LIST_ITEM` for individual list items
+
+   **CRITICAL**: All TEXT nodes MUST be wrapped in PARAGRAPH nodes within their parent containers.
+
+   **Correct Ricos structure example:**
+
+   ```json
+   {
+     "nodes": [
+       {
+         "type": "PARAGRAPH",
+         "nodes": [
+           {
+             "type": "TEXT",
+             "textData": {
+               "text": "This is a paragraph with some content.",
+               "decorations": []
+             }
+           }
+         ],
+         "paragraphData": {}
+       }
+     ]
+   }
+   ```
+
+   **Correct BLOCKQUOTE structure:**
+
+   ```json
+   {
+     "type": "BLOCKQUOTE",
+     "nodes": [
+       {
+         "type": "PARAGRAPH",
+         "nodes": [
+           {
+             "type": "TEXT",
+             "textData": { "text": "Quote text here", "decorations": [] }
+           }
+         ],
+         "paragraphData": {}
+       }
+     ],
+     "blockquoteData": { "indentation": 1 }
+   }
+   ```
+
+   **Correct LIST_ITEM structure:**
+
+   ```json
+   {
+     "type": "LIST_ITEM",
+     "nodes": [
+       {
+         "type": "PARAGRAPH",
+         "nodes": [
+           {
+             "type": "TEXT",
+             "textData": { "text": "List item text", "decorations": [] }
+           }
+         ],
+         "paragraphData": {}
+       }
+     ]
+   }
+   ```
+
+3. For embedded images in rich content, use IMAGE nodes with Wix Media IDs:
+
+   ```json
+   {
+     "type": "IMAGE",
+     "nodes": [],
+     "imageData": {
+       "containerData": {
+         "width": { "size": "CONTENT" },
+         "alignment": "CENTER"
+       },
+       "image": {
+         "src": { "id": "mediaId" },
+         "width": 900,
+         "height": 600
+       },
+       "altText": "Descriptive alt text"
+     }
+   }
+   ```
+
+4. Set `publish: true` to immediately publish the post rather than saving as draft.
+
+### Part 3: Handle Categories and Tags (Optional)
+
+1. Resolve category IDs using [List Categories](https://dev.wix.com/docs/api-reference/business-solutions/blog/category/list-categories) if user provides category names.
+
+2. Resolve tag IDs using [Query Tags](https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/query-tags) if user provides tag labels.
+
+3. Include resolved IDs in `categoryIds` and `tagIds` arrays in the draft post object.
+
+### IMPORTANT NOTES:
+
+- Never mock blog posts or media IDs - always use the APIs to import images and create posts
+- Always read the full documentation of methods before implementation
+- External images MUST be imported via Import File API before use in blog posts - direct external URLs will not work
+- For 3rd-party app integrations, `memberId` is mandatory - use the [List Members](https://dev.wix.com/docs/rest/crm/members-contacts/members/member-management/members/list-members) API if needed to get member ID
+- Use ONLY the file ID (without `wix:image://v1/` prefix) for both cover images and embedded images
+- Rich content IMAGE nodes require both `width` and `height` properties in the `image` object
+- Images with `"operationStatus": "PENDING"` from import can be used immediately in blog posts
+- Set `publish: true` in the request to publish immediately rather than save as draft
+- For multiple posts, use Bulk Create Draft Posts API with `draftPosts` array
+- Include `fieldsets: ['URL']` to get post URLs in the response
+- Handle image import failures gracefully - continue without images if import fails
+- Provide meaningful `displayName` values during image import for better organization
+- Use appropriate Ricos node types (PARAGRAPH, HEADING, LIST, etc.) for semantic content structure
+- Consider batching image imports when creating multiple posts with many images
+
+### CRITICAL RICOS JSON STRUCTURE RULES:
+
+- **NEVER place TEXT nodes directly in BLOCKQUOTE, LIST_ITEM, or other container nodes**
+- **ALL TEXT nodes MUST be wrapped in PARAGRAPH nodes within their parent containers**
+- **BLOCKQUOTE nodes must contain PARAGRAPH nodes, which contain TEXT nodes**
+- **LIST_ITEM nodes must contain PARAGRAPH nodes, which contain TEXT nodes**
+- **Failure to follow proper nesting will result in parsing errors: "Expected a paragraph node but found TEXT"**
+- **Always validate Ricos structure before sending to ensure TEXT nodes are properly nested**
+
+### Troubleshooting
+
+| Error                                      | Cause                       | Solution                                                            |
+| ------------------------------------------ | --------------------------- | ------------------------------------------------------------------- |
+| "Missing post owner information"           | `memberId` not provided     | Add `draftPost.memberId` - see Part 0 for how to get one            |
+| "memberIds ... do not exist"               | Invalid member ID           | Query members first using List Members API to get valid IDs         |
+| "Expected a paragraph node but found TEXT" | Invalid Ricos structure     | Wrap TEXT nodes in PARAGRAPH nodes (see structure rules above)      |
+| Image not displaying                       | Using external URL directly | Import image via Media Manager first, then use the returned file ID |

--- a/skills/wix-manage/references/bookings/booking-service-policy-setup.md
+++ b/skills/wix-manage/references/bookings/booking-service-policy-setup.md
@@ -1,0 +1,95 @@
+---
+name: "Booking Service Policy Setup"
+description: Sets up booking policies, cancellation rules, and waitlist configuration using the Services API policy fields. Covers bookingPolicy, cancellationPolicy, and waitlist settings.
+---
+
+# Technical Step-by-Step Instructions: Configuring Wix Bookings Service Policies (Real-World, API-First)
+
+## Description
+
+Below are the recommended steps to successfully configure booking, cancellation, and waitlist policies for Wix Bookings services. This recipe covers policy inheritance, service-specific overrides, and common policy configurations for different business models.
+
+---
+
+## Overview
+
+Wix Bookings policy configuration allows businesses to set rules for:
+
+- **Booking policies**: When customers can book, how far in advance, booking deadlines
+- **Cancellation policies**: Cancellation deadlines, refund rules, fees
+- **Waitlist policies**: When waitlists are enabled, capacity handling
+- **Group booking policies**: Maximum participants per booking
+
+Policies can be configured at two levels:
+
+- **Site-wide (business) policies**: Default rules that apply to all services
+- **Service-specific policies**: Override rules for individual services
+
+### IMPORTANT NOTES
+
+- Services inherit from site-wide booking policies by default
+- Service policies only override fields you explicitly specify - unspecified fields keep site defaults
+- Policy options available may vary based on service type (APPOINTMENT, CLASS, COURSE)
+- All policy configurations support the same core features across service types
+
+---
+
+## Steps
+
+### 1. Configure Site-Wide Business Policy (Optional)
+
+Set default policies that will apply to all services unless overridden. Use the Business Policy API to configure booking deadlines, cancellation rules, waitlist settings, and group booking limits.
+
+### 2. Create or Update Service with Policy Overrides
+
+When creating or updating a service, specify policy fields that should differ from business defaults. Only include the policy fields you want to override - unspecified fields will inherit from business defaults.
+
+### 3. Configure Course-Specific Policies
+
+Courses may have additional policy options such as `bookUntilXMinutesAfterStart` which allows customers to join courses even after they've started.
+
+### 4. Verify Policy Application
+
+Query the service to confirm policies are applied correctly. The service should show explicitly set policy fields with your specified values and unspecified fields inheriting from business defaults.
+
+### IMPORTANT NOTES
+
+- **Policy inheritance**: Only specify fields you want to override - leave others undefined to inherit business defaults
+- **Partial updates**: When updating service policies, only include fields you want to change
+- **Capacity requirements**: Waitlist policies require service capacity settings to be configured
+- **Group booking considerations**: `maxParticipantsPerBooking` works with all service types
+- **Time calculations**: Policy deadlines are calculated from booking start time in business timezone
+- **Course flexibility**: Course services support additional policy options like `bookUntilXMinutesAfterStart`
+
+### Troubleshooting Common Issues
+
+**Policies not applying:**
+
+- Verify you're setting policies on the service object, not as separate policy entities
+- Check that policy fields are properly nested under `service.policy`
+- Ensure you're updating the correct service ID
+
+**Waitlist not working:**
+
+- Confirm service has `maxParticipants` capacity set
+- Verify `waitingListPolicy.enabled` is `true`
+- Check that `waitingListPolicy.capacity` is set if you want limited waitlist size
+
+**Cancellation policies not enforced:**
+
+- Ensure `cancelRescheduleUpToInMinutes` is set to appropriate value
+- Verify `cancelationAllowed` is `true` if cancellations should be permitted
+- Check that payment and booking flow supports the configured policy
+
+**Group booking limits not working:**
+
+- Confirm `maxParticipantsPerBooking` is set to desired limit
+- Verify service type supports group bookings (all types do)
+- Check that booking UI respects the participant limit
+
+## API Documentation References
+
+- [Booking Policies API](https://dev.wix.com/docs/api-reference/business-solutions/bookings/policies/introduction)
+- [Bulk Create Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services) — `POST https://www.wixapis.com/bookings/v2/bulk/services/create`
+- [Update Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/update-service) — `PATCH https://www.wixapis.com/bookings/v2/services/<SERVICE_ID>`
+- [Query Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services) — `POST https://www.wixapis.com/bookings/v2/services/query`

--- a/skills/wix-manage/references/bookings/booking-system-integration-gaps.md
+++ b/skills/wix-manage/references/bookings/booking-system-integration-gaps.md
@@ -1,0 +1,416 @@
+---
+name: "Booking System Integration Gaps"
+description: Documents undocumented API patterns for booking payments. Covers Bookings→Ecommerce integration, booking ID transformation to catalog items, and async payment confirmation flows.
+---
+# Technical Step-by-Step Instructions: Wix Bookings System Integration Gaps - Complete API Documentation Analysis
+
+## Description
+
+This recipe addresses **critical undocumented API patterns and business integration gaps** across the entire Wix Bookings ecosystem. While Wix extensively documents individual booking creation APIs, there exist fundamental undocumented integration patterns that are essential for any payment-enabled booking business but completely absent from all official documentation sources.
+
+
+---
+
+## Prerequisites
+
+### Required App Installations
+
+Before implementing any booking integration, ensure the following requirements are met:
+
+1. **Wix Bookings** - Core app must be installed and configured
+2. **Wix Ecommerce** - Required for payment processing (undocumented dependency)
+3. **Services Created** - At least one bookable service must exist on the site
+4. **Staff Resources** - Staff members must be available for service delivery
+5. **Business Schedule** - Operating hours must be configured
+
+### App Installation Process
+
+If you encounter service-related errors, install the required apps using the Apps Installer API.
+
+**For detailed app installation procedures, refer to:**
+- [Apps Installer API Documentation](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)
+- Business setup recipes for comprehensive app installation workflows
+
+## Overview
+
+The Wix Bookings system contains **fundamental undocumented integration patterns** that affect every booking scenario requiring payment processing. These gaps create confusion and implementation barriers across all booking types:
+
+- **Single Appointment Bookings**: How booking payments actually work
+- **Class Bookings**: Payment processing for group services
+- **Course Bookings**: Complex dual-API requirements for scheduling
+- **Multi-Service Packages**: Completely undocumented unified booking endpoint
+
+### CRITICAL API DOCUMENTATION GAPS
+
+**The Universal Undocumented Pattern**: **Bookings→Ecommerce Integration Architecture**
+
+**Documentation Status Across ALL Booking Types**:
+- ❌ **NOT** documented how booking IDs become catalog items
+- ❌ **NOT** documented that ecom system handles all pricing/tax calculations
+- ❌ **NOT** documented async payment confirmation patterns
+- ❌ **NOT** documented booking status vs order status separation
+- ❌ **NOT** documented service properties preservation in checkout
+- ❌ **NO** mention of `BACKOFFICE_MERCHANT` channel requirement
+- ❌ **NO** explanation of why checkout/order APIs are needed for bookings
+
+**Additional Service-Specific Gaps**:
+- ❌ **Courses**: Dual API requirement (booking + calendar events) completely undocumented
+- ❌ **Multi-Service**: Entire endpoint missing from all documentation
+- ❌ **Payment Flow**: Universal integration pattern affects all booking types
+
+### Key Discovery: Universal Architecture Gap
+
+**What Developers Expect** (Based on Documentation):
+- Create booking → Booking system handles payment → Done
+- Payment status managed within booking system
+- Booking APIs contain all necessary functionality
+
+**Actual Undocumented Architecture**:
+- Create booking → Booking system creates reservation only
+- Use booking ID as catalog item in ecom system
+- Ecom system handles all pricing, tax, discount calculations
+- Create checkout and order for actual payment processing
+- Async messaging system handles payment confirmation
+- Booking status (CONFIRMED) independent of payment status
+
+**Reality Check**:
+```
+Standard Documentation Shows: Booking API → Payment ✓
+Actual Required Flow: Booking API → Ecom Integration → Payment ✓
+```
+
+### Business Impact of These Gaps
+
+**Without Understanding Universal Integration Patterns:**
+- Developers assume booking creation includes payment processing
+- No knowledge that ecom system handles all financial calculations
+- Missing understanding of async payment confirmation architecture
+- Confusion about booking status vs payment status separation
+- Unknown relationship between booking system and ecommerce system
+
+**Without Service-Specific Knowledge:**
+- Course businesses cannot create functioning course delivery schedules
+- Package-based businesses cannot create unified booking experiences
+- Payment implementation becomes trial-and-error process
+- Integration projects fail due to missing critical steps
+
+**Current Developer Confusion Patterns:**
+- "Why do I need ecommerce APIs for booking payments?"
+- "How do booking payments actually work?"
+- "Why are my course bookings invisible on the calendar?"
+- "How do I create spa day packages?"
+- "What's the difference between booking status and payment status?"
+
+### IMPORTANT NOTES
+
+* **Universal Integration Gap**: Every booking requiring payment uses undocumented ecom integration
+* **Service Type Complexity**: Different booking structures but same payment patterns
+* **Async Architecture**: Payment confirmation decoupled from booking creation
+* **Status Separation**: Booking confirmation independent of payment processing
+* **Hidden Dependencies**: Ecommerce system required for all booking payments
+* **Business Model Impact**: Documentation gaps prevent entire business models
+
+---
+
+## Steps
+
+### 1. Understand Universal Booking→Payment Architecture
+
+**CRITICAL DISCOVERY**: All Wix booking payments flow through undocumented ecommerce integration.
+
+**The Hidden Architecture**:
+- **Booking System**: Handles time slot reservations, service coordination, scheduling
+- **Ecommerce System**: Handles pricing, tax calculations, discount processing, payment collection
+- **Integration Bridge**: Booking IDs automatically become catalog item IDs
+
+**Universal Pattern** (Works for ALL Service Types):
+```
+Create Booking → Extract Booking ID → Use as Catalog Item ID → Create Checkout → Create Order → Process Payment
+```
+
+### 2. Identify Service Type-Specific Booking Patterns
+
+Different service types use different booking structures but same payment integration:
+
+**Appointments**: Use `bookedEntity.slot` with all required fields
+```json
+{
+  "booking": {
+    "bookedEntity": {
+      "slot": {
+        "serviceId": "<SERVICE_ID>",
+        "scheduleId": "<SCHEDULE_ID>",
+        "startDate": "2024-06-14T14:00:00",
+        "endDate": "2024-06-14T15:15:00",
+        "timezone": "America/New_York",
+        "resource": { "id": "<RESOURCE_ID>" },
+        "location": { "locationType": "OWNER_BUSINESS" }
+      }
+    },
+    "contactDetails": {
+      "firstName": "John",
+      "email": "john@example.com"
+    },
+    "totalParticipants": 1
+  }
+}
+```
+
+> **Critical**: All slot fields (`scheduleId`, `resource.id`, `location.locationType`, `timezone`) are **required** for appointments. Omitting any of them returns a 400 error. The `locationType` must be `OWNER_BUSINESS` (not `BUSINESS` which is what Time Slots V2 returns).
+
+**Classes**: Use `bookedEntity.slot` with `eventId` (auto-derives other fields)
+```json
+{
+  "booking": {
+    "bookedEntity": {
+      "slot": {
+        "serviceId": "<SERVICE_ID>",
+        "eventId": "<EVENT_ID>"
+      }
+    },
+    "contactDetails": {
+      "firstName": "Jane",
+      "email": "jane@example.com"
+    },
+    "totalParticipants": 1
+  }
+}
+```
+
+**Courses**: Use `bookedEntity.schedule` structure + require separate calendar events
+```json
+{
+  "booking": {
+    "bookedEntity": {
+      "schedule": {
+        "scheduleId": "<SCHEDULE_ID>",
+        "serviceId": "<SERVICE_ID>",
+        "timezone": "America/New_York",
+        "location": { "locationType": "OWNER_BUSINESS" }
+      }
+    },
+    "contactDetails": {
+      "firstName": "Bob",
+      "email": "bob@example.com"
+    },
+    "totalParticipants": 1
+  }
+}
+```
+
+### 3. Create Booking Using Appropriate Service Pattern
+
+Use standard booking creation APIs with service-specific structures:
+
+**Standard Booking Endpoint**: `POST https://www.wixapis.com/_api/bookings-service/v2/bookings` ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking))
+
+**Critical Parameters for All Types**:
+- `booking.contactDetails` — at minimum `firstName` and `email`
+- `booking.totalParticipants` — number of participants
+- `selectedPaymentOption: "OFFLINE"` — for ecom integration flows
+- `flowControlSettings.skipBusinessConfirmation: true` — for administrative bookings
+- Service-appropriate `bookedEntity` structure (see Step 2 above)
+
+### 4. Handle Course-Specific Calendar Requirements
+
+**MAJOR DISCOVERY**: Courses require dual API implementation - booking alone is insufficient.
+
+**Course Booking Problem**: Creating course booking without calendar sessions results in:
+- Participant enrollment and payment processing works
+- No visible sessions on business calendar
+- Staff unaware of when/where to conduct sessions
+- Course delivery schedule missing
+
+**Required Additional Step for Courses**:
+Create calendar events using `POST https://www.wixapis.com/calendar/v3/bulk/events/create` ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)):
+```json
+{
+  "events": [{
+    "event": {
+      "type": "COURSE",
+      "scheduleId": "<COURSE_SCHEDULE_ID>",
+      "externalScheduleId": "<STAFF_RESOURCE_ID>",
+      "start": { "localDate": "2025-06-16T09:00:00" },
+      "end": { "localDate": "2025-06-16T10:00:00" },
+      "resources": [{ "id": "<STAFF_RESOURCE_ID>" }],
+      "recurrenceRule": {
+        "frequency": "WEEKLY",
+        "interval": 1,
+        "days": ["MONDAY"],
+        "until": { "localDate": "2025-08-11T23:59:59" }
+      }
+    }
+  }]
+}
+```
+
+> **Critical**: Each element in the `events` array must be wrapped in `{ "event": {...} }`. The `resources` array with at least one resource ID is **required** for CLASS/COURSE events — without it the API returns 400. `start`/`end` fields and `externalScheduleId` are also required.
+
+### 5. Implement Multi-Service Package Bookings (Advanced)
+
+**CRITICAL UNDOCUMENTED ENDPOINT**: For businesses requiring unified package experiences.
+
+**Endpoint**: `POST https://manage.wix.com/_api/bookings-service/v2/multi_service_bookings`
+
+**Business Use Cases**:
+- Spa packages (massage + facial + manicure as single booking)
+- Beauty services (cut + color + styling as unified experience)
+- Wellness programs (consultation + treatment + follow-up coordination)
+
+**Undocumented Requirements**:
+- Identical contact information across all services in package
+- Sequential service timing coordination (second service start = first service end)
+- `skipAvailabilityValidation: true` for back-to-back scheduling
+
+### 6. Process Payment Through Universal Ecom Integration
+
+**MAJOR DISCOVERY**: ALL booking payments use identical ecommerce integration pattern.
+
+**Step 6A: Create Checkout with Booking ID as Catalog Item**
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/checkouts` ([REST](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/checkout/create-checkout))
+
+```json
+{
+  "lineItems": [{
+    "catalogReference": {
+      "catalogItemId": "<BOOKING_ID>",
+      "appId": "13d21c63-b5ec-5912-8397-c3a5ddb27a97"
+    },
+    "quantity": 1
+  }],
+  "channelType": "WEB"
+}
+```
+
+**Step 6B: Create Order for Payment Processing**
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/checkouts/{checkoutId}/createOrder`
+
+**Critical Architecture Discoveries**:
+- **Automatic ID Transformation**: Booking IDs automatically valid as catalog item IDs
+- **Service Properties Preserved**: Booking context (scheduledDate, numberOfParticipants) maintained
+- **Pricing Calculation**: Ecom system handles all financial calculations (not booking system)
+- **Item Type Assignment**: `"preset": "SERVICE"` automatically applied
+
+### 7. Understand Async Payment Confirmation Architecture
+
+**Payment Processing Architecture**:
+```
+Booking (CONFIRMED) → Checkout → Order → Payment Processing (async)
+                                              ↓
+                                        Messaging System
+                                              ↓
+                                    Final Status Updates
+```
+
+**Status Management Patterns**:
+- **Booking Status**: CONFIRMED (reserves time slot regardless of payment)
+- **Order Status**: PAID/NOT_PAID (reflects payment processing outcome)
+- **Business Logic**: Time slot reservation independent of payment success
+
+**Operational Benefits**:
+- Payment failures don't lose reserved time slots
+- Supports multiple payment models (prepaid, deposits, invoicing)
+- Retry payment without recreating complex booking coordination
+
+### 8. Implement Business-Specific Integration Patterns
+
+**Single Appointments**: Basic booking + ecom integration
+**Group Classes**: Booking with participant count + ecom integration
+**Course Programs**: Booking + calendar events + ecom integration
+**Service Packages**: Multi-service booking + ecom integration
+
+**Universal Integration Considerations**:
+- All service types use same checkout/order creation pattern
+- Pricing calculations always handled by ecom system
+- Async payment confirmation applies to all booking types
+- Service properties preserved across all integration points
+
+### IMPORTANT NOTES
+
+* **Universal Integration Required**: Every booking payment flows through ecommerce system
+* **Service-Specific Booking Creation**: Different booking structures for different service types
+* **Courses Require Dual APIs**: Booking system + calendar events system
+* **Multi-Service Endpoint Undocumented**: Complete gap for package-based businesses
+* **Async Payment Architecture**: Payment confirmation decoupled from booking creation
+* **Status Independence**: Booking confirmation separate from payment processing
+* **Hidden Ecommerce Dependency**: Not mentioned in any booking documentation
+
+### Troubleshooting Universal Integration Issues
+
+**Booking ID Not Working as Catalog Item**:
+- Verify booking was created successfully and has valid ID
+- Ensure using correct Wix Bookings app ID in catalog reference
+- Check that booking status is CONFIRMED before attempting checkout
+
+**Course Bookings Not Visible on Calendar**:
+- Course bookings handle enrollment only, not session scheduling
+- Must create calendar events separately using calendar API
+- Session scheduling independent of participant enrollment
+
+**Payment Status Confusion**:
+- Booking status (CONFIRMED) indicates time slot reservation
+- Order status (PAID/NOT_PAID) indicates payment processing outcome
+- These statuses operate independently through async messaging
+
+**Multi-Service Booking Failures**:
+- Contact details must be identical across all services in package
+- Service timing must be precisely coordinated (end time = next start time)
+- Resource allocation requires manual verification with `skipAvailabilityValidation`
+
+**Ecommerce Integration Errors**:
+- Verify ecommerce app is installed and enabled
+- Ensure using `"BACKOFFICE_MERCHANT"` channel type for owner flows
+- Check that service pricing is properly configured in booking system
+
+### Cross-Platform Implementation Challenges
+
+**Headless Implementation**:
+- No documented SDK methods for booking→ecom integration
+- Manual API orchestration required for payment processing
+- Frontend developers must understand backend integration patterns
+
+**Mobile Integration**:
+- Booking creation patterns differ across service types
+- Payment flow design requires understanding async confirmation
+- Course management requires dual API coordination
+
+**Third-Party Integration**:
+- Booking export may not include payment status information
+- External calendar systems may not receive course session details
+- CRM integration requires understanding booking vs payment status separation
+
+### Business Architecture Considerations
+
+**Payment Model Planning**:
+- Booking system reserves capacity, ecom system processes payments
+- Multiple payment models supported (full prepaid, deposits, invoicing)
+- Refund processing requires coordination between both systems
+
+**Service Type Planning**:
+- Appointments: Immediate booking and payment
+- Classes: Group bookings with participant management
+- Courses: Long-term enrollment with session scheduling
+- Packages: Unified experience across multiple services
+
+**Scaling Considerations**:
+- Integration complexity increases with service variety
+- Payment processing load handled by ecommerce system
+- Booking coordination managed by booking system
+- Analytics require data from both systems
+
+## API Documentation References
+
+**Documented APIs** (That Don't Explain Integration Requirements):
+* [Standard Booking Flow](https://dev.wix.com/docs/api-reference/business-solutions/bookings/flow-single-service-booking) - Missing payment integration
+* [Create Booking](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking) - No payment processing guidance
+* [Service Types](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types) - Missing integration patterns
+* [Ecommerce Checkout](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/introduction) - No booking integration mention
+
+**Completely Undocumented**:
+* **Booking→Ecom Integration**: Universal pattern affecting all booking payments
+* **Multi-Service Bookings**: `https://manage.wix.com/_api/bookings-service/v2/multi_service_bookings`
+* **Course Calendar Requirements**: Dual API necessity for course functionality
+* **Async Payment Confirmation**: Messaging system architecture
+* **Status Separation Patterns**: Booking vs payment status independence

--- a/skills/wix-manage/references/bookings/bookings-staff-setup.md
+++ b/skills/wix-manage/references/bookings/bookings-staff-setup.md
@@ -1,0 +1,255 @@
+---
+name: "Bookings Staff Setup"
+description: Creates staff members and configures custom working hours using Staff API + Calendar Events API. Critical two-step process: create staff → assign schedule → create working hours events.
+---
+# Technical Step-by-Step Instructions: Setting Up Wix Bookings Staff Members with Custom Working Hours (Real-World, API-First)
+
+## Description
+
+Below are the recommended steps to successfully set up Wix Bookings staff members and configure their custom working schedules on Wix, with real-world troubleshooting and fixes for common API issues.
+
+---
+
+## Prerequisites
+
+- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
+
+> **Note:** If you receive errors from Bookings APIs, the Wix Bookings app may not be installed on the site. Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install it if missing.
+
+---
+
+## Overview
+
+A Wix Bookings staff member setup involves multiple interconnected steps that must be executed in the correct sequence. This recipe covers the complete workflow from foundation setup to custom working hours configuration.
+
+### 🚨 CRITICAL: Staff Inheritance Timing
+
+**STAFF INHERIT BUSINESS HOURS AT CREATION TIME**: When you create a new staff member, they immediately inherit whatever business hours exist at that moment. This inheritance is NOT dynamic - it's a one-time copy during creation.
+
+**Order of Operations Matters**:
+1. **Option A (Recommended)**: Fix business hours FIRST, then create staff (staff inherit correct hours)
+2. **Option B**: Create staff first, then detach them from default hours and configure custom schedules
+
+**Understanding the Impact**:
+- If you create staff when business hours are 9 AM - 5 PM, staff inherit 9 AM - 5 PM
+- If you later change business hours to 8 AM - 6 PM, existing staff STILL have 9 AM - 5 PM
+- New staff created after the change would inherit 8 AM - 6 PM
+
+Staff schedule configuration includes:
+- **Default behavior**: Staff inherit business hours and are available at all business locations
+- **Custom schedules**: Staff can have individual working hours different from business defaults
+- **Working hours creation**: Custom hours are created as events with `"type": "WORKING_HOURS"` and recurrence rules
+
+### Key Concepts
+
+* **Staff Member**: An individual providing services within Wix Bookings. Each staff member has an associated resource with schedules for working hours and events.
+* **Working Hours Schedule**: Defines when a staff member is available to provide services. Can be either business default hours or custom hours.
+* **Event Schedule**: The actual calendar events that define specific working time blocks (WORKING_HOURS events).
+* **Resource ID**: Each staff member has a `resourceId` that links them to their schedules and availability.
+* **Inheritance Timestamp**: The exact moment when a staff member is created determines which business hours they inherit.
+
+### Critical Workflow Requirements
+
+The complete custom working hours setup requires understanding three distinct ID types and their relationships:
+- **Staff Member ID**: Used for staff updates and schedule assignment
+- **Resource ID**: Used for linking to services and events (`externalScheduleId` and `resources` array)
+- **Events Schedule ID**: Used for creating working hours events (`scheduleId`)
+
+The most common mistake is confusing which ID to use in which API call, leading to "Resource not found" or "Invalid scheduleId" errors.
+
+### 🚨 INHERITANCE WARNINGS
+
+* **One-Time Inheritance**: Business hours are copied (not linked) to staff at creation time
+* **Creation Order Impact**: The state of business hours when you create staff determines their initial schedule
+* **Retroactive Changes**: Changing business hours does NOT affect existing staff schedules
+* **Multiple Staff Issue**: If you create multiple staff at different times, they may inherit different business hours
+
+### IMPORTANT NOTES
+
+* **Two-Step Requirement**: Custom working hours requires both `assignWorkingHoursSchedule` AND creating `WORKING_HOURS` events. Only doing the first step results in staff with no actual working hours.
+* **Foundation Dependencies**: Staff operations require Wix Bookings app installation and proper business schedule configuration. "Business schedule not found" errors indicate missing foundation setup.
+* **Event Field Requirements**: When creating `WORKING_HOURS` events, several fields that appear optional in documentation are actually required: `externalScheduleId`, `adjustedStart`, `adjustedEnd`, `resources` array, and `appId`.
+* **Revision Numbers**: Event updates ALWAYS require the current revision number. Fetch current event details before any update operation.
+* **Time Format Precision**: All date/time fields must use precise ISO 8601 format (`YYYY-MM-DDTHH:mm:ss`) without timezone indicators.
+* **Separate Events for Each Day**: Each working day requires a separate event with single-day recurrence rules. You cannot specify multiple days in one event's `recurrenceRule.days` array.
+
+---
+
+## Steps
+
+### Step 0: Choose Your Strategy (CRITICAL DECISION)
+
+Before proceeding, decide your approach based on business hour requirements:
+
+#### Strategy A: Fix Business Hours First (Recommended)
+**When to use**: All staff will have the same working hours or similar schedules
+1. Configure correct business hours (see business hours recipe)
+2. Create staff members (they inherit correct hours automatically)
+3. Only customize specific staff if needed
+
+**Advantages**:
+- Staff inherit correct hours immediately
+- Minimal post-creation configuration
+- Consistent scheduling across staff
+
+#### Strategy B: Create Staff First, Configure Later
+**When to use**: Each staff member needs completely different schedules
+1. Create staff with whatever business hours exist
+2. Detach each staff from business hours
+3. Configure individual custom schedules for each
+
+**Disadvantages**:
+- Requires more API calls per staff member
+- Risk of forgetting to configure some staff
+- Temporary period with incorrect availability
+
+### 1. Verify Foundation Setup (Prerequisites - Optional if Already Configured)
+
+**Note**: If your site already has Wix Bookings properly configured with business schedules, you can skip this step and go directly to Step 2.
+
+Before creating staff members, ensure the foundation is properly configured:
+
+**Check Wix Bookings Installation**: Query staff members (`POST https://www.wixapis.com/bookings/v1/staff-members/query`) to test if Bookings is installed. If you receive "Business schedule not found" errors, the foundation needs setup.
+
+**Install Wix Bookings App** (if needed): Use the App Installer API with Wix Bookings app ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`.
+
+**Configure Business Schedule**: Set up site properties with business operating hours using the Site Properties API.
+
+**Create Calendar Schedule and Working Hours**: Create a calendar schedule for Wix Bookings integration and populate it with business `WORKING_HOURS` events.
+
+### 2. Verify Current Business Hours (CRITICAL)
+
+Before creating any staff, query the current business hours (`POST https://www.wixapis.com/calendar/v3/events/query`) to understand what staff will inherit:
+
+```json
+{
+  "recurrenceType": ["MASTER"],
+  "query": {
+    "filter": {
+      "scheduleId": "business-schedule-id",
+      "type": "WORKING_HOURS"
+    }
+  }
+}
+```
+
+**Document the current hours** - this is what your staff will inherit!
+
+### 3A. Strategy A: Configure Business Hours First
+
+If following Strategy A, ensure business hours are set correctly BEFORE creating staff:
+1. Update or replace existing business hours (follow business hours recipe)
+2. Verify the final business hours configuration
+3. Proceed to create staff (they'll inherit these correct hours)
+
+### 3B. Strategy B: Create Staff with Current Hours
+
+If following Strategy B, accept that staff will inherit current (possibly incorrect) hours and plan to configure them individually later.
+
+### 4. Create Staff Members
+
+Create staff members using the Staff API (`POST https://www.wixapis.com/bookings/v1/staff-members`) with required information:
+- Name (required)
+- Email (optional but recommended)
+- Phone (optional)
+- Description/Professional bio (optional)
+
+**⚠️ INHERITANCE MOMENT**: The moment this API call completes, the staff member inherits the current business hours. There's no "undo" for this inheritance.
+
+**Save Critical IDs from Response**:
+- `staffMember.id` for updates and schedule assignment
+- `staffMember.resourceId` for services and event resources
+- `staffMember.resource.eventsSchedule.id` for working hours events
+- `staffMember.resource.usesDefaultWorkingHours` (should be `true` initially)
+
+### 5. Set Up Custom Working Hours (Two-Step Process)
+
+**Only needed if**: You want staff to have different hours than what they inherited, OR you followed Strategy B.
+
+**Step 5A: Assign Custom Working Hours Schedule**
+
+Get staff member details (`GET https://www.wixapis.com/bookings/v1/staff-members/<STAFF_MEMBER_ID>?fields=RESOURCE_DETAILS`) to extract the events schedule ID. Call `assignWorkingHoursSchedule` (`POST https://www.wixapis.com/bookings/v1/staff-members/<STAFF_MEMBER_ID>/assign-working-hours-schedule`) using the staff member ID and their events schedule ID. This detaches the staff member from business default hours.
+
+Verify the response shows `"usesDefaultWorkingHours": false`.
+
+**Step 5B: Create WORKING_HOURS Events**
+
+Use the Events API (`POST https://www.wixapis.com/calendar/v3/bulk/events/create`) to create working hours events for each working day. Each event must include:
+- `scheduleId`: Staff member's events schedule ID
+- `externalScheduleId`: Staff member's resource ID
+- `type`: `"WORKING_HOURS"`
+- `resources` array: Staff member's resource ID
+- `appId`: Wix Bookings app ID
+- Proper recurrence rules with single-day specification
+
+Create separate events for each day of the week the staff member works.
+
+### 6. Verify Setup
+
+Query the staff member to confirm:
+- `"usesDefaultWorkingHours": false` (if you set custom hours)
+- Query working hours events to verify proper creation with correct `type` and resource associations
+- Test booking availability to ensure hours are applied correctly
+
+### IMPORTANT NOTES
+
+* **ID Relationship Critical**: Use staff member ID for assignment, events schedule ID for event `scheduleId`, and resource ID for `externalScheduleId` and `resources` array
+* **Foundation First**: Complete foundation setup before staff operations to avoid "Business schedule not found" errors
+* **Complete Two-Step Process**: Both schedule assignment AND event creation are mandatory for custom working hours
+* **Event Field Requirements**: Include all required fields even if they appear optional in basic documentation
+* **Revision Management**: Always fetch current revision numbers before updating events
+* **Date Format Strict**: Use precise ISO 8601 format without timezone indicators
+* **Inheritance is Permanent**: Once inherited, business hours changes don't affect existing staff
+
+### Troubleshooting Common Issues
+
+**"Business schedule not found" Error**:
+Execute systematic diagnosis: check app installation, site properties, calendar schedule, and working hours events in sequence. Fix the first failed component before proceeding.
+
+**Staff Member Still Shows Default Hours**:
+Completed assignment but missing event creation. Create `WORKING_HOURS` events using the Bulk Create Events API.
+
+**Staff Inherited Wrong Hours**:
+- **Root Cause**: Business hours were incorrect when staff was created
+- **Solution**: Either update business hours first (affects future staff) or configure each existing staff member individually
+
+**Multiple Staff Have Different Inherited Hours**:
+- **Root Cause**: Business hours changed between staff creation times
+- **Solution**: Standardize by configuring custom hours for all staff, or recreate staff after fixing business hours
+
+**"Invalid scheduleId" or "Resource not found" Errors**:
+Using wrong ID type in API calls. Verify you're using events schedule ID for `scheduleId`, resource ID for `externalScheduleId` and `resources` array, and staff member ID for updates.
+
+**Event Update Fails with Revision Error**:
+Get current event details first and include the revision number in update requests.
+
+**Cannot Create Events for Past Dates**:
+Use current or future dates for recurring event start dates.
+
+**Events Not Linked to Staff Member**:
+Ensure `resources` array contains staff member's resource ID and `externalScheduleId` is properly set.
+
+### Working with Existing Staff
+
+If working with existing staff members, first retrieve their details using `queryStaffMembers` with `RESOURCE_DETAILS` fieldmask to get the necessary IDs for schedule configuration. This allows you to configure custom working hours for staff members that were created previously.
+
+**Check Their Current Inheritance**:
+- Look at `usesDefaultWorkingHours` field
+- If `true`: They're still using business hours they inherited at creation
+- If `false`: They have custom hours (may have been configured previously)
+
+### Common Gotchas
+
+1. **Wrong Order**: Creating staff before fixing business hours leads to incorrect inheritance
+2. **Inheritance Assumption**: Thinking business hour changes affect existing staff
+3. **Incomplete Custom Setup**: Only doing schedule assignment without creating events
+4. **Mixed Timing**: Creating staff at different times when business hours are changing
+5. **ID Confusion**: Using wrong ID types in API calls
+
+## API Documentation References
+
+* [Create Staff Member](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/create-staff-member)
+* [Query Staff Members](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/query-staff-members)
+* [Assign Working Hours Schedule](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/assign-working-hours-schedule)
+* [Schedules and Sessions API](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/schedules-and-sessions/introduction)
+* [Apps Created by Wix](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix)

--- a/skills/wix-manage/references/bookings/create-and-update-booking-services.md
+++ b/skills/wix-manage/references/bookings/create-and-update-booking-services.md
@@ -1,0 +1,429 @@
+---
+name: "Create and Update Booking Services"
+description: Full CRUD operations for Wix Bookings services using Services API. Covers service types (APPOINTMENT, CLASS, COURSE), pricing configuration, location setup, and schedule management.
+---
+
+# Technical Step-by-Step Instructions: Creating or Updating a Wix Bookings Service (Real-World, API-First)
+
+## Description
+
+Below are the recommended steps to successfully create or update a Wix Bookings service (or several at once) on Wix, with real-world troubleshooting and fixes for common API issues.
+
+---
+
+## Prerequisites
+
+- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
+
+> **Note:** If you receive errors from Bookings APIs, the Wix Bookings app may not be installed on the site. Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install it if missing.
+
+## Overview
+
+A Bookings service defines a time based offering and includes the following considerations:
+
+- type - for detailed information about service type - refer to the [article](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types)
+- `APPOINTMENT` - Appointments allow customers to book services at their preferred time during the business hours. For example, a hair salon might offer different appointment-based hair cutting and styling services. Appointments appear in the booking calendar once they're booked by a customer. Not-yet-booked times during the business hours are displayed as available slots to potential customers while booking. The availability of the service is based on the availability of the staff member providing it
+- `CLASS` - A class is a single event or a series of recurring events that multiple customers can book. For example, a yoga studio might offer a twice-weekly vinyasa flow class. Classes may have a set end date or continue indefinitely. If a class includes more than a single event, customers can sign up for 1, several, or all of the events. Upon creation, classes are listed immediately in the booking calendar.
+- `COURSE` - A course starts and ends on pre-defined dates with a limited number of events that multiple customers can book. For example, a yoga studio might offer a teacher training course with 5 events. In contrast to classes, customers must book the entire course. Upon creation, courses are displayed immediately in the booking calendar.
+- Staff Member - a resource required in order to provide a service. [REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/create-staff-member) A staff member availability is defined by the schedule associated with the staff member, by default it is the main business schedule and cannot be modified by schedule APIs, but a staff member can have its own schedule by calling `assignWorkingHoursSchedule` which allows the staff member to have its own availability. The property `staffMember.usesDefaultWorkingHours` defines whether the default hours (business hours) are used.
+- Schedule (availability) - availability is defined by `Events` ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/introduction)) defined on a schedule.
+- The schedule which defines the service availability is based on the service type.
+- For appointment service, it is based on the schedule of staff members which provides it (`service.staffMemberIds` which is mapped to `staffMember.resourceId`). In order to fetch the staff schedule you should retrieve the staff member with `RESOURCE_DETAILS` fieldmask and read the schedule id from the `staffMember.resource.eventsSchedule.id` - This is needed if you wish to define the staff member's availability as part of the process
+- For classes and courses it is based on the schedule of the service itself (`service.schedule`)
+- When creating an APPOINTMENT service and specifying `staffMemberIds`, ensure you are using the staff member's resourceId, not their primary staff member id.
+- Service Images - the service may have several images - `service.media.mainMedia` - presented in the services list, `service.media.coverMedia` - presented in the service page and `service.media.items` - array of images presented as a gallery in the service page for site visitors.
+- In order to add a media (image) to a service, it should first be defined in Wix Media Manager - search existing ([REST](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/search-files)) or new ([REST](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/bulk-import-file))
+- You should only set the image id (for example `item.id` -> `service.media.mainMedia.id`) there is no need to set the entire object.
+
+### Service Type Selection Guide
+
+Choose based on these documented behaviors:
+
+- **APPOINTMENT**: Customer picks available time slot. Availability based on staff schedules. One customer (or dedicated group) per booking.
+- **CLASS**: Business sets recurring times. Multiple customers book same session. Customers can book 1, some, or all sessions in series.
+- **COURSE**: Business sets fixed series. Multiple customers book. Customers must book entire course (all sessions).
+
+When unsure, refer to [About Service Types](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types).
+
+### CRITICAL: Staff Assignment Behavior by Service Type
+
+**APPOINTMENT Services:**
+
+- **Staff assignment WORKS**: Can specify `staffMemberIds` array with staff member `resourceId` values
+- **Behavior**: Service availability based on assigned staff schedules
+- **Example**: Personal training session assigned to specific trainer
+
+**CLASS and COURSE Services:**
+
+- **Staff assignment IGNORED**: Setting `staffMemberIds` has no effect on service creation
+- **Behavior**: Service uses its own schedule (`service.schedule`), not staff schedules
+- **Workaround**: Staff association must be handled separately through calendar events or other mechanisms
+- **Example**: Yoga class where any qualified instructor can teach
+
+This is a critical API limitation that affects service planning and staff resource management.
+
+### IMPORTANT NOTES
+
+- I MUST read the full articles about [service types](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types), [service payments](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-payments), [service location](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-locations) in order to fully understand how to set the service properties
+- If the service type is `CLASS` or `COURSE` I MUST read the full articles service's _schedule_ and _events_ mentioned before
+- If the service type is `APPOINTMENT` I MUST read the relevant full article about staff members ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/introduction)) in order to determine whether I should create a new staff member (or members)
+- For free service I MUST set `service.payment.rateType` as `"NO_FEE"` and `service.payment.options.inPerson` as `true` (at least one payment option must be true)
+- For paid service I MUST set the `service.payment.fixed.price.value` (must be above 0) as well as `service.payment.fixed.price.currency`
+
+### Payment Options Validation Rules
+
+| rateType | `options.online` | `options.inPerson` | Valid?                            |
+| -------- | ---------------- | ------------------ | --------------------------------- |
+| FIXED    | true             | false              | ✓                                 |
+| FIXED    | false            | true               | ✓                                 |
+| FIXED    | true             | true               | ✓                                 |
+| VARIED   | true             | false              | ✓                                 |
+| VARIED   | false            | true               | ✓                                 |
+| NO_FEE   | false            | true               | ✓                                 |
+| NO_FEE   | true             | false              | ✗ (online not allowed for NO_FEE) |
+| Any      | false            | false              | ✗ (at least one must be true)     |
+
+- Always Prioritize Reading Full API Method Documentation: this overview article provides a general workflow. However, it repeatedly stresses the importance of reading the full documentation for each specific REST method you intend to use. This is critical for understanding detailed requirements.
+- I should pay close attention to all required fields, data types, enum values, and specific ID types (e.g., resourceId vs. id) as defined in the detailed schema of each API endpoint. The overview article serves as a guide but doesn't replace the need to consult these specifics.
+
+### Service Categories - CRITICAL for UI Visibility
+
+**IMPORTANT**: Services without categories may not appear in category-based UI filters, which are commonly used in booking interfaces.
+
+**Service Category Considerations:**
+
+- **Default Behavior**: Services created without explicit category assignment may not be visible in filtered views
+- **UI Impact**: Many booking interfaces filter services by `category.id`, hiding uncategorized services
+- **Best Practice**: Always assign services to appropriate categories during creation
+
+**Category Management Steps:**
+
+1. **Query existing categories** using [Query Categories](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories) to see available options
+2. **Create new category if needed** using [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category)
+3. **Assign category during service creation** by including `category.id` in the service object
+4. **Update existing services** using [Update Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/update-service) to add missing categories
+
+**Common Category Filter Patterns:**
+
+```json
+{
+  "filter": {
+    "category.id": {
+      "$exists": true
+    }
+  }
+}
+```
+
+This filter will only show services with assigned categories, making uncategorized services invisible to users.
+
+### Querying Existing Services
+
+You can retrieve a list of existing booking services using the [Query Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services) endpoint. This allows you to filter, sort, and page through up to 100 services at a time, making it easy to find and manage your current offerings.
+
+---
+
+## Steps
+
+### 0. Query and Setup Categories (CRITICAL FIRST STEP)
+
+1. **Query existing categories** using `queryCategories` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories)) to identify available categories
+2. **Create category if needed** using `createCategory` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category)) if no suitable category exists
+3. **Record category ID** for use in service creation - this prevents services from being hidden in UI filters
+
+**Query Categories:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/bookings/v2/categories/query' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{ "query": {} }'
+```
+
+**Create Category (if none exist):**
+
+```bash
+curl -X POST 'https://www.wixapis.com/bookings/v2/categories' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{ "category": { "name": "General" } }'
+```
+
+### 1. Define staff member to use (REQUIRED for APPOINTMENT)
+
+> **IMPORTANT:** For APPOINTMENT services, `staffMemberIds` is **required**. The API will return a 400 error without it. You must query staff members first to obtain a valid `resourceId`.
+
+1. **Query existing staff members** to get their `resourceId` values
+2. For new staff, create using `createStaffMember` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/create-staff-member)) and keep the response `staffMember.id` and `resourceId`
+3. If you wish to update working hours, call `getStaffMember` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/get-staff-member)) to get `resource.eventsSchedule.id`
+
+**Query Staff Members (to get resourceId):**
+
+```bash
+curl -X POST 'https://www.wixapis.com/bookings/v1/staff-members/query' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": {},
+    "fields": ["RESOURCE_DETAILS"]
+  }'
+```
+
+Use the `resourceId` from the response (not `id`) in `staffMemberIds` when creating APPOINTMENT services.
+
+**Staff Selection Strategy:**
+
+- If a staff member has `default: true` → use it
+- If only one staff member exists → use it
+- If multiple exist → pick the first or most appropriate
+- If none exist → create one using the [Staff Setup recipe](bookings-staff-setup.md)
+
+**Service Type Requirements:**
+
+- **APPOINTMENT**: `staffMemberIds` is **required** - API will fail without it
+- **CLASS/COURSE**: `staffMemberIds` is ignored; use `service.schedule` instead
+
+### 2. Creating or Updating a service
+
+Based on the information gathered above, use the relevant API based on the desired outcome.
+
+- **Create services**: `bulkCreateServices` endpoint ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services))
+- **Update single service**: `updateService` endpoint ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/update-service))
+- **Update services (bulk)**: `bulkUpdateServices` ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-update-services))
+- **Update by filter**: `bulkUpdateServicesByFilter` ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-update-services-by-filter))
+- **Get single service**: `getService` endpoint ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/get-service))
+
+**Create Service Example (paid APPOINTMENT, 60 minutes):**
+
+```bash
+curl -X POST 'https://www.wixapis.com/bookings/v2/bulk/services/create' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "services": [{
+      "name": "Consultation",
+      "type": "APPOINTMENT",
+      "onlineBooking": { "enabled": true },
+      "staffMemberIds": ["<RESOURCE_ID_FROM_STEP_1>"],
+      "schedule": {
+        "availabilityConstraints": {
+          "sessionDurations": [60]
+        }
+      },
+      "payment": {
+        "rateType": "FIXED",
+        "options": { "online": true, "inPerson": false },
+        "fixed": {
+          "price": { "value": "50", "currency": "USD" }
+        }
+      },
+      "category": {
+        "id": "<CATEGORY_ID_FROM_STEP_0>"
+      }
+    }]
+  }'
+```
+
+> **Note:** Currency may default to the site's business currency regardless of what you specify. Verify the response if currency is critical.
+
+**Create Service Example (free APPOINTMENT, 60 minutes):**
+
+```bash
+curl -X POST 'https://www.wixapis.com/bookings/v2/bulk/services/create' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "services": [{
+      "name": "Free Consultation",
+      "type": "APPOINTMENT",
+      "onlineBooking": { "enabled": true },
+      "staffMemberIds": ["<RESOURCE_ID_FROM_STEP_1>"],
+      "schedule": {
+        "availabilityConstraints": {
+          "sessionDurations": [60]
+        }
+      },
+      "payment": {
+        "rateType": "NO_FEE",
+        "options": { "online": false, "inPerson": true }
+      },
+      "category": {
+        "id": "<CATEGORY_ID_FROM_STEP_0>"
+      }
+    }]
+  }'
+```
+
+**Create Service Example (CLASS with capacity):**
+
+> **Note:** CLASS services do not use `staffMemberIds` or `sessionDurations`. After creation, you must create events via `bulkCreateEvents` using the returned `service.schedule.id` to define when the class occurs.
+
+```bash
+curl -X POST 'https://www.wixapis.com/bookings/v2/bulk/services/create' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "services": [{
+      "name": "Yoga Class",
+      "type": "CLASS",
+      "onlineBooking": { "enabled": true },
+      "defaultCapacity": 20,
+      "payment": {
+        "rateType": "FIXED",
+        "options": { "online": true, "inPerson": false },
+        "fixed": {
+          "price": { "value": "25", "currency": "USD" }
+        }
+      },
+      "category": {
+        "id": "<CATEGORY_ID_FROM_STEP_0>"
+      }
+    }]
+  }'
+```
+
+After creation, use the `service.schedule.id` from the response to create class events with `bulkCreateEvents` (see Step 3).
+
+**Required Fields:**
+
+- `name` - Service name
+- `type` - `APPOINTMENT`, `CLASS`, or `COURSE`
+- `onlineBooking: { enabled: true }` - Required for all services
+- `staffMemberIds` - **Required for APPOINTMENT only** (use `resourceId` values); ignored for CLASS/COURSE
+- `schedule.availabilityConstraints.sessionDurations` - Duration in minutes (APPOINTMENT only)
+- `defaultCapacity` - **Required for CLASS/COURSE** (max participants per session)
+- `payment.options` - At least one of `online` or `inPerson` must be `true` (required for all services, including free; see validation table above)
+
+**Service Type Specific Considerations:**
+
+- **APPOINTMENT**: Must include `staffMemberIds` with staff `resourceId` values
+- **CLASS/COURSE**: Omit `staffMemberIds`; configure `service.schedule` instead
+
+**Update Service Example (PATCH):**
+
+> **Note:** Updates require the current `revision` value (from a GET response) placed **inside** the `service` object, not at the top level.
+
+```bash
+# First, get current service to obtain revision
+curl -X GET 'https://www.wixapis.com/bookings/v2/services/<SERVICE_ID>' \
+  -H 'Authorization: <AUTH>'
+
+# Then update with revision inside service object
+curl -X PATCH 'https://www.wixapis.com/bookings/v2/services/<SERVICE_ID>' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "service": {
+      "revision": "<REVISION_FROM_GET>",
+      "category": {
+        "id": "<CATEGORY_ID>"
+      }
+    }
+  }'
+```
+
+### 3. Set the availability of the service
+
+Once the service and staff member are available, you can define when the service is available:
+
+**3a. Determine the schedule to use** based on the service type:
+
+- **APPOINTMENT**: The staff member working hours determine the service availability. If the staff member needs different hours from the business defaults, call `assignWorkingHoursSchedule` (`POST https://www.wixapis.com/bookings/v1/staff-members/<STAFF_MEMBER_ID>/assign-working-hours-schedule`) ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/assign-working-hours-schedule)). Use the `resource.eventsSchedule.id` as the `scheduleId`.
+- **CLASS or COURSE**: Use the `service.schedule.id` from the service created/updated in Step 2.
+
+**3b. Create events** using `bulkCreateEvents` (`POST https://www.wixapis.com/calendar/v3/bulk/events/create`) ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)) or update existing ones with `bulkUpdateEvents` (`POST https://www.wixapis.com/calendar/v3/bulk/events/update`) ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)).
+
+**Event requirements**:
+
+- `event.resources` array **must include at least one resource** (a staff member/room/etc.) using the `resourceId`. CLASS and COURSE events will fail with a 400 error if no resources are provided.
+- `event.scheduleId` — use the staff member's events schedule ID for APPOINTMENT availability, or `service.schedule.id` for CLASS/COURSE.
+- `event.type` — set to `WORKING_HOURS` for staff availability, `CLASS` for class sessions, or `COURSE` for course sessions.
+
+### Troubleshooting Common Issues
+
+**APPOINTMENT Service Creation Fails (staffMemberIds required):**
+
+- **Error**: `"service of type appointment requires at least one staff member id"`
+- **Cause**: APPOINTMENT services cannot be created without at least one staff member assigned
+- **Solution**: Query staff members first (Step 1) to get a valid `resourceId`, then include it in `staffMemberIds`
+
+**Service Creation Fails (payment.options required):**
+
+- **Error**: `INVALID_PAYMENT_OPTIONS - "It is mandatory to specify either payment.options.online or payment.options.inPerson as true"`
+- **Cause**: All services (including free) require at least one payment option to be `true`
+- **Solution**: Add `"options": { "online": true, "inPerson": false }` (or `inPerson: true` for free services) to the `payment` object
+
+**Free Service Fails with online=true:**
+
+- **Error**: `INVALID_PAYMENT_OPTIONS - "Specifying payment.paymentOptions.online as true is applicable only to payments of types FIXED or VARIED"`
+- **Cause**: `payment.options.online: true` is only valid for paid services (FIXED or VARIED)
+- **Solution**: For free services (NO_FEE), use `"options": { "online": false, "inPerson": true }`
+
+**Services Not Appearing in UI Filters:**
+
+- **Problem**: Services created without category assignment are invisible in category-based filters
+- **Root Cause**: Many UI implementations filter by `category.id` existence or specific category values
+- **Solution**: Query all services, identify those missing categories, and update them using bulk update operations
+- **Prevention**: Always assign categories during service creation (Step 0)
+
+**Staff Assignment Not Working for CLASS/COURSE Services:**
+
+- **Problem**: Setting `staffMemberIds` in CLASS or COURSE services appears to be ignored
+- **Solution**: This is expected behavior; use service schedules instead of staff assignments
+- **Alternative**: Manage staff-to-class relationships through calendar events or custom data structures
+
+**App Not Installed Errors:**
+
+- **Problem**: 428 "App not installed" errors when creating services
+- **Solution**: Install Wix Bookings app using Apps Installer API before creating services
+- **Verification**: Query existing services to confirm app installation
+
+**Resource ID vs Staff ID Confusion:**
+
+- **Problem**: Using wrong ID type for `staffMemberIds` array
+- **Solution**: Always use `staffMember.resourceId`, not `staffMember.id`
+- **Verification**: Query staff with `RESOURCE_DETAILS` fieldMask to get correct IDs
+
+**Service Schedule vs Staff Schedule Confusion:**
+
+- **Problem**: Mixing up schedule IDs between service and staff schedules
+- **Solution**:
+  - APPOINTMENT: Use staff schedule ID (`staffMember.resource.eventsSchedule.id`)
+  - CLASS/COURSE: Use service schedule ID (`service.schedule.id`)
+
+**Update Service Fails with revision error:**
+
+- **Error**: `revision must not be empty` or `service.revision is required`
+- **Cause**: `revision` placed at top level of request body instead of inside `service` object
+- **Solution**: Structure as `{ "service": { "revision": "...", ...fields } }` - get revision value from GET response first
+
+### IMPORTANT NOTES
+
+- I MUST read the full article about the REST method I wish to use
+- `onlineBooking` Field: The onlineBooking object (e.g., {"enabled": true}) is a required field when creating services, even if not explicitly highlighted as mandatory in the high-level overview. This is a schema-level requirement.
+- Event Creation (BulkCreateEvents): When specifying recurrenceRule.days, I MUST use full day names (e.g., "TUESDAY", "FRIDAY")
+- The recurrenceRule.days field within an event object can only accept a single day of the week (e.g., ["TUESDAY"]).
+- If I need to set up recurring events for multiple days of the week (e.g., a staff member working every Tuesday and Friday), I MUST define a separate event for each day and send them as separate items for BulkCreateEvents.
+- Start Dates for Recurring Events: Recurring events must have a start.localDate that is today or in the future, relative to the server's current time. If I am not sure what the current date and time are I MUST check it.
+- When setting `event.type` as `WORKING_HOURS` (APPOINTMENT) I MUST call `assignWorkingHoursSchedule` BEFORE CREATING THE EVENTS so that the staff member is no longer linked to the business working hours
+- When setting `event.type` as `CLASS` or `COURSE` I MUST use the service schedule id, so the service has to exist (created/updated) before setting the availability of it
+
+## Booking REST API Documentation Reference
+
+- [Query Categories](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories)
+- [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category)
+- [Get Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/get-service)
+- [Update Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/update-service)
+- [Create Staff Member](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/create-staff-member)
+- [Get Staff Member](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/get-staff-member)
+- [Query Staff Members](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/query-staff-members)
+- [Bulk Create Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services)
+- [Bulk Update Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-update-services)
+- [Bulk Update Services By Filter](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-update-services-by-filter)
+- [Assign Working Hours Schedule](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/assign-working-hours-schedule)
+- [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)
+- [Bulk Update Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)
+- [Media Manager: Search Files](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/search-files)
+- [Media Manager: Bulk Import File](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/bulk-import-file)
+- [Query Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services)
+- [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)

--- a/skills/wix-manage/references/bookings/end-to-end-booking-flow.md
+++ b/skills/wix-manage/references/bookings/end-to-end-booking-flow.md
@@ -1,0 +1,278 @@
+---
+name: "End-to-End Booking Flow"
+description: Complete booking flow from service discovery to payment. Query services, check availability with Time Slots V2, create bookings, and process payment via eCommerce checkout.
+---
+
+# End-to-End Booking Flow (REST)
+
+Step-by-step flow for implementing a complete booking experience using REST APIs.
+
+## Prerequisites
+
+- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
+- For paid services: Wix Payments or eCommerce configured
+
+> **Note:** If you receive errors from Bookings APIs, the Wix Bookings app may not be installed on the site. Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install it if missing.
+
+## Required APIs
+
+- **Services API**: [Query Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services)
+- **Time Slots V2 API**: [List Availability Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots)
+- **Bookings API**: [Create Booking](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking), [Confirm Booking](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/confirm-booking)
+- **eCommerce API**: [Create Checkout](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/checkout/create-checkout)
+
+---
+
+## Step 1: Query Available Services
+
+**Endpoint**: `POST https://www.wixapis.com/bookings/v2/services/query`
+
+```json
+{
+  "query": {
+    "filter": {
+      "type": "APPOINTMENT"
+    },
+    "paging": {
+      "limit": 20
+    }
+  }
+}
+```
+
+**Service Types**:
+
+- `APPOINTMENT` — One-on-one sessions with a staff member
+- `CLASS` — Group sessions at scheduled times
+- `COURSE` — Multi-session series (customers book the entire course)
+
+**Save from the response**:
+
+- `id` — service ID
+- `schedule.id` — schedule ID (needed for appointment bookings and course bookings)
+- `type` — determines the booking flow (slot vs schedule)
+- `staffMemberIds` — resource IDs of assigned staff (for appointments)
+
+---
+
+## Step 2: Check Availability
+
+**Endpoint**: `POST https://www.wixapis.com/_api/service-availability/v2/time-slots`
+
+> **Important**: The old Availability Calendar API (`/bookings/v2/availability/query`) is deprecated. Always use Time Slots V2.
+
+```json
+{
+  "serviceId": "<SERVICE_ID>",
+  "fromLocalDate": "2024-06-15T08:00:00",
+  "toLocalDate": "2024-06-16T18:00:00",
+  "timeZone": "America/New_York",
+  "bookable": true,
+  "includeResourceTypeIds": ["<RESOURCE_TYPE_ID>"]
+}
+```
+
+### Date format
+
+Dates **must** be in `YYYY-MM-DDThh:mm:ss` format (local datetime). Plain dates like `2024-06-15` will be rejected with a 400 error.
+
+### Parameters
+
+| Parameter                | Required | Description                                                             |
+| ------------------------ | -------- | ----------------------------------------------------------------------- |
+| `serviceId`              | Yes      | From Step 1                                                             |
+| `fromLocalDate`          | Yes      | Start of range in `YYYY-MM-DDThh:mm:ss` format                          |
+| `toLocalDate`            | Yes      | End of range in `YYYY-MM-DDThh:mm:ss` format                            |
+| `timeZone`               | Yes      | IANA timezone (e.g. `America/New_York`)                                 |
+| `bookable`               | No       | Set `true` to only get bookable slots                                   |
+| `includeResourceTypeIds` | No       | Array of resource type IDs — populates `availableResources` in response |
+
+### Save from each time slot
+
+- `serviceId`, `scheduleId` — needed for Create Booking
+- `localStartDate`, `localEndDate` — slot times
+- `availableResources[].resources[].id` — resource ID (only populated if `includeResourceTypeIds` was provided)
+- `location.locationType` — **warning**: returns `BUSINESS` but Create Booking requires `OWNER_BUSINESS` (see Step 3)
+
+### For Classes
+
+Use [List Event Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots) instead. Each class session has an `eventId` — save it for the booking.
+
+---
+
+## Step 3: Create the Booking
+
+**Endpoint**: `POST https://www.wixapis.com/_api/bookings-service/v2/bookings`
+
+### For Appointments (use `slot`)
+
+```json
+{
+  "booking": {
+    "bookedEntity": {
+      "slot": {
+        "serviceId": "<SERVICE_ID>",
+        "scheduleId": "<SCHEDULE_ID>",
+        "startDate": "2024-06-15T14:00:00",
+        "endDate": "2024-06-15T15:00:00",
+        "timezone": "America/New_York",
+        "resource": {
+          "id": "<RESOURCE_ID>"
+        },
+        "location": {
+          "locationType": "OWNER_BUSINESS"
+        }
+      }
+    },
+    "contactDetails": {
+      "firstName": "John",
+      "lastName": "Doe",
+      "email": "john@example.com"
+    },
+    "totalParticipants": 1
+  }
+}
+```
+
+All slot fields are **required** for appointments when no `eventId` is provided:
+
+| Field                   | Source | Notes                                                                                                                        |
+| ----------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `serviceId`             | Step 1 | Service GUID                                                                                                                 |
+| `scheduleId`            | Step 2 | From the time slot response                                                                                                  |
+| `startDate` / `endDate` | Step 2 | `YYYY-MM-DDThh:mm:ss` format                                                                                                 |
+| `timezone`              | Step 2 | IANA tz format                                                                                                               |
+| `resource.id`           | Step 2 | From `availableResources` in time slot response                                                                              |
+| `location.locationType` | —      | Must be `OWNER_BUSINESS`, `OWNER_CUSTOM`, or `CUSTOM`. Time Slots returns `BUSINESS` but that value is **not accepted** here |
+
+### For Classes (use `slot` with `eventId`)
+
+```json
+{
+  "booking": {
+    "bookedEntity": {
+      "slot": {
+        "serviceId": "<SERVICE_ID>",
+        "eventId": "<EVENT_ID>"
+      }
+    },
+    "contactDetails": {
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "email": "jane@example.com"
+    },
+    "totalParticipants": 1
+  }
+}
+```
+
+When you provide `eventId`, all other slot fields (`startDate`, `endDate`, `timezone`, `resource`, `location`) are **auto-derived** from the event. You only need `serviceId` + `eventId`.
+
+### For Courses (use `schedule`)
+
+```json
+{
+  "booking": {
+    "bookedEntity": {
+      "schedule": {
+        "scheduleId": "<SCHEDULE_ID>",
+        "serviceId": "<SERVICE_ID>",
+        "timezone": "America/New_York",
+        "location": {
+          "locationType": "OWNER_BUSINESS"
+        }
+      }
+    },
+    "contactDetails": {
+      "firstName": "Bob",
+      "lastName": "Test",
+      "email": "bob@example.com"
+    },
+    "totalParticipants": 1
+  }
+}
+```
+
+### Participants
+
+Specify exactly one of:
+
+- `totalParticipants` — for services with fixed pricing and no variants
+- `participantsChoices` — for services with [variants and options](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/service-options-and-variants/introduction)
+
+### Result
+
+Booking is created with `status: CREATED`. This is **not yet visible** in the booking calendar. You must either:
+
+- **Confirm it** (Step 4, for offline/free payments), or
+- **Process payment** (Step 4, for online payments) — confirmation happens automatically after checkout
+
+---
+
+## Step 4: Confirm or Process Payment
+
+### For free or offline-payment bookings: Confirm directly
+
+**Endpoint**: `POST https://www.wixapis.com/_api/bookings-service/v2/bookings/<BOOKING_ID>/confirm`
+
+```json
+{
+  "revision": "<REVISION>",
+  "paymentStatus": "EXEMPT"
+}
+```
+
+Use the `id` and `revision` from the Create Booking response. Set `paymentStatus` to `EXEMPT` for free services or `NOT_PAID` for pay-at-location.
+
+**Result**: Booking status changes to `CONFIRMED` and is visible in the booking calendar.
+
+### For online payments: Create checkout
+
+**4a. Create Checkout**
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/checkouts`
+
+```json
+{
+  "lineItems": [
+    {
+      "catalogReference": {
+        "catalogItemId": "<BOOKING_ID>",
+        "appId": "13d21c63-b5ec-5912-8397-c3a5ddb27a97"
+      },
+      "quantity": 1
+    }
+  ],
+  "channelType": "WEB"
+}
+```
+
+Use the booking ID as `catalogItemId` with the Wix Bookings app ID.
+
+**4b. Get Checkout URL**
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/checkouts/{checkoutId}/getCheckoutUrl`
+
+Redirect the user to the returned `checkoutUrl`. After payment, the booking is automatically confirmed.
+
+**4c. Create Order (alternative, server-to-server)**
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/checkouts/{checkoutId}/createOrder`
+
+Creates an order directly without redirect.
+
+---
+
+## Service Type Summary
+
+| Service Type | `bookedEntity`                        | Availability API                           | Key Difference                                             |
+| ------------ | ------------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| APPOINTMENT  | `slot` (all fields required)          | Time Slots V2                              | Single session, specific time, needs resource + scheduleId |
+| CLASS        | `slot` (only `serviceId` + `eventId`) | Event Time Slots                           | Group session, auto-derives fields from event              |
+| COURSE       | `schedule`                            | Check capacity via Query Extended Bookings | Multi-session, books entire schedule                       |
+
+## See Also
+
+- [Flow: Single-Service Booking](https://dev.wix.com/docs/api-reference/business-solutions/bookings/flow-single-service-booking)
+- [Create Booking Sample Flows](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/sample-flows)
+- [Time Slots V2 Sample Flows](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/sample-flows)

--- a/skills/wix-manage/references/bookings/external-calendar-integration.md
+++ b/skills/wix-manage/references/bookings/external-calendar-integration.md
@@ -1,0 +1,258 @@
+---
+name: "External Calendar Integration"
+description: OAuth-based integration with Google Calendar, Microsoft Outlook, and Apple Calendar. Covers authentication flows, sync configuration, and bidirectional event management.
+---
+# Technical Step-by-Step Instructions: Connecting External Calendars (Google, Microsoft, Apple) to Wix Bookings (Real-World, API-First)
+
+## Description
+
+Below are the recommended steps to successfully connect and sync external calendars (Google Calendar, Microsoft Outlook, Apple Calendar) with Wix Bookings, with real-world troubleshooting and fixes for common API issues. This recipe covers the complete OAuth flow, sync configuration, and verification procedures.
+
+
+---
+
+## Prerequisites
+
+### Required Features and Apps
+
+Before connecting external calendars, ensure the following requirements are met:
+
+1. **Wix Bookings** - Core app must be installed and configured
+2. **Premium Plan** - External calendar integration requires premium features enabled
+3. **Active Staff or Business Schedule** - Target schedule must exist for connection
+
+### Premium Feature Validation
+
+**CRITICAL**: External calendar integration is a **premium feature**. If not enabled, you'll receive a 403 error with `"PREMIUM_FEATURE_NOT_ENABLED"` code.
+
+**Verification Steps:**
+1. Attempt to list providers - should return Google, Microsoft, Apple
+2. If 403 error occurs, upgrade plan or enable premium features
+3. Contact Wix support if premium features aren't accessible after upgrade
+
+### App Installation Process
+
+If you encounter app-related errors, install the required apps using the Apps Installer API.
+
+**For detailed app installation procedures, refer to:**
+- [Apps Installer API Documentation](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)
+- Business setup recipes for comprehensive app installation workflows
+
+## Overview
+
+Wix External Calendar integration allows bidirectional sync between Wix schedules and external calendar providers. The system supports:
+
+- **Google Calendar** - OAuth authentication, primary calendar sync
+- **Microsoft Outlook/365** - OAuth authentication, specific calendar selection
+- **Apple Calendar** - Credential authentication, dedicated calendar creation
+
+### CRITICAL API DISCOVERY
+
+**❌ COMMON ENDPOINT MISTAKES**:
+- `/bookings/v2/external-calendar/providers` (missing 's' in calendars)
+- `/calendar/v3/external-calendars/` (wrong namespace)
+
+**✅ CORRECT ENDPOINTS**:
+- List Providers: `/bookings/v2/external-calendars/providers`
+- Connect OAuth: `/bookings/v2/external-calendars/connections:connectByOAuth`
+- List Connections: `/bookings/v2/external-calendars/connections`
+
+### Key Discovery: Schedule Selection Strategy
+
+**Schedule Types Available:**
+- **Business Schedule**: Universal external ID `4e0579a5-491e-4e70-a872-d097eed6e520`
+- **Staff Schedules**: Individual staff member schedules with unique IDs
+
+**Recommendation:**
+- Use **Staff Schedules** for personal calendar sync (individual staff members)
+- Use **Business Schedule** for company-wide calendar integration
+- **Never connect the same external calendar to multiple schedules** - causes conflicts
+
+### IMPORTANT NOTES
+
+* **Premium Feature Gate**: Always verify premium features are enabled before attempting connections
+* **OAuth Flow Complexity**: The OAuth process requires user interaction - cannot be fully automated
+* **Sync Configuration**: Default settings may not match your needs - always review `syncConfig` after connection
+* **Provider-Specific Behaviors**: Google only syncs primary calendar, Microsoft allows specific calendar selection
+* **Connection Ownership**: If schedule ownership changes, external calendar connection is automatically disconnected
+* **Real-Time Limitations**: External Calendar API doesn't provide webhooks or real-time event notifications
+* **Revision Numbers**: External calendar connections don't use revision numbers like other calendar entities
+
+---
+
+## Steps
+
+### 1. Verify Premium Features and List Providers
+
+First, confirm external calendar features are available and identify supported providers.
+
+Use `listProviders` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/list-providers)):
+
+**Expected Response Structure:**
+- **Google Provider**: `name: "Google"`, `features.connectMethods: ["OAUTH"]`
+- **Microsoft Provider**: `name: "Outlook or Office 365"`, `features.connectMethods: ["OAUTH"]`
+- **Apple Provider**: `name: "Apple"`, `features.connectMethods: ["CREDENTIALS"]`
+
+Save the `providerId` for your desired provider and note the required `connectMethods`.
+
+### 2. Query Available Schedules
+
+Identify which schedule to connect the external calendar to using `querySchedules` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)):
+
+**Schedule Selection Guide:**
+- **Staff Schedule**: Use for individual staff member calendar sync
+- **Business Schedule**: Use for company-wide availability sync
+- **Multiple Schedules**: Create separate connections for each schedule if needed
+
+Save the `scheduleId` for your chosen schedule.
+
+### 3. Initiate OAuth Connection (Google/Microsoft)
+
+For OAuth providers (Google, Microsoft), create a connection using `connectByOAuth` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/connect-by-o-auth)):
+
+**Required Parameters:**
+- `providerId`: From step 1
+- `scheduleId`: From step 2
+- `redirectUrl`: Where user returns after authorization (can be placeholder)
+
+**Response Contains:**
+- `oauthUrl`: URL to redirect user for authorization
+
+**User Authorization Flow:**
+1. Direct user to the `oauthUrl`
+2. User completes Google/Microsoft authorization
+3. User is redirected to `redirectUrl` with `connectionId` parameter
+4. Extract `connectionId` from redirect URL query parameters
+
+### 4. Alternative: Connect by Credentials (Apple)
+
+For credential-based providers (Apple), use `connectByCredentials` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/connect-by-credentials)):
+
+**Required Parameters:**
+- `providerId`: Apple provider ID
+- `scheduleId`: Target schedule ID
+- `email`: Apple ID email
+- `password`: Apple ID password
+
+**Important**: This method requires collecting sensitive credentials from users.
+
+### 5. Verify Connection and Configure Sync
+
+After successful connection, verify the connection status and configure sync settings:
+
+**Check Connection:**
+Use `getConnection` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/get-connection)) with the `connectionId`.
+
+**Review Sync Configuration:**
+- **Connection Status**: Should show `"CONNECTED"` when successful
+- **Import Settings**: `syncConfig.listEventFromCalendars.enabled` controls importing external events to Wix
+- **Export Settings**: `syncConfig.syncToCalendar.enabled` controls exporting Wix events to external calendar
+
+**Update Sync Settings (if needed):**
+Use `updateSyncConfig` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/update-sync-config)) to modify import/export behavior.
+
+### 6. Test Connection and List Events
+
+Verify the integration is working by listing external calendar events:
+
+Use `listEvents` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/list-events)) with date range filters:
+
+**Required Parameters:**
+- `from`: Start date (required)
+- `to`: End date (required)
+- `scheduleIds`: Optional filter by specific schedules
+
+This should return events from the connected external calendar.
+
+### IMPORTANT NOTES
+
+* **OAuth Completion**: OAuth flow requires actual user interaction - cannot be automated
+* **Connection Persistence**: Connections remain active until manually disconnected or ownership changes
+* **Sync Timing**: Event synchronization is not real-time - may take several minutes
+* **Calendar Permissions**: External calendar must grant appropriate read/write permissions
+* **Multiple Connections**: Each schedule can connect to multiple external calendar providers
+* **Error Recovery**: Failed OAuth attempts can be retried with new `connectByOAuth` calls
+
+### Troubleshooting Common Issues
+
+**"PREMIUM_FEATURE_NOT_ENABLED" Error (403):**
+- Verify site has premium plan enabled
+- Contact Wix support to enable external calendar features
+- Cannot proceed without premium feature access
+
+**"Not Found" Error (404) on Providers:**
+- Check endpoint URL has 's' in 'calendars': `/external-calendars/providers`
+- Verify Wix Bookings app is installed
+- Ensure using correct API version (v2)
+
+**OAuth Authorization Fails:**
+- Check `redirectUrl` is accessible and properly formatted
+- Verify user has appropriate permissions for external calendar
+- Try incognito/private browsing to avoid cached authorization issues
+- Check external calendar provider status (Google/Microsoft outages)
+
+**OAuth Internal Server Errors:**
+- **"Internal Server Error" during Google OAuth**: Common issue that can occur after account selection
+- **Immediate retry strategy**: Try the same OAuth flow again - temporary server issues often resolve
+- **Alternative schedule approach**: If business schedule fails, try connecting to a staff schedule instead (or vice versa)
+- **Browser troubleshooting**: Clear cookies/cache for the calendar provider's domain, or use incognito/private mode
+- **Different redirect URL**: Try using a different `redirectUrl` parameter (e.g., `https://www.wix.com` instead of custom URLs)
+- **Account-specific issues**: Try a different Google/Microsoft account if available for testing
+- **Timing-based retry**: Wait 5-10 minutes between failed attempts - OAuth rate limiting may be involved
+
+**OAuth Flow Recovery Steps:**
+1. **First attempt fails** → Retry immediately with same parameters
+2. **Second attempt fails** → Try alternative schedule type (business ↔ staff)
+3. **Third attempt fails** → Clear browser data and use incognito mode
+4. **Fourth attempt fails** → Try different redirect URL parameter
+5. **All attempts fail** → Switch to different calendar provider (Google → Microsoft → Apple)
+
+**Connection Shows "DISCONNECTED" Status:**
+- Schedule ownership may have changed
+- External calendar permissions may have been revoked
+- User may have disconnected from external calendar provider side
+- Recreate connection with fresh OAuth flow
+
+**Events Not Syncing:**
+- Check `syncConfig` settings match intended behavior
+- Verify date range filters in `listEvents` calls
+- Allow 5-10 minutes for sync to complete
+- Check external calendar permissions and sharing settings
+
+**Multiple Calendar Connections Conflict:**
+- Avoid connecting same external calendar to multiple Wix schedules
+- Use specific calendar selection for Microsoft Outlook connections
+- Document which staff schedules connect to which external calendars
+
+**Apple Calendar Credential Issues:**
+- Verify Apple ID supports third-party app access
+- Check if two-factor authentication requires app-specific passwords
+- Test credentials in Apple Calendar app before API calls
+
+### Provider-Specific Notes
+
+**Google Calendar:**
+- Only syncs with primary calendar
+- Requires Google account with calendar access
+- OAuth scope: `https://www.googleapis.com/auth/calendar`
+
+**Microsoft Outlook/365:**
+- Allows specific calendar selection
+- Supports both personal and business accounts
+- May require additional organizational permissions
+
+**Apple Calendar:**
+- Uses credential authentication (email/password)
+- Creates dedicated calendar for Wix events
+- May require app-specific password if 2FA enabled
+
+## API Documentation References
+
+* [List Providers](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/list-providers)
+* [Connect By OAuth](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/connect-by-o-auth)
+* [Connect By Credentials](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/connect-by-credentials)
+* [Get Connection](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/get-connection)
+* [Update Sync Config](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/update-sync-config)
+* [List Events](https://dev.wix.com/docs/api-reference/business-solutions/bookings/calendar/external-calendar-v2/list-events)
+* [Query Schedules](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)
+* [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)

--- a/skills/wix-manage/references/bookings/multi-resource-service-creation.md
+++ b/skills/wix-manage/references/bookings/multi-resource-service-creation.md
@@ -1,0 +1,231 @@
+---
+name: "Multi-Resource Service Creation"
+description: Creates resource types and individual resources using Resources API. Enables services that require multiple resources (rooms + equipment + staff) with automatic allocation.
+---
+# Technical Step-by-Step Instructions: Creating Multi-Resource Bookings Services (Rooms, Equipment, Staff) - Real-World, API-First
+
+## Description
+
+Below are the recommended steps to successfully create Wix Bookings services that require multiple resource types (e.g., Room + Equipment + Instructor). This recipe covers the **gaps** in individual API documentation: resource architecture planning, entity relationship patterns, availability dependencies, and real-world coordination challenges that aren't clear from reading individual API references.
+
+
+---
+
+## Prerequisites
+
+### Required App Installations
+
+Before creating multi-resource services, ensure the following requirements are met:
+
+1. **Wix Bookings** - Core app must be installed and configured
+2. **Premium Plan** - Advanced resource management typically requires premium features
+3. **Business Location** - At least one business location must be configured
+
+### App Installation Process
+
+If you encounter resource-related errors, install the required apps using the Apps Installer API.
+
+**For detailed app installation procedures, refer to:**
+- [Apps Installer API Documentation](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)
+- Business setup recipes for comprehensive app installation workflows
+
+## Overview
+
+Multi-resource services allow businesses to create bookings that require multiple types of resources simultaneously. Common examples:
+- **Fitness Classes**: Room + Equipment + Instructor
+- **Meeting Services**: Conference Room + AV Equipment + Catering Staff
+- **Spa Treatments**: Treatment Room + Specialized Equipment + Therapist
+
+The system involves three independent entity types that can be connected:
+1. **Resource Types** - Category definitions (Room, Equipment, Staff) - independent entities
+2. **Resources** - Individual resource instances with their own schedules and availability - independent entities
+3. **Services** - Booking services that can optionally reference resource types - independent entities
+
+**Key Architecture Principle**: Resources and Services are **separate, independent entities**. Resources exist independently but their availability depends on business location hours (for non-staff resources) or working hour schedules (for staff resources). Services can optionally connect to resource types (not individual resources) to require resource allocation during booking, but this connection is loose and flexible.
+
+### CRITICAL API DISCOVERY
+
+**❌ COMMON ARCHITECTURE MISTAKES** (Not Clear in Individual Docs):
+- Creating resources without resource types first (creation sequence matters)
+- Assuming resources automatically inherit business hours (availability dependency isn't clear)
+- Thinking you can connect same resource to conflicting schedules
+
+**✅ CORRECT RESOURCE ARCHITECTURE**:
+- **Independent Creation**: Resource Types → Resources (both exist independently)
+- **Optional Service Connection**: Services can reference resource types when resource allocation is needed
+- **Loose Coupling**: Resources maintain their own schedules and availability regardless of service connections
+- **Type-Based References**: Services connect to `resourceType.id`, not individual resource IDs
+- **Resource Autonomy**: Resources function independently - services simply request allocation from available resources of specified types
+
+### Key Discovery: Resource Schedule Behavior
+
+**Resource Availability Behavior:**
+- Each resource automatically gets a dedicated `eventsSchedule` for tracking bookings
+- **Non-staff resources**: Availability depends on business location hours (not 24/7)
+- **Staff resources**: Have working hour schedules in addition to event schedules
+- **Working hours override**: When `workingHoursSchedules` is configured, it takes precedence over location hours
+
+**Schedule Sharing Patterns:**
+- `shared: false` = Dedicated schedule per resource (recommended for most cases)
+- `shared: true` = Multiple resources use same working hours schedule
+- Business schedule is always `shared: true` among staff
+
+### Key Discovery: Service-Resource Connection Pattern
+
+**Service Configuration Pattern:**
+```json
+"serviceResources": [
+  {"resourceType": {"id": "room-type-id"}},
+  {"resourceType": {"id": "equipment-type-id"}},
+  {"resourceType": {"id": "staff-type-id"}}
+]
+```
+**Critical**: Services specify resource **types**, not individual resources. This creates a **loose coupling** where:
+- Resources exist independently but availability follows business location hours (non-staff) or working hours (staff)
+- Services request allocation from available resources of specified types during booking
+- No direct binding between individual resources and services
+- Resource management (updates, working hours) is independent of service configuration
+
+### IMPORTANT NOTES
+
+* **Entity Independence**: Resources and Services are separate entities - you can create and manage resources without any services, and vice versa
+* **Optional Connection**: Services only need to reference resource types if they require resource allocation for bookings
+* **Location Complexity**: `availableInAllLocations: true` is simplest; specific location configuration is complex and often unnecessary
+* **Service Pricing**: Multi-resource services often justify higher pricing due to resource coordination complexity
+
+---
+
+## Steps
+
+### 1. Plan Resource Type Architecture
+
+Before creating anything, plan your resource type structure. Each type should represent a category of resources that can be substituted for each other in bookings.
+
+**Common Resource Type Patterns:**
+- **Physical Spaces**: Room, Studio, Meeting Room, Treatment Room
+- **Equipment Categories**: AV Equipment, Medical Equipment, Sports Equipment
+- **Human Resources**: Instructor, Therapist, Consultant, Technician
+
+**Design Principle**: If resources are interchangeable for a service, they belong to the same type.
+
+### 2. Create Resource Types
+
+Create resource types using `createResourceType` API (`POST https://www.wixapis.com/bookings/v2/resources/resource-types`) ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/resources/resource-types-v2/create-resource-type)):
+
+**Key Requirements:**
+- `name` must be unique across the site
+- Keep `name` descriptive but concise (appears in booking interface)
+- Save the returned `resourceType.id` for resource creation
+
+**Important**: Cannot change `name` after creation if conflicts occur - plan carefully.
+
+### 3. Create Individual Resources
+
+For each resource type, create the individual resource instances using `createResource` API (`POST https://www.wixapis.com/bookings/v2/resources`) ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/resources/resources-v2/create-resource)):
+
+**Gap Not in Docs**: The docs don't clearly explain that `availableInAllLocations: true` is the simplest approach and that specific location configuration is complex and often unnecessary.
+
+**Advanced Configuration (Gap):**
+- Custom working hours override business location hours (this behavior isn't clearly documented)
+- Specific locations: Use `specificLocationOptions` (complex - avoid unless required)
+
+**Critical**: Each resource automatically gets its own `eventsSchedule` for booking management (this is documented but the implications for multi-resource coordination aren't clear).
+
+### 4. Create Multi-Resource Service (Optional Connection)
+
+Create the service that optionally connects to multiple resource types using `bulkCreateServices` API ([REST](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services)):
+
+**Service Resource Configuration:**
+```json
+"serviceResources": [
+  {"resourceType": {"id": "room-type-id"}},
+  {"resourceType": {"id": "equipment-type-id"}},
+  {"resourceType": {"id": "instructor-type-id"}}
+]
+```
+
+**Key Principle**: This creates a **loose connection** where the service requests resource allocation during booking, but resources remain independent entities with their own lifecycle and management.
+
+**Pricing Strategy**: Multi-resource services typically command premium pricing due to coordination complexity.
+
+### 5. Understand Resource Allocation Behavior (Gap in Docs)
+
+The docs don't explain how multi-resource allocation actually works during booking. Key behaviors to understand:
+- **Peak time conflicts**: When Room 1 is booked, Wix automatically tries Room 2 for the same resource type
+- **Equipment maintenance**: Blocking specific resources affects all services requiring that resource type
+- **Cross-resource dependencies**: If ANY required resource type has no availability, the entire booking fails
+
+**Architecture Implication**: Plan resource quantities based on expected concurrent demand across all services.
+
+### IMPORTANT NOTES
+
+* **Resource Allocation Logic**: Wix automatically handles resource selection during booking - you specify types, not individual resources
+* **Conflict Resolution**: If any required resource type has no available resources, the entire booking fails
+* **Service Modification**: Adding/removing resource type requirements from existing services may affect existing bookings
+* **Performance Consideration**: Complex multi-resource services may have slower booking availability calculation
+
+### Troubleshooting Common Issues
+
+**"Resource type not found" Error:**
+- Verify resource type was created successfully before creating resources
+- Check that `typeId` exactly matches the resource type `id`
+- Ensure you're not using resource type `name` when `id` is required
+
+**"Resource type name already exists" Error (409):**
+- Resource type names must be unique across the site
+- Query existing resource types to avoid duplicates
+- Consider using more specific names (e.g., "Meeting Room" vs "Room")
+
+**Service doesn't show resource requirements:**
+- Verify `serviceResources` array includes all required resource types
+- Check that resource type IDs are correct
+- Confirm service creation was successful with proper resource configuration
+
+**Resources showing as unavailable:**
+- Check if `workingHoursSchedules` is too restrictive
+- Verify `locationOptions` matches your business location setup
+- Test with `availableInAllLocations: true` to eliminate location issues
+
+**Resource updates failing:**
+- Handle revision conflicts with retry logic (revision requirement is documented but conflict handling strategies aren't)
+
+**Complex location availability issues:**
+- Start with `availableInAllLocations: true` for all resources
+- Only add location restrictions if absolutely necessary
+- Location configuration is complex and often causes more problems than it solves
+
+**Resource deletion concerns:**
+- Deleting resources with active bookings may cause issues (deletion cleanup is documented but impact on existing bookings isn't clear)
+- Consider disabling/hiding resources instead of deletion
+
+### Resource Architecture Best Practices
+
+**Resource Type Design:**
+- Keep types broad enough to allow flexibility but specific enough to be meaningful
+- Plan for growth - easier to split types later than merge them
+- Use clear, customer-facing names (they appear in booking interfaces)
+
+**Resource Naming:**
+- Include location/identifier in resource names for easy management
+- Be consistent with naming patterns across resource types
+- Consider how names appear in booking confirmations and staff interfaces
+
+**Availability Strategy:**
+- Default to 24/7 availability unless business rules require restrictions
+- Use working hours sparingly - they add complexity without always adding value
+- Test availability scenarios thoroughly before going live
+
+**Service Design:**
+- Start with simpler single-resource services before attempting multi-resource
+- Consider premium pricing for multi-resource services due to coordination complexity
+- Plan for resource substitution scenarios (what if preferred room is unavailable?)
+
+## API Documentation References
+
+* [Create Resource Type](https://dev.wix.com/docs/api-reference/business-solutions/bookings/resources/resource-types-v2/create-resource-type)
+* [Create Resource](https://dev.wix.com/docs/api-reference/business-solutions/bookings/resources/resources-v2/create-resource)
+* [Update Resource](https://dev.wix.com/docs/api-reference/business-solutions/bookings/resources/resources-v2/update-resource)
+* [Bulk Create Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services)
+* [Query Resources](https://dev.wix.com/docs/api-reference/business-solutions/bookings/resources/resources-v2/query-resources)
+* [Calendar Schedules API](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/introduction)
+* [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)

--- a/skills/wix-manage/references/calendar/configure-default-business-hours.md
+++ b/skills/wix-manage/references/calendar/configure-default-business-hours.md
@@ -1,0 +1,226 @@
+---
+name: "Configure Default Business Hours"
+description: Uses Calendar Events API to create WORKING_HOURS events on the business schedule. Covers the critical distinction between Calendar Events API (correct) vs Site Properties API (incorrect) for setting base availability.
+---
+# Technical Step-by-Step Instructions: Setting Up Wix Bookings Default Business Hours (Real-World, API-First)
+
+## Description
+
+Below are the recommended steps to successfully configure default business hours for Wix Bookings, which control the base availability shown in the "Set default hours" dashboard. This recipe covers the correct API usage, common pitfalls, and cleanup procedures for managing business schedule events.
+
+---
+
+## Prerequisites
+
+- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
+
+> **Note:** If you receive errors from Bookings APIs, the Wix Bookings app may not be installed on the site. Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install it if missing.
+
+## Overview
+
+Wix Bookings default business hours define the base availability for your booking system and appear in the Bookings dashboard under "Set default hours". These hours:
+
+- **Control base availability**: Set when your business is generally available for bookings
+- **Apply to new staff**: Default working hours that new staff members inherit
+- **Display in dashboard**: Show as time slots in the "Set default hours" interface
+
+### 🚨 CRITICAL: Default Hours Upon Installation
+
+**IMPORTANT**: When Wix Bookings is first installed on a site, it automatically creates DEFAULT business hours (typically 9 AM - 5 PM, Monday through Friday). You CANNOT simply create new hours without handling these existing default hours first.
+
+**You MUST either:**
+1. **Update the existing default hours** to your desired schedule, OR
+2. **Delete the existing default hours** and create new ones
+
+**Failure to handle existing hours will result in:**
+- Duplicate time slots in the dashboard
+- Conflicting availability schedules
+- Unexpected booking behavior
+
+### CRITICAL API DISCOVERY
+
+**❌ WRONG API**: Site Properties API (`/site-properties/v4/properties/business-schedule`)
+- This sets general site business schedule, NOT Bookings default hours
+
+**✅ CORRECT API**: Calendar Events V3 API (`/calendar/v3/events`)
+- Creates `WORKING_HOURS` events on the business schedule
+- Each `MASTER` event creates one time slot in the dashboard
+- Uses fixed business resource ID: `4e0579a5-491e-4e70-a872-d097eed6e520`
+
+### Key Discovery: Universal Business Schedule External ID
+
+**VERIFIED**: The business schedule external ID `"4e0579a5-491e-4e70-a872-d097eed6e520"` is **universal across all Wix sites**.
+
+This has been tested and confirmed on multiple different Wix sites:
+- All sites have a business schedule with this exact external ID
+- The schedule name is consistently `"business"`
+- While the internal schedule `id` varies per site, the `externalId` is constant
+- This makes the recipe reliable without requiring site-specific discovery
+
+### IMPORTANT NOTES
+
+* **Universal External ID**: The business schedule external ID `"4e0579a5-491e-4e70-a872-d097eed6e520"` is verified to work across all Wix sites
+* **Default Hours Always Exist**: Every Wix Bookings installation creates default hours automatically
+* **Event Scheduling Flexibility**: Businesses can create multiple time slots per day or complex schedules as needed - there are no restrictions on number of events per day
+* **MASTER vs INSTANCE Events**: Based on observed behavior, MASTER events appear to generate INSTANCE events automatically, but always verify current event state when working with recurring events
+* **Query Patterns**: Use `"recurrenceType": ["MASTER"]` to focus on the primary recurring event definitions
+* **Revision Numbers**: Calendar events require current revision numbers for updates - always get fresh revision before bulk operations
+
+---
+
+## Steps
+
+### 1. Find Business Schedule
+
+Query the business schedule that controls default hours using the fixed external ID.
+
+**Endpoint**: `POST https://www.wixapis.com/calendar/v3/schedules/query`
+
+Use `querySchedules` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)) with filter:
+- `externalId`: `"4e0579a5-491e-4e70-a872-d097eed6e520"`
+
+Keep the returned `schedule.id` for creating events.
+
+### 2. Query Existing Working Hours (MANDATORY)
+
+**🚨 CRITICAL STEP**: You MUST query for existing `WORKING_HOURS` events because Wix Bookings automatically creates default hours upon installation.
+
+**Endpoint**: `POST https://www.wixapis.com/calendar/v3/events/query`
+
+Use `queryEvents` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/query-events)):
+
+Query pattern:
+```json
+{
+    "recurrenceType": ["MASTER"],
+    "query": {
+        "filter": {
+            "scheduleId": "business-schedule-id",
+            "type": "WORKING_HOURS"
+        }
+    }
+}
+```
+
+**Important**: Always query for MASTER events specifically to see actual recurring schedules.
+
+**Expected Result**: You will typically find 5 existing MASTER events (Monday through Friday, 9 AM - 5 PM) from the default Bookings installation.
+
+### 3. Choose Your Strategy: Update OR Replace
+
+Based on the existing hours found in Step 2, choose one approach:
+
+#### Strategy A: Update Existing Hours (Recommended)
+If you want to modify the times but keep the same days, update the existing events.
+
+#### Strategy B: Replace All Hours
+If you want completely different days/times, delete existing events and create new ones.
+
+### 4A. Update Existing Business Hours (Strategy A)
+
+**Endpoint**: `POST https://www.wixapis.com/calendar/v3/bulk/events/update`
+
+Use `bulkUpdateEvents` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)) with `fieldmask` pattern:
+
+Update fields:
+- `start`/`end`: New times
+- `revision`: Current revision number (from Step 2 query)
+- `fieldmask`: `"start,end"`
+
+**Example**: Change Monday hours from 9 AM-5 PM to 12 AM-4 PM:
+```json
+{
+  "events": [{
+    "event": {
+      "id": "existing-monday-event-id",
+      "start": {"localDate": "2025-06-16T00:00:00"},
+      "end": {"localDate": "2025-06-16T16:00:00"},
+      "revision": "current-revision-number"
+    }
+  }],
+  "fieldmask": "start,end"
+}
+```
+
+### 4B. Replace All Business Hours (Strategy B)
+
+#### Step 4B.1: Delete Existing Hours
+Cancel existing MASTER events using `bulkCancelEvents` API (`POST https://www.wixapis.com/calendar/v3/bulk/events/cancel`) ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-cancel-event)):
+
+```json
+{
+  "eventIds": ["event-id-1", "event-id-2", "event-id-3", "event-id-4", "event-id-5"]
+}
+```
+
+#### Step 4B.2: Create New Business Hours
+Create `WORKING_HOURS` events for each day using `bulkCreateEvents` API (`POST https://www.wixapis.com/calendar/v3/bulk/events/create`) ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)).
+
+**Each event pattern**:
+- `type`: `"WORKING_HOURS"`
+- `scheduleId`: Business schedule ID from step 1
+- `scheduleOwnerId`: `"4e0579a5-491e-4e70-a872-d097eed6e520"`
+- `externalScheduleId`: `"4e0579a5-491e-4e70-a872-d097eed6e520"`
+- `recurrenceRule`: Weekly recurring with single day
+- `start`/`end`: Business hours times
+
+**Note**: Create separate events for each day of the week (Monday, Tuesday, etc.).
+
+### 5. Verify Final Configuration
+
+Query the business schedule events again to confirm:
+1. No duplicate time slots exist
+2. Each desired day has exactly one MASTER event
+3. Times match your requirements
+
+### IMPORTANT NOTES
+
+* **Future dates required**: Recurring events must start today or in the future
+* **Revision management**: Always use current revision numbers when updating events
+* **MASTER vs INSTANCE**: Based on observed behavior, MASTER events appear to control recurring patterns while INSTANCE events are auto-generated, but always verify current event state
+* **Default Hours Impact**: Remember that these hours will be inherited by any new staff members created after this configuration
+
+### Troubleshooting Common Issues
+
+**"App not installed" Error (428):**
+- Install Wix Bookings app using Apps Installer API
+- Verify installation by querying existing services
+
+**Duplicate time slots in dashboard:**
+- **Root Cause**: You created new events without handling existing default hours
+- **Solution**: Query MASTER events to find duplicates and cancel unwanted ones
+- Each day should have only one MASTER event unless split hours are needed
+
+**Updates not reflecting in dashboard:**
+- Verify you're updating MASTER events, not INSTANCE events
+- Check that revision numbers are current
+- Confirm `fieldmask` includes the fields you're changing
+
+**Cannot create events in the past:**
+- Set `start.localDate` to current date or future
+- Recurring events automatically generate past INSTANCE events
+
+**Business schedule not found:**
+- Query schedules using the fixed external ID: `4e0579a5-491e-4e70-a872-d097eed6e520`
+- Ensure Wix Bookings is installed (schedule is created when Bookings is installed)
+
+**Working hours not affecting staff/services:**
+- Default hours only apply to staff using `usesDefaultWorkingHours: true`
+- Services with custom schedules ignore default business hours
+- Staff with assigned custom schedules override default hours
+
+### Common Gotchas
+
+1. **Skipping the Query Step**: Never assume no hours exist - always query first
+2. **Creating Without Cleaning**: Adding new hours without removing defaults creates duplicates
+3. **Wrong Event Type**: Using INSTANCE instead of MASTER events for queries/updates
+4. **Missing Revision Numbers**: Updates require current revision numbers from the query response
+
+## API Documentation References
+
+* [Query Schedules](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)
+* [Query Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/query-events)
+* [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)
+* [Bulk Update Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)
+* [Bulk Cancel Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-cancel-event)
+* [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)

--- a/skills/wix-manage/references/cms/cms-data-items-crud.md
+++ b/skills/wix-manage/references/cms/cms-data-items-crud.md
@@ -1,0 +1,422 @@
+---
+name: "CMS Data Items CRUD"
+description: Add, query, update, and delete items in CMS collections. Use this to insert content, bulk insert/update/patch/delete items, query with filters, and manage collection data. Key endpoints: /wix-data/v2/items, /wix-data/v2/bulk/items/*.
+---
+# CMS Data Items CRUD
+
+This recipe covers basic Create, Read, Update, Delete (CRUD) operations for Wix CMS data items.
+
+## Prerequisites
+
+1. Wix CMS enabled on the site
+2. Collections already created (see [CMS Schema Management](cms-schema-management.md))
+3. API access with CMS permissions
+
+## Required APIs
+
+- **Data Items API**: [REST](https://dev.wix.com/docs/rest/business-solutions/cms/data-items/introduction)
+
+---
+
+## Know the Schema First
+
+Before inserting or updating items, you need to know the collection's field names and types. If you don't already know the schema:
+
+1. **Query existing items** - Fetch a few items to infer field names from the data
+2. **Get collection schema** - Use `GET /collections/{collectionId}` for full field definitions
+3. **List collections** - Use `GET /collections?fields=id` to see what collections exist (see [Schema Management](cms-schema-management.md))
+
+---
+
+## Insert Data Item
+
+**Endpoint**: `POST /wix-data/v2/items`
+
+**Request Body**:
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItem": {
+    "data": {
+      "title": "Wireless Headphones",
+      "price": 149.99,
+      "description": "Premium wireless headphones with noise cancellation",
+      "inStock": true,
+      "tags": ["wireless", "audio", "premium"]
+    }
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "dataItem": {
+    "id": "generated-item-id",
+    "dataCollectionId": "Products",
+    "data": {
+      "_id": "generated-item-id",
+      "title": "Wireless Headphones",
+      "price": 149.99,
+      "_createdDate": { "$date": "2024-01-15T10:00:00.000Z" },
+      "_updatedDate": { "$date": "2024-01-15T10:00:00.000Z" }
+    }
+  }
+}
+```
+
+## Bulk Insert Items
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/insert`
+
+**Request Body**:
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItems": [
+    {
+      "data": {
+        "title": "Bluetooth Speaker",
+        "price": 79.99,
+        "inStock": true
+      }
+    },
+    {
+      "data": {
+        "title": "USB-C Cable",
+        "price": 12.99,
+        "inStock": true
+      }
+    },
+    {
+      "data": {
+        "title": "Laptop Stand",
+        "price": 49.99,
+        "inStock": false
+      }
+    }
+  ],
+  "returnEntity": true
+}
+```
+
+## Query Data Items
+
+**Endpoint**: `POST /wix-data/v2/items/query`
+
+**Basic Query**:
+```json
+{
+  "dataCollectionId": "Products",
+  "query": {
+    "filter": {
+      "inStock": true
+    },
+    "sort": [
+      {
+        "fieldName": "price",
+        "order": "ASC"
+      }
+    ],
+    "paging": {
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}
+```
+
+**Advanced Query with Multiple Conditions**:
+```json
+{
+  "dataCollectionId": "Products",
+  "query": {
+    "filter": {
+      "$and": [
+        { "inStock": true },
+        { "price": { "$gte": 50, "$lte": 200 } }
+      ]
+    }
+  }
+}
+```
+
+**Text Search**:
+```json
+{
+  "dataCollectionId": "Products",
+  "query": {
+    "filter": {
+      "title": {
+        "$contains": "wireless"
+      }
+    }
+  }
+}
+```
+
+## Get Single Item
+
+**Endpoint**: `GET /wix-data/v2/items/{itemId}?dataCollectionId={collectionId}`
+
+```bash
+curl -X GET \
+'https://www.wixapis.com/wix-data/v2/items/abc123?dataCollectionId=Products' \
+-H 'Authorization: <AUTH>'
+```
+
+## Update Data Item
+
+**Endpoint**: `PUT /wix-data/v2/items/{itemId}`
+
+**Request Body**:
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItem": {
+    "data": {
+      "title": "Wireless Headphones Pro",
+      "price": 199.99,
+      "description": "Updated premium wireless headphones",
+      "inStock": true
+    }
+  }
+}
+```
+
+## Patch Data Item (Partial Update - Single Item)
+
+**Endpoint**: `PATCH /wix-data/v2/items/{dataItemId}`
+
+Unlike Update, this only modifies the specified fields — all other fields remain unchanged.
+
+> **Note**: Only works on user-created collections. Wix app collections (e.g. Wix Stores Products) cannot be patched.
+
+```json
+{
+  "dataCollectionId": "Products",
+  "patch": {
+    "dataItemId": "item-guid",
+    "fieldModifications": [
+      {
+        "fieldPath": "price",
+        "action": "SET_FIELD",
+        "setFieldOptions": {
+          "value": 159.99
+        }
+      },
+      {
+        "fieldPath": "description",
+        "action": "REMOVE_FIELD"
+      },
+      {
+        "fieldPath": "viewCount",
+        "action": "INCREMENT_FIELD",
+        "incrementFieldOptions": {
+          "value": 1
+        }
+      }
+    ]
+  }
+}
+```
+
+## Bulk Update Items
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/update`
+
+> **Important**: Use `id` (not `_id`) at the element level. The `data` object should NOT contain `_id`.
+
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItems": [
+    {
+      "id": "item-guid-1",
+      "data": {
+        "price": 159.99,
+        "inStock": true
+      }
+    },
+    {
+      "id": "item-guid-2",
+      "data": {
+        "price": 89.99,
+        "inStock": false
+      }
+    }
+  ]
+}
+```
+
+> **Note**: This replaces the entire item. Include all fields you want to keep, not just the ones you're changing.
+
+## Bulk Patch Items (Partial Update)
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/patch`
+
+Unlike bulk update, this only modifies the specified fields - other fields remain unchanged. **Use this for partial updates.**
+
+> **Important**: This endpoint uses `patches` array with `fieldModifications`, NOT `dataItems`. Do not confuse with bulk update.
+
+```json
+{
+  "dataCollectionId": "Products",
+  "patches": [
+    {
+      "dataItemId": "item-guid-1",
+      "fieldModifications": [
+        {
+          "fieldPath": "price",
+          "action": "SET_FIELD",
+          "setFieldOptions": {
+            "value": 159.99
+          }
+        }
+      ]
+    },
+    {
+      "dataItemId": "item-guid-2",
+      "fieldModifications": [
+        {
+          "fieldPath": "price",
+          "action": "SET_FIELD",
+          "setFieldOptions": {
+            "value": 89.99
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Setting a reference field** (single REFERENCE only):
+```json
+{
+  "dataCollectionId": "events",
+  "patches": [
+    {
+      "dataItemId": "event-id",
+      "fieldModifications": [
+        {
+          "fieldPath": "venue",
+          "action": "SET_FIELD",
+          "setFieldOptions": {
+            "value": "venue-item-id"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Available actions**: `SET_FIELD`, `REMOVE_FIELD`, `INCREMENT_FIELD`, `APPEND_TO_ARRAY`, `REMOVE_FROM_ARRAY`
+
+> **Common error**: If you get `WDE0080: patches must not be empty`, you sent `dataItems` instead of `patches`. Use the format above.
+
+> **Recommended**: Use bulk patch instead of bulk update when you only need to change specific fields.
+
+> **Reference Fields**:
+> - **Single REFERENCE**: CAN be set during insert/update by providing the referenced item's ID as the field value (e.g., `"venue": "venue-item-id"`)
+> - **MULTI_REFERENCE**: **STOP** - You cannot use this recipe for multi-reference fields. They cannot be set via insert/update/patch.
+>
+> **For MULTI_REFERENCE operations (add speakers, assign tags, link categories, etc.):**
+> **READ [CMS References & Relationships](cms-references-and-relationships.md)** for the exact endpoints and request bodies:
+> - `POST /wix-data/v2/bulk/items/insert-references` - add references
+> - `POST /wix-data/v2/items/replace-references` - replace all references
+> - `POST /wix-data/v2/bulk/items/remove-references` - remove references
+>
+> Error `WDE0303` occurs when attempting to set multi-reference fields via data operations.
+
+## Delete Data Item
+
+**Endpoint**: `DELETE /wix-data/v2/items/{itemId}?dataCollectionId={collectionId}`
+
+```bash
+curl -X DELETE \
+'https://www.wixapis.com/wix-data/v2/items/abc123?dataCollectionId=Products' \
+-H 'Authorization: <AUTH>'
+```
+
+## Bulk Delete Items
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/remove`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItemIds": ["item-id-1", "item-id-2", "item-id-3"]
+}
+```
+
+---
+
+## Query Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `$eq` | Equal | `{ "status": { "$eq": "active" } }` |
+| `$ne` | Not equal | `{ "status": { "$ne": "archived" } }` |
+| `$gt` | Greater than | `{ "price": { "$gt": 100 } }` |
+| `$gte` | Greater or equal | `{ "price": { "$gte": 100 } }` |
+| `$lt` | Less than | `{ "price": { "$lt": 50 } }` |
+| `$lte` | Less or equal | `{ "price": { "$lte": 50 } }` |
+| `$in` | In array | `{ "status": { "$in": ["active", "pending"] } }` |
+| `$contains` | Contains string | `{ "title": { "$contains": "pro" } }` |
+| `$startsWith` | Starts with | `{ "title": { "$startsWith": "Wireless" } }` |
+| `$and` | All conditions | `{ "$and": [{...}, {...}] }` |
+| `$or` | Any condition | `{ "$or": [{...}, {...}] }` |
+
+---
+
+## Pagination
+
+### Offset-Based (Simple)
+```json
+{
+  "query": {
+    "paging": {
+      "limit": 50,
+      "offset": 100
+    }
+  }
+}
+```
+
+### Cursor-Based (Large Datasets)
+```json
+{
+  "query": {
+    "cursorPaging": {
+      "limit": 50,
+      "cursor": "cursor-from-previous-response"
+    }
+  }
+}
+```
+
+---
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `COLLECTION_NOT_FOUND` | Invalid collection ID | Check collection exists |
+| `ITEM_NOT_FOUND` | Invalid item ID | Verify item exists |
+| `VALIDATION_ERROR` | Invalid field value | Check field types |
+| `DUPLICATE_KEY` | Duplicate unique field | Use unique values |
+| `PERMISSION_DENIED` | Insufficient access | Check API permissions |
+| `WDE0007` | Bulk update: wrong ID field name | Use `id` not `_id` at element level |
+| `WDE0080` | Validation failed (multiple causes) | Bulk update: don't include `_id` in `data`; Bulk patch: use `patches` array not `dataItems` |
+| `WDE0303` | Can't set multi-reference field via data operations | Use reference endpoints: `insert-references`, `replace-references` |
+
+---
+
+## Related Documentation
+
+- [Data Items API Reference](https://dev.wix.com/docs/rest/business-solutions/cms/data-items/introduction)
+- [CMS Schema Management](cms-schema-management.md) - Creating and modifying collections
+- [CMS References & Relationships](cms-references-and-relationships.md) - Linking collections
+- [CMS Data Operations Extended](cms-data-operations-extended.md) - Count, upsert, aggregate

--- a/skills/wix-manage/references/cms/cms-data-operations-extended.md
+++ b/skills/wix-manage/references/cms/cms-data-operations-extended.md
@@ -1,0 +1,263 @@
+---
+name: "CMS Data Operations Extended"
+description: Additional CMS data operations including count, upsert (bulk save), and update by filter patterns.
+---
+# CMS Data Operations Extended
+
+This recipe covers additional CMS data operations not included in the basic CRUD recipe.
+
+## Prerequisites
+
+1. Wix CMS enabled on the site
+2. Collections created with data
+3. API access with CMS permissions
+
+## Required APIs
+
+- **Data Items API**: [REST](https://dev.wix.com/docs/rest/business-solutions/cms/data-items/introduction)
+
+## Count Data Items
+
+Count items in a collection, optionally with filters.
+
+**Endpoint**: `POST /wix-data/v2/items/count`
+
+**Count All Items**:
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/items/count' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products"
+}'
+```
+
+**Response**:
+```json
+{
+  "totalCount": 42
+}
+```
+
+**Count with Filter**:
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/items/count' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "filter": {
+    "inStock": true
+  }
+}'
+```
+
+**Count with Complex Filter**:
+```json
+{
+  "dataCollectionId": "Products",
+  "filter": {
+    "$and": [
+      { "inStock": true },
+      { "price": { "$gte": 50 } }
+    ]
+  }
+}
+```
+
+## Bulk Save (Upsert)
+
+Insert new items or update existing items in a single operation. This is useful for syncing data.
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/save`
+
+**Request Body**:
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItems": [
+    {
+      "id": "existing-item-id",
+      "data": {
+        "title": "Updated Product",
+        "price": 199.99,
+        "inStock": true
+      }
+    },
+    {
+      "data": {
+        "title": "New Product",
+        "price": 79.99,
+        "inStock": true
+      }
+    }
+  ],
+  "returnEntity": true
+}
+```
+
+### Bulk Save Behavior
+
+| Scenario | Action |
+|----------|--------|
+| No `id` provided | INSERT - Creates new item with generated ID |
+| `id` provided, doesn't exist | INSERT - Creates new item with provided ID |
+| `id` provided, exists | UPDATE - Replaces existing item |
+
+> **Warning**: When updating, the entire item is replaced. Include all fields you want to keep.
+
+## Update by Filter Pattern
+
+Wix CMS doesn't have a direct "update by filter" API. Use this two-step pattern:
+
+### 3.1: Query Items to Update
+
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/items/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "query": {
+    "filter": {
+      "category": "electronics"
+    }
+  }
+}'
+```
+
+### 3.2: Bulk Update Those Items
+
+> **Important**: Use `id` (not `_id`) at the element level. The `data` object should NOT contain `_id`.
+
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/bulk/items/update' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "dataItems": [
+    {
+      "id": "item-1-from-query",
+      "data": {
+        "title": "Updated Title 1",
+        "price": 99.99,
+        "onSale": true
+      }
+    },
+    {
+      "id": "item-2-from-query",
+      "data": {
+        "title": "Updated Title 2",
+        "price": 149.99,
+        "onSale": true
+      }
+    }
+  ]
+}'
+```
+
+### Alternative: Bulk Patch (Partial Update)
+
+If you only want to update specific fields without replacing the entire item, use Bulk Patch:
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/patch`
+
+> **Important**: This endpoint uses `patches` array with `fieldModifications`, NOT `dataItems`. Do not confuse with bulk update.
+
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/bulk/items/patch' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "patches": [
+    {
+      "dataItemId": "item-1",
+      "fieldModifications": [
+        {
+          "fieldPath": "onSale",
+          "action": "SET_FIELD",
+          "setFieldOptions": {
+            "value": true
+          }
+        }
+      ]
+    }
+  ]
+}'
+```
+
+> **Common error**: If you get `WDE0080: patches must not be empty`, you sent `dataItems` instead of `patches`. Use the format above.
+
+## Truncate Collection
+
+Remove all items from a collection (dangerous operation).
+
+**Endpoint**: `POST /wix-data/v2/items/truncate`
+
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/items/truncate' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "TestCollection"
+}'
+```
+
+> **Warning**: This permanently deletes ALL items in the collection. Use with extreme caution.
+
+## Aggregate Data
+
+Perform calculations on collection data using a pipeline of sequential stages.
+
+**Endpoint**: `POST /wix-data/v2/items/aggregate-pipeline`
+
+**Count by Category**:
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/items/aggregate-pipeline' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "pipeline": {
+    "stages": [
+      {
+        "group": {
+          "groupIds": [
+            {"key": "category", "expression": {"fieldPath": "category"}}
+          ],
+          "accumulators": [
+            {
+              "resultFieldName": "count",
+              "sum": {"expression": {"numeric": 1}}
+            }
+          ]
+        }
+      }
+    ]
+  }
+}'
+```
+
+## Operation Comparison
+
+| Operation | Use Case | Behavior |
+|-----------|----------|----------|
+| **Bulk Insert** | Add new items only | Fails if ID exists |
+| **Bulk Update** | Update existing items | Fails if ID doesn't exist, replaces entire item |
+| **Bulk Save** | Upsert (insert or update) | Creates or updates based on ID |
+| **Bulk Patch** | Partial update | Only modifies specified fields |
+
+## Related Documentation
+
+- [Data Items API Reference](https://dev.wix.com/docs/rest/business-solutions/cms/data-items/introduction)
+- [CMS Operations Best Practices](cms-data-items-crud.md)
+- [CMS Schema Management](cms-schema-management.md)

--- a/skills/wix-manage/references/cms/cms-ecommerce-catalog-integration.md
+++ b/skills/wix-manage/references/cms/cms-ecommerce-catalog-integration.md
@@ -1,0 +1,136 @@
+---
+name: "CMS eCommerce Catalog Integration"
+description: The recommended way to sell existing CMS collection items (tickets, bookings, memberships) through Wix checkout. Add the CATALOG plugin to convert any CMS collection into purchasable products with cart and payment integration.
+---
+# CMS eCommerce Catalog Integration
+
+This recipe documents how to convert CMS collections into sellable product catalogs that integrate with Wix eCommerce (cart, checkout, orders).
+
+## Overview
+
+Converting a CMS collection to a catalog enables:
+- Items in the collection become purchasable products
+- Integration with Wix Cart and Checkout APIs
+- Real-time price and availability from your CMS data
+
+## Prerequisites
+
+Your collection needs these fields (or mappable equivalents):
+- **Name field** (TEXT) - Product display name
+- **Price field** (NUMBER) - Product price
+
+Optional catalog fields:
+- **Description** (TEXT) - Product description
+- **Image** (IMAGE) - Product image
+- **URL** (URL) - Product link
+- **Quantity** (NUMBER) - Inventory quantity
+
+## Step 1: Add CATALOG Plugin to Collection
+
+### API Endpoint
+
+```
+POST https://www.wixapis.com/wix-data/v2/collections/add-plugin
+```
+
+### Example: Convert Collection with Custom Field Names
+
+```json
+{
+  "dataCollectionId": "Products",
+  "plugin": {
+    "type": "CATALOG",
+    "catalogOptions": {
+      "name": "title",
+      "price": "price",
+      "description": "description"
+    }
+  }
+}
+```
+
+### Example: Full Catalog with All Optional Fields
+
+```json
+{
+  "dataCollectionId": "Products",
+  "plugin": {
+    "type": "CATALOG",
+    "catalogOptions": {
+      "name": "itemName",
+      "price": "itemPrice",
+      "description": "itemDescription",
+      "image": "itemImage",
+      "url": "itemUrl",
+      "quantity": "itemQuantity"
+    }
+  }
+}
+```
+
+## Step 2: Verify eCommerce App is Installed
+
+Most Wix sites with Stores, Bookings, or similar apps already have eCommerce installed. Check by querying the Cart API:
+
+```
+POST https://www.wixapis.com/ecom/v1/carts
+```
+
+## Step 3: Use Catalog Items in Cart
+
+### CMS App ID (for catalogReference)
+
+```
+e593b0bd-b783-45b8-97c2-873d42aacaf4
+```
+
+### Add CMS Catalog Item to Cart
+
+```
+POST https://www.wixapis.com/ecom/v1/carts/{cartId}/add-to-cart
+```
+
+```json
+{
+  "lineItems": [
+    {
+      "catalogReference": {
+        "appId": "e593b0bd-b783-45b8-97c2-873d42aacaf4",
+        "catalogItemId": "<cms-item-id>"
+      },
+      "quantity": 1
+    }
+  ]
+}
+```
+
+## Removing CATALOG Plugin
+
+```
+POST https://www.wixapis.com/wix-data/v2/collections/delete-plugin
+```
+
+```json
+{
+  "dataCollectionId": "Products",
+  "pluginType": "CATALOG"
+}
+```
+
+## Differences from Wix Stores
+
+| Feature | CMS Catalog | Wix Stores |
+|---------|-------------|------------|
+| Product management | CMS collections | Stores dashboard |
+| Variants | Manual (separate items) | Built-in variant system |
+| Inventory tracking | Manual via quantity field | Automatic |
+| Product options | Not supported | Full support |
+| Discounts | Manual price changes | Built-in discount system |
+
+CMS Catalogs are best for simple product catalogs. For complex eCommerce needs, consider Wix Stores.
+
+## See Also
+
+- [CMS Schema Management](cms-schema-management.md)
+- [CMS Data Operations](cms-data-items-crud.md)
+- [Wix Cart API](https://dev.wix.com/docs/rest/business-solutions/e-commerce/purchase-flow/cart/cart/introduction)

--- a/skills/wix-manage/references/cms/cms-references-and-relationships.md
+++ b/skills/wix-manage/references/cms/cms-references-and-relationships.md
@@ -1,0 +1,160 @@
+---
+name: "CMS References & Relationships"
+description: "Add, replace, or remove items from MULTI_REFERENCE fields. Use insert-references, replace-references, remove-references endpoints. Required for managing multi-reference relationships - these CANNOT be set via regular insert/update/patch operations. Also covers single references and querying with expanded references."
+---
+# CMS References & Relationships
+
+This recipe covers linking CMS collections together using reference fields.
+
+## Prerequisites
+
+1. Wix CMS enabled on the site
+2. At least two collections to link together
+3. API access with CMS permissions
+
+## Required APIs
+
+- **Collections API**: [REST](https://dev.wix.com/docs/rest/business-solutions/cms/collection-management/data-collections/introduction)
+- **Data Items API**: [REST](https://dev.wix.com/docs/rest/business-solutions/cms/data-items/introduction)
+
+## Reference Types
+
+| Type | Field Type | Relationship | Example |
+|------|------------|--------------|---------|
+| Single Reference | `REFERENCE` | One-to-one, Many-to-one | Product → Category |
+| Multi-Reference | `MULTI_REFERENCE` | One-to-many, Many-to-many | Product → Tags |
+
+## Add a Single Reference Field
+
+**Endpoint**: `POST /wix-data/v2/collections/create-field`
+
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/collections/create-field' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "field": {
+    "key": "category",
+    "displayName": "Category",
+    "type": "REFERENCE",
+    "typeMetadata": {
+      "reference": {
+        "referencedCollectionId": "Categories"
+      }
+    }
+  }
+}'
+```
+
+## Add a Multi-Reference Field
+
+**Endpoint**: `POST /wix-data/v2/collections/create-field`
+
+```bash
+curl -X POST \
+'https://www.wixapis.com/wix-data/v2/collections/create-field' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "dataCollectionId": "Products",
+  "field": {
+    "key": "tags",
+    "displayName": "Tags",
+    "type": "MULTI_REFERENCE",
+    "typeMetadata": {
+      "multiReference": {
+        "referencedCollectionId": "Tags",
+        "referencingFieldKey": "products",
+        "referencingDisplayName": "Products"
+      }
+    }
+  }
+}'
+```
+
+## Insert Multi-Reference Links
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/insert-references`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItemReferences": [
+    {
+      "referringItemId": "product-item-id",
+      "referringItemFieldName": "tags",
+      "referencedItemId": "tag-1-item-id"
+    },
+    {
+      "referringItemId": "product-item-id",
+      "referringItemFieldName": "tags",
+      "referencedItemId": "tag-2-item-id"
+    }
+  ],
+  "returnEntity": true
+}
+```
+
+## Replace All References
+
+**Endpoint**: `POST /wix-data/v2/items/replace-references`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "referringItemId": "product-item-id",
+  "referringItemFieldName": "tags",
+  "newReferencedItemIds": ["new-tag-1-id", "new-tag-2-id", "new-tag-3-id"]
+}
+```
+
+> **Note**: To remove all references, pass an empty array for `newReferencedItemIds`.
+
+## Remove References (Bulk)
+
+**Endpoint**: `POST /wix-data/v2/bulk/items/remove-references`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "dataItemReferences": [
+    {
+      "referringItemId": "product-id-1",
+      "referringItemFieldName": "tags",
+      "referencedItemId": "tag-to-remove-id"
+    }
+  ]
+}
+```
+
+## Query with Referenced Items Expanded
+
+**Endpoint**: `POST /wix-data/v2/items/query`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "query": {
+    "filter": {
+      "inStock": true
+    }
+  },
+  "includeReferencedItems": ["category", "tags"]
+}
+```
+
+## Reference Query Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `$eq` | Exact match (single reference) | `{ "category": "id" }` |
+| `$hasSome` | Has at least one of | `{ "tags": { "$hasSome": ["id1", "id2"] } }` |
+| `$hasAll` | Has all of | `{ "tags": { "$hasAll": ["id1", "id2"] } }` |
+
+## Related Documentation
+
+- [Data Items API Reference](https://dev.wix.com/docs/rest/business-solutions/cms/data-items/introduction)
+- [Collections API Reference](https://dev.wix.com/docs/rest/business-solutions/cms/collection-management/data-collections/introduction)
+- [CMS Schema Management Recipe](cms-schema-management.md)

--- a/skills/wix-manage/references/cms/cms-schema-management.md
+++ b/skills/wix-manage/references/cms/cms-schema-management.md
@@ -1,0 +1,143 @@
+---
+name: "CMS Schema Management"
+description: Create and modify CMS collection structures. Covers listing collections, creating collections with fields, adding/removing fields, and updating collection settings.
+---
+# CMS Schema Management
+
+This recipe covers managing the structure (schema) of Wix CMS collections using the REST API.
+
+## Prerequisites
+
+1. Wix CMS enabled on the site
+2. API access with CMS permissions (Manage Data Collections scope)
+
+## Required APIs
+
+- **Collections API**: [REST](https://dev.wix.com/docs/rest/business-solutions/cms/collection-management/data-collections/introduction)
+
+## List All Collections
+
+**Lightweight listing (recommended for existence checks)**:
+```bash
+curl -X GET \
+'https://www.wixapis.com/wix-data/v2/collections?fields=id' \
+-H 'Authorization: <AUTH>'
+```
+
+**Full listing (includes all field schemas)**:
+```bash
+curl -X GET \
+'https://www.wixapis.com/wix-data/v2/collections' \
+-H 'Authorization: <AUTH>'
+```
+
+**Collection Types**: `NATIVE` (user-created), `WIX_APP` (Wix app collections), `BLOCKS_APP`, `EXTERNAL`
+
+## Get Collection Schema
+
+**Endpoint**: `GET /wix-data/v2/collections/{collectionId}`
+
+```bash
+curl -X GET \
+'https://www.wixapis.com/wix-data/v2/collections/Products' \
+-H 'Authorization: <AUTH>'
+```
+
+## Create a New Collection
+
+**Endpoint**: `POST /wix-data/v2/collections`
+
+```json
+{
+  "collection": {
+    "id": "Products",
+    "displayName": "Products",
+    "fields": [
+      {"key": "title", "displayName": "Title", "type": "TEXT", "required": true},
+      {"key": "price", "displayName": "Price", "type": "NUMBER"},
+      {"key": "description", "displayName": "Description", "type": "TEXT"},
+      {"key": "inStock", "displayName": "In Stock", "type": "BOOLEAN"}
+    ],
+    "permissions": {
+      "insert": "ADMIN",
+      "update": "ADMIN",
+      "remove": "ADMIN",
+      "read": "ANYONE"
+    }
+  }
+}
+```
+
+## Add a Field to Existing Collection
+
+**Endpoint**: `POST /wix-data/v2/collections/create-field`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "field": {
+    "key": "sku",
+    "displayName": "SKU",
+    "type": "TEXT",
+    "description": "Product SKU code"
+  }
+}
+```
+
+## Delete a Field from Collection
+
+> **Warning**: This permanently deletes all data stored in this field across all items.
+
+**Endpoint**: `POST /wix-data/v2/collections/delete-field`
+
+```json
+{
+  "dataCollectionId": "Products",
+  "fieldKey": "sku"
+}
+```
+
+## Update Collection Settings
+
+**Endpoint**: `PATCH /wix-data/v2/collections/{collectionId}`
+
+```json
+{
+  "dataCollection": {
+    "id": "Products",
+    "displayName": "Product Catalog"
+  }
+}
+```
+
+## Field Types Reference
+
+| Type | Description | Example Value |
+|------|-------------|---------------|
+| `TEXT` | String | `"Hello World"` |
+| `NUMBER` | Numeric | `99.99` |
+| `BOOLEAN` | True/false | `true` |
+| `DATE` | Date only | `"2024-01-15"` |
+| `DATETIME` | Date and time | `{ "$date": "2024-01-15T10:00:00.000Z" }` |
+| `IMAGE` | Image reference | `"wix:image://v1/..."` |
+| `URL` | Web URL | `"https://example.com"` |
+| `RICH_TEXT` | HTML content | `"<p>Rich text</p>"` |
+| `ARRAY_STRING` | Array of strings | `["tag1", "tag2"]` |
+| `OBJECT` | JSON object | `{"key": "value"}` |
+| `REFERENCE` | Single reference | Item ID string |
+| `MULTI_REFERENCE` | Multiple references | Array of IDs |
+
+## Permission Levels
+
+| Role | Description |
+|------|-------------|
+| `ANYONE` | All visitors (including anonymous) |
+| `SITE_MEMBER` | Logged-in site members |
+| `SITE_MEMBER_AUTHOR` | Members who created the item |
+| `ADMIN` | Site admins only |
+
+## Related Documentation
+
+- [Data Collections API Reference](https://dev.wix.com/docs/rest/business-solutions/cms/collection-management/data-collections/introduction)
+- [Data Types in Wix Data](https://dev.wix.com/docs/rest/business-solutions/cms/data-types-in-wix-data)
+- [CMS Data Items CRUD Recipe](cms-data-items-crud.md)

--- a/skills/wix-manage/references/contacts/bulk-delete-contacts.md
+++ b/skills/wix-manage/references/contacts/bulk-delete-contacts.md
@@ -1,0 +1,73 @@
+---
+name: "Bulk Delete Contacts"
+description: Deletes multiple contacts using filter-based bulk delete. Covers safe deletion patterns, GDPR compliance, soft delete alternatives, and batch processing strategies.
+---
+# Bulk Delete Contacts
+
+## Description
+Deletes multiple contacts using the Wix Contacts REST API.
+
+All contacts that meet the specified `filter` and `search` criteria are deleted.
+The request should contain a `filter` value or a `search` value, or both.
+To perform a dry run, call [Query Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/query-contacts) with the intended filter options.
+
+When this method is called, a bulk job is started and the job ID is returned.
+The job might not complete right away, depending on its size.
+The job's status can be retrieved with [Get Bulk Job](https://dev.wix.com/docs/rest/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job).
+
+**IMPORTANT NOTE:** When specific contacts are to be deleted, they should be filtered by id.
+
+## API Endpoint
+`POST https://www.wixapis.com/contacts/v4/bulk/contacts/delete`
+
+## Request Example
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/contacts/v4/bulk/contacts/delete' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "filter": {
+      "info.name.last": "Smith"
+    }
+  }'
+```
+
+## Request Parameters
+
+- `filter` (object, optional): Filter criteria to identify contacts. When specific contacts are to be deleted, filter by `id`.
+- `search` (string, optional): Search query to identify contacts.
+
+**Note:** The request should contain a `filter` value or a `search` value, or both.
+
+## Response
+
+The response includes a `jobId` which can be used to track the bulk job status:
+
+```json
+{
+  "jobId": "00000000-0000-0000-0000-000000000001"
+}
+```
+
+Use the [Get Bulk Job](https://dev.wix.com/docs/rest/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job) endpoint to check the job status.
+
+## Common Errors
+
+The following errors might occur during the bulk processing and will appear in the bulk job:
+
+- `CANNOT_DELETE_SITE_MEMBERS` - Contact is a site member and can't be deleted. Member must be deleted first.
+- `CANNOT_DELETE_CONTACT_WITH_BILLING_SUBSCRIPTION` - Contact has a valid billing subscription and can't be deleted.
+- `CANNOT_DELETE_MEMBER_OWNER_OR_CONTRIBUTOR` - Member is a Wix user and can't be deleted. This can happen only if the request indicated to delete the member.
+- `FAILED_DELETE_CONTACT_AFTER_MEMBER_DELETION` - Member was deleted, but contact was not. This can happen only if the request indicated to delete the member.
+- `FAILED_DELETE_CONTACT` - Contact could not be deleted.
+
+## Permissions Required
+- `CONTACTS.MODIFY`
+- `MEMBERS.MEMBER_DELETE` (if deleting members)
+
+## Related Documentation
+- [Bulk Delete Contacts API Reference](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/bulk-delete-contacts)
+- [Query Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/query-contacts)
+- [Get Bulk Job](https://dev.wix.com/docs/rest/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job)

--- a/skills/wix-manage/references/contacts/bulk-label-and-unlabel-contacts.md
+++ b/skills/wix-manage/references/contacts/bulk-label-and-unlabel-contacts.md
@@ -1,0 +1,67 @@
+---
+name: "Bulk Label and Unlabel Contacts"
+description: Adds/removes labels from multiple contacts using Contacts API bulk operations. Covers label creation, contact filtering, batch processing, and rate limit handling.
+---
+# Bulk Label And Unlabel Contacts
+
+## Description
+Adds and removes labels from multiple contacts using the Wix Contacts REST API.
+
+Labels are added to and removed from all contacts that meet the specified `filter` and `search` criteria.
+The request should specify a `filter` value, a `search` value, or both.
+To perform a dry run, call [Query Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/query-contacts) with the intended filter options.
+
+When this method is used, a bulk job is started and the job ID is returned.
+The job might not complete right away, depending on its size.
+The job's status can be retrieved with [Get Bulk Job](https://dev.wix.com/docs/rest/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job).
+
+**IMPORTANT NOTE:** When specific contacts are to be labeled, they should be filtered by id.
+
+## API Endpoint
+`POST https://www.wixapis.com/contacts/v4/bulk/contacts/add-remove-labels`
+
+## Request Example
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/contacts/v4/bulk/contacts/add-remove-labels' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "filter": {
+      "info.name.first": "John"
+    },
+    "labelKeysToAdd": ["custom.name-john", "custom.name-starts-with-J"],
+    "labelKeysToRemove": ["custom.last-name-smith"]
+  }'
+```
+
+## Request Parameters
+
+- `filter` (object, optional): Filter criteria to identify contacts. When specific contacts are to be labeled, filter by `id`.
+- `search` (string, optional): Search query to identify contacts.
+- `labelKeysToAdd` (array of strings): Array of label keys to add to matching contacts.
+- `labelKeysToRemove` (array of strings): Array of label keys to remove from matching contacts.
+
+**Note:** The request should specify a `filter` value, a `search` value, or both.
+
+## Response
+
+The response includes a `jobId` which can be used to track the bulk job status:
+
+```json
+{
+  "jobId": "00000000-0000-0000-0000-000000000001"
+}
+```
+
+Use the [Get Bulk Job](https://dev.wix.com/docs/rest/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job) endpoint to check the job status.
+
+## Permissions Required
+- `CONTACTS.MODIFY`
+
+## Related Documentation
+- [Bulk Label And Unlabel Contacts API Reference](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/bulk-label-and-unlabel-contacts)
+- [Query Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/query-contacts)
+- [Get Bulk Job](https://dev.wix.com/docs/rest/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job)
+- [Labels API Reference](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/introduction)

--- a/skills/wix-manage/references/domains/domain-search-and-purchase.md
+++ b/skills/wix-manage/references/domains/domain-search-and-purchase.md
@@ -1,0 +1,195 @@
+---
+name: "Domain Search and Purchase"
+description: Search for available domains, get domain suggestions, and generate purchase links using Domain Search V2 API. Covers availability checks, TLD filtering, and connecting domains to Wix sites.
+---
+# Domain Search and Purchase
+
+This recipe guides you through searching for available domains, getting domain suggestions, and purchasing a domain to connect to a Wix site. Use this recipe when a user wants to buy a domain, find a domain, check domain availability, connect a domain to their site, or get a custom domain for their Wix site.
+
+## Prerequisites
+
+- Wix account with domain management permissions
+- Account-level API access
+
+## Required APIs
+
+- **Domain Search API**: [REST](https://dev.wix.com/docs/api-reference/account-level/domains/domain-search/introduction)
+- **Check Domain Availability API**: [Check Domain Availability](https://dev.wix.com/docs/api-reference/account-level/domains/domain-search/availability-v2/check-domain-availability) — `GET https://www.wixapis.com/domain-search/v2/check-domain-availability`
+- **Suggest Domains API**: [Suggest Domains](https://dev.wix.com/docs/api-reference/account-level/domains/domain-search/suggestion-v2/suggest-domains) — `GET https://www.wixapis.com/domain-search/v2/suggest-domains`
+
+---
+
+## Step 1: Understand User Requirements
+
+Before searching for domains, gather information:
+
+1. **Ask the user** what domain name they're looking for (e.g., `mybusiness.com`)
+2. **Clarify preferences** — do they want a specific TLD (.com, .net, .org) or are they open to suggestions?
+
+---
+
+## Step 2: Check Domain Availability
+
+If the user has a specific domain in mind, check whether it's available for purchase.
+
+**Endpoint**: `GET https://www.wixapis.com/domain-search/v2/check-domain-availability`
+
+**Query Parameters**:
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `domain` | The full domain name including TLD | `mybusiness.com` |
+
+**Example Request**:
+```bash
+curl -X GET \
+  'https://www.wixapis.com/domain-search/v2/check-domain-availability?domain=mybusiness.com' \
+  -H 'Authorization: <AUTH>'
+```
+
+**Example Response**:
+```json
+{
+  "availability": {
+    "domain": "mybusiness.com",
+    "available": true,
+    "premium": false,
+    "premiumType": "UNKNOWN_PREMIUM_TYPE"
+  }
+}
+```
+
+### Response Fields
+
+| Field | Description |
+|-------|-------------|
+| `domain` | The domain that was checked |
+| `available` | `true` if available for purchase, `false` if taken |
+| `premium` | `true` if this is a premium-priced domain |
+| `premiumType` | Type of premium pricing (if applicable) |
+
+### IMPORTANT NOTES:
+- The `domain` field **must** include the TLD (e.g., `mybusiness.com`, not just `mybusiness`)
+- Not all TLDs are supported. If you receive a `DOMAINS_UNSUPPORTED_TLD` error, inform the user and suggest supported alternatives
+- This is an **account-level API** — use the account-level authentication method (e.g., `ManageWixSite` tool)
+
+---
+
+## Step 3: Get Domain Suggestions
+
+If the user wants alternatives, or if their preferred domain is unavailable, use the suggestions API.
+
+**Endpoint**: `GET https://www.wixapis.com/domain-search/v2/suggest-domains`
+
+**Query Parameters**:
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `query` | Keyword or domain to base suggestions on | `mybusiness` |
+| `paging.limit` | Number of suggestions to return | `10` |
+| `tlds` | Filter by specific TLDs (can be repeated). Do **not** include the dot. | `com`, `net`, `org` |
+
+**Example Request**:
+```bash
+curl -X GET \
+  'https://www.wixapis.com/domain-search/v2/suggest-domains?query=mybusiness&paging.limit=10' \
+  -H 'Authorization: <AUTH>'
+```
+
+**Example Request with TLD filter**:
+```bash
+curl -X GET \
+  'https://www.wixapis.com/domain-search/v2/suggest-domains?query=mybusiness&paging.limit=5&tlds=com&tlds=net' \
+  -H 'Authorization: <AUTH>'
+```
+
+**Example Response**:
+```json
+{
+  "suggestions": [
+    { "domain": "mybusiness.com", "premium": false },
+    { "domain": "mybusiness.net", "premium": false },
+    { "domain": "mybusiness.org", "premium": false },
+    { "domain": "mybusiness.co", "premium": false },
+    { "domain": "mybusiness.online", "premium": false }
+  ],
+  "pagingMetadata": {
+    "count": 5,
+    "cursors": { "next": "..." },
+    "hasNext": true
+  }
+}
+```
+
+### Pagination
+
+If `pagingMetadata.hasNext` is `true`, more suggestions are available. Use the `cursors.next` value to fetch the next page.
+
+### Present Suggestions to User
+
+Show the suggestions in a clear format, highlighting:
+- Domain name
+- Whether it's a premium domain
+- Recommendations based on use case (e.g., `.com` for general, `.me` for personal branding, `.shop`/`.store` for e-commerce)
+
+---
+
+## Step 4: Select Target Site
+
+Before generating a purchase link, **ask the user which site** they'd like to connect the domain to.
+
+Use the `ListWixSites` tool to retrieve the user's sites and present them for selection. The user must pick a site, as the site ID is required for the purchase URL.
+
+---
+
+## Step 5: Generate Purchase Link
+
+Once the user picks a domain and a target site, first **verify availability** using Step 2, then generate a purchase link.
+
+**Purchase URL format**:
+```
+https://manage.wix.com/dashboard/{SITE_ID}/premium-express-checkout-app/storefront-bundle-selection?domainName={DOMAIN_NAME}&locale=en
+```
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `{SITE_ID}` | The Wix site ID (GUID) the domain will be connected to | `57d71937-e772-44ab-a89a-e4d0a7d9d814` |
+| `{DOMAIN_NAME}` | The chosen domain name including TLD | `mybusiness.com` |
+
+**Example**:
+```
+https://manage.wix.com/dashboard/57d71937-e772-44ab-a89a-e4d0a7d9d814/premium-express-checkout-app/storefront-bundle-selection?domainName=mybusiness.com&locale=en
+```
+
+Replace `{SITE_ID}` with the selected site's ID and `{DOMAIN_NAME}` with the user's chosen domain (e.g., `ravitgonen.online`).
+
+### Getting the Site ID
+
+Use the `ListWixSites` tool to list the user's sites and retrieve the site ID from the response.
+
+### IMPORTANT NOTES:
+- **Always verify availability** before generating the purchase link
+- If the domain has an unsupported TLD, inform the user and suggest alternatives
+- The actual purchase is completed by the user through the Wix dashboard — the API cannot process domain purchases directly
+
+---
+
+## Error Handling
+
+| Error Code | Description | Action |
+|------------|-------------|--------|
+| `DOMAINS_UNSUPPORTED_TLD` | The TLD is not supported by Wix | Inform the user and suggest supported TLDs using the Suggest Domains API |
+| `access_denied` | Authentication issue | Use account-level API authentication (not site-level) |
+
+---
+
+## Example Full Flow
+
+1. User asks to buy `mysite.io`
+2. Check availability → `DOMAINS_UNSUPPORTED_TLD` error
+3. Inform user that `.io` is not supported
+4. Get suggestions for `mysite` → present alternatives
+5. User picks `mysite.online`
+6. Verify `mysite.online` is available → `available: true`
+7. List user's sites and ask which site they'd like to connect the domain to
+8. User selects their site (e.g., site ID `57d71937-e772-44ab-a89a-e4d0a7d9d814`)
+9. Generate purchase link: `https://manage.wix.com/dashboard/57d71937-e772-44ab-a89a-e4d0a7d9d814/premium-express-checkout-app/storefront-bundle-selection?domainName=mysite.online&locale=en`
+10. Share link with user to complete purchase

--- a/skills/wix-manage/references/ecommerce/setup-store-pickup-location.md
+++ b/skills/wix-manage/references/ecommerce/setup-store-pickup-location.md
@@ -1,0 +1,209 @@
+---
+name: "Recipe: Set Up Store Pickup Location"
+description: Configures a pickup option for an online store so customers can choose in-store pickup at checkout. Uses the Delivery Profiles API to discover the Pickup carrier, add a delivery region, and attach the carrier with a free pickup rate.
+---
+# Set Up Store Pickup Location
+
+## Prerequisites
+
+- Wix Stores (or another eCommerce business solution) installed on the site
+- The **Pickup** carrier must be installed on the site (it is a built-in carrier, not a third-party app)
+
+## Required APIs
+
+- [List Installed Delivery Carriers](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/list-installed-delivery-carriers)
+- [Query Delivery Profiles](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/query-delivery-profiles)
+- [Add Delivery Region](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/add-delivery-region)
+- [Add Delivery Carrier](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/add-delivery-carrier)
+
+---
+
+## Step 1: Discover the Pickup carrier
+
+Call [List Installed Delivery Carriers](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/list-installed-delivery-carriers) to find the Pickup carrier's `id`.
+
+**Endpoint**: `GET https://www.wixapis.com/ecom/v1/delivery-profiles/installed-carriers`
+
+**Response**:
+```json
+{
+  "installedDeliveryCarriers": [
+    {
+      "id": "50d8c12f-715e-41ad-be25-d0f61375dbee",
+      "displayName": "Pickup",
+      "fallbackDefinitionMandatory": false,
+      "toggleGetCarrierSettingsEnabled": true
+    },
+    {
+      "id": "45c44b27-ca7b-4891-8c0d-1747d588b835",
+      "displayName": "Basic Shipping",
+      "description": "Manage shipping rates and options for this region",
+      "fallbackDefinitionMandatory": false,
+      "toggleGetCarrierSettingsEnabled": true
+    }
+  ]
+}
+```
+
+Look for the carrier with `"displayName": "Pickup"` and save its `id`. This is the `appId` you will use in Step 4.
+
+If no Pickup carrier appears in the list, the Pickup app is not installed on the site and must be installed before proceeding.
+
+---
+
+## Step 2: Find the default delivery profile
+
+Call [Query Delivery Profiles](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/query-delivery-profiles) to retrieve the site's default delivery profile.
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/delivery-profiles/query`
+
+**Request**:
+```json
+{}
+```
+
+The response contains an array of `deliveryProfiles`. Find the one where `"default": true`. Save its `id` and `revision`. Inspect its `deliveryRegions` array.
+
+**Decision point:**
+- **Region exists for the user's country** (match on `destinations[].countryCode`): save that region's `id` → skip to Step 4.
+- **No matching region**: proceed to Step 3.
+
+---
+
+## Step 3: Add a delivery region for the pickup country
+
+If no region exists for the user's country in the default profile, call [Add Delivery Region](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/add-delivery-region) to create one.
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/delivery-profiles/{deliveryProfileId}/delivery-region`
+
+Replace `{deliveryProfileId}` with the default profile's `id` from Step 2.
+
+**Request**:
+```json
+{
+  "deliveryRegion": {
+    "name": "US Pickup",
+    "active": true,
+    "destinations": [
+      {
+        "countryCode": "US"
+      }
+    ]
+  },
+  "revision": "3"
+}
+```
+
+- `name`: descriptive, e.g. `"{Country} Pickup"`.
+- `countryCode`: [ISO-3166 alpha-2](https://www.iso.org/obp/ui/#search/code/) code (e.g. `"US"`, `"IL"`, `"DE"`, `"GB"`).
+- `revision`: from the profile returned in Step 2.
+
+**Response**:
+```json
+{
+  "deliveryProfile": {
+    "id": "02625bf4-70b4-49b7-93f0-5c9d72608937",
+    "name": "General profile",
+    "default": true,
+    "deliveryRegions": [
+      {
+        "id": "23823d4a-0ad2-4f92-a48a-467497a9470a",
+        "name": "US Pickup",
+        "active": true,
+        "deliveryCarriers": [],
+        "destinations": [
+          {
+            "countryCode": "US",
+            "subdivisions": []
+          }
+        ]
+      }
+    ],
+    "revision": "4"
+  }
+}
+```
+
+Save the new region's `id` from the response.
+
+---
+
+## Step 4: Add the Pickup carrier to the region
+
+Call [Add Delivery Carrier](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/add-delivery-carrier) to attach the Pickup carrier to the delivery region.
+
+**Endpoint**: `POST https://www.wixapis.com/ecom/v1/delivery-profiles/add-delivery-carrier`
+
+**Request**:
+```json
+{
+  "deliveryRegionId": "<REGION_ID>",
+  "deliveryCarrier": {
+    "appId": "50d8c12f-715e-41ad-be25-d0f61375dbee",
+    "backupRate": {
+      "title": "Pickup at 123 Main St, New York",
+      "amount": "0",
+      "active": true
+    }
+  }
+}
+```
+
+- `deliveryRegionId`: from Step 2 (existing region) or Step 3 (new region).
+- `appId`: the Pickup carrier `id` from Step 1.
+- `backupRate.title`: the pickup address customers see at checkout.
+- `backupRate.amount`: `"0"` for free pickup, or a price string like `"5.00"`.
+- `backupRate.active`: must be `true` for the option to appear at checkout.
+
+**Response**:
+```json
+{
+  "deliveryProfile": {
+    "id": "02625bf4-70b4-49b7-93f0-5c9d72608937",
+    "name": "General profile",
+    "default": true,
+    "deliveryRegions": [
+      {
+        "id": "23823d4a-0ad2-4f92-a48a-467497a9470a",
+        "name": "US Pickup",
+        "active": true,
+        "deliveryCarriers": [
+          {
+            "appId": "50d8c12f-715e-41ad-be25-d0f61375dbee",
+            "backupRate": {
+              "title": "Pickup at 123 Main St, New York",
+              "amount": "0",
+              "active": true
+            },
+            "additionalCharges": []
+          }
+        ],
+        "destinations": [
+          {
+            "countryCode": "US",
+            "subdivisions": []
+          }
+        ]
+      }
+    ],
+    "revision": "5"
+  }
+}
+```
+
+---
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `DESTINATIONS_COLLISION` | The country is already assigned to another region in the same profile. | Skip Step 3 — use the existing region's `id` and add the carrier to it in Step 4. |
+| `CARRIER_ALREADY_EXISTS_IN_REGION` | The Pickup carrier is already configured in this region. | The pickup option is already set up. No action needed. |
+| `DELIVERY_CARRIER_MISSING_BACKUP_RATE` | The `backupRate` or `backupRate.amount` field is missing. | Ensure `backupRate` includes `title`, `amount`, and `active`. |
+
+---
+
+## Related Documentation
+
+- [Delivery Profiles: Introduction](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/introduction)
+- [Delivery Profiles: Sample Flows](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/shipping-delivery/delivery-profiles/sample-flows)

--- a/skills/wix-manage/references/events/list-events.md
+++ b/skills/wix-manage/references/events/list-events.md
@@ -1,0 +1,203 @@
+---
+name: "List Events"
+description: Queries events from Wix Events using Events API. Covers field sets (DETAILS, URLS, REGISTRATION), filtering by status/date, and pagination.
+---
+# List Events with Wix Events API
+
+This recipe demonstrates how to query and list events from Wix Events using the REST API.
+
+## Prerequisites
+
+- Wix Events app installed on the site
+- API access with events permissions
+
+## Required APIs
+
+- **Events API**: [REST](https://dev.wix.com/docs/rest/business-solutions/events/events-v3/query-events)
+- **Filter and Sort Guidelines**: [Documentation](https://dev.wix.com/docs/rest/business-solutions/events/events-v3/filter-and-sort)
+
+---
+
+## Step 1: Verify Events App is Installed
+
+Before querying events, ensure Wix Events is installed on the site. If not, use the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe to install it.
+
+---
+
+## Step 2: Query Events
+
+**Endpoint**: `POST https://www.wixapis.com/events/v3/events/query`
+
+**Request Body**:
+```json
+{
+  "query": {
+    "paging": {
+      "limit": 10
+    }
+  },
+  "fields": ["DETAILS", "URLS"]
+}
+```
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/events/v3/events/query' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": {
+      "paging": {
+        "limit": 10
+      }
+    },
+    "fields": ["DETAILS", "URLS"]
+  }'
+```
+
+### Available Field Sets
+
+The `fields` parameter determines which data is returned. You MUST specify at least `"DETAILS"`.
+
+| Field Set | Description |
+|-----------|-------------|
+| `DETAILS` | Core event information (required) |
+| `URLS` | Event page URLs |
+| `CATEGORIES` | Event categories |
+| `AGENDA` | Event schedule/agenda |
+| `SEO_SETTINGS` | SEO metadata |
+| `REGISTRATION` | Registration settings |
+| `TEXTS` | Custom text content |
+| `FORM` | Registration form configuration |
+| `DASHBOARD` | Dashboard settings |
+| `FEED` | Social feed settings |
+| `ONLINE_CONFERENCING_SESSION` | Virtual event settings |
+
+### IMPORTANT NOTES:
+- I MUST specify at least `"DETAILS"` in the `fields` array
+- I MUST NEVER use `"FULL"` as a field value
+- If the user wants event links, I MUST include `"URLS"` in the fields
+- Follow the [Filter and Sort Guidelines](https://dev.wix.com/docs/rest/business-solutions/events/events-v3/filter-and-sort) for query filtering
+
+---
+
+## Step 3: Filter Events (Optional)
+
+Apply filters to narrow down results:
+
+**Filter by Status**:
+```json
+{
+  "query": {
+    "filter": {
+      "status": "UPCOMING"
+    },
+    "paging": {
+      "limit": 10
+    }
+  },
+  "fields": ["DETAILS"]
+}
+```
+
+> **Note:** Valid status values are: `UPCOMING`, `STARTED`, `ENDED`, `CANCELED`, `DRAFT`.
+
+**Filter by Date Range**:
+```json
+{
+  "query": {
+    "filter": {
+      "dateAndTimeSettings.startDate": {
+        "$gte": "2024-01-01T00:00:00Z",
+        "$lte": "2024-12-31T23:59:59Z"
+      }
+    },
+    "paging": {
+      "limit": 10
+    }
+  },
+  "fields": ["DETAILS"]
+}
+```
+
+---
+
+## Response Structure
+
+```json
+{
+  "events": [
+    {
+      "id": "event-id-123",
+      "title": "Event Title",
+      "shortDescription": "Event description",
+      "status": "UPCOMING",
+      "dateAndTimeSettings": {
+        "startDate": "2024-06-15T10:00:00Z",
+        "endDate": "2024-06-15T18:00:00Z",
+        "timeZoneId": "America/New_York",
+        "dateAndTimeTbd": false,
+        "recurrenceStatus": "ONE_TIME"
+      },
+      "location": {
+        "type": "VENUE",
+        "address": {}
+      },
+      "slug": "event-slug"
+    }
+  ],
+  "pagingMetadata": {
+    "count": 10,
+    "hasNext": true
+  }
+}
+```
+
+---
+
+## Common Use Cases
+
+### List Upcoming Events
+```json
+{
+  "query": {
+    "filter": {
+      "status": "UPCOMING",
+      "dateAndTimeSettings.startDate": {
+        "$gte": "2024-01-01T00:00:00Z"
+      }
+    },
+    "sort": [
+      {
+        "fieldName": "dateAndTimeSettings.startDate",
+        "order": "ASC"
+      }
+    ],
+    "paging": {
+      "limit": 20
+    }
+  },
+  "fields": ["DETAILS", "URLS"]
+}
+```
+
+### List Events with Registration Info
+```json
+{
+  "query": {
+    "paging": {
+      "limit": 10
+    }
+  },
+  "fields": ["DETAILS", "REGISTRATION", "FORM"]
+}
+```
+
+---
+
+## Next Steps
+
+- Create events using the [Create Event API](https://dev.wix.com/docs/rest/business-solutions/events/events-v3/create-event)
+- Manage RSVPs and registrations
+- Configure event tickets and pricing

--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -1,0 +1,260 @@
+---
+name: "Create Form"
+description: Creates a form with fields (name, email, etc.) using the Form Schemas API. Covers field configuration, layout, and post-submission triggers.
+---
+# RECIPE: Create a Wix Form
+
+Create a form on a Wix site that appears in the Forms & Submissions dashboard. The form collects visitor information (e.g., name, email) and can automatically upsert contacts on submission.
+
+---
+
+## Create the form
+
+Call the Create Form endpoint with the `wix.form_app.form` namespace. The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) is usually already installed on sites.
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/form-schema-service/v4/forms' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  -d '{
+    "form": {
+      "name": "Contact Form",
+      "namespace": "wix.form_app.form",
+      "enabled": true,
+      "spamFilterProtectionLevel": "ADVANCED",
+      "formFields": [
+        {
+          "id": "c1a2b3d4-0001-4a00-b000-000000000001",
+          "hidden": false,
+          "identifier": "CONTACTS_FIRST_NAME",
+          "fieldType": "INPUT",
+          "inputOptions": {
+            "target": "first_name_0001",
+            "pii": true,
+            "required": false,
+            "inputType": "STRING",
+            "readOnly": false,
+            "stringOptions": {
+              "validation": {
+                "format": "UNKNOWN_FORMAT",
+                "enum": []
+              },
+              "componentType": "TEXT_INPUT",
+              "textInputOptions": {
+                "label": "First name",
+                "showLabel": true
+              }
+            }
+          }
+        },
+        {
+          "id": "c1a2b3d4-0002-4a00-b000-000000000002",
+          "hidden": false,
+          "identifier": "CONTACTS_LAST_NAME",
+          "fieldType": "INPUT",
+          "inputOptions": {
+            "target": "last_name_0002",
+            "pii": true,
+            "required": false,
+            "inputType": "STRING",
+            "readOnly": false,
+            "stringOptions": {
+              "validation": {
+                "format": "UNKNOWN_FORMAT",
+                "enum": []
+              },
+              "componentType": "TEXT_INPUT",
+              "textInputOptions": {
+                "label": "Last name",
+                "showLabel": true
+              }
+            }
+          }
+        },
+        {
+          "id": "c1a2b3d4-0003-4a00-b000-000000000003",
+          "hidden": false,
+          "identifier": "CONTACTS_EMAIL",
+          "fieldType": "INPUT",
+          "inputOptions": {
+            "target": "email_0003",
+            "pii": true,
+            "required": true,
+            "inputType": "STRING",
+            "readOnly": false,
+            "stringOptions": {
+              "validation": {
+                "format": "EMAIL",
+                "enum": []
+              },
+              "componentType": "TEXT_INPUT",
+              "textInputOptions": {
+                "label": "Email",
+                "showLabel": true
+              }
+            }
+          }
+        },
+        {
+          "id": "c1a2b3d4-0004-4a00-b000-000000000004",
+          "hidden": false,
+          "identifier": "TEXT_INPUT",
+          "fieldType": "INPUT",
+          "inputOptions": {
+            "target": "message_0004",
+            "pii": false,
+            "required": false,
+            "inputType": "STRING",
+            "readOnly": false,
+            "stringOptions": {
+              "validation": {
+                "format": "UNKNOWN_FORMAT",
+                "enum": []
+              },
+              "componentType": "TEXT_INPUT",
+              "textInputOptions": {
+                "label": "Message",
+                "showLabel": true
+              }
+            }
+          }
+        },
+        {
+          "id": "c1a2b3d4-0005-4a00-b000-000000000005",
+          "hidden": false,
+          "identifier": "SUBMIT_BUTTON",
+          "fieldType": "DISPLAY",
+          "displayOptions": {
+            "displayFieldType": "PAGE_NAVIGATION",
+            "pageNavigationOptions": {
+              "nextPageText": "Next",
+              "previousPageText": "Back",
+              "submitText": "Submit"
+            }
+          }
+        }
+      ],
+      "steps": [
+        {
+          "id": "d1e2f3a4-0001-4b00-c000-000000000001",
+          "name": "Page 1",
+          "hidden": false,
+          "layout": {
+            "large": {
+              "items": [
+                { "fieldId": "c1a2b3d4-0001-4a00-b000-000000000001", "row": 0, "column": 0, "width": 6, "height": 1 },
+                { "fieldId": "c1a2b3d4-0002-4a00-b000-000000000002", "row": 0, "column": 6, "width": 6, "height": 1 },
+                { "fieldId": "c1a2b3d4-0003-4a00-b000-000000000003", "row": 1, "column": 0, "width": 12, "height": 1 },
+                { "fieldId": "c1a2b3d4-0004-4a00-b000-000000000004", "row": 2, "column": 0, "width": 12, "height": 1 },
+                { "fieldId": "c1a2b3d4-0005-4a00-b000-000000000005", "row": 3, "column": 6, "width": 6, "height": 1 }
+              ],
+              "sections": []
+            }
+          }
+        }
+      ],
+      "postSubmissionTriggers": {
+        "upsertContact": {
+          "fieldsMapping": {
+            "first_name_0001": { "contactField": "FIRST_NAME" },
+            "last_name_0002": { "contactField": "LAST_NAME" },
+            "email_0003": { "contactField": "EMAIL", "emailInfo": { "tag": "UNTAGGED" } }
+          },
+          "labels": []
+        }
+      },
+      "submitSettings": {
+        "submitSuccessAction": "THANK_YOU_MESSAGE",
+        "thankYouMessageOptions": {
+          "durationInSeconds": 8,
+          "richContent": {
+            "nodes": [
+              {
+                "type": "PARAGRAPH",
+                "id": "ty1",
+                "nodes": [
+                  {
+                    "type": "TEXT",
+                    "id": "",
+                    "nodes": [],
+                    "textData": {
+                      "text": "Thanks, we received your submission.",
+                      "decorations": []
+                    }
+                  }
+                ],
+                "paragraphData": {
+                  "textStyle": { "textAlignment": "CENTER" }
+                }
+              }
+            ],
+            "metadata": {
+              "version": 1,
+              "createdTimestamp": "2025-01-01T00:00:00.000Z",
+              "updatedTimestamp": "2025-01-01T00:00:00.000Z",
+              "id": "thank-you-msg-001"
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+
+The response includes the created form with its `id`. Store this ID to manage the form later.
+
+Verify the form in the dashboard: `https://manage.wix.com/dashboard/{siteId}/forms`
+
+## Key Details
+
+### Field Configuration
+
+- All `id` fields (for `formFields`, `steps`) and all `fieldId` references in the layout **must be valid UUIDs**. Generate fresh UUIDs for each form you create — do not reuse the example UUIDs above.
+- Each field needs a unique `id` and a unique `target` value. The `target` is used to map submissions to contact fields.
+- **CRITICAL: The `identifier` must be a recognized Wix value.** Custom identifiers like `"product_name"` or `"color_preference"` will cause the field to be silently dropped from the form — no error is thrown. For any generic/custom text field, use `"TEXT_INPUT"` as the identifier and set the display name via the `label` property in `textInputOptions`.
+- For plain text fields, use `"format": "UNKNOWN_FORMAT"`. For email fields, use `"format": "EMAIL"`. For phone fields, use `"format": "PHONE"`. Valid format values: `UNKNOWN_FORMAT`, `DATE`, `TIME`, `DATE_TIME`, `EMAIL`, `URL`, `UUID`, `PHONE`, `URI`, `HOSTNAME`, `COLOR_HEX`, `CURRENCY`, `LANGUAGE`, `DATE_OPTIONAL_TIME`.
+- The submit button is a `DISPLAY` field with `identifier: "SUBMIT_BUTTON"`.
+
+### Field Types Reference
+
+| Identifier | componentType | format | Use case |
+|---|---|---|---|
+| `TEXT_INPUT` | `TEXT_INPUT` | `UNKNOWN_FORMAT` | Generic single-line text (use `label` for display name) |
+| `CONTACTS_FIRST_NAME` | `TEXT_INPUT` | `UNKNOWN_FORMAT` | Contact first name |
+| `CONTACTS_LAST_NAME` | `TEXT_INPUT` | `UNKNOWN_FORMAT` | Contact last name |
+| `CONTACTS_EMAIL` | `TEXT_INPUT` | `EMAIL` | Contact email |
+| `CONTACTS_PHONE` | `TEXT_INPUT` | `PHONE` | Contact phone |
+| `SUBMIT_BUTTON` | N/A (`DISPLAY` field) | N/A | Submit button |
+
+> **Note:** `LONG_TEXT_INPUT` is not supported as a `componentType` via REST — it throws `INVALID_ARGUMENT`. Use `TEXT_INPUT` for all text fields.
+
+### Layout
+
+The `steps[].layout.large.items` array controls how fields are positioned:
+- `row` and `column` set the position (0-based grid)
+- `width` sets the column span (max 12 for full width, 6 for half)
+- `height` is typically 1
+
+### Post-Submission Triggers
+
+The `postSubmissionTriggers.upsertContact` object maps form field targets to contact fields, so each submission automatically creates or updates a contact. The `fieldsMapping` keys must match the `target` values from the form fields.
+
+### Prerequisites
+
+The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be installed on the site. It is usually pre-installed, but if the API returns a "missing installed app" error, install it first using the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Unrecognized value passed for enum` | Invalid `componentType` value (e.g., `LONG_TEXT_INPUT`) | Use only `componentType` values from the schema: `TEXT_INPUT`, `RADIO_GROUP`, `DROPDOWN`, `DATE_TIME`, `PHONE_INPUT`, `DATE_INPUT`, `TIME_INPUT`, `DATE_PICKER`, `PASSWORD` |
+| Field silently missing from created form | Custom `identifier` value (e.g., `"product_name"`) | Use a recognized identifier like `TEXT_INPUT` and set display name via `label` |
+| `Permissions for given namespace not found` | `wix.form_app.form` namespace not active | Ensure the Wix Forms app is installed; try creating a form through the UI first to activate the namespace |
+| `missing installed app` | Wix Forms app not installed | Install app `14ce1214-b278-a7e4-1373-00cebd1bef7c` via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
+
+## Related Documentation
+
+- [Form Schemas API Introduction](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/introduction)
+- [Create Form API Reference](https://dev.wix.com/docs/api-reference/crm/forms/form-schemas/create-form)
+- [Form Submissions API](https://dev.wix.com/docs/api-reference/crm/forms/form-submissions/introduction)

--- a/skills/wix-manage/references/get-paid/create-payment-links.md
+++ b/skills/wix-manage/references/get-paid/create-payment-links.md
@@ -1,0 +1,212 @@
+---
+name: "Create Payment Links"
+description: Creates payment links for collecting payments without a checkout flow. Covers store products (catalog items), custom line items, variants, due dates, and sending links via email.
+---
+# Create Payment Links
+
+This recipe shows how to create and manage payment links using the current Payment Links REST API.
+
+## Prerequisites
+
+1. Site is premium.
+2. Site is published.
+3. Site is set up to accept payments (Wix Payments onboarding completed).
+4. App has payment-link permissions.
+5. Wix Stores is installed if you plan to charge for catalog products.
+
+## Required APIs
+
+- **Payment Links API**: [REST](https://dev.wix.com/docs/api-reference/business-management/get-paid/payment-links/payment-links/create-payment-link)
+- **Products API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v1/catalog/query-products)
+
+## Overview
+
+Payment links are created at:
+
+- `POST https://www.wixapis.com/payment-links/v1/payment-links`
+
+Use one of these payment-link types:
+
+- `ECOM`: charge for custom or catalog line items.
+- `ECOM_ORDER`: collect payment for an existing unpaid eCommerce order.
+
+## Step 1: Retrieve product details (optional)
+
+If you plan to use catalog items, fetch the product first.
+
+**Examples**:
+
+- Catalog V1: `GET https://www.wixapis.com/stores/v1/products/{productId}`
+- Catalog V1 query: `POST https://www.wixapis.com/stores/v1/products/query`
+
+```json
+{
+  "query": {
+    "paging": {
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}
+```
+
+## Step 2: Create an `ECOM` payment link with custom line items
+
+```json
+{
+  "paymentLink": {
+    "title": "Business Listing Fee",
+    "description": "One-time listing fee",
+    "currency": "USD",
+    "type": "ECOM",
+    "ecomPaymentLink": {
+      "lineItems": [
+        {
+          "type": "CUSTOM",
+          "customItem": {
+            "name": "Listing Fee",
+            "quantity": 1,
+            "price": "200.00"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Step 3: Create an `ECOM` payment link with catalog items
+
+```json
+{
+  "paymentLink": {
+    "title": "Product Payment",
+    "currency": "USD",
+    "type": "ECOM",
+    "ecomPaymentLink": {
+      "lineItems": [
+        {
+          "type": "CATALOG",
+          "catalogItem": {
+            "quantity": 1,
+            "catalogReference": {
+              "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "catalogItemId": "PRODUCT_ID",
+              "options": {
+                "variantId": "VARIANT_ID"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Step 4: Create an `ECOM_ORDER` payment link for an existing order
+
+```json
+{
+  "paymentLink": {
+    "title": "Order Balance",
+    "currency": "USD",
+    "type": "ECOM_ORDER",
+    "paymentsLimit": 1,
+    "ecomOrderPaymentLink": {
+      "orderId": "ORDER_ID",
+      "amount": "50"
+    }
+  }
+}
+```
+
+## Step 5: Send payment link to recipients
+
+Use:
+
+- `POST https://www.wixapis.com/payment-links/v1/payment-links/{paymentLinkId}/send`
+
+Request body:
+
+```json
+{
+  "paymentLinkId": "PAYMENT_LINK_ID",
+  "recipients": [
+    {
+      "contactId": "CONTACT_ID",
+      "sendMethods": ["EMAIL_METHOD"]
+    }
+  ]
+}
+```
+
+## Step 6: Query and manage payment links
+
+Query:
+
+- `POST https://www.wixapis.com/payment-links/v1/payment-links/query`
+
+```json
+{
+  "query": {
+    "filter": {
+      "status": "ACTIVE"
+    },
+    "cursorPaging": {
+      "limit": 50
+    }
+  }
+}
+```
+
+Get one:
+
+- `GET https://www.wixapis.com/payment-links/v1/payment-links/{paymentLinkId}`
+
+Deactivate:
+
+- `POST https://www.wixapis.com/payment-links/v1/payment-links/{paymentLinkId}/deactivate`
+
+Activate:
+
+- `POST https://www.wixapis.com/payment-links/v1/payment-links/{paymentLinkId}/activate`
+
+Delete (only when no payments were received):
+
+- `DELETE https://www.wixapis.com/payment-links/v1/payment-links/{paymentLinkId}`
+
+## Payment Link Statuses
+
+| Status | Description |
+|--------|-------------|
+| `ACTIVE` | Link is active and can receive payments |
+| `INACTIVE` | Link is inactive and cannot receive payments |
+| `PAID` | Payment has been completed |
+| `EXPIRED` | Link has passed its expiration date |
+
+## Common Errors
+
+| Error Code | Meaning |
+|------------|---------|
+| `UNPUBLISHED_SITE` | Site must be published before creating payment links |
+| `MISSING_ACCEPT_PAYMENTS` | Site is not set up to accept payments |
+| `FAILED_TO_INSTALL_ECOM` | Required eCommerce capability is missing |
+| `RECIPIENT_NOT_FOUND` | Provided recipient contact does not exist |
+| `ORDER_NOT_FOUND` | Provided order ID does not exist |
+| `INVALID_PAYMENTS_LIMIT_FOR_ECOM_ORDER_PAYMENT_LINK` | `ECOM_ORDER` links require `paymentsLimit: 1` |
+
+## Best Practices
+
+1. Validate prerequisites first (premium, published, payments enabled).
+2. Use `ECOM` for line-item collection and `ECOM_ORDER` for existing unpaid orders.
+3. Use IDs from real entities (products, variants, contacts, orders).
+4. Keep currency aligned with your business/order currency rules.
+5. Persist payment-link IDs and monitor status via query/get methods.
+
+## Related Documentation
+
+- [Payment Links API Reference](https://dev.wix.com/docs/api-reference/business-management/get-paid/payment-links/payment-links/introduction)
+- [Payments Overview](https://dev.wix.com/docs/api-reference/business-management/get-paid/payment-links/introduction)
+- [Products API Reference](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v1/catalog/introduction)
+- [Send Payment Link](https://dev.wix.com/docs/api-reference/business-management/get-paid/payment-links/payment-links/send-payment-link)

--- a/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
+++ b/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
@@ -1,0 +1,57 @@
+---
+name: "How to Setup Wix Payments"
+description: Configures Wix Payments as the payment provider. Covers eligibility checking, business verification, bank account setup, and payment method configuration (cards, PayPal, Apple Pay).
+---
+# How to Set Up Wix Payments
+
+This recipe covers the setup flow needed before creating payment links or collecting payments.
+
+## Step 1: Collect required user inputs
+
+Before connecting Wix Payments, collect and confirm:
+
+1. Terms acceptance: https://www.wix.com/about/terms-of-payments
+2. First name
+3. Last name
+4. Product/service description (minimum meaningful business description)
+
+## Step 2: Connect Wix Payments account
+
+Call:
+
+- `POST https://www.wixapis.com/payments/v1/wix-payments-account/connect`
+
+```json
+{
+  "account": {
+    "firstName": "<USER_FIRST_NAME>",
+    "lastName": "<USER_LAST_NAME>",
+    "tosAccepted": true,
+    "productDescription": "<PRODUCT_DESCRIPTION>"
+  }
+}
+```
+
+## Step 3: Handle common setup blockers
+
+### Location-related failure
+
+If setup fails due to location details, update the business location and retry:
+
+- `PUT https://www.wixapis.com/locations/v1/locations/{locationId}`
+- Reference: [Update Location](https://dev.wix.com/docs/api-reference/business-management/locations/update-location)
+
+### Already connected
+
+If the API returns an "already connected" style response, skip reconnect and continue with onboarding checks.
+
+## Step 4: Complete dashboard onboarding
+
+Connecting the account is not always the final step. To receive payments, the site owner may still need to complete Wix Payments onboarding in the site dashboard.
+
+## Important Notes
+
+1. Never invent or assume user identity/business details.
+2. Always obtain explicit user consent before calling connect.
+3. Use the exact accepted values provided by the user.
+4. Verify readiness by testing a real payment flow (for example, create payment link) after setup.

--- a/skills/wix-manage/references/get-paid/payment-links-for-bookings.md
+++ b/skills/wix-manage/references/get-paid/payment-links-for-bookings.md
@@ -1,0 +1,101 @@
+---
+name: "Payment Links for Bookings"
+description: Creates payment links for unpaid bookings using Payment Links API. Links booking IDs to payment requests with proper redirect handling.
+---
+# Payment Links for Bookings
+
+Use this recipe to collect payment for booking-related flows by generating payment links with the Payment Links API.
+
+## When to Use Which Type
+
+### Use `ECOM_ORDER` for existing unpaid orders
+
+If a booking already has an associated unpaid eCommerce order, create an `ECOM_ORDER` payment link.
+
+```json
+{
+  "paymentLink": {
+    "title": "Booking Balance",
+    "currency": "USD",
+    "type": "ECOM_ORDER",
+    "paymentsLimit": 1,
+    "ecomOrderPaymentLink": {
+      "orderId": "ORDER_ID",
+      "amount": "50"
+    }
+  }
+}
+```
+
+Notes:
+- `orderId` must exist and be unpaid.
+- `ECOM_ORDER` links require `paymentsLimit: 1`.
+
+### Use `ECOM` for ad-hoc booking charges
+
+If there is no existing order, create an `ECOM` payment link with custom line items.
+
+```json
+{
+  "paymentLink": {
+    "title": "Booking Fee",
+    "currency": "USD",
+    "type": "ECOM",
+    "ecomPaymentLink": {
+      "lineItems": [
+        {
+          "type": "CUSTOM",
+          "customItem": {
+            "name": "Booking Fee",
+            "quantity": 1,
+            "price": "50.00"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Send Flow
+
+Creating a payment link does not deliver it. Send it explicitly:
+
+- `POST https://www.wixapis.com/payment-links/v1/payment-links/{paymentLinkId}/send`
+
+```json
+{
+  "paymentLinkId": "PAYMENT_LINK_ID",
+  "recipients": [
+    {
+      "contactId": "CONTACT_ID",
+      "sendMethods": ["EMAIL_METHOD"]
+    }
+  ]
+}
+```
+
+## Prerequisites
+
+Before creating booking payment links, ensure:
+
+1. Site is premium.
+2. Site is published.
+3. Site is set up to accept payments.
+4. Required payment-link permissions are granted to the app.
+5. Recipient contacts exist if you plan to send links.
+
+## Common Errors
+
+| Error Code | Meaning |
+|------------|---------|
+| `UNPUBLISHED_SITE` | Site must be published before creating payment links |
+| `MISSING_ACCEPT_PAYMENTS` | Site is not set up to accept payments |
+| `ORDER_NOT_FOUND` | The provided order ID does not exist |
+| `INVALID_PAYMENTS_LIMIT_FOR_ECOM_ORDER_PAYMENT_LINK` | `ECOM_ORDER` links require `paymentsLimit: 1` |
+| `RECIPIENT_NOT_FOUND` | Recipient contact ID does not exist |
+
+## API Documentation References
+
+- [Create Payment Link](https://dev.wix.com/docs/api-reference/business-management/get-paid/payment-links/payment-links/create-payment-link)
+- [Send Payment Link](https://dev.wix.com/docs/api-reference/business-management/get-paid/payment-links/payment-links/send-payment-link)

--- a/skills/wix-manage/references/media/upload-media-to-wix.md
+++ b/skills/wix-manage/references/media/upload-media-to-wix.md
@@ -1,0 +1,216 @@
+---
+name: "Upload Media to Wix"
+description: Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
+---
+# RECIPE: Upload Media to Wix Media Manager
+
+Learn how to upload images and files to a Wix site's Media Manager using the REST API.
+
+---
+
+## Overview
+
+The Wix Media Manager stores all media files for a site. When you need to use images or files in other Wix APIs, you should first upload them to the Media Manager to get a reliable wixstatic.com URL.
+
+**Key Points:**
+- Uploaded files are permanently stored on Wix servers
+- You get back a `url` (wixstatic.com) that works reliably in other APIs
+- External URLs can fail if the source server blocks requests - Media Manager URLs never fail
+
+---
+
+## Method: Import File from External URL
+
+The simplest way to add media is to import it from an external URL. Wix will download and store the file.
+
+### API Endpoint
+
+```
+POST https://www.wixapis.com/site-media/v1/files/import
+```
+
+### Request Example
+
+```bash
+curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "url": "https://images.unsplash.com/photo-1563729784474-d77dbb933a9e?w=400",
+    "mimeType": "image/jpeg",
+    "displayName": "My Image"
+}'
+```
+
+### Request Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `url` | Yes | The external URL of the file to import |
+| `mimeType` | Recommended | MIME type (e.g., `image/jpeg`, `image/png`). If omitted, Wix tries to detect it |
+| `displayName` | No | Display name in Media Manager. Include extension (e.g., `My Image.jpg`) |
+| `parentFolderId` | No | Folder ID to store the file. Defaults to `media-root` |
+
+### Response Example
+
+```json
+{
+    "file": {
+        "id": "e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "displayName": "My Image.jpg",
+        "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "parentFolderId": "media-root",
+        "mediaType": "IMAGE",
+        "operationStatus": "PENDING",
+        "sizeInBytes": "31911"
+    }
+}
+```
+
+### Key Response Fields
+
+| Field | Description |
+|-------|-------------|
+| `id` | Media ID |
+| `url` | **The wixstatic.com URL - use this in other APIs** |
+| `operationStatus` | `PENDING` → `READY` when processed, or `FAILED` if import failed |
+
+> **Can I Use the URL Immediately?**
+>
+> **In most cases, yes.** The returned `wixstatic.com` URL typically works immediately for basic use cases like adding to products or blog posts.
+>
+> **Wait for READY when:**
+> - You need image dimensions or metadata
+> - You're using image transformations (resize, crop)
+> - You want guaranteed consistency for critical operations
+>
+> **Practical approach:** Try using the URL immediately. If it fails, poll until `operationStatus: "READY"`.
+
+---
+
+## Checking File Status
+
+After importing, the file goes through async processing. For guaranteed consistency, verify `operationStatus: "READY"` before using the file.
+
+### Get File by ID (Recommended)
+
+Use this endpoint to check the status of a specific file:
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-media/v1/files/get-file-by-id?fileId={fileId}' \
+-H 'Authorization: <AUTH>'
+```
+
+**Example:**
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-media/v1/files/get-file-by-id?fileId=e6a89e_9d32c0dbae954582bce7b2bf35981ca6~mv2.jpg' \
+-H 'Authorization: <AUTH>'
+```
+
+### List Recent Files (Alternative)
+
+If you need to find files without knowing the ID:
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-media/v1/files?parentFolderId=media-root&mediaTypes=IMAGE&sort.fieldName=updatedDate&sort.order=DESC&paging.limit=5' \
+-H 'Authorization: <AUTH>'
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `PENDING` | Still processing - wait before using |
+| `READY` | File is ready to use |
+| `FAILED` | Import failed |
+
+### Response When Ready
+
+```json
+{
+    "files": [{
+        "id": "e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "operationStatus": "READY",
+        "media": {
+            "image": {
+                "image": {
+                    "height": 600,
+                    "width": 400
+                }
+            }
+        },
+        "labels": ["cupcakes", "pastry", "dessert"]
+    }]
+}
+```
+
+> **Note:** Wix automatically generates labels (tags) for images using AI.
+
+---
+
+## Alternative: Upload from Local Device
+
+If you need to upload files from a local device (not from a URL), use the two-step upload process:
+
+### Step 1: Generate Upload URL
+
+```bash
+curl -X POST 'https://www.wixapis.com/site-media/v1/files/generate-upload-url' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "mimeType": "image/jpeg",
+    "fileName": "my-photo.jpg"
+}'
+```
+
+### Step 2: Upload to the Generated URL
+
+```bash
+curl -X PUT '<UPLOAD_URL_FROM_RESPONSE>' \
+-H 'Content-Type: image/jpeg' \
+--data-binary @my-photo.jpg
+```
+
+> **Note:** For files larger than 10MB, use the Resumable Upload URL API instead.
+
+---
+
+## Common Issues
+
+### Issue 1: Import Fails (operationStatus: FAILED)
+
+**Problem:** The file shows `operationStatus: "FAILED"` after import.
+
+**Causes:**
+- Source server blocks external requests (e.g., Wikipedia, some CDNs)
+- Source server requires authentication
+- Invalid URL or file not found
+- File type not supported
+
+**Solution:** Use image sources that allow hotlinking:
+- Unsplash (`images.unsplash.com`)
+- Pexels (`images.pexels.com`)
+- Your own hosted images
+- Public cloud storage (S3, GCS with public access)
+
+### Issue 2: File Stuck in PENDING
+
+**Problem:** File stays in `PENDING` status for a long time.
+
+**Solution:**
+- Large files take longer to process
+- Check back after a few seconds
+- If still pending after 30+ seconds, the import may have silently failed
+
+---
+
+## Summary
+
+| Step | Action | Result |
+|------|--------|--------|
+| 1 | Call Import File API with external URL | Get file `id` and `url` with status `PENDING` |
+| 2 | Poll List Files API | Wait for `operationStatus: "READY"` |
+| 3 | Use in other APIs | Use the `url` field (wixstatic.com URL) |

--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -1,0 +1,77 @@
+---
+name: "Create and Update Pricing Plans"
+description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, and plan visibility.
+---
+# Technical Step-by-Step Instructions: Creating or Updating a Wix Pricing Plans (Real-World, API-First)
+
+## Description
+Below are the recommended steps to successfully create or update a Wix Pricing Plans (or several at once) on Wix and attach a booking session to a pricing plan, with real-world troubleshooting and fixes for common API issues.
+
+---
+
+## Overview
+Wix Pricing Plans includes Plans that allows Wix users to build a customized membership plan experiences and sell them to their customers. Pricing plans can also have bundled booking session as benefits.
+
+- With Plans, a site owner can create different types of plans, such as, free, one-time or recurring subscriptions and memberships.
+- With Benefits, a site owner can connect other wix apps like booking service to a pricing plan subscription or membership. Read the full list of pricing plan integration [here](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/introduction#integrations).
+
+### IMPORTANT NOTES
+- Always Prioritize Reading Full API Method Documentation: this overview article provides a general workflow. However, it repeatedly stresses the importance of reading the full documentation for each specific REST method you intend to use. This is critical for understanding detailed requirements.
+- Pay close attention to all required fields, data types, enum values, and specific ID types (e.g., resourceId vs. id) as defined in the detailed schema of each API endpoint. The overview article serves as a guide but doesn't replace the need to consult these specifics.
+
+---
+
+## Steps
+### 0. Read pricing plans API docs
+Before proceeding to further steps I must read the following [documentation](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/introduction) on how to form request to pricing plans API.
+
+### 1. Create a pricing plan
+Creating a pricing plan can be done by using [create plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan) endpoint.
+
+### 2. Attach integrating app entity to pricing plans
+
+To attach integrating app entity, like bookings or blog to pricing plans read the [Benefit Programs](https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/introduction) documentation and proceed to further steps.
+
+#### 2.1. Find program definition
+
+Use [Get Program Definition By External Id And Namespace](https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/program-definitions/get-program-definition-by-external-id-and-namespace) endpoint to find the corresponding program definition of the plan. The call must have these query params:
+- `externalId` must be equal to pricing plan id.
+- `namespace` must be `@wix/pricing-plans`
+
+Example the request in curl:
+```bash
+curl --request GET \
+  "https://www.wixapis.com/benefit-programs/v1/program-definitions/by-namespace-and-external-id?externalId=00000000-0000-0000-0000-000000000001&namespace=@wix/pricing-plans" \
+  -H 'Authorization: <AUTH>' \
+  -H "Content-Type: application/json"
+```
+
+#### 2.2. Create a pool definition
+
+Only one pool definition per integrating app must be created. The pool definition should be created using [create pool definition](https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/pool-definitions/create-pool-definition) endpoint.
+
+The request for this endpoint must adhere to these rules:
+- `namespace` must be `@wix/pricing-plans`
+-  only one benefit can be defined in the pool definition
+- benefit benefitKey must be a random generated UUID
+- benefit provider app id must be the integrating app def id. For the full list of wix app def ids read [this](https://dev.wix.com/docs/api-reference/articles/get-started/apps-created-by-wix) article.
+- benefit price must be only 1 or 0. 0 - if you want the benefit to have unlimited credits and 1 - for the benefit to be limited.
+- `creditConfiguration` must be empty if the benefit is unlimited
+
+#### 2.3. Create benefit items
+
+This step is needed to attach the integrating app entity to benefit program. This is done by using [bulk create items](https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/items/bulk-create-items) endpoint.
+
+Each item in the request for this endpoint must adhere to these rules:
+- `namespace` must be `@wix/pricing-plans`
+-  `category` must be empty string
+- provider app id must be the integrating app def id. For the full list of wix app def ids read [this](https://dev.wix.com/docs/api-reference/articles/get-started/apps-created-by-wix) article.
+- `itemSetId` must set to the created pool definition benefit item set id.
+- `externalId` must be set to the integrating app entity id, example: booking service id or blog post id.
+
+## Pricing plans REST API Documentation Reference
+- [Create plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan)
+- [Get plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/get-plan)
+- [Update plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/update-plan)
+- [Query Plans](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/query-plans)
+- [Pricing Plans Introduction](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/introduction)

--- a/skills/wix-manage/references/pricing-plans/pricing-plans-bookings-integration.md
+++ b/skills/wix-manage/references/pricing-plans/pricing-plans-bookings-integration.md
@@ -1,0 +1,166 @@
+---
+name: "Pricing Plans Bookings Integration"
+description: Links Pricing Plans to Bookings services using the Benefit Programs API. Enables package deals and memberships that grant booking access.
+---
+
+# Technical Step-by-Step Instructions: Integrating Wix Pricing Plans with Bookings Services (Real-World, API-First)
+
+## Description
+
+Below are the recommended steps to successfully integrate Wix Pricing Plans with Wix Bookings services, enabling customers to purchase packages and memberships for booking sessions. This recipe covers the complete workflow including the required Benefit Programs integration.
+
+---
+
+## Prerequisites
+
+### Required App Installations
+
+Before starting the integration, ensure the following apps are installed on the site:
+
+1. **Wix Bookings** - Usually pre-installed, but verify using site queries
+2. **Pricing Plans** - Must be installed if not present
+   - Install if you encounter 428 "App not installed" errors
+
+### App Installation Process
+
+If you receive app-related errors, install the missing app using the Apps Installer API.
+
+**Steps:**
+
+1. Identify the required app through error messages or API documentation
+2. Use the Apps Installer API to install the missing app
+3. Verify installation before proceeding
+
+**For detailed app installation procedures, refer to:**
+
+- [Apps Installer API Documentation](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)
+- Business setup recipes for app installation workflows
+- API error messages which typically indicate the required app and installation steps
+
+## Overview
+
+Integrating Pricing Plans with Bookings allows businesses to offer:
+
+- **Packages**: Fixed session count (e.g., "10 sessions") that can be used within validity period
+- **Memberships with session limits**: Sessions per billing cycle (e.g., "10 sessions a month")
+- **Unlimited memberships**: Unlimited access during subscription period (shows as "Unlimited Sessions")
+
+The integration requires coordination between three APIs:
+
+1. **Pricing Plans API** - Creates the plan structure and pricing
+2. **Benefit Programs API** - Creates the bridge between plans and services
+3. **Bookings API** - Services automatically support pricing plan payments
+
+### IMPORTANT NOTES
+
+- The integration requires using all three APIs in sequence - there's no direct connection between Pricing Plans and Bookings
+- This is a complex integration that requires careful error handling and state management
+- Service `payment.options.pricingPlan` automatically becomes `true` when benefit programs are properly connected
+- The benefit program `externalId` must exactly match the pricing plan `id` for the connection to work
+- **Minimum Duration Requirements**: Plans must have minimum 7-day validity periods - cannot create 1-day plans
+- **Revision Number Management**: The Benefit Programs API uses revision numbers that can conflict with concurrent operations
+
+---
+
+## Steps
+
+### 1. Create the Pricing Plan
+
+Create the pricing plan first using the Pricing Plans API. You can create either:
+
+- **Package plans** using `singlePaymentForDuration` pricing model with `"type": "bookings-package"` in `clientData`
+- **Membership plans** using `subscription` pricing model with `"type": "bookings-membership"` in `clientData`
+
+**Important Validation Requirements:**
+
+- `validity.duration` must be minimum 7 days (`P7D` format)
+- Cannot use `P1D` or shorter periods due to API validation
+- For subscription plans, billing cycles have similar minimum requirements
+
+Keep the returned `plan.id` for the next step.
+
+### 2. Create Benefit Program Definition
+
+Use the Benefit Programs API to create the program definition that links to your pricing plan. The `externalId` must exactly match the pricing plan `id` from step 1, and use `"@wix/pricing-plans"` as the namespace.
+
+**Error Handling Note**: If you receive "Entity already exists" errors, the program definition may already exist from a previous attempt. Query existing programs first or handle the error gracefully.
+
+### 3. Create Benefit Definition for Bookings Service
+
+Create the benefit definition that connects the program to your specific booking service:
+
+- For **packages with session limits**: Include `creditAmount` set to the desired session count
+- For **unlimited memberships**: Omit the `creditAmount` field entirely
+- Always use the correct `serviceId` from your bookings service and `"@wix/pricing-plans"` namespace
+
+**Revision Number Handling**: The Benefit Programs API requires revision numbers. If operations fail due to revision conflicts, retrieve the current revision number and retry.
+
+### 4. Verify Service Integration
+
+Query the service to confirm integration is working. The service should now show `payment.options.pricingPlan: true` and the plan should appear in the booking UI as a payment option.
+
+### IMPORTANT NOTES
+
+- **Sequence matters**: Create pricing plan → benefit program definition → benefit definition. Wrong order will cause "Plan not found" errors
+- **Complex State Management**: This integration involves multiple APIs with different revision systems and error handling patterns
+- **ID relationships**:
+  - Pricing Plan `id` → Benefit Program Definition `externalId`
+  - Service `id` → Benefit Definition `serviceId`
+  - Program Definition `id` → Benefit Definition `programDefinitionId`
+- **Session behavior**:
+  - With `creditAmount`: Users consume credits per session
+  - Without `creditAmount`: Users get unlimited access during subscription
+- **Namespace requirement**: Always use `"@wix/pricing-plans"` as namespace for pricing plan integrations
+- **Service updates**: Services automatically update when benefit programs are connected - no manual service modification needed
+
+### Troubleshooting Common Issues
+
+**"App not installed" Error (428):**
+
+- Install Pricing Plans app using Apps Installer API
+- Verify installation before proceeding with plan creation
+
+**"Plan not found" Error:**
+
+- Verify `externalId` exactly matches pricing plan `id`
+- Ensure pricing plan was created successfully before creating benefit program
+- Check that the plan hasn't been deleted or modified
+
+**"Entity already exists" Error:**
+
+- Query existing benefit program definitions to check for duplicates
+- Consider updating existing programs instead of creating new ones
+- Implement proper error handling for idempotent operations
+
+**Service doesn't show pricing plan option:**
+
+- Check that benefit definition has correct `serviceId`
+- Verify all three entities (plan, program definition, benefit definition) were created successfully
+- Confirm service query shows `payment.options.pricingPlan: true`
+
+**Credits not working correctly:**
+
+- For packages: Ensure `creditAmount` is set to desired session count
+- For unlimited: Ensure `creditAmount` is omitted entirely
+- Verify the benefit definition is properly linked to the correct program definition
+
+**Minimum Duration Validation Errors:**
+
+- Ensure `validity.duration` is at least `P7D` (7 days)
+- Adjust single-session plans to weekly validity instead of daily
+- For subscription plans, use appropriate billing cycle minimums
+
+**Revision Number Conflicts:**
+
+- Implement retry logic with fresh revision number retrieval
+- Handle concurrent operations gracefully
+- Consider queuing operations if dealing with high-frequency updates
+
+## API Documentation References
+
+- [Create Plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan) — `POST https://www.wixapis.com/pricing-plans/v3/plans`
+- [Create Program Definition](https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/program-definitions/create-program-definition) — `POST https://www.wixapis.com/_api/benefit-programs/v1/program-definitions`
+- [Pricing Plans API](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/introduction)
+- [Benefit Programs API](https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/introduction)
+- [Bookings Services API](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/introduction)
+- [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)

--- a/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+++ b/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
@@ -1,0 +1,337 @@
+---
+name: "Wix Restaurants Setup"
+description: Configures restaurant menus, sections, and items using Menus API. Covers menu structure (Menu → Section → Item), modifiers, pricing, availability schedules, and ordering settings.
+---
+# Wix Restaurants Setup API Reference
+
+This recipe covers setting up and configuring Wix Restaurants using the REST API, including menus, items, and ordering configuration.
+
+## Prerequisites
+
+1. Wix Restaurants app installed on the site
+2. API access with restaurant management permissions
+
+## Required APIs
+
+- **Menus API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/create-menu)
+- **Menu Items API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/create-item)
+- **Menu Sections API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/create-section)
+- **Item Modifier Groups API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifier-groups/create-modifier-group)
+- **Item Variants API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-variants/bulk-create-variants)
+
+## Overview
+
+Wix Restaurants uses a hierarchical structure:
+- **Menus** (e.g., Breakfast, Lunch, Dinner)
+  - **Sections** (e.g., Appetizers, Main Courses, Desserts)
+    - **Items** (e.g., Caesar Salad, Grilled Salmon)
+
+## Step 1: Create a Menu
+
+**Endpoint**: `POST https://www.wixapis.com/restaurants/menus-menu/v1/menus`
+
+**Request Body**:
+```json
+{
+  "menu": {
+    "name": "Dinner Menu",
+    "description": "Our evening dining selections",
+    "visible": true
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "menu": {
+    "id": "menu-id-123",
+    "name": "Dinner Menu",
+    "description": "Our evening dining selections",
+    "visible": true,
+    "createdDate": "2024-01-15T10:00:00.000Z"
+  }
+}
+```
+
+## Step 2: Create Menu Sections
+
+**Endpoint**: `POST https://www.wixapis.com/restaurants/menus-section/v1/sections`
+
+**Request Body**:
+```json
+{
+  "section": {
+    "name": "Appetizers",
+    "description": "Start your meal with our delicious starters",
+    "visible": true,
+    "sortOrder": 1
+  }
+}
+```
+
+Create multiple sections:
+```json
+// Section 1: Appetizers
+{
+  "section": {
+    "name": "Appetizers",
+    "sortOrder": 1
+  }
+}
+
+// Section 2: Main Courses
+{
+  "section": {
+    "name": "Main Courses",
+    "sortOrder": 2
+  }
+}
+
+// Section 3: Desserts
+{
+  "section": {
+    "name": "Desserts",
+    "sortOrder": 3
+  }
+}
+```
+
+## Step 3: Create Menu Items
+
+**Endpoint**: `POST https://www.wixapis.com/restaurants/menus-item/v1/items`
+
+**Request Body**:
+```json
+{
+  "item": {
+    "name": "Caesar Salad",
+    "description": "Fresh romaine lettuce with house-made Caesar dressing, croutons, and parmesan",
+    "priceInfo": { "price": "14.99" },
+    "visible": true,
+    "labels": [],
+    "modifierGroups": []
+  }
+}
+```
+
+## Step 4: Add Items to Sections
+
+**Endpoint**: `PATCH https://www.wixapis.com/restaurants/menus-section/v1/sections/{sectionId}`
+
+Each section update requires the latest section `revision`.
+
+```json
+{
+  "section": {
+    "id": "<SECTION_ID>",
+    "revision": "<SECTION_REVISION>",
+    "itemIds": ["item-id-1", "item-id-2", "item-id-3"]
+  }
+}
+```
+
+## Step 5: Configure Item Options and Modifiers
+
+Create modifiers for customization (e.g., cooking temperature, add-ons):
+
+**Endpoint**: `POST https://www.wixapis.com/restaurants/item-modifier-group/v1/modifier-groups`
+
+```json
+{
+  "modifier": {
+    "name": "Cooking Temperature",
+    "required": true,
+    "minSelections": 1,
+    "maxSelections": 1,
+    "options": [
+      {
+        "name": "Rare",
+        "price": {
+          "amount": "0",
+          "currency": "USD"
+        }
+      },
+      {
+        "name": "Medium Rare",
+        "price": {
+          "amount": "0",
+          "currency": "USD"
+        }
+      },
+      {
+        "name": "Medium",
+        "price": {
+          "amount": "0",
+          "currency": "USD"
+        }
+      },
+      {
+        "name": "Well Done",
+        "price": {
+          "amount": "0",
+          "currency": "USD"
+        }
+      }
+    ]
+  }
+}
+```
+
+Add-on modifier with pricing:
+```json
+{
+  "modifier": {
+    "name": "Add-ons",
+    "required": false,
+    "minSelections": 0,
+    "maxSelections": 5,
+    "options": [
+      {
+        "name": "Extra Cheese",
+        "price": {
+          "amount": "2.00",
+          "currency": "USD"
+        }
+      },
+      {
+        "name": "Bacon",
+        "price": {
+          "amount": "3.00",
+          "currency": "USD"
+        }
+      },
+      {
+        "name": "Avocado",
+        "price": {
+          "amount": "2.50",
+          "currency": "USD"
+        }
+      }
+    ]
+  }
+}
+```
+
+## Step 6: Set Menu Structure (Attach Sections to Menu)
+
+Attach section IDs to a menu. This call requires the latest menu `revision`.
+
+**Endpoint**: `PATCH https://www.wixapis.com/restaurants/menus-menu/v1/menus/{menuId}`
+
+```json
+{
+  "menu": {
+    "id": "<MENU_ID>",
+    "revision": "<MENU_REVISION>",
+    "sectionIds": ["<SECTION_ID_1>", "<SECTION_ID_2>"]
+  }
+}
+```
+
+## Step 7: Bulk Operations for Large Menus
+
+For restaurant setup flows with many sections/items, use bulk endpoints:
+
+- **Bulk Create Sections**: `POST https://www.wixapis.com/restaurants/menus-section/v1/bulk/sections/create`
+- **Bulk Create Items**: `POST https://www.wixapis.com/restaurants/menus-item/v1/bulk/items/create`
+- **Bulk Create Variants**: `POST https://www.wixapis.com/restaurants/item-variants/v1/bulk/variants/create`
+
+```json
+{
+  "sections": [
+    { "name": "Appetizers", "visible": true },
+    { "name": "Main Courses", "visible": true }
+  ],
+  "returnEntity": true
+}
+```
+
+## Step 8: Query Menus / Sections / Items
+
+Use query APIs for retrieval and UI display flows.
+
+- **Query Menus**: `POST https://www.wixapis.com/restaurants/menus-menu/v1/menus/query`
+- **Query Sections**: `POST https://www.wixapis.com/restaurants/menus-section/v1/sections/query`
+- **Query Items**: `POST https://www.wixapis.com/restaurants/menus-item/v1/items/query`
+
+```json
+{
+  "query": {
+    "cursorPaging": {
+      "limit": 50
+    }
+  }
+}
+```
+
+## Query Menus
+
+**Endpoint**: `GET https://www.wixapis.com/restaurants/menus-menu/v1/menus`
+
+**Response**:
+```json
+{
+  "menus": [
+    {
+      "id": "menu-1",
+      "name": "Breakfast Menu",
+      "visible": true,
+      "sections": [...]
+    },
+    {
+      "id": "menu-2",
+      "name": "Lunch Menu",
+      "visible": true,
+      "sections": [...]
+    }
+  ]
+}
+```
+
+## Recommended Setup Order
+
+For complex restaurant menus, use this order to avoid dependency issues:
+
+1. Create variants (sizes/options) if needed.
+2. Create items (single or bulk).
+3. Create sections (single or bulk).
+4. Update each section with `itemIds`.
+5. Update menu with `sectionIds`.
+
+## Item Labels
+
+Common dietary labels:
+- `vegetarian`
+- `vegan`
+- `gluten-free`
+- `gluten-free-option`
+- `dairy-free`
+- `nut-free`
+- `spicy`
+- `chef-recommendation`
+
+## Best Practices
+
+1. **High-Quality Images**: Use appetizing food photography
+2. **Clear Descriptions**: Include ingredients and preparation methods
+3. **Accurate Pricing**: Keep prices up-to-date
+4. **Stock Management**: Update availability in real-time
+5. **Modifier Organization**: Group related customizations logically
+6. **Menu Structure**: Organize sections in logical dining order
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `MENU_NOT_FOUND` | Invalid menu ID | Verify menu exists |
+| `ITEM_NOT_FOUND` | Invalid item ID | Verify item exists |
+| `INVALID_PRICE` | Negative price | Use positive amounts |
+| `DUPLICATE_NAME` | Section/item name exists | Use unique names |
+
+## Related Documentation
+
+- [Menus API Reference](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/introduction)
+- [Menu Items API Reference](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/introduction)
+- [Menu Sections API Reference](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/introduction)
+- [Restaurant Orders API](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/orders/introduction)

--- a/skills/wix-manage/references/rich-content/ricos-converter-service.md
+++ b/skills/wix-manage/references/rich-content/ricos-converter-service.md
@@ -1,0 +1,295 @@
+---
+name: "Ricos Converter Service"
+description: Validates and converts content between Ricos documents and HTML/Markdown/plain text using the Ricos Documents API. Covers plugin configuration, format conversion in both directions, and document validation.
+---
+# Rich Content (Ricos) Converter Service
+
+This recipe covers how to validate and convert content between Ricos documents (Wix's rich content format) and other formats like HTML, Markdown, and plain text.
+
+## Overview
+
+Ricos is Wix's rich content format used across various Wix applications (Blog, Stores, etc.). The [Ricos Documents API](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/introduction) provides:
+- **Validation**: Check if a document conforms to the Ricos format
+- **Convert to Ricos**: Transform HTML, Markdown, or plain text into a Ricos document
+- **Convert from Ricos**: Transform a Ricos document back to HTML, Markdown, or plain text
+
+Learn more about [Rich Content](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-rich-content) and [Ricos document structure](https://dev.wix.com/docs/ricos/getting-started/introduction).
+
+## Required API Endpoints
+
+| Method | Endpoint | Docs |
+|--------|----------|------|
+| Validate Document | `POST https://www.wixapis.com/ricos/v1/ricos-document/validate` | [Schema](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/validate-document) |
+| Convert To Ricos | `POST https://www.wixapis.com/ricos/v1/ricos-document/convert/to-ricos` | [Schema](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/convert-to-ricos-document) |
+| Convert From Ricos | `POST https://www.wixapis.com/ricos/v1/ricos-document/convert/from-ricos` | [Schema](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/convert-from-ricos-document) |
+
+---
+
+## Available Plugins
+
+Plugins determine which content types are recognized when validating or converting. Specify them as uppercase enum values:
+
+| Plugin Enum | Description |
+|-------------|-------------|
+| `ACTION_BUTTON` | Call-to-action buttons |
+| `AUDIO` | Audio content |
+| `CODE_BLOCK` | Code snippets |
+| `COLLAPSIBLE_LIST` | Expandable/collapsible lists |
+| `DIVIDER` | Section dividers |
+| `EMOJI` | Emoji support |
+| `FILE` | File attachments |
+| `FONT_FAMILY` | Font family selection |
+| `GALLERY` | Image galleries |
+| `GIPHY` | GIF integration |
+| `HASHTAG` | Hashtag support |
+| `HEADING` | Headings (h1-h6) |
+| `HTML` | Raw HTML blocks |
+| `IMAGE` | Images |
+| `INDENT` | Text indentation |
+| `LAYOUT` | Layout containers |
+| `LINE_SPACING` | Line spacing control |
+| `LINK` | Hyperlinks |
+| `LINK_BUTTON` | Link buttons |
+| `LINK_PREVIEW` | Link previews |
+| `MENTIONS` | @mentions |
+| `POLL` | Polls |
+| `SPOILER` | Spoiler/hidden content |
+| `TABLE` | Tables |
+| `TEXT_COLOR` | Text color |
+| `TEXT_HIGHLIGHT` | Text highlighting |
+| `VERTICAL_EMBED` | Vertical embeds |
+| `VIDEO` | Video content |
+
+### IMPORTANT NOTES:
+- Plugin values must be **UPPERCASE** enum strings (e.g., `"HEADING"`, not `"heading"`)
+- Content using unsupported plugins will result in validation violations
+- When converting HTML, only elements matching your plugins are converted
+
+---
+
+## Step 1: Validate a Ricos Document
+
+Check if a document conforms to the Ricos format and optionally fix issues.
+
+**Endpoint**: `POST https://www.wixapis.com/ricos/v1/ricos-document/validate` ([docs](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/validate-document))
+
+**Request Body**:
+```json
+{
+  "document": {
+    "nodes": [
+      {
+        "type": "PARAGRAPH",
+        "id": "p1",
+        "nodes": [
+          {
+            "type": "TEXT",
+            "id": "t1",
+            "textData": {
+              "text": "Hello World",
+              "decorations": []
+            }
+          }
+        ],
+        "paragraphData": {}
+      }
+    ]
+  },
+  "plugins": ["HEADING", "LINK", "IMAGE", "TEXT_COLOR"],
+  "fixDocument": true
+}
+```
+
+**Response**:
+```json
+{
+  "valid": true,
+  "violations": [],
+  "validDocument": {
+    "nodes": [
+      {
+        "type": "PARAGRAPH",
+        "id": "p1",
+        "nodes": [
+          {
+            "type": "TEXT",
+            "id": "t1",
+            "textData": {
+              "text": "Hello World",
+              "decorations": []
+            }
+          }
+        ],
+        "paragraphData": {}
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Step 2: Convert HTML to Ricos
+
+Transform HTML content into Ricos document format.
+
+**Endpoint**: `POST https://www.wixapis.com/ricos/v1/ricos-document/convert/to-ricos` ([docs](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/convert-to-ricos-document))
+
+**Request Body**:
+```json
+{
+  "html": "<h1>Welcome</h1><p>This is a <strong>bold</strong> paragraph with a <a href=\"https://example.com\">link</a>.</p>",
+  "options": {
+    "plugins": ["HEADING", "LINK", "TEXT_COLOR", "TEXT_HIGHLIGHT"]
+  }
+}
+```
+
+**Response**:
+```json
+{
+  "document": {
+    "nodes": [
+      {
+        "type": "HEADING",
+        "id": "",
+        "headingData": { "level": 1 },
+        "nodes": [
+          { "type": "TEXT", "textData": { "text": "Welcome", "decorations": [] } }
+        ]
+      },
+      {
+        "type": "PARAGRAPH",
+        "id": "",
+        "nodes": [
+          { "type": "TEXT", "textData": { "text": "This is a ", "decorations": [] } },
+          { "type": "TEXT", "textData": { "text": "bold", "decorations": [{ "type": "BOLD", "fontWeightValue": 700 }] } },
+          { "type": "TEXT", "textData": { "text": " paragraph with a ", "decorations": [] } },
+          { "type": "TEXT", "textData": { "text": "link", "decorations": [{ "type": "LINK", "linkData": { "link": { "url": "https://example.com", "target": "SELF" } } }] } },
+          { "type": "TEXT", "textData": { "text": ".", "decorations": [] } }
+        ]
+      }
+    ],
+    "metadata": { "version": 1 }
+  }
+}
+```
+
+---
+
+## Step 3: Convert Markdown to Ricos
+
+Uses the same endpoint as HTML conversion, with `markdown` instead of `html`.
+
+**Request Body**:
+```json
+{
+  "markdown": "# Welcome\n\nThis is a **bold** paragraph with a [link](https://example.com).",
+  "options": {
+    "plugins": ["HEADING", "LINK", "CODE_BLOCK"]
+  }
+}
+```
+
+---
+
+## Step 4: Convert Plain Text to Ricos
+
+**Request Body**:
+```json
+{
+  "plainText": "This is plain text content.\n\nIt will be converted to paragraphs.",
+  "options": {
+    "plugins": []
+  }
+}
+```
+
+---
+
+## Step 5: Convert Ricos to HTML / Markdown / Plain Text
+
+Convert a Ricos document back to another format.
+
+**Endpoint**: `POST https://www.wixapis.com/ricos/v1/ricos-document/convert/from-ricos` ([docs](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/convert-from-ricos-document))
+
+**Request Body (to HTML)**:
+```json
+{
+  "document": {
+    "nodes": [
+      {
+        "type": "HEADING",
+        "id": "h1",
+        "headingData": { "level": 1 },
+        "nodes": [
+          { "type": "TEXT", "id": "t1", "textData": { "text": "Welcome", "decorations": [] } }
+        ]
+      },
+      {
+        "type": "PARAGRAPH",
+        "id": "p1",
+        "nodes": [
+          { "type": "TEXT", "id": "t2", "textData": { "text": "Hello world with ", "decorations": [] } },
+          { "type": "TEXT", "id": "t3", "textData": { "text": "bold", "decorations": [{ "type": "BOLD", "fontWeightValue": 700 }] } }
+        ],
+        "paragraphData": {}
+      }
+    ]
+  },
+  "targetFormat": "HTML"
+}
+```
+
+**Response**:
+```json
+{
+  "html": "<h1>Welcome</h1><p>Hello world with <span style=\"font-weight: 700\">bold</span></p>"
+}
+```
+
+**Target format options**: `"HTML"`, `"MARKDOWN"`, `"PLAIN_TEXT"`
+
+For plain text, you can include optional settings:
+```json
+{
+  "document": { "nodes": [...] },
+  "targetFormat": "PLAIN_TEXT",
+  "plainTextOptions": {
+    "includeLinks": true,
+    "includeMediaLinks": true
+  }
+}
+```
+
+---
+
+## Common Use Cases
+
+### Blog Post Content Import
+When importing blog content from external sources:
+1. Convert HTML/Markdown to Ricos format using Convert To Ricos
+2. Validate the converted document with `fixDocument: true`
+3. Use the validated document in the Blog Posts API
+
+### Rich Content Validation Before Saving
+Before saving rich content:
+1. Validate with `fixDocument: true`
+2. Use the returned `validDocument` for saving
+3. Check `violations` array for any issues
+
+### Round-Trip Conversion
+Convert between formats for editing workflows:
+1. Convert Ricos to Markdown for a Markdown editor
+2. Convert edited Markdown back to Ricos for storage
+3. See [Sample Flows](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/sample-flows) for a detailed example
+
+---
+
+## Gotchas & Troubleshooting
+- Maximum content length: 10,000 characters for HTML, Markdown, or plain text
+- Plugin limits: Maximum 100 plugins per request
+- Plugin name max length: 30 characters
+- If converting HTML with images but `IMAGE` plugin not specified, images are silently dropped
+- Always validate converted content before using in production
+- The plain text `convert/from-ricos` response concatenates text without separators between nodes — use `includeLinks: true` in `plainTextOptions` if you need link URLs preserved

--- a/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
+++ b/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
@@ -1,0 +1,59 @@
+---
+name: "RECIPE: Change a Site's Payment (Store) Currency via Site Properties API"
+description: "Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask."
+---
+
+# RECIPE: Change a Site's Payment (Store) Currency via Site Properties API
+
+## Goal
+Update a Wix site's **payment currency** (the ISO-4217 currency code used to bill customers) programmatically.
+
+## When to use
+- You need to switch a site's store/payment currency (for example, from `USD` to `EUR`).
+- You want to automate regional/business setup for sites.
+
+## Important notes before you start
+- The `paymentCurrency` field is part of **Site Properties** (often shown in the dashboard under regional/business info).
+- A successful update increments the Site Properties `version`.
+- Use a **field mask** (`fields.paths`) to indicate which fields you're updating.
+
+## Step 1 — (Optional) Read current site properties version
+This is useful to understand the current snapshot version and other regional fields.
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-properties/v4/properties' \
+  -H 'Authorization: <AUTH>'
+```
+
+## Step 2 — Update the payment currency
+Use the `PATCH /site-properties/v4/properties` endpoint: put the new currency under `properties.paymentCurrency` and include a `fields.paths` mask.
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/site-properties/v4/properties' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "properties": {
+      "paymentCurrency": "EUR"
+    },
+    "fields": {
+      "paths": ["paymentCurrency"]
+    }
+  }'
+```
+
+### Expected response
+A successful call returns an updated Site Properties snapshot version, for example:
+
+```json
+{ "version": "123" }
+```
+
+## Gotchas & troubleshooting
+- **Always send a field mask**: omitting `fields.paths` will fail with `400` and `"Illegal request - No updates on request body"`.
+- Currency must be a **3-letter ISO-4217** code (for example, `USD`, `CAD`, `EUR`, `GBP`).
+
+## Related APIs
+- **Site Properties API**: [REST](https://dev.wix.com/docs/rest/business-management/site-properties/properties/introduction)
+- Stores Currency Converter (conversion utilities, not for setting the site currency):
+  - `POST https://www.wixapis.com/currency_converter/v1/currencies/amounts/{from}/convert/{to}`

--- a/skills/wix-manage/references/sites/create-site-from-template.md
+++ b/skills/wix-manage/references/sites/create-site-from-template.md
@@ -1,0 +1,183 @@
+---
+name: "Create Site from Template"
+description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless site setup, OAuth app creation, and publishing.
+---
+# Create Site from Template
+
+This recipe guides you through creating a new Wix site from a template, including template selection and optional publishing.
+
+## Prerequisites
+
+- Wix account with site creation permissions
+- Account-level API access
+
+## Required APIs
+
+- **Templates Search API**: `GET https://www.wix.com/_api/template-cms-view-service/view/v2/templates/search`
+- **Create Site API**: `POST https://www.wixapis.com/msm/v1/meta-site/create-from-template`
+- **Publish Site API**: `POST https://www.wixapis.com/site-publisher/v1/site/publish`
+
+---
+
+## Step 1: Understand User Requirements
+
+Before searching templates, gather information:
+
+1. **Ask the user** to describe the site they want in a few sentences
+2. **Ask if they want** Wix Editor or Wix Studio
+3. **Identify main apps** needed (Stores, Bookings, Blog, etc.)
+
+### Quick Start (Skip Template Search)
+
+If user wants an empty/blank site:
+- **Wix Studio blank**: `fe86a14e-ef67-49b4-a409-d086f3abaa1a`
+- **Wix Editor blank**: `b55bdf43-95e0-4cef-b9bb-92dcc7af2742`
+
+Skip to Step 3 with these template IDs.
+
+---
+
+## Step 2: Search for Templates
+
+**Endpoint**: `GET https://www.wix.com/_api/template-cms-view-service/view/v2/templates/search`
+
+**Query Parameters**:
+| Parameter | Description | Values |
+|-----------|-------------|--------|
+| `language` | Always use | `en` |
+| `limit` | Results per page | `24` |
+| `offset` | Pagination offset | Start at `0`, increment by 24 |
+| `bookType` | Editor type | `studio` or `main-v2` |
+| `query` | Search keywords | `yoga+studio`, `ecommerce`, etc. |
+
+**Example Request**:
+```bash
+curl -X GET \
+  'https://www.wix.com/_api/template-cms-view-service/view/v2/templates/search?language=en&limit=24&offset=0&bookType=studio&query=yoga+studio' \
+  -H 'Authorization: <AUTH>'
+```
+
+**Response** includes for each template:
+- `metaSiteId` - Template ID for creation
+- `templateSlug` - For preview URL
+- Template name and description
+- Color scheme
+
+### Present Templates to User
+
+For each relevant template, show:
+- Template name
+- Description (without "Click Edit" text)
+- "Good for" description
+- Color scheme
+- Preview link: `https://www.wix.com/website-template/view/html/{templateSlug}`
+
+---
+
+## Step 3: Create the Site
+
+**Endpoint**: `POST https://www.wixapis.com/msm/v1/meta-site/create-from-template`
+
+**Request Body**:
+```json
+{
+  "originTemplateId": "<TEMPLATE_METASITE_ID>",
+  "siteName": "my-new-site"
+}
+```
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/msm/v1/meta-site/create-from-template' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "originTemplateId": "<TEMPLATE_ID>",
+    "siteName": "my-new-site"
+  }'
+```
+
+### Site Name Requirements
+
+The `siteName` must follow these rules:
+- 4-20 characters
+- Only lowercase letters, numbers, hyphens, underscores
+- Pattern: `[a-z0-9_-]{4,20}`
+- Must be unique
+
+If `siteName` is not provided, one is generated automatically.
+
+### For Headless Sites
+
+Add `"namespace": "HEADLESS"` to the request body:
+
+```json
+{
+  "originTemplateId": "<TEMPLATE_ID>",
+  "siteName": "my-headless-site",
+  "namespace": "HEADLESS"
+}
+```
+
+**Response** includes the new site's `metaSiteId`.
+
+### IMPORTANT NOTES:
+- Only mention headless if user specifically requests it
+- If user doesn't ask for headless, do NOT include the `namespace` field
+
+---
+
+## Step 4: Publish the Site (Optional)
+
+**Ask the user** if they want to publish their site before proceeding.
+
+**Endpoint**: `POST https://www.wixapis.com/site-publisher/v1/site/publish`
+
+This is a **site-level API** - use the site ID from the creation response.
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/site-publisher/v1/site/publish' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+### IMPORTANT NOTES:
+- NEVER publish without asking the user first
+- This makes the site publicly accessible
+
+---
+
+## Step 5: For Headless Sites - Create OAuth App
+
+If the site was created as headless, you MUST create an OAuth app for authentication.
+
+See [Create OAuth App](https://dev.wix.com/docs/rest/business-management/headless-authentication/oauth-apps/create-oauth-app) documentation.
+
+This is a site-level call in the context of the newly created site.
+
+---
+
+## Common Template IDs
+
+For quick access without searching:
+
+| Type | Template ID |
+|------|-------------|
+| Blank (Studio) | `fe86a14e-ef67-49b4-a409-d086f3abaa1a` |
+| Blank (Editor) | `b55bdf43-95e0-4cef-b9bb-92dcc7af2742` |
+| Store | `b783f9f9-4f4d-4139-9659-cc95a51b9ee5` |
+| Bookings/Services | `17b2bf9e-8661-4c92-973c-67502b415e58` |
+| Beauty | `0281d415-0682-42ac-b35e-49b349f19332` |
+
+---
+
+## Next Steps
+
+After creating the site:
+- Install required apps using [Install Wix Apps](../app-installation/install-wix-apps.md)
+- Configure site settings
+- Add content (products, services, blog posts, etc.)

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -1,0 +1,125 @@
+---
+name: "Query Sites"
+description: Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
+---
+# Query Sites
+
+This recipe demonstrates how to list and query all sites associated with a Wix account.
+
+## Prerequisites
+
+- Account-level API access
+- Authorization for site listing permissions
+
+## Required APIs
+
+- **Query Sites API**: [REST](https://dev.wix.com/docs/rest/account-level-apis/sites/sites/query-sites)
+
+---
+
+## Query All Sites
+
+**Endpoint**: `POST https://www.wixapis.com/site-list/v2/sites/query`
+
+**Request Body**:
+```json
+{
+  "query": {
+    "cursorPaging": {
+      "limit": 50
+    }
+  }
+}
+```
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/site-list/v2/sites/query' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": {
+      "cursorPaging": {
+        "limit": 50
+      }
+    }
+  }'
+```
+
+---
+
+## Response Structure
+
+```json
+{
+  "sites": [
+    {
+      "id": "site-id-123",
+      "name": "My Website",
+      "displayName": "My Website",
+      "siteUrl": "https://username.wixsite.com/mywebsite",
+      "published": true,
+      "createdDate": "2024-01-15T10:30:00Z",
+      "updatedDate": "2024-06-20T14:45:00Z"
+    }
+  ],
+  "pagingMetadata": {
+    "count": 50,
+    "cursors": {
+      "next": "cursor-for-next-page"
+    },
+    "hasNext": true
+  }
+}
+```
+
+---
+
+## Pagination
+
+For accounts with many sites, use cursor-based pagination:
+
+**First Request**:
+```json
+{
+  "query": {
+    "cursorPaging": {
+      "limit": 50
+    }
+  }
+}
+```
+
+**Next Page** (using cursor from response):
+```json
+{
+  "query": {
+    "cursorPaging": {
+      "limit": 50,
+      "cursor": "<cursor-from-previous-response>"
+    }
+  }
+}
+```
+
+Continue until `hasNext` is `false`.
+
+---
+
+## Common Use Cases
+
+### List All Sites
+Retrieve all sites without filtering - useful for account dashboards or site selection interfaces.
+
+### Find a Specific Site
+After querying, filter results by name or ID to locate a specific site.
+
+---
+
+## Next Steps
+
+After finding a site:
+- Use the site ID for site-level API calls
+- Create new sites using [Create Site from Template](create-site-from-template.md)
+- Manage site settings and content

--- a/skills/wix-manage/references/stores/add-store-pages-to-site.md
+++ b/skills/wix-manage/references/stores/add-store-pages-to-site.md
@@ -1,0 +1,57 @@
+---
+name: "Add Store Pages to Site"
+description: Adds missing checkout and cart pages to a site when Stores app is installed. Used when store pages are missing after migration or setup issues.
+---
+# Add Store Pages to Site
+
+This recipe demonstrates how to add checkout and cart pages to a Wix site when the Stores app is installed but pages are missing.
+
+## Overview
+
+When Wix Stores is installed on a site, it should automatically create cart and checkout pages. However, in some cases these pages may be missing. This recipe provides a way to add them programmatically.
+
+## Prerequisites
+
+- Wix Stores app installed on the site
+- API access with site management permissions
+
+---
+
+## Step 1: Add Pages to Site
+
+**Endpoint**: `POST https://www.wix.com/_api/add-pages-to-site/install`
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wix.com/_api/add-pages-to-site/install' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+**Response**: Empty body on success.
+
+### IMPORTANT NOTES:
+- This endpoint adds missing store pages (cart, checkout) if they don't exist
+- The request body is empty - no parameters needed
+- Only required Authorization header
+
+---
+
+## When to Use This Recipe
+
+Use this recipe when:
+- Checkout flow fails because checkout page is missing
+- Cart functionality doesn't work
+- Store was migrated or had page issues
+- You receive errors about missing store pages
+
+---
+
+## Next Steps
+
+After adding pages:
+- Verify checkout flow works by creating a test order
+- Customize page designs if needed via the Editor
+- Set up payment methods if not already configured

--- a/skills/wix-manage/references/stores/bulk-create-products-with-options.md
+++ b/skills/wix-manage/references/stores/bulk-create-products-with-options.md
@@ -1,0 +1,1041 @@
+---
+name: "Bulk Create Products with Options"
+description: Uses bulk products endpoint to create multiple products with inventory in a single request. Handles variant generation from options, media format requirements, and error handling for partial failures.
+---
+# RECIPE: Business Recipe - Bulk Creating Wix Store Products with inventory and options
+
+Learn how to create multiple Wix store products with customizable options like colors, sizes, or other variants in a single bulk operation, allowing efficient creation of product catalogs.
+
+---
+
+## ⚠️ CRITICAL REQUIREMENTS - READ FIRST
+
+**API ENDPOINT:** `https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create`
+
+**MEDIA FORMAT - MUST INCLUDE BOTH SECTIONS:**
+
+```json
+"media": {
+    "main": {
+        "url": "https://images.unsplash.com/photo-example?w=400&h=400&fit=crop&crop=center",
+        "altText": "Product Name - Main Product Image"
+    },
+    "itemsInfo": {
+        "items": [
+            {
+                "url": "https://images.unsplash.com/photo-example?w=400&h=400&fit=crop&crop=center",
+                "altText": "Product Name - Product View"
+            }
+        ]
+    }
+}
+```
+
+**VARIANTS:** The recipe shows ALL possible variant combinations (Cartesian product) with 3 visible variants per product. Each product has 6 total variants: 3 visible + 3 hidden for future use.
+
+**❌ COMMON FAILURES:**
+
+* Missing `itemsInfo` section in media (media won't work)
+* Missing URL parameters `?w=400&h=400&fit=crop&crop=center`
+
+## Article: Steps for Bulk Creating Wix Store Products with Options
+
+## STEP 1: bulk create products with options and variants
+
+1. bulk create products with options and create variants for them - Wix REST API: [Bulk Create Products With Inventory](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/products-v3/bulk-create-products-with-inventory) **CRITICAL: USE THIS WORKING EXAMPLE - if more products are required copy the same format exactly to create more**
+
+```bash
+curl -X POST "https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <AUTH>" \
+  -d '{
+    "products": [
+        {
+            "name": "Pro Basketball Sneaker",
+            "description": {
+                "nodes": [
+                    {
+                        "type": "PARAGRAPH",
+                        "id": "desc1",
+                        "nodes": [
+                            {
+                                "type": "TEXT",
+                                "textData": {
+                                    "text": "High-performance basketball sneaker with superior ankle support and responsive court feel."
+                                }
+                            }
+                        ],
+                        "paragraphData": {
+                            "textStyle": {
+                                "textAlignment": "AUTO"
+                            }
+                        }
+                    }
+                ],
+                "metadata": {
+                    "version": 1,
+                    "id": "basketball-desc-001"
+                }
+            },
+            "visible": true,
+            "visibleInPos": true,
+            "productType": "PHYSICAL",
+            "physicalProperties": {},
+            "media": {
+                "main": {
+                    "url": "https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=400&h=400&fit=crop&crop=center",
+                    "altText": "Pro Basketball Sneaker - Main Product Image"
+                },
+                "itemsInfo": {
+                    "items": [
+                        {
+                            "url": "https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=400&h=400&fit=crop&crop=center",
+                            "altText": "Pro Basketball Sneaker - Product View"
+                        }
+                    ]
+                }
+            },
+            "options": [
+                {
+                    "name": "Size",
+                    "optionRenderType": "TEXT_CHOICES",
+                    "choicesSettings": {
+                        "choices": [
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "8"
+                            },
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "9"
+                            },
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "Color",
+                    "optionRenderType": "SWATCH_CHOICES",
+                    "choicesSettings": {
+                        "choices": [
+                            {
+                                "choiceType": "ONE_COLOR",
+                                "name": "Red",
+                                "colorCode": "#FF0000"
+                            },
+                            {
+                                "choiceType": "ONE_COLOR",
+                                "name": "Blue",
+                                "colorCode": "#0000FF"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "variantsInfo": {
+                "variants": [
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "8",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Red",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "159.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "200.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 25,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "8",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Blue",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "159.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "200.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 25,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "9",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Red",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "159.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "200.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 30,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "9",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Blue",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "159.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "200.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 30,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "10",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Red",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "159.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "200.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 20,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "10",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Blue",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "159.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "200.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 20,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Classic Canvas Shoes",
+            "description": {
+                "nodes": [
+                    {
+                        "type": "PARAGRAPH",
+                        "id": "desc2",
+                        "nodes": [
+                            {
+                                "type": "TEXT",
+                                "textData": {
+                                    "text": "Timeless canvas shoes with durable construction and comfortable fit for everyday wear."
+                                }
+                            }
+                        ],
+                        "paragraphData": {
+                            "textStyle": {
+                                "textAlignment": "AUTO"
+                            }
+                        }
+                    }
+                ],
+                "metadata": {
+                    "version": 1,
+                    "id": "canvas-desc-002"
+                }
+            },
+            "visible": true,
+            "visibleInPos": true,
+            "productType": "PHYSICAL",
+            "physicalProperties": {},
+            "media": {
+                "main": {
+                    "url": "https://images.unsplash.com/photo-1560769629-975ec94e6a86?w=400&h=400&fit=crop&crop=center",
+                    "altText": "Classic Canvas Shoes - Main Product Image"
+                },
+                "itemsInfo": {
+                    "items": [
+                        {
+                            "url": "https://images.unsplash.com/photo-1560769629-975ec94e6a86?w=400&h=400&fit=crop&crop=center",
+                            "altText": "Classic Canvas Shoes - Product View"
+                        }
+                    ]
+                }
+            },
+            "options": [
+                {
+                    "name": "Size",
+                    "optionRenderType": "TEXT_CHOICES",
+                    "choicesSettings": {
+                        "choices": [
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "7"
+                            },
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "8"
+                            },
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "9"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "Color",
+                    "optionRenderType": "SWATCH_CHOICES",
+                    "choicesSettings": {
+                        "choices": [
+                            {
+                                "choiceType": "ONE_COLOR",
+                                "name": "White",
+                                "colorCode": "#FFFFFF"
+                            },
+                            {
+                                "choiceType": "ONE_COLOR",
+                                "name": "Navy",
+                                "colorCode": "#000080"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "variantsInfo": {
+                "variants": [
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "7",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "White",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "89.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "100.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 15,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "7",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Navy",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "89.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "100.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 15,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "8",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "White",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "89.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "100.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 18,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "8",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Navy",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "89.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "100.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 18,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "9",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "White",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "89.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "100.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 12,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "9",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Navy",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "89.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "100.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 12,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Running Track Shoes",
+            "description": {
+                "nodes": [
+                    {
+                        "type": "PARAGRAPH",
+                        "id": "desc3",
+                        "nodes": [
+                            {
+                                "type": "TEXT",
+                                "textData": {
+                                    "text": "Lightweight running shoes with responsive cushioning and breathable mesh construction for optimal performance."
+                                }
+                            }
+                        ],
+                        "paragraphData": {
+                            "textStyle": {
+                                "textAlignment": "AUTO"
+                            }
+                        }
+                    }
+                ],
+                "metadata": {
+                    "version": 1,
+                    "id": "running-desc-003"
+                }
+            },
+            "visible": true,
+            "visibleInPos": true,
+            "productType": "PHYSICAL",
+            "physicalProperties": {},
+            "media": {
+                "main": {
+                    "url": "https://images.unsplash.com/photo-1551107696-a4b0c5a0d9a2?w=400&h=400&fit=crop&crop=center",
+                    "altText": "Running Track Shoes - Main Product Image"
+                },
+                "itemsInfo": {
+                    "items": [
+                        {
+                            "url": "https://images.unsplash.com/photo-1551107696-a4b0c5a0d9a2?w=400&h=400&fit=crop&crop=center",
+                            "altText": "Running Track Shoes - Product View"
+                        }
+                    ]
+                }
+            },
+            "options": [
+                {
+                    "name": "Size",
+                    "optionRenderType": "TEXT_CHOICES",
+                    "choicesSettings": {
+                        "choices": [
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "8"
+                            },
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "9"
+                            },
+                            {
+                                "choiceType": "CHOICE_TEXT",
+                                "name": "10"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "Color",
+                    "optionRenderType": "SWATCH_CHOICES",
+                    "choicesSettings": {
+                        "choices": [
+                            {
+                                "choiceType": "ONE_COLOR",
+                                "name": "Black",
+                                "colorCode": "#000000"
+                            },
+                            {
+                                "choiceType": "ONE_COLOR",
+                                "name": "Gray",
+                                "colorCode": "#808080"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "variantsInfo": {
+                "variants": [
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "8",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Black",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "119.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "180.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 0,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "8",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Gray",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "119.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "180.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 0,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "9",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Black",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "119.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "180.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 0,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "9",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Gray",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "119.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "180.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 0,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "10",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Black",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "119.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "180.00"
+                            }
+                        },
+                        "visible": true,
+                        "inventoryItem": {
+                            "quantity": 0,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    },
+                    {
+                        "choices": [
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Size",
+                                    "choiceName": "10",
+                                    "renderType": "TEXT_CHOICES"
+                                }
+                            },
+                            {
+                                "optionChoiceNames": {
+                                    "optionName": "Color",
+                                    "choiceName": "Gray",
+                                    "renderType": "SWATCH_CHOICES"
+                                }
+                            }
+                        ],
+                        "price": {
+                            "actualPrice": {
+                                "amount": "119.99"
+                            },
+                            "compareAtPrice": {
+                              "amount": "180.00"
+                            }
+                        },
+                        "visible": false,
+                        "inventoryItem": {
+                            "quantity": 0,
+                            "preorderInfo": {
+                                "enabled": false
+                            }
+                        },
+                        "physicalProperties": {}
+                    }
+                ]
+            }
+        }
+    ],
+    "returnEntity": true
+}'
+```
+
+### IMPORTANT NOTES:
+
+* When bulk creating products with inventory YOU MUST follow the same format as single product creation but wrap all products in a "products" array. Each product MUST leave the physicalProperties and all other non required fields empty. for example: "physicalProperties": {}. In most cases the products will be physical products, and therefore MUST have the empty physicalProperties object ("physicalProperties": {}) and a corresponding "productType": "PHYSICAL".
+* In case part of the request fails, retry bulk creating the failed products, by copying the exact format from the previous working example.
+* When creating a Color option **YOU MUST** use the `"optionRenderType": "SWATCH_CHOICES"` and the appropriate choice type: `"choiceType": "ONE_COLOR"`, while also providing the relevant `colorCode`. This must be done similar to the example above.
+
+**CRITICAL: Bulk Request Structure**The bulk create API requires a different endpoint and request structure:
+
+* **URL**: `https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create`
+* **Body**: `{"products": [array of product objects]}`
+* Each product in the array follows the exact same format as single product creation
+
+**CRITICAL: Description Format**If you include a description, it MUST use Wix's rich text nodes structure, NOT a plain string. Plain strings will cause "Expected an object" API errors.
+
+**WRONG:** `"description": "Your text here"` **CORRECT:**
+
+```json
+"description": {
+    "nodes": [
+        {
+            "type": "PARAGRAPH",
+            "id": "desc1",
+            "nodes": [
+                {
+                    "type": "TEXT",
+                    "textData": {
+                        "text": "Your product description here"
+                    }
+                }
+            ],
+            "paragraphData": {
+                "textStyle": {
+                    "textAlignment": "AUTO"
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "version": 1,
+        "id": "unique-desc-id"
+    }
+}
+```
+
+**CRITICAL: Media Format**To add product images, use the media object with main image and optional additional items.**YOU MUST** add an image to each product, with a url from the web which should be relevant to the product.
+
+```json
+"media": {
+    "main": {
+        "url": "https://images.unsplash.com/photo-example?w=400&h=400&fit=crop&crop=center",
+        "altText": "Product Name - Main Product Image"
+    },
+    "itemsInfo": {
+        "items": [
+            {
+                "url": "https://images.unsplash.com/photo-example?w=400&h=400&fit=crop&crop=center",
+                "altText": "Product Name - Product View"
+            }
+        ]
+    }
+}
+```
+
+**CRITICAL: Options Structure**Each option MUST include:
+
+* `optionRenderType`: "TEXT_CHOICES" for text-based choices
+* `choicesSettings`: Object containing the choices array
+* `choicesSettings.choices`: Array with at least one choice
+* Each choice MUST have `choiceType`: "CHOICE_TEXT" and `name`
+
+**CRITICAL: Variants Structure**
+
+* Create one variant for EVERY combination of option choices (Cartesian product of all options)
+* In these examples: Each product creates ALL possible combinations: Size options x Color options = 6 total variants each
+* Each variant must reference ALL options defined on the product
+* Use `optionChoiceNames` structure with `optionName`, `choiceName`, and `renderType`
+* Price must use `price.actualPrice.amount` with string values
+* Include inventory information with `inventoryItem.quantity`
+* Use `visible: true` for variants you want customers to see, `visible: false` for variants you want to keep hidden but available for future use
+* **Pro Basketball Sneaker**: 6 variants total (3 visible: Size 8+Red, Size 9+Blue, Size 10+Red)
+* **Classic Canvas Shoes**: 6 variants total (3 visible: Size 7+White, Size 8+Navy, Size 9+Navy)
+* **Running Track Shoes**: 6 variants total (3 visible: Size 8+Black, Size 9+Gray, Size 10+Black)
+
+## Common Issues and Troubleshooting
+
+### 1. "Expected an object" Error in Description
+This occurs when using a plain string instead of the rich text nodes structure. Always use the nodes format shown above.
+
+### 2. Media Not Displaying
+Ensure both `main` and `itemsInfo` sections are included in the media object, and URLs include the required parameters.
+
+### 3. Options Not Working
+Verify that each option has the correct `optionRenderType` and `choicesSettings` structure.
+
+### 4. Variants Missing Choices
+Each variant must include choices for ALL options defined on the product.
+
+### 5. Invalid Color Options
+Color options must use `optionRenderType: "SWATCH_CHOICES"` and `choiceType: "ONE_COLOR"` with a valid `colorCode`.
+
+### 6. Bulk Request Failures
+If part of the bulk request fails, extract the failed products and retry them separately using the same format.

--- a/skills/wix-manage/references/stores/create-product-catalog-v1.md
+++ b/skills/wix-manage/references/stores/create-product-catalog-v1.md
@@ -1,0 +1,125 @@
+---
+name: "Create Product (Catalog V1)"
+description: Create products using the Catalog V1 Products API. Use this recipe when the site's catalog version is CATALOG_V1. Covers simple product creation, product with options, and key V1 request structure differences from V3.
+---
+# RECIPE: Business Recipe - Create Product (Catalog V1)
+
+## STEP 1: Create a Simple Product
+
+Use `POST https://www.wixapis.com/stores/v1/products` to create a product.
+
+**CRITICAL: Description accepts an HTML string in V1** (unlike V3 which requires rich text nodes).
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v1/products' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "product": {
+    "name": "Air Max Runner",
+    "description": "<p>Premium running sneaker with advanced cushioning technology.</p>",
+    "visible": true,
+    "productType": "physical",
+    "priceData": {
+      "price": 129.99
+    }
+  }
+}'
+```
+
+**Key V1 fields:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Required. Max 80 characters |
+| `description` | string | HTML string — NOT rich text nodes (e.g. `"<p>text</p>"`) |
+| `productType` | string | `"physical"` only (digital not supported via API) |
+| `priceData.price` | number | Product base price |
+| `visible` | boolean | Whether the product is visible to customers |
+
+---
+
+## STEP 2: Create a Product with Options
+
+In V1, options are defined via `productOptions`. Variants are **auto-generated** from the choices — you do not need to define them manually.
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v1/products' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "product": {
+    "name": "Colombian Arabica",
+    "description": "<p>The best organic coffee that Colombia has to offer.</p>",
+    "visible": true,
+    "productType": "physical",
+    "priceData": {
+      "price": 35
+    },
+    "productOptions": [
+      {
+        "name": "Weight",
+        "optionType": "drop_down",
+        "choices": [
+          { "value": "250g", "description": "250g", "inStock": true, "visible": true },
+          { "value": "500g", "description": "500g", "inStock": true, "visible": true }
+        ]
+      },
+      {
+        "name": "Ground for",
+        "optionType": "drop_down",
+        "choices": [
+          { "value": "Stovetop", "description": "Stovetop", "inStock": true, "visible": true },
+          { "value": "Filter", "description": "Filter", "inStock": true, "visible": true }
+        ]
+      }
+    ]
+  }
+}'
+```
+
+**V1 Options structure:**
+- `optionType`: `"drop_down"` for text choices, `"color"` for color swatches
+- `choices[].description`: Display name shown to customers
+- `choices[].value`: Internal value (use hex color code for `color` type, e.g. `"#000000"`)
+- `choices[].inStock`: Whether this choice is in stock
+- `choices[].visible`: Whether this choice is visible to customers
+
+**Variants in V1 responses** are returned as an object with option name keys:
+```json
+"choices": {
+  "Weight": "250g",
+  "Ground for": "Stovetop"
+}
+```
+This is different from V3 which uses an array structure.
+
+---
+
+## Key Differences from V3
+
+| Feature | Catalog V1 | Catalog V3 |
+|---|---|---|
+| Create endpoint | `POST /stores/v1/products` | `POST /stores/v3/products` |
+| Description | HTML string (`"<p>text</p>"`) | Rich text nodes object |
+| Options field | `productOptions` | `options` |
+| Option type field | `optionType` (`drop_down`, `color`) | `optionRenderType` (`TEXT_CHOICES`, `SWATCH_CHOICES`) |
+| Choice visibility | `choices[].visible` | `choices[].isVisible` |
+| Variants | Auto-generated from choices | Must be explicitly defined in `variantsInfo.variants` |
+| Variant choices | Object: `{"Weight": "250g"}` | Array of `optionChoiceNames` |
+| Price field | `priceData.price` (number) | `price.actualPrice.amount` (string) |
+
+---
+
+## Important Notes
+
+- **Never use `/stores/v3/` endpoints on a CATALOG_V1 site** — they return `428 Precondition Required`.
+- Check the site's catalog version in dynamic context before choosing endpoints.
+- `productType` only supports `"physical"` via the API.
+- To add media to a product, use the separate **Add Product Media** endpoint after creation.
+- To query products on a V1 site, see [Query Products (Catalog V1)](query-products-catalog-v1.md).
+
+## References
+
+- [V1 Create Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v1/catalog/create-product)
+- [Catalog Versioning Overview](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-versioning/introduction)

--- a/skills/wix-manage/references/stores/create-product-with-options-catalog-v3.md
+++ b/skills/wix-manage/references/stores/create-product-with-options-catalog-v3.md
@@ -1,0 +1,566 @@
+---
+name: "Create Product with Options (Catalog V3)"
+description: Single product creation with options using Catalog V3 Products API. Covers option types (TEXT_CHOICES, SWATCH_CHOICES), choice configuration, and automatic variant generation.
+---
+# RECIPE: Business Recipe - Creating a Wix Store Product with options (Catalog V3)
+
+Learn how to create a Wix store product with customizable options like colors, sizes, or other variants, allowing customers to select their preferences when purchasing.
+
+---
+
+## Article: Steps for creating a Wix Store Product with Options
+
+## STEP 1: create the product with options and variants
+
+1. create the product with options and create variants for them - Wix REST API: [Create Product](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/products-v3/create-product) **CRITICAL: USE THIS WORKING EXAMPLE**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v3/products' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "product": {
+        "name": "Air Max Runner",
+        "description": {
+            "nodes": [
+                {
+                    "type": "PARAGRAPH",
+                    "id": "desc1",
+                    "nodes": [
+                        {
+                            "type": "TEXT",
+                            "textData": {
+                                "text": "Premium running sneaker with advanced cushioning technology and breathable mesh design for ultimate comfort."
+                            }
+                        }
+                    ],
+                    "paragraphData": {
+                        "textStyle": {
+                            "textAlignment": "AUTO"
+                        }
+                    }
+                }
+            ],
+            "metadata": {
+                "version": 1,
+                "id": "sneaker-desc-001"
+            }
+        },
+        "productType": "PHYSICAL",
+        "physicalProperties": {},
+        "media": {
+            "main": {
+                "url": "https://images.unsplash.com/photo-1549298916-b41d501d3772?w=400&h=400&fit=crop&crop=center",
+                "altText": "Air Max Runner - Main Product Image"
+            },
+            "itemsInfo": {
+                "items": [
+                    {
+                        "url": "https://images.unsplash.com/photo-1549298916-b41d501d3772?w=400&h=400&fit=crop&crop=center",
+                        "altText": "Air Max Runner - Product View"
+                    }
+                ]
+            }
+        },
+        "options": [
+            {
+                "name": "Size",
+                "optionRenderType": "TEXT_CHOICES",
+                "choicesSettings": {
+                    "choices": [
+                        {
+                            "choiceType": "CHOICE_TEXT",
+                            "name": "8"
+                        },
+                        {
+                            "choiceType": "CHOICE_TEXT",
+                            "name": "9"
+                        },
+                        {
+                            "choiceType": "CHOICE_TEXT",
+                            "name": "10"
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "Color",
+                "optionRenderType": "TEXT_CHOICES",
+                "choicesSettings": {
+                    "choices": [
+                        {
+                            "choiceType": "CHOICE_TEXT",
+                            "name": "Black"
+                        },
+                        {
+                            "choiceType": "CHOICE_TEXT",
+                            "name": "White"
+                        }
+                    ]
+                }
+            }
+        ],
+        "variantsInfo": {
+            "variants": [
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Size",
+                                "choiceName": "8",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        },
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "Black",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "129.99"
+                        }
+                    },
+                    "physicalProperties": {},
+                    "visible": true
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Size",
+                                "choiceName": "8",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        },
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "White",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "129.99"
+                        }
+                    },
+                    "physicalProperties": {},
+                    "visible": false
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Size",
+                                "choiceName": "9",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        },
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "Black",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "129.99"
+                        }
+                    },
+                    "physicalProperties": {},
+                    "visible": false
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Size",
+                                "choiceName": "9",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        },
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "White",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "129.99"
+                        }
+                    },
+                    "physicalProperties": {},
+                    "visible": true
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Size",
+                                "choiceName": "10",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        },
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "Black",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "129.99"
+                        }
+                    },
+                    "physicalProperties": {},
+                    "visible": true
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Size",
+                                "choiceName": "10",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        },
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "White",
+                                "renderType": "TEXT_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "129.99"
+                        }
+                    },
+                    "physicalProperties": {},
+                    "visible": false
+                }
+            ]
+        }
+    }
+}'
+```
+
+### IMPORTANT NOTES:
+
+When Creating a product YOU MUST leave the physicalProperties and all other non required fields empty. for example: "physicalProperties": {}. In most cases the product will be a physical product, and therefore MUST have the empty physicalProperties object ("physicalProperties": {}) and a corresponding "productType": "PHYSICAL".
+
+**CRITICAL: variantsInfo is Always Required**
+`variantsInfo.variants` must contain at least one variant, even for simple products without options. Omitting it causes: `"variantsInfo must not be empty"`.
+
+**CRITICAL: Description Format**If you include a description, it MUST use Wix's rich text nodes structure, NOT a plain string. Plain strings will cause "Expected an object" API errors.
+
+**WRONG:** `"description": "Your text here"` **CORRECT:**
+
+```json
+"description": {
+    "nodes": [
+        {
+            "type": "PARAGRAPH",
+            "id": "desc1",
+            "nodes": [
+                {
+                    "type": "TEXT",
+                    "textData": {
+                        "text": "Your product description here"
+                    }
+                }
+            ],
+            "paragraphData": {
+                "textStyle": {
+                    "textAlignment": "AUTO"
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "version": 1,
+        "id": "unique-desc-id"
+    }
+}
+```
+
+**CRITICAL: Media Format**
+To add product images, use the `media` object with `main` for the primary image and `itemsInfo.items` for additional gallery images. **YOU MUST** add an image to each product.
+
+> **Important:** The V3 Products API requires **URLs** for media, not media IDs. Even when using files from the Media Manager, you must use the full wixstatic.com URL.
+
+**Option 1: Using External URLs Directly**
+
+You can reference images directly from external URLs that allow hotlinking (e.g., Unsplash, Pexels):
+
+```json
+"media": {
+    "main": {
+        "url": "https://images.unsplash.com/photo-1549298916-b41d501d3772?w=400",
+        "altText": "Product Main Image"
+    },
+    "itemsInfo": {
+        "items": [
+            {
+                "url": "https://images.unsplash.com/photo-1549298916-b41d501d3772?w=400",
+                "altText": "Product View"
+            }
+        ]
+    }
+}
+```
+
+> **Warning:** Some external URLs may fail if the source server blocks requests or has hotlink protection. For reliable media, use Option 2.
+
+**Option 2: Using Media Manager (Recommended)**
+
+For reliable, permanent media storage, first upload the image to the site's Media Manager, then use the returned wixstatic.com URL.
+
+**Step 1:** Upload the image to Media Manager using the Import File API:
+
+```bash
+curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "url": "https://images.unsplash.com/photo-1563729784474-d77dbb933a9e?w=400",
+    "mimeType": "image/jpeg",
+    "displayName": "Product Image"
+}'
+```
+
+Response includes the wixstatic.com URL:
+
+```json
+{
+    "file": {
+        "id": "e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "operationStatus": "PENDING"
+    }
+}
+```
+
+> **Note:** Wait for `operationStatus` to become `READY` before using the media. You can verify by calling the List Files API (`GET /site-media/v1/files`).
+
+**Step 2:** Use the wixstatic.com **URL** (not the ID) when creating the product:
+
+```json
+"media": {
+    "main": {
+        "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "altText": "Product Image"
+    },
+    "itemsInfo": {
+        "items": [
+            {
+                "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+                "altText": "Product Image"
+            }
+        ]
+    }
+}
+```
+
+> **Why use Media Manager?** External URLs can fail if the source server blocks requests. Once uploaded to Media Manager, the file is permanently stored on Wix servers and the wixstatic.com URL is always reliable.
+
+**CRITICAL: Options Structure**Each option MUST include:
+
+* `optionRenderType`: "TEXT_CHOICES" for text-based choices
+* `choicesSettings`: Object containing the choices array
+* `choicesSettings.choices`: Array with at least one choice
+* Each choice MUST have `choiceType`: "CHOICE_TEXT" and `name` properties
+
+**CRITICAL: Variants Structure**
+
+* Create one variant for EVERY combination of option choices (Cartesian product of all options)
+* In this example: 2 colors and 3 sizes creates 6 variants (2 x 3) - all combinations must be included
+* Each variant must reference ALL options defined on the product
+* Use `optionChoiceNames` structure with `optionName`, `choiceName`, and `renderType`
+* Price must use `price.actualPrice.amount` with string values
+* Use `visible: true` for variants you want customers to see and purchase
+* Use `visible: false` for variants that exist but should be hidden from customers
+
+The Create Product API can handle creating customizations and choices in a single call. There's no need to separately check for existing customizations, create new ones, or add choices to them—the API handles all of this automatically:
+
+1. If you provide an option with a name that doesn't exist as a customization, a new customization will be created
+2. If a customization with that name already exists, it will be associated with the product
+3. New choices will be added to the customization if they don't exist
+4. When creating variants, use optionChoiceNames rather than optionChoiceIds to reference the options and choices
+5. Always include the choicesSettings object with the complete list of choices
+6. You must create one variant for each combination of option choices
+
+### Next Steps:
+
+After Creating the product, verify that the options appear correctly in the store and that customers can select different variants.
+
+> **Need to Update This Product Later?**
+>
+> See [Update Product with Options](update-product-with-options.md) for updating existing products.
+>
+> **Important:** All update operations (PATCH) require the current `product.revision` value. Always GET the product first to obtain the revision before updating.
+
+## Troubleshooting Common Issues
+
+### Issue 1: "ChoicesSettings must not be empty" error
+
+* **Problem**: When creating a product with options, you get an error saying `choicesSettings must not be empty`. This can appear in several forms:
+   * `"product is invalid: options [at index 0] is invalid: value choicesSettings must not be empty"`
+   * `"product is invalid: options [at index 0] is invalid: value choicesSettings must not be empty"` with `"violatedRule":"REQUIRED_ONE_OF_FIELD"`
+   * `"choicesSettings must not be empty"` with field violations showing `"supported":["choicesSettings"]`
+* **Solution**: Always include the `choicesSettings` object with the full array of `choices` when creating a product with options. Every option MUST have a complete choicesSettings structure with at least one choice, even when using an existing customization.
+
+**Common Causes:**
+
+1. **Missing choicesSettings entirely** - The option object doesn't include any choicesSettings
+2. **Empty choicesSettings object** - The choicesSettings exists but has no choices array or empty choices array
+3. **Null or undefined choicesSettings** - The choicesSettings field is present but set to null/undefined
+
+**Example of correct choicesSettings structure:**
+
+```json
+"options": [
+    {
+        "name": "Size",
+        "optionRenderType": "TEXT_CHOICES",
+        "choicesSettings": {
+            "choices": [
+                {
+                    "choiceType": "CHOICE_TEXT",
+                    "name": "Small"
+                }
+            ]
+        }
+    }
+]
+```
+
+**What NOT to do:**
+
+```json
+// WRONG - Missing choicesSettings entirely
+"options": [
+    {
+        "name": "Size",
+        "optionRenderType": "TEXT_CHOICES"
+    }
+]
+
+// WRONG - Empty choicesSettings
+"options": [
+    {
+        "name": "Size",
+        "optionRenderType": "TEXT_CHOICES",
+        "choicesSettings": {}
+    }
+]
+
+// WRONG - Empty choices array
+"options": [
+    {
+        "name": "Size",
+        "optionRenderType": "TEXT_CHOICES",
+        "choicesSettings": {
+            "choices": []
+        }
+    }
+]
+```
+
+### Issue 2: "optionSettings.choicesSettings.choices must not be empty" error
+
+* **Problem**: You get an error like `"product is invalid: options [at index 0] is invalid: optionSettings.choicesSettings is invalid: choices has size 0, expected 1 or more"` or `"choices must not be empty"`.
+* **Solution**: This error occurs when using the incorrect nested structure `optionSettings.choicesSettings` instead of the correct `choicesSettings` directly under the option.
+
+**WRONG Structure (causes the error):**
+
+```json
+"options": [
+    {
+        "name": "Size",
+        "optionRenderType": "TEXT_CHOICES",
+        "optionSettings": {
+            "choicesSettings": {
+                "choices": []
+            }
+        }
+    }
+]
+```
+
+**CORRECT Structure (use this instead):**
+
+```json
+"options": [
+    {
+        "name": "Size",
+        "optionRenderType": "TEXT_CHOICES",
+        "choicesSettings": {
+            "choices": [
+                {
+                    "choiceType": "CHOICE_TEXT",
+                    "name": "Small"
+                }
+            ]
+        }
+    }
+]
+```
+
+**Key Points:**
+
+* Use `choicesSettings` directly under the option object, NOT nested under `optionSettings`
+* The `choicesSettings.choices` array MUST contain at least one choice
+* Each choice MUST have `choiceType` and `name` properties
+* Always include the complete choices array even when referencing existing customizations
+
+### Issue 3: Variants not matching options
+
+* **Problem**: The API returns errors about variants not matching the product's options.
+* **Solution**:
+* Create one variant for each possible combination of option choices
+* Ensure each variant references all options defined on the product
+* If the product has only one option with three choices, you need three variants
+* Make sure each variant's option choice name exactly matches the corresponding option choice
+
+### Issue 4: Conflicts when using existing customizations
+
+* **Problem**: When attempting to use existing customizations, you encounter name conflicts or choice conflicts.
+* **Solution**:
+* If you need to use a specific existing customization ID, first query customizations to get the correct ID
+* When working with existing customizations, ensure all choices you reference actually exist in that customization
+* If you're creating a new customization with the same name as an existing one, the API will use the existing one
+* Be aware that customizations are shared across all products in your store
+
+### Issue 5: "Expected an object" error for description
+
+* **Problem**: Using a plain string for the description field causes API failure.
+* **Solution**: Always use the rich text nodes structure for descriptions as shown in the CRITICAL section above.
+
+### Issue 6: Inconsistencies in documentation vs. actual API behavior
+
+* **Problem**: Several API requirements are not well-documented or are documented differently from how the API actually behaves.
+* **Solution**:
+* Always include choicesSettings with all choices when creating a product
+* Use optionChoiceNames rather than optionChoiceIds in variants for more reliable results
+* Include the renderType in optionChoiceNames
+* Use the exact same choice names as defined in the customization
+
+## Conclusion
+
+Creating a Wix store product with options involves understanding the relationship between store-wide customizations and product-specific options and variants. The key is to ensure consistency between customization definitions, product options, and product variants.
+
+By following this recipe and being aware of the common pitfalls, you can successfully create a Wix store product with options.

--- a/skills/wix-manage/references/stores/query-products-catalog-v1.md
+++ b/skills/wix-manage/references/stores/query-products-catalog-v1.md
@@ -1,0 +1,80 @@
+---
+name: "Query Products (Catalog V1)"
+description: Query and list products from a Wix Store using the Catalog V1 Query Products endpoint. Use this recipe when the site's catalog version is CATALOG_V1. Covers basic queries, filtering, sorting, and paging.
+---
+# RECIPE: Business Recipe - Query Products (Catalog V1)
+
+## STEP 1: Query Products
+
+Use `POST https://www.wixapis.com/stores-reader/v1/products/query` to query products from a V1 store.
+
+**Basic query (all products):**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores-reader/v1/products/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "query": {}
+}'
+```
+
+---
+
+## STEP 2: Filtering and Sorting
+
+> **CRITICAL:** In V1, `filter` and `sort` are **JSON-encoded strings**, not objects — unlike V3 where they are plain objects.
+
+**Query with filter and sort:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores-reader/v1/products/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "query": {
+    "filter": "{\"visible\": true}",
+    "sort": "[{\"fieldName\": \"name\", \"order\": \"ASC\"}]",
+    "paging": {
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}'
+```
+
+**Query by product IDs:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores-reader/v1/products/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "query": {
+    "filter": "{\"id\": {\"$in\": [\"product-id-1\", \"product-id-2\"]}}"
+  }
+}'
+```
+
+---
+
+## Key Differences from V3
+
+| Feature | Catalog V1 | Catalog V3 |
+|---|---|---|
+| Query endpoint | `POST /stores-reader/v1/products/query` | `POST /stores/v3/products/query` |
+| Filter/sort | JSON-encoded strings | Plain objects |
+| Additional fields | Not applicable | Enum values like `DESCRIPTION`, `URL` |
+
+---
+
+## Important Notes
+
+- **Never use `/stores/v3/` endpoints on a CATALOG_V1 site** — they return `428 Precondition Required`.
+- Check the site's catalog version in dynamic context before choosing endpoints.
+- To create products on a V1 site, see [Create Product (Catalog V1)](create-product-catalog-v1.md).
+
+## References
+
+- [V1 Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v1/catalog/query-products)
+- [Catalog Versioning Overview](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-versioning/introduction)

--- a/skills/wix-manage/references/stores/query-products.md
+++ b/skills/wix-manage/references/stores/query-products.md
@@ -1,0 +1,154 @@
+---
+name: Query Products
+description: Query and list products from a Wix Store using Catalog V3 Query Products endpoint. Covers correct fields enum values, filtering, sorting, and paging.
+---
+
+# RECIPE: Business Recipe – Query Products from a Wix Store
+
+Retrieve products from a Wix store using the Catalog V3 Query Products API.
+
+## Article: How to Query Products
+
+### STEP 1: Call Query Products endpoint
+
+Use the **POST** [Query Products](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/products-v3/query-products) endpoint to query products. The endpoint returns up to 100 products per request.
+
+**Endpoint:** `POST https://www.wixapis.com/stores/v3/products/query`
+
+**Basic query (all products, default fields):**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "query": {}
+}'
+```
+
+This returns all products with their default fields (id, name, slug, visible, productType, priceData, stock, media, etc.).
+
+### STEP 2: Understanding the `fields` parameter
+
+The `fields` array requests **additional** fields beyond the defaults. It does **NOT** accept property names like `"name"` or `"id"`.
+
+**⚠️ CRITICAL: Valid `fields` enum values:**
+
+| Enum Value                         | Description                  |
+| ---------------------------------- | ---------------------------- |
+| `URL`                              | Product page URL             |
+| `CURRENCY`                         | Currency information         |
+| `INFO_SECTION`                     | Info sections (rich content) |
+| `MERCHANT_DATA`                    | Merchant-specific data       |
+| `PLAIN_DESCRIPTION`                | Plain text description       |
+| `INFO_SECTION_PLAIN_DESCRIPTION`   | Info section plain text      |
+| `SUBSCRIPTION_PRICES_INFO`         | Subscription pricing         |
+| `BREADCRUMBS_INFO`                 | Category breadcrumbs         |
+| `WEIGHT_MEASUREMENT_UNIT_INFO`     | Weight unit info             |
+| `VARIANT_OPTION_CHOICE_NAMES`      | Variant option choice names  |
+| `MEDIA_ITEMS_INFO`                 | Additional media items       |
+| `DESCRIPTION`                      | Rich text description        |
+| `DIRECT_CATEGORIES_INFO`           | Direct category info         |
+| `ALL_CATEGORIES_INFO`              | All category info            |
+| `MIN_VARIANT_PRICE_INFO`           | Minimum variant price        |
+| `INFO_SECTION_DESCRIPTION`         | Info section rich content    |
+| `THUMBNAIL`                        | Thumbnail image              |
+| `DIRECT_CATEGORY_IDS`              | Direct category IDs          |
+| `PRODUCT_CHOICES_MEDIA_REFERENCES` | Choice-specific media        |
+
+**WRONG – these are NOT valid field values:**
+
+```json
+"fields": ["id", "name", "slug", "visible", "priceData"]
+```
+
+**CORRECT – use enum constants or leave empty for defaults:**
+
+```json
+"fields": []
+```
+
+**CORRECT – requesting additional fields:**
+
+```json
+"fields": ["DESCRIPTION", "URL", "ALL_CATEGORIES_INFO"]
+```
+
+### STEP 3: Filtering and sorting
+
+**Query with filter and sort:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "fields": [],
+  "query": {
+    "filter": {
+      "visible": true
+    },
+    "sort": [
+      {
+        "field_name": "name",
+        "order": "ASC"
+      }
+    ],
+    "paging": {
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}'
+```
+
+**Filter by product IDs:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "fields": [],
+  "query": {
+    "filter": {
+      "id": {
+        "$in": [
+          "product-id-1",
+          "product-id-2"
+        ]
+      }
+    }
+  }
+}'
+```
+
+### STEP 4: Handling pagination
+
+When there are more products than the page limit, use cursor-based or offset-based paging:
+
+```json
+{
+  "query": {
+    "paging": {
+      "limit": 100,
+      "offset": 0
+    }
+  }
+}
+```
+
+Check the response `pagingMetadata` to determine if more pages exist.
+
+---
+
+## Important Notes
+
+- **Variant data is NOT returned** by Query Products. To get variant details, use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) for individual products.
+- **Non-visible products** require the `SCOPE.STORES.PRODUCT_READ_ADMIN` permission.
+- Default fields include: `id`, `name`, `slug`, `visible`, `productType`, `priceData`, `stock`, `media`, `createdDate`, `updatedDate`.
+- The `fields` parameter adds fields **on top of** the defaults — you never need to request `id` or `name` explicitly.
+
+## Conclusion
+
+To query products, use `POST https://www.wixapis.com/stores/v3/products/query` with an empty `query` object for all products. Use `fields: []` for defaults, or pass valid enum values like `DESCRIPTION`, `URL`, `ALL_CATEGORIES_INFO` for additional data. Never pass property names as field values.

--- a/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
+++ b/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
@@ -1,0 +1,99 @@
+---
+name: "Setup Online Store (Catalog V3)"
+description: Initializes a Stores catalog with Catalog V3 Products API, bulk products endpoint, and Categories API. Covers product creation, option configuration, variant management, and category assignment.
+---
+**RECIPE**: Business Recipe – Initial Setup for a Wix Online Store (Catalog V3)
+
+A concise checklist for preparing any new Wix site that uses the Online Stores app with Catalog V3.
+**Notice** that this recipe is **NOT** meant for coding purposes and is **ONLY** meant for initial catalog setup.
+
+---
+
+## Article: Steps for Setting Up a Wix Online Store
+**YOU MUST** Complete all the following steps **in the given order** (1 -5) without skipping any and **without requiring additional user input**.
+**YOU MUST** remind yourself as many times as needed throughout the process that you most complete all the steps and not stop at all in the middle.
+
+
+**⚠️ CRITICAL ORDER REQUIREMENT: You MUST start with creating products FIRST (Steps 1-2), then categories (Steps 3-5). Categories API might take some time to be fully available after Stores installation, so always create products before attempting category operations.**
+
+### STEP 1: Confirm Catalog V3 & Stick to V3 APIs
+
+- **Check if the site uses Catalog V3.**
+ This can be done using the [Get Catalog Version](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-versioning/get-catalog-version) endpoint.
+ path: `https://www.wixapis.com/stores/v3/provision/version`
+
+
+- From this point forward, as long as the result is V3, use only Catalog V3 REST endpoints.
+All API calls should be directed to endpoints starting with `/stores/v3/....` Do not mix V3 calls with earlier versions.
+
+
+- Exception for Categories:
+The Categories API is an exception. It uses a v1 endpoint, as it replaces the older Collections API. For example, to create a category in V3, use the following endpoint:
+`https://www.wixapis.com/categories/v1/categories`
+
+
+### STEP 2: Create 5 new products based on the format specified in the Bulk Create Products with Options recipe (4 in stock, 1 out of stock)
+1. First *YOU MUST* pull up the [Bulk Create Wix Store Products with Options](bulk-create-products-with-options.md) recipe to understand the exact format required for creating products.
+2. Create 5 products according to this format using bulk creation (use a single bulk request). 4 of the created products **MUST** have ALL there variants in-stock, and the last (5th) product **MUST** have all its variants be out-of-stock.
+3. **Make sure** to add in image (using media) using  a url from the web that matches each product.
+4. **YOU MUST** use the price formatting as seen in the example, meaning using actualPrice and compareAtPrice.
+5. **ALL** products **MUST** be created **EXACTLY** from the same format as the full example in the Bulk Create Wix Store Products with Options recipe. **ONLY** information within the strings of the given fields may differ based on the products.
+
+
+**⚠️ CRITICAL: EXACT FORMAT REQUIREMENTS**
+**YOU MUST** use the following recipe to create ALL products with the EXACT same format:
+- **Bulk Create Wix Store Products with Options**
+ [Recipe: Bulk Create Products with Options](bulk-create-products-with-options.md)
+
+
+### STEP 3: Prepare Three Store Categories
+1. Determine how many categories the user requested.
+2. If fewer than **3** are provided, create additional categories until the total equals **3** which are relevant for the type of store.
+3. Examples for different types of stores:
+  - **Book store** → Drama, Kids, Sci-Fi
+  - **Fashion** → Men, Women, Kids
+  - **Other industries** → any logical grouping that fits the catalog.
+4. Use the Categories API to create each category. **YOU MUST USE** the endpoint: [Create Category](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/categories/create-category) based on the example below.
+**⚠️ CRITICAL: Use correct endpoint `/categories/v1/bulk/categories/{categoryId}/add-items` with `catalogItemId`, `appId: "215238eb-22a5-4c36-9e7b-e7c08025e04e"`, and `treeReference` object.**
+When calling the endpoint, make sure the request body includes a top-level `treeReference` field. It must **not** be nested inside the `category` object.
+
+Use the following example format:
+
+```json
+{
+  "category": {
+    "name": "Drinkware",
+    "description": "The Drinkware category includes a wide range of containers designed for holding beverages",
+    "visible": true
+  },
+  "treeReference": {
+    "appNamespace": "@wix/stores",
+    "treeKey": null
+  }
+}
+```
+
+
+### STEP 4: Add Each Product to a Category
+1. **YOU MUST** add each existing product to at least one category that most makes sense.
+2. First acquire the product's ids to use for this action.
+3. Then adding a product to a category **MUST** be done using the Category API, specifically [Bulk Add Items To Category](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/categories/bulk-add-items-to-category), where products are referred to as items. This endpoint enables adding multiple products at once to a category.
+
+**⚠️ CRITICAL: Use correct endpoint `/categories/v1/bulk/categories/{categoryId}/add-items` with `catalogItemId`, `appId: "215238eb-22a5-4c36-9e7b-e7c08025e04e"`, and `treeReference` object.**
+**Make Sure** you pass the treeReference correctly at the same level as "items".
+
+
+### STEP 5: Ensure Each Product was Added to a Category
+1. **YOU MUST** ensure that each product is connected to at least one category.
+2. **You MUST** do this by using the [List Items In Category](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/categories/list-items-in-category) for EVERY Category (for example: 3 required api calls for 3 categories). If the list of items is empty, it means that the product was not added to that category and **YOU MUST** repeat step 4.
+The path for this endpoint in REST is: `https://www.wixapis.com/categories/v1/categories/{categoryId}/list-items`
+3. When calling the endpoint, make sure the request body includes a top-level `treeReference` field. It must **not** be nested inside the `category` object.
+
+---
+
+## Conclusion
+Following these steps **in order** guarantees the creation flow for new V3 Wix Online Store sites:
+- Contains exactly **3** categories
+- Contains exactly **5** products (unless the user explicitly requests fewer)
+- Each product is connected to at least one category.
+- All products follow the correct Catalog V3 API format as specified in the referenced recipe.

--- a/skills/wix-manage/references/stores/update-product-pre-order.md
+++ b/skills/wix-manage/references/stores/update-product-pre-order.md
@@ -1,0 +1,213 @@
+---
+name: "Update Product Pre-Order"
+description: Manages pre-order settings for product variants using V3 Inventory API. Covers enabling/disabling pre-orders, setting messages, configuring limits, and handling trackQuantity requirements.
+---
+# Update Product Pre-Order Information
+
+This recipe outlines the steps to manage pre-orders for product variants, including enabling/disabling pre-orders, setting messages, and configuring limits.
+
+## Prerequisites
+
+- Wix Stores app installed
+- Product with variants already created
+- API access with stores permissions
+
+## Required APIs
+
+- **Products Search API**: [REST](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/products-v3/search-products)
+- **Query Inventory Items API**: [REST](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/inventory-items-v3/query-inventory-items)
+- **Bulk Update Inventory Items API**: [REST](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/inventory-items-v3/bulk-update-inventory-items)
+- **Update Inventory Item API**: [REST](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/inventory-items-v3/update-inventory-item)
+
+---
+
+## Step 1: Find the Product and Get Variant Information
+
+### 1.1 Search for the Product
+
+**Endpoint**: `POST https://www.wixapis.com/stores/v3/products/search`
+
+```json
+{
+  "search": {
+    "expression": "Product Name"
+  }
+}
+```
+
+### 1.2 Query Inventory Items for Variant Details
+
+Use the `productId` from the search to get variant information:
+
+**Endpoint**: `POST https://www.wixapis.com/stores/v3/inventory-items/query`
+
+```json
+{
+  "query": {
+    "filter": {
+      "productId": {
+        "$in": ["<PRODUCT_ID>"]
+      }
+    }
+  }
+}
+```
+
+The response includes:
+- `product.variantName` - identifies each variant
+- `inventoryItemId` - needed for updates
+- `revision` - required for update operations
+- `locationId` - inventory location
+- Current `preorderInfo` settings
+
+### IMPORTANT NOTES:
+- I MUST get user input on which specific variant(s) to update
+- I MUST NEVER update all variants without explicit user selection
+- I MUST ask the user whether to enable or disable pre-orders for each variant
+- If enabling, I MUST get the pre-order message from the user
+- If setting a pre-order limit, I MUST ensure `trackQuantity: true` is set
+
+---
+
+## Step 2: Update Pre-Order Information
+
+### Method A: Bulk Update (PREFERRED for multiple variants)
+
+Use when applying the same pre-order settings to multiple variants:
+
+**Endpoint**: `POST https://www.wixapis.com/stores/v3/bulk/inventory-items/update`
+
+**Request Body (Enable Pre-Order)**:
+```json
+{
+  "inventoryItems": [
+    {
+      "inventoryItem": {
+        "id": "<inventoryItemId_variant1>",
+        "revision": "<revision_as_integer>",
+        "preorderInfo": {
+          "enabled": true,
+          "message": "Available for pre-order! Ships in 2 weeks."
+        }
+      }
+    },
+    {
+      "inventoryItem": {
+        "id": "<inventoryItemId_variant2>",
+        "revision": "<revision_as_integer>",
+        "preorderInfo": {
+          "enabled": true,
+          "message": "Available for pre-order! Ships in 2 weeks."
+        }
+      }
+    }
+  ],
+  "returnEntity": true,
+  "reason": "MANUAL"
+}
+```
+
+**Request Body (With Pre-Order Limit)**:
+```json
+{
+  "inventoryItems": [
+    {
+      "inventoryItem": {
+        "id": "<inventoryItemId>",
+        "revision": "<revision_as_integer>",
+        "trackQuantity": true,
+        "quantity": 100,
+        "preorderInfo": {
+          "enabled": true,
+          "message": "Pre-order now!",
+          "limit": 50
+        }
+      }
+    }
+  ],
+  "returnEntity": true,
+  "reason": "MANUAL"
+}
+```
+
+### IMPORTANT NOTES:
+- Pre-order limits ONLY work when `trackQuantity: true`
+- If variant wasn't tracking quantity, I MUST ask user for initial quantity
+- The `revision` field is required and must be an integer
+
+---
+
+### Method B: Individual Update (Single variant or unique settings)
+
+**Endpoint**: `PATCH https://www.wixapis.com/stores/v3/inventory-items/{inventoryItemId}`
+
+**Request Body (Enable Pre-Order)**:
+```json
+{
+  "inventoryItem": {
+    "id": "<inventoryItemId>",
+    "revision": "<revision_as_integer>",
+    "preorderInfo": {
+      "enabled": true,
+      "message": "Coming soon! Pre-order today."
+    }
+  },
+  "reason": "MANUAL"
+}
+```
+
+**Request Body (Disable Pre-Order)**:
+```json
+{
+  "inventoryItem": {
+    "id": "<inventoryItemId>",
+    "revision": "<revision_as_integer>",
+    "preorderInfo": {
+      "enabled": false,
+      "limit": null
+    }
+  },
+  "reason": "MANUAL"
+}
+```
+
+---
+
+## Pre-Order Limit Behavior
+
+When you set a `preorderInfo.limit`:
+- It specifies how many units can be pre-ordered **after stock reaches zero**
+- Example: 10 in stock + limit of 50 = customers can order up to 60 total (10 regular + 50 pre-order)
+
+### CRITICAL: Enabling Quantity Tracking
+
+If setting a limit on a variant that wasn't tracking quantity:
+
+1. **Inform the user**: "`trackQuantity` will be enabled for this variant"
+2. **Ask for initial quantity**: "What initial stock quantity should I set?"
+3. **Include both in update**:
+```json
+{
+  "inventoryItem": {
+    "id": "<inventoryItemId>",
+    "revision": "<revision_as_integer>",
+    "trackQuantity": true,
+    "quantity": "<USER_PROVIDED_QUANTITY>",
+    "preorderInfo": {
+      "enabled": true,
+      "message": "Pre-order message",
+      "limit": 50
+    }
+  },
+  "reason": "MANUAL"
+}
+```
+
+---
+
+## Next Steps
+
+After updating pre-order settings:
+- Confirm the changes with the user
+- Offer to update other products or variants
+- Consider updating product descriptions to mention pre-order availability

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -1,0 +1,247 @@
+---
+name: "Update Product with Options"
+description: Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, variant-specific pricing, and revision-based updates to prevent conflicts.
+---
+**RECIPE**: Business Recipe - Updating a Wix Store Product (V3)
+
+Learn how to update existing Wix store products, including adding options, changing media, updating prices, or modifying other product properties.
+
+---
+
+> **CRITICAL: Revision Required for All Updates**
+>
+> All PATCH operations on Catalog V3 products require the current `product.revision`. Without it, you'll get: `"revision must not be empty"`
+>
+> **Always:**
+> 1. GET the product first to obtain current revision
+> 2. Include `product.revision` in every PATCH body
+
+---
+
+## Article: Steps for Updating Wix Store Products
+
+## STEP 1: Get the current product to obtain its revision
+1. Before updating the product, you need to retrieve its current revision to prevent conflicts using [Get Product](https://dev.wix.com/docs/rest/business-solutions/stores/catalog-v3/products-v3/get-product):
+
+```bash
+curl -X GET "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Authorization: <AUTH>"
+```
+
+The response will include a `revision` field in the product object. Save this value for use in Step 2.
+
+## STEP 2: Update the product with options and variants
+1. Update the product to add options and create variants using the revision obtained in Step 1 - [Wix REST API: Update Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/update-product)
+
+```bash
+curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <AUTH>" \
+  -d '{
+    "product": {
+        "id": "{productId}",
+        "revision": "{currentRevision}",
+        "options": [
+            {
+                "name": "Color",
+                "optionRenderType": "SWATCH_CHOICES",
+                "choicesSettings": {
+                    "choices": [
+                        {
+                            "name": "White",
+                            "choiceType": "ONE_COLOR",
+                            "colorCode": "#FFFFFF"
+                        },
+                        {
+                            "name": "Red",
+                            "choiceType": "ONE_COLOR",
+                            "colorCode": "#FF0000"
+                        },
+                        {
+                            "name": "Black",
+                            "choiceType": "ONE_COLOR",
+                            "colorCode": "#000000"
+                        }
+                    ]
+                }
+            }
+        ],
+        "variantsInfo": {
+            "variants": [
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "White",
+                                "renderType": "SWATCH_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "270.00"
+                        }
+                    }
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "Red",
+                                "renderType": "SWATCH_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "270.00"
+                        }
+                    }
+                },
+                {
+                    "choices": [
+                        {
+                            "optionChoiceNames": {
+                                "optionName": "Color",
+                                "choiceName": "Black",
+                                "renderType": "SWATCH_CHOICES"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "actualPrice": {
+                            "amount": "270.00"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}'
+```
+
+## Common Update Patterns (Minimal Examples)
+
+### Update Media Only
+
+To update just the product's media without changing other fields:
+
+```bash
+curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <AUTH>" \
+  -d '{
+    "product": {
+      "revision": "{currentRevision}",
+      "media": {
+        "itemsInfo": {
+          "items": [
+            {
+              "url": "https://static.wixstatic.com/media/your-image.jpg",
+              "altText": "Product image"
+            }
+          ]
+        }
+      }
+    }
+  }'
+```
+
+### Update Price Only
+
+To update just the variant prices:
+
+```bash
+curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <AUTH>" \
+  -d '{
+    "product": {
+      "revision": "{currentRevision}",
+      "variantsInfo": {
+        "variants": [
+          {
+            "id": "{existingVariantId}",
+            "price": {
+              "actualPrice": {
+                "amount": "29.99"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }'
+```
+
+> **Note:** When updating variants, you must include the variant `id` to update existing variants. Without the `id`, a new variant will be created.
+
+---
+
+### IMPORTANT NOTES:
+The Update Product API can handle creating customizations and choices in a single call. There's no need to separately check for existing customizations, create new ones, or add choices to them—the API handles all of this automatically:
+
+1. If you provide an option with a name that doesn't exist as a customization, a new customization will be created
+2. If a customization with that name already exists, it will be associated with the product
+3. New choices will be added to the customization if they don't exist
+4. When creating variants, use optionChoiceNames rather than optionChoiceIds to reference the options and choices
+5. Always include the choicesSettings object with the complete list of choices
+6. You must create one variant for each combination of option choices
+
+### Next Steps:
+After updating the product, verify that the options appear correctly in the store and that customers can select different variants.
+
+## Troubleshooting Common Issues
+
+### Issue 1: "ChoicesSettings must not be empty" error
+- **Problem**: When updating a product with options, you get an error saying `choicesSettings must not be empty`.
+- **Solution**: Always include the `choicesSettings` object with the full array of `choices` when updating a product with options, even when using an existing customization.
+
+### Issue 2: "Missing product option choices" error
+- **Problem**: You get an error message like `Missing product option choices. Every variant option id (variants.choices.optionId field) must exist in options.id`.
+- **Solution**:
+- Use `optionChoiceNames` instead of `optionChoiceIds` in variants
+- Make sure the option name in variants exactly matches the option name defined in the options array
+- Include the renderType in optionChoiceNames
+
+### Issue 3: Variants not matching options
+- **Problem**: The API returns errors about variants not matching the product's options.
+- **Solution**:
+- Create one variant for each possible combination of option choices
+- Ensure each variant references all options defined on the product
+- If the product has only one option with three choices, you need three variants
+- Make sure each variant's option choice name exactly matches the corresponding option choice
+
+### Issue 4: Conflicts when using existing customizations
+- **Problem**: When attempting to use existing customizations, you encounter name conflicts or choice conflicts.
+- **Solution**:
+- If you need to use a specific existing customization ID, first query customizations to get the correct ID
+- When working with existing customizations, ensure all choices you reference actually exist in that customization
+- If you're creating a new customization with the same name as an existing one, the API will use the existing one
+- Be aware that customizations are shared across all products in your store
+
+### Issue 5: Inconsistencies in documentation vs. actual API behavior
+- **Problem**: Several API requirements are not well-documented or are documented differently from how the API actually behaves.
+- **Solution**:
+- Always include choicesSettings with all choices when updating a product
+- Use optionChoiceNames rather than optionChoiceIds in variants for more reliable results
+- Include the renderType in optionChoiceNames
+- Use the exact same choice names as defined in the customization
+- Always get the current product revision before updating to prevent conflicts
+
+## Error Message Reference
+
+| Error Message | Meaning | Fix |
+|---------------|---------|-----|
+| `revision must not be empty` | Missing optimistic lock | GET product first, include `revision` in PATCH |
+| `revision mismatch` | Stale revision (product was updated elsewhere) | Re-GET product, retry with new revision |
+| `choicesSettings must not be empty` | Missing choices array | Include full `choicesSettings.choices` array |
+| `Missing product option choices` | Variant references non-existent option | Use `optionChoiceNames` with exact match to option names |
+
+## Conclusion
+
+Updating a Wix store product involves understanding the revision-based optimistic concurrency model and the relationship between store-wide customizations and product-specific options and variants. The key is to always fetch the current revision before updating and ensure consistency between customization definitions, product options, and product variants.
+
+By following this recipe and being aware of the common pitfalls, you can successfully update your Wix store products.

--- a/yaml/wix-manage/app-installation/documentation.yaml
+++ b/yaml/wix-manage/app-installation/documentation.yaml
@@ -1,0 +1,12 @@
+apiDoc:
+  title: Wix App Installation Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/app-installation/install-wix-apps.md
+      title: Install Wix Apps
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
+      tags: [app-installation]
+    - file: ../../../skills/wix-manage/references/app-installation/list-installed-apps.md
+      title: List Installed Apps
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
+      tags: [app-installation]

--- a/yaml/wix-manage/blog/documentation.yaml
+++ b/yaml/wix-manage/blog/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Blog Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/blog/how-to-create-blog-posts.md
+      title: How to Create Blog Posts
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/blog
+      tags: [blog]

--- a/yaml/wix-manage/bookings/documentation.yaml
+++ b/yaml/wix-manage/bookings/documentation.yaml
@@ -1,0 +1,32 @@
+apiDoc:
+  title: Wix Bookings Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/bookings/end-to-end-booking-flow.md
+      title: End-to-End Booking Flow
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/create-and-update-booking-services.md
+      title: Create and Update Booking Services
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/bookings-staff-setup.md
+      title: Bookings Staff Setup
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/booking-service-policy-setup.md
+      title: Booking Service Policy Setup
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/multi-resource-service-creation.md
+      title: Multi-Resource Service Creation
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/external-calendar-integration.md
+      title: External Calendar Integration
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings, calendar]
+    - file: ../../../skills/wix-manage/references/bookings/booking-system-integration-gaps.md
+      title: Booking System Integration Gaps
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]

--- a/yaml/wix-manage/calendar/documentation.yaml
+++ b/yaml/wix-manage/calendar/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Calendar Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/calendar/configure-default-business-hours.md
+      title: Configure Default Business Hours
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/calendar
+      tags: [bookings, calendar]

--- a/yaml/wix-manage/cms/documentation.yaml
+++ b/yaml/wix-manage/cms/documentation.yaml
@@ -1,0 +1,24 @@
+apiDoc:
+  title: Wix CMS Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/cms/cms-data-items-crud.md
+      title: CMS Data Items CRUD
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
+      tags: [cms]
+    - file: ../../../skills/wix-manage/references/cms/cms-data-operations-extended.md
+      title: CMS Data Operations Extended
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
+      tags: [cms]
+    - file: ../../../skills/wix-manage/references/cms/cms-schema-management.md
+      title: CMS Schema Management
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
+      tags: [cms]
+    - file: ../../../skills/wix-manage/references/cms/cms-references-and-relationships.md
+      title: CMS References & Relationships
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
+      tags: [cms]
+    - file: ../../../skills/wix-manage/references/cms/cms-ecommerce-catalog-integration.md
+      title: CMS eCommerce Catalog Integration
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
+      tags: [cms, ecommerce]

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -1,0 +1,12 @@
+apiDoc:
+  title: Wix Contacts Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/contacts/bulk-delete-contacts.md
+      title: Bulk Delete Contacts
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
+      tags: [contacts]
+    - file: ../../../skills/wix-manage/references/contacts/bulk-label-and-unlabel-contacts.md
+      title: Bulk Label and Unlabel Contacts
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
+      tags: [contacts]

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Domains Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/domains/domain-search-and-purchase.md
+      title: Domain Search and Purchase
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
+      tags: [domains]

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix eCommerce Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/ecommerce/setup-store-pickup-location.md
+      title: Setup Store Pickup Location
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [stores, ecommerce]

--- a/yaml/wix-manage/events/documentation.yaml
+++ b/yaml/wix-manage/events/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Events Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/events/list-events.md
+      title: List Events
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
+      tags: [events]

--- a/yaml/wix-manage/forms/documentation.yaml
+++ b/yaml/wix-manage/forms/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Forms Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/forms/create-form.md
+      title: Create Form
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/forms
+      tags: [forms]

--- a/yaml/wix-manage/get-paid/documentation.yaml
+++ b/yaml/wix-manage/get-paid/documentation.yaml
@@ -1,0 +1,16 @@
+apiDoc:
+  title: Wix Get Paid Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/get-paid/create-payment-links.md
+      title: Create Payment Links
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
+      tags: [get-paid, stores]
+    - file: ../../../skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
+      title: How to Setup Wix Payments
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
+      tags: [get-paid]
+    - file: ../../../skills/wix-manage/references/get-paid/payment-links-for-bookings.md
+      title: Payment Links for Bookings
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
+      tags: [get-paid, bookings]

--- a/yaml/wix-manage/media/documentation.yaml
+++ b/yaml/wix-manage/media/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Media Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/media/upload-media-to-wix.md
+      title: Upload Media to Wix
+      docsEntry: https://dev.wix.com/docs/api-reference/assets/media
+      tags: [media]

--- a/yaml/wix-manage/pricing-plans/documentation.yaml
+++ b/yaml/wix-manage/pricing-plans/documentation.yaml
@@ -1,0 +1,12 @@
+apiDoc:
+  title: Wix Pricing Plans Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+      title: Create and Update Pricing Plans
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
+      tags: [pricing-plans]
+    - file: ../../../skills/wix-manage/references/pricing-plans/pricing-plans-bookings-integration.md
+      title: Pricing Plans Bookings Integration
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
+      tags: [bookings, pricing-plans]

--- a/yaml/wix-manage/restaurants/documentation.yaml
+++ b/yaml/wix-manage/restaurants/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Restaurants Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+      title: Wix Restaurants Setup
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/restaurants
+      tags: [restaurants]

--- a/yaml/wix-manage/rich-content/documentation.yaml
+++ b/yaml/wix-manage/rich-content/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Rich Content Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/rich-content/ricos-converter-service.md
+      title: Ricos Converter Service
+      docsEntry: https://dev.wix.com/docs/api-reference/assets/rich-content
+      tags: [rich-content]

--- a/yaml/wix-manage/site-properties/documentation.yaml
+++ b/yaml/wix-manage/site-properties/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Site Properties Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
+      title: Change Payment Currency (Site Properties)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/site-properties
+      tags: [site-properties]

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -1,0 +1,12 @@
+apiDoc:
+  title: Wix Sites Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/sites/query-sites.md
+      title: Query Sites
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
+      tags: [sites]
+    - file: ../../../skills/wix-manage/references/sites/create-site-from-template.md
+      title: Create Site from Template
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
+      tags: [sites]

--- a/yaml/wix-manage/stores/documentation.yaml
+++ b/yaml/wix-manage/stores/documentation.yaml
@@ -1,0 +1,40 @@
+apiDoc:
+  title: Wix Stores Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/stores/query-products.md
+      title: Query Products
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/query-products-catalog-v1.md
+      title: Query Products (Catalog V1)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/create-product-with-options-catalog-v3.md
+      title: Create Product with Options (Catalog V3)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/create-product-catalog-v1.md
+      title: Create Product (Catalog V1)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/bulk-create-products-with-options.md
+      title: Bulk Create Products with Options
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/update-product-with-options.md
+      title: Update Product with Options
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/update-product-pre-order.md
+      title: Update Product Pre-Order
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
+      title: Setup Online Store (Catalog V3)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/add-store-pages-to-site.md
+      title: Add Store Pages to Site
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]


### PR DESCRIPTION
The skills md were already exist so they just copied. (https://github.com/wix-private/igor-tools/blob/master/packages/docs/recipes-v2/manage/index.md)
we located the yaml under yaml folder to not effect the context of the skill downloading. 
We used the same index that was using till now by the mcp. 

The plugin will be called wix-manage, and for adding new skill, one will be need to write the skill to the matched reference folder, write the yaml and update the index file that it will now the new skill.

The most important changes are:

**Plugin Manifest Update:**
* Added the `./skills/wix-manage` entry to the `skills` array in `.claude-plugin/plugin.json`, registering the new management skill with the plugin.

**New Skill and Documentation:**
* Added the `skills/wix-manage/SKILL.md` file, which introduces the "wix-manage" skill. This file provides an index and detailed descriptions of management recipes for various Wix business entities (e.g., stores, bookings, CMS, contacts, events, forms, media, sites, blog, calendar, domains, ecommerce, etc.), focusing on backend REST API operations for configuration and administration.

**App Installation Recipes:**
* Added `skills/wix-manage/references/app-installation/install-wix-apps.md`, a technical guide for installing Wix apps on a site using the Apps Installer API, including handling Velo (Wix Code) enablement and listing common app definition IDs.
* Added `skills/wix-manage/references/app-installation/list-installed-apps.md`, providing instructions for listing all apps installed on a Wix site via API, with guidance for verifying installations and troubleshooting authorization errors.Add already exist skill to the public repo.