### PR TITLE
feat(wix-manage): add create-product-from-image store skill

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -197,6 +197,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Bulk Create Products with Options](references/stores/bulk-create-products-with-options.md)
 **Technical:** Uses bulk products endpoint to create multiple products with inventory in a single request. Handles variant generation from options, media format requirements, and error handling for partial failures.
 
+### [Create Product from Image](references/stores/create-product-from-image.md)
+**Technical:** Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, then attaching the media to the created product. Combines Media Upload + LLM analysis + Product Creation + Add Product Media into a single flow.
+
 ### [Create Product (Catalog V1)](references/stores/create-product-catalog-v1.md)
 **Technical:** Create products using the Catalog V1 Products API. Use this recipe when the site's catalog version is CATALOG_V1. Covers simple product creation, product with options, and key V1 request structure differences from V3.
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -197,8 +197,8 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Bulk Create Products with Options](references/stores/bulk-create-products-with-options.md)
 **Technical:** Uses bulk products endpoint to create multiple products with inventory in a single request. Handles variant generation from options, media format requirements, and error handling for partial failures.
 
-### [Create Product from Image](references/stores/create-product-from-image.md)
-**Technical:** Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, then attaching the media to the created product. Combines Media Upload + LLM analysis + Product Creation + Add Product Media into a single flow.
+### [Create Product from Image (Catalog V1)](references/stores/create-product-from-image.md)
+**Technical:** Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, then attaching the media to the created product. Combines Media Upload + LLM analysis + Product Creation + Add Product Media into a single flow. **Catalog V1 only** — for V3 sites, use Create Product with Options (Catalog V3) with inline media instead.
 
 ### [Create Product (Catalog V1)](references/stores/create-product-catalog-v1.md)
 **Technical:** Create products using the Catalog V1 Products API. Use this recipe when the site's catalog version is CATALOG_V1. Covers simple product creation, product with options, and key V1 request structure differences from V3.

