### PR TITLE
ci: add verbose output to debug EvalForge POC auth issue

### DIFF
--- a/.github/workflows/evalforge-poc.yml
+++ b/.github/workflows/evalforge-poc.yml
@@ -14,9 +14,11 @@ jobs:
     steps:
       - name: Fetch projects from EvalForge
         run: |
-          echo "Calling ${{ github.event.inputs.base_url }}/projects"
-          curl -sf \
+          echo "=== Request ==="
+          echo "URL: ${{ github.event.inputs.base_url }}/projects"
+          echo ""
+          echo "=== Response ==="
+          curl -s -w "\n\n--- HTTP Status: %{http_code} ---\n" \
             -H "x-app-id: ${{ secrets.ORLEIB_POC_EVALFORGE_APP_ID }}" \
             -H "x-app-secret: ${{ secrets.ORLEIB_POC_EVALFORGE_APP_SECRET }}" \
-            "${{ github.event.inputs.base_url }}/projects" \
-            | python3 -m json.tool
+            "${{ github.event.inputs.base_url }}/projects"


### PR DESCRIPTION
Removes -f flag from curl to show the actual response body + HTTP status code instead of silently failing.