### PR TITLE
ci: switch EvalForge POC to ubuntu-latest + manage.wix.com

### DIFF
--- a/.github/workflows/evalforge-poc.yml
+++ b/.github/workflows/evalforge-poc.yml
@@ -6,11 +6,11 @@ on:
       base_url:
         description: EvalForge backend base URL
         required: false
-        default: https://bo.wix.com/_api/evalforge-backend
+        default: https://manage.wix.com/_api/evalforge-backend
 
 jobs:
   fetch-projects:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch projects from EvalForge
         run: |


### PR DESCRIPTION
Fixes stuck queued run — self-hosted runners not available in public wix org. Using ubuntu-latest + manage.wix.com instead (same pattern as existing skill-eval workflow).