--- a/skills/wix-manage/references/stores/create-product-from-image.md
+++ b/skills/wix-manage/references/stores/create-product-from-image.md
@@ -1,0 +1,190 @@
+---
+name: "Create Product from Image"
+description: Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, and then creating the product with the image attached.
+---
+# RECIPE: Create Product from Image
+
+Create a product by uploading an image URL to Wix Media Manager, analyzing the image with the LLM to generate product details (name, description, price), creating the product, and attaching the uploaded media.
+
+---
+
+## STEP 1: Upload Image to Wix Media Manager
+
+Import the image from the provided external URL into the site's Media Manager.
+
+```bash
+curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "url": "<IMAGE_URL>",
+    "mimeType": "image/jpeg",
+    "displayName": "product-image.jpg"
+}'
+```
+
+**Response:**
+
+```json
+{
+    "file": {
+        "id": "e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "displayName": "product-image.jpg",
+        "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "parentFolderId": "media-root",
+        "mediaType": "IMAGE",
+        "operationStatus": "PENDING"
+    }
+}
+```
+
+Save the `url` field (wixstatic.com URL) — you will use it in Step 3 and Step 4.
+
+> **Tip:** The wixstatic.com URL can typically be used immediately. If you need guaranteed consistency, poll until `operationStatus: "READY"` using `GET https://www.wixapis.com/site-media/v1/files/get-file-by-id?fileId={fileId}`.
+
+---
+
+## STEP 2: Analyze the Image with the LLM
+
+Use the original image URL to analyze the image. Based on what you see, generate:
+
+- **name**: A concise, appealing product name (max 80 characters).
+- **description**: A short marketing description (2-3 sentences) as an HTML string wrapped in `<p>` tags.
+- **price**: A reasonable retail price as a number, based on the type of product shown.
+
+**CRITICAL:** You MUST actually look at the image and describe the real product shown. Do not use placeholder or generic text.
+
+---
+
+## STEP 3: Create the Product
+
+Use the Catalog V1 API to create the product with the LLM-generated details.
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v1/products' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "product": {
+    "name": "<LLM_GENERATED_NAME>",
+    "description": "<LLM_GENERATED_DESCRIPTION_HTML>",
+    "visible": true,
+    "productType": "physical",
+    "priceData": {
+      "price": <LLM_GENERATED_PRICE>
+    }
+  }
+}'
+```
+
+**Example with LLM-generated values:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v1/products' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "product": {
+    "name": "Handcrafted Ceramic Mug",
+    "description": "<p>A beautifully handcrafted ceramic mug with an earthy glaze finish. Perfect for your morning coffee or tea. Holds approximately 12oz.</p>",
+    "visible": true,
+    "productType": "physical",
+    "priceData": {
+      "price": 24.99
+    }
+  }
+}'
+```
+
+**Response (partial):**
+
+```json
+{
+  "product": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "name": "Handcrafted Ceramic Mug",
+    "visible": true,
+    "productType": "physical",
+    "priceData": {
+      "price": 24.99
+    }
+  }
+}
+```
+
+Save the `product.id` — you need it in Step 4.
+
+---
+
+## STEP 4: Add the Uploaded Media to the Product
+
+Attach the uploaded image to the product using the Add Product Media endpoint.
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v1/products/<PRODUCT_ID>/media' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "media": [
+    {
+      "url": "<WIXSTATIC_URL_FROM_STEP_1>"
+    }
+  ]
+}'
+```
+
+**Example:**
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v1/products/a1b2c3d4-e5f6-7890-abcd-ef1234567890/media' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "media": [
+    {
+      "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg"
+    }
+  ]
+}'
+```
+
+This endpoint returns an empty object `{}` on success.
+
+---
+
+## Full Flow Summary
+
+| Step | Action | API | Key Output |
+|------|--------|-----|------------|
+| 1 | Upload image to Media Manager | `POST /site-media/v1/files/import` | wixstatic.com `url` |
+| 2 | Analyze image with LLM | — | Product name, description, price |
+| 3 | Create the product | `POST /stores/v1/products` | `product.id` |
+| 4 | Attach image to product | `POST /stores/v1/products/{id}/media` | — |
+
+---
+
+## Important Notes
+
+- **Image URL requirements:** Use publicly accessible image URLs. Sources like Unsplash, Pexels, and public cloud storage work reliably. URLs behind authentication or that block hotlinking will fail.
+- **Description format:** The Catalog V1 API requires HTML strings for descriptions (e.g., `"<p>text</p>"`). Do NOT use plain text or rich text nodes.
+- **Product type:** Only `"physical"` is supported via the API.
+- **Media via URL vs mediaId:** You can attach media using either the wixstatic.com `url` (for newly uploaded files) or a `mediaId` (for files already in the Media Manager). This recipe uses `url`.
+- **Multiple images:** You can upload multiple images in Step 1 and pass them all in the `media` array in Step 4.
+- **Catalog version:** This recipe uses Catalog V1 endpoints. Never use `/stores/v3/` endpoints on a CATALOG_V1 site — they return `428 Precondition Required`. Check the site's catalog version in dynamic context before choosing endpoints.
+
+## Troubleshooting
+
+### Image import fails (operationStatus: FAILED)
+The source server may block external requests. Use a different image host (Unsplash, Pexels, public S3/GCS).
+
+### Product created but no image visible
+Ensure you used the wixstatic.com URL from Step 1 (not the original external URL) in Step 4. Also verify the product ID matches the one returned in Step 3.
+
+### 428 Precondition Required on product creation
+You are using V3 endpoints on a V1 catalog site. Use `POST /stores/v1/products` instead.
+
+## References
+
+- [Upload Media to Wix](../media/upload-media-to-wix.md)
+- [Create Product (Catalog V1)](create-product-catalog-v1.md)
+- [Add Product Media](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v1/catalog/add-product-media)

--- a/skills/wix-manage/references/stores/create-product-from-image.md
+++ b/skills/wix-manage/references/stores/create-product-from-image.md
@@ -1,12 +1,15 @@
 ---
 name: "Create Product from Image"
-description: Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, and then creating the product with the image attached. Requires a publicly accessible image URL.
+description: Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, and then creating the product with the image attached. Requires a publicly accessible image URL. Uses Catalog V1 API — only for sites with CATALOG_V1 catalog version.
 ---
-# RECIPE: Create Product from Image
+# RECIPE: Create Product from Image (Catalog V1)
+
+> **Catalog V1 only.** This recipe uses the Catalog V1 API (`/stores/v1/products`). It will NOT work on sites using Catalog V3. If the site uses Catalog V3, use the [Create Product with Options (Catalog V3)](create-product-with-options-catalog-v3.md) recipe instead and include media inline in the product creation request. Check the site's catalog version in dynamic context before proceeding.
 
 This recipe creates a Wix Store product from an image. It has exactly 4 steps that MUST ALL be completed in order. Do NOT report success until ALL 4 steps have been executed successfully.
 
 **Prerequisites:**
+- The site MUST be using **Catalog V1**. If the site uses Catalog V3, do NOT use this recipe.
 - The user MUST provide a publicly accessible image URL (starts with `https://` or `http://`).
 - If the user uploaded an image directly to the chat instead of providing a URL, you MUST ask them: "Please provide a public URL where the image is hosted (e.g., an Unsplash, Imgur, or any https:// link). I cannot use images uploaded directly to the chat — I need a publicly accessible URL that the Wix Media API can download from."
 - Do NOT proceed until you have a valid public URL.

--- a/skills/wix-manage/references/stores/create-product-from-image.md
+++ b/skills/wix-manage/references/stores/create-product-from-image.md
@@ -1,31 +1,40 @@
 ---
 name: "Create Product from Image"
-description: Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, and then creating the product with the image attached.
+description: Creates a product by uploading an image to Wix Media, using the LLM to generate the product name, description, and price from the image, and then creating the product with the image attached. Requires a publicly accessible image URL.
 ---
 # RECIPE: Create Product from Image
 
-Create a product by uploading an image URL to Wix Media Manager, analyzing the image with the LLM to generate product details (name, description, price), creating the product, and attaching the uploaded media.
+This recipe creates a Wix Store product from an image. It has exactly 4 steps that MUST ALL be completed in order. Do NOT report success until ALL 4 steps have been executed successfully.
+
+**Prerequisites:**
+- The user MUST provide a publicly accessible image URL (starts with `https://` or `http://`).
+- If the user uploaded an image directly to the chat instead of providing a URL, you MUST ask them: "Please provide a public URL where the image is hosted (e.g., an Unsplash, Imgur, or any https:// link). I cannot use images uploaded directly to the chat — I need a publicly accessible URL that the Wix Media API can download from."
+- Do NOT proceed until you have a valid public URL.
 
 ---
 
-## STEP 1: Upload Image to Wix Media Manager
+## STEP 1: Upload the Image to Wix Media Manager (MANDATORY)
 
-Import the image from an external URL into the site's Media Manager.
+**API Endpoint:** `POST https://www.wixapis.com/site-media/v1/files/import`
 
-**CRITICAL: The `url` field MUST be a publicly accessible HTTP/HTTPS URL** (e.g., `https://images.unsplash.com/...` or `https://example.com/photo.jpg`). It CANNOT be a local file reference, a client-side file ID, or an internal file token. If the user uploaded an image directly to the chat (not as a URL), ask them to provide a public URL where the image is hosted instead.
+**Request body fields:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | Yes | The publicly accessible HTTP/HTTPS URL of the image. MUST start with `https://` or `http://`. CANNOT be a file ID, file reference, local path, or chat-uploaded file token. |
+| `mimeType` | string | Recommended | The MIME type of the image. Use `image/jpeg` for .jpg/.jpeg files, `image/png` for .png files, `image/webp` for .webp files. |
+| `displayName` | string | No | A display name for the file in Media Manager. Include the file extension (e.g., `product-image.jpg`). |
 
-```bash
-curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
--H 'Content-Type: application/json' \
--H 'Authorization: <AUTH>' \
--d '{
-    "url": "<IMAGE_URL>",
+**Exact request example:**
+
+```json
+{
+    "url": "https://images.unsplash.com/photo-1563729784474-d77dbb933a9e?w=400",
     "mimeType": "image/jpeg",
     "displayName": "product-image.jpg"
-}'
+}
 ```
 
-**Response:**
+**Expected response:**
 
 ```json
 {
@@ -40,150 +49,134 @@ curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
 }
 ```
 
-Save the `url` field (wixstatic.com URL) — you will use it in Step 3 and Step 4.
+**After this step, save these values — you need them later:**
+- `file.url` — the wixstatic.com URL (use in Step 4)
+- `file.id` — the media file ID
 
-> **Tip:** The wixstatic.com URL can typically be used immediately. If you need guaranteed consistency, poll until `operationStatus: "READY"` using `GET https://www.wixapis.com/site-media/v1/files/get-file-by-id?fileId={fileId}`.
+**If the response contains `operationStatus: "FAILED"`:** The source URL is not accessible. Ask the user for a different image URL.
 
 ---
 
-## STEP 2: Analyze the Image with the LLM
+## STEP 2: Analyze the Image and Generate Product Details
 
-Use the original image URL to analyze the image. Based on what you see, generate:
+Look at the image from the URL provided by the user. Based on what you see in the image, generate the following three values:
 
-- **name**: A concise, appealing product name (max 80 characters).
-- **description**: A short marketing description (2-3 sentences) as an HTML string wrapped in `<p>` tags.
-- **price**: A reasonable retail price as a number, based on the type of product shown.
+1. **Product name** — A concise, appealing product name. Maximum 80 characters. Example: `"Premium Spinning Fishing Reel"`.
+2. **Product description** — A marketing description of 2-3 sentences. MUST be wrapped in HTML `<p>` tags. Example: `"<p>A sleek black-and-gold spinning fishing reel designed for smooth retrieves. Ideal for freshwater or light saltwater fishing.</p>"`. Do NOT use plain text without `<p>` tags — the API will reject it.
+3. **Product price** — A reasonable retail price as a number (not a string). Example: `79.99`.
 
-**CRITICAL:** You MUST actually look at the image and describe the real product shown. Do not use placeholder or generic text.
+**CRITICAL:** These values MUST describe the actual product visible in the image. Do NOT use generic placeholder text.
 
 ---
 
 ## STEP 3: Create the Product
 
-Use the Catalog V1 API to create the product with the LLM-generated details.
+**API Endpoint:** `POST https://www.wixapis.com/stores/v1/products`
 
-```bash
-curl -X POST 'https://www.wixapis.com/stores/v1/products' \
--H 'Content-Type: application/json' \
--H 'Authorization: <AUTH>' \
--d '{
-  "product": {
-    "name": "<LLM_GENERATED_NAME>",
-    "description": "<LLM_GENERATED_DESCRIPTION_HTML>",
-    "visible": true,
-    "productType": "physical",
-    "priceData": {
-      "price": <LLM_GENERATED_PRICE>
-    }
-  }
-}'
-```
+**Request body fields:**
+| Field | Type | Required | Value |
+|-------|------|----------|-------|
+| `product.name` | string | Yes | The product name from Step 2 (max 80 chars) |
+| `product.description` | string | Yes | The HTML description from Step 2 (wrapped in `<p>` tags) |
+| `product.visible` | boolean | Yes | `true` |
+| `product.productType` | string | Yes | `"physical"` (only supported value) |
+| `product.priceData.price` | number | Yes | The price from Step 2 |
 
-**Example with LLM-generated values:**
-
-```bash
-curl -X POST 'https://www.wixapis.com/stores/v1/products' \
--H 'Content-Type: application/json' \
--H 'Authorization: <AUTH>' \
--d '{
-  "product": {
-    "name": "Handcrafted Ceramic Mug",
-    "description": "<p>A beautifully handcrafted ceramic mug with an earthy glaze finish. Perfect for your morning coffee or tea. Holds approximately 12oz.</p>",
-    "visible": true,
-    "productType": "physical",
-    "priceData": {
-      "price": 24.99
-    }
-  }
-}'
-```
-
-**Response (partial):**
+**Exact request example (using values from Step 2):**
 
 ```json
 {
   "product": {
-    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "name": "Handcrafted Ceramic Mug",
+    "name": "Premium Spinning Fishing Reel",
+    "description": "<p>A sleek black-and-gold spinning fishing reel designed for smooth retrieves and dependable performance. Ideal for anglers targeting freshwater or light saltwater species.</p>",
     "visible": true,
     "productType": "physical",
     "priceData": {
-      "price": 24.99
+      "price": 79.99
     }
   }
 }
 ```
 
-Save the `product.id` — you need it in Step 4.
+**Expected response (partial):**
+
+```json
+{
+  "product": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "name": "Premium Spinning Fishing Reel",
+    "visible": true,
+    "productType": "physical",
+    "priceData": {
+      "price": 79.99
+    }
+  }
+}
+```
+
+**After this step, save this value — you need it in Step 4:**
+- `product.id` — the product ID (a UUID string like `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`)
 
 ---
 
-## STEP 4: Add the Uploaded Media to the Product
+## STEP 4: Attach the Image to the Product (MANDATORY — DO NOT SKIP)
 
-Attach the uploaded image to the product using the Add Product Media endpoint.
+**API Endpoint:** `POST https://www.wixapis.com/stores/v1/products/{id}/media`
 
-```bash
-curl -X POST 'https://www.wixapis.com/stores/v1/products/<PRODUCT_ID>/media' \
--H 'Content-Type: application/json' \
--H 'Authorization: <AUTH>' \
--d '{
-  "media": [
-    {
-      "url": "<WIXSTATIC_URL_FROM_STEP_1>"
-    }
-  ]
-}'
-```
+Replace `{id}` in the URL with the `product.id` from Step 3.
 
-**Example:**
+**Request body fields:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `media` | array | Yes | Array of media objects to attach |
+| `media[].url` | string | Yes | The `file.url` (wixstatic.com URL) from Step 1. Do NOT use the original image URL — use the wixstatic.com URL returned by the Media Manager. |
 
-```bash
-curl -X POST 'https://www.wixapis.com/stores/v1/products/a1b2c3d4-e5f6-7890-abcd-ef1234567890/media' \
--H 'Content-Type: application/json' \
--H 'Authorization: <AUTH>' \
--d '{
+**Exact request example:**
+
+URL: `POST https://www.wixapis.com/stores/v1/products/a1b2c3d4-e5f6-7890-abcd-ef1234567890/media`
+
+```json
+{
   "media": [
     {
       "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg"
     }
   ]
-}'
+}
 ```
 
-This endpoint returns an empty object `{}` on success.
+**Expected response:** Empty object `{}` — this means success.
+
+**This step is MANDATORY.** The product is not complete without its image. Do NOT report success to the user before this step returns successfully.
 
 ---
 
-## Full Flow Summary
+## Completion Checklist
 
-| Step | Action | API | Key Output |
-|------|--------|-----|------------|
-| 1 | Upload image to Media Manager | `POST /site-media/v1/files/import` | wixstatic.com `url` |
-| 2 | Analyze image with LLM | — | Product name, description, price |
-| 3 | Create the product | `POST /stores/v1/products` | `product.id` |
-| 4 | Attach image to product | `POST /stores/v1/products/{id}/media` | — |
+Before reporting success to the user, verify ALL of the following:
+
+- [ ] Step 1 completed: Image was uploaded to Wix Media Manager and you received a wixstatic.com URL.
+- [ ] Step 2 completed: You analyzed the image and generated a name, description, and price.
+- [ ] Step 3 completed: Product was created and you received a product ID.
+- [ ] Step 4 completed: Image was attached to the product using the Add Product Media endpoint.
+
+Only after ALL 4 steps succeed, report to the user: the product name, price, and that it was created with the image attached.
 
 ---
-
-## Important Notes
-
-- **Image URL requirements:** Use publicly accessible image URLs. Sources like Unsplash, Pexels, and public cloud storage work reliably. URLs behind authentication or that block hotlinking will fail.
-- **Description format:** The Catalog V1 API requires HTML strings for descriptions (e.g., `"<p>text</p>"`). Do NOT use plain text or rich text nodes.
-- **Product type:** Only `"physical"` is supported via the API.
-- **Media via URL vs mediaId:** You can attach media using either the wixstatic.com `url` (for newly uploaded files) or a `mediaId` (for files already in the Media Manager). This recipe uses `url`.
-- **Multiple images:** You can upload multiple images in Step 1 and pass them all in the `media` array in Step 4.
-- **Catalog version:** This recipe uses Catalog V1 endpoints. Never use `/stores/v3/` endpoints on a CATALOG_V1 site — they return `428 Precondition Required`. Check the site's catalog version in dynamic context before choosing endpoints.
 
 ## Troubleshooting
 
+### "The url field must be a publicly accessible URL"
+The user provided a file ID, file token, or local file reference instead of a public URL. Ask for a URL that starts with `https://`.
+
 ### Image import fails (operationStatus: FAILED)
-The source server may block external requests. Use a different image host (Unsplash, Pexels, public S3/GCS).
+The source server blocks external requests. Ask the user for a different image URL. Reliable sources: Unsplash (`images.unsplash.com`), Pexels (`images.pexels.com`), Imgur, public S3/GCS buckets.
 
 ### Product created but no image visible
-Ensure you used the wixstatic.com URL from Step 1 (not the original external URL) in Step 4. Also verify the product ID matches the one returned in Step 3.
+You used the original external URL instead of the wixstatic.com URL in Step 4. Always use the `file.url` from Step 1's response.
 
 ### 428 Precondition Required on product creation
-You are using V3 endpoints on a V1 catalog site. Use `POST /stores/v1/products` instead.
+The site uses Catalog V3, not V1. Use `POST https://www.wixapis.com/stores/v3/products` instead and format the description as rich text nodes (not HTML).
 
 ## References
 

--- a/skills/wix-manage/references/stores/create-product-from-image.md
+++ b/skills/wix-manage/references/stores/create-product-from-image.md
@@ -10,7 +10,9 @@ Create a product by uploading an image URL to Wix Media Manager, analyzing the i
 
 ## STEP 1: Upload Image to Wix Media Manager
 
-Import the image from the provided external URL into the site's Media Manager.
+Import the image from an external URL into the site's Media Manager.
+
+**CRITICAL: The `url` field MUST be a publicly accessible HTTP/HTTPS URL** (e.g., `https://images.unsplash.com/...` or `https://example.com/photo.jpg`). It CANNOT be a local file reference, a client-side file ID, or an internal file token. If the user uploaded an image directly to the chat (not as a URL), ask them to provide a public URL where the image is hosted instead.
 
 ```bash
 curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \

--- a/yaml/wix-manage/stores/documentation.yaml
+++ b/yaml/wix-manage/stores/documentation.yaml
@@ -38,3 +38,7 @@ apiDoc:
       title: Add Store Pages to Site
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
       tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/create-product-from-image.md
+      title: Create Product from Image
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores, media]


### PR DESCRIPTION
## Summary
- Adds a new skill `create-product-from-image` under `skills/wix-manage/references/stores/`
- Combines Media Upload + LLM image analysis + Product Creation + Add Product Media into a single 4-step recipe
- Uses Catalog V1 endpoints with proper HTML description format

## Test plan
- [x] Test via local MCP with image upload
- [x] Verify all 4 API steps execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)