### PR TITLE
ci: add EvalForge POC workflow to fetch projects

### DIFF
--- a/.github/workflows/evalforge-poc.yml
+++ b/.github/workflows/evalforge-poc.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "Calling ${{ github.event.inputs.base_url }}/projects"
           curl -sf \
-            -H "x-app-id: ${{ secrets.EVALFORGE_APP_ID }}" \
-            -H "x-app-secret: ${{ secrets.EVALFORGE_APP_SECRET }}" \
+            -H "x-app-id: ${{ secrets.ORLEIB_POC_EVALFORGE_APP_ID }}" \
+            -H "x-app-secret: ${{ secrets.ORLEIB_POC_EVALFORGE_APP_SECRET }}" \
             "${{ github.event.inputs.base_url }}/projects" \
             | python3 -m json.tool

--- a/.github/workflows/evalforge-poc.yml
+++ b/.github/workflows/evalforge-poc.yml
@@ -1,0 +1,22 @@
+name: EvalForge POC - fetch projects
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: EvalForge backend base URL
+        required: false
+        default: https://bo.wix.com/_api/evalforge-backend
+
+jobs:
+  fetch-projects:
+    runs-on: self-hosted
+    steps:
+      - name: Fetch projects from EvalForge
+        run: |
+          echo "Calling ${{ github.event.inputs.base_url }}/projects"
+          curl -sf \
+            -H "x-app-id: ${{ secrets.EVALFORGE_APP_ID }}" \
+            -H "x-app-secret: ${{ secrets.EVALFORGE_APP_SECRET }}" \
+            "${{ github.event.inputs.base_url }}/projects" \
+            | python3 -m json.tool


### PR DESCRIPTION
## Summary
- Adds a manually-triggered (`workflow_dispatch`) GitHub Actions workflow
- Calls `GET /projects` on the EvalForge backend to validate GH Actions can reach Wix internal services
- Auth via `EVALFORGE_APP_ID` / `EVALFORGE_APP_SECRET` repo secrets

## Before running
Add two secrets to this repo (`Settings → Secrets → Actions`):
- `EVALFORGE_APP_ID`
- `EVALFORGE_APP_SECRET`

This is a POC — not intended to merge as-is.