### PR TITLE
Update README to reflect Claude installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Agent skills for building Wix applications with AI coding assistants.
 In [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run:
 
 ```bash
-/plugin marketplace add wix/skills
 /plugin install wix@wix
 ```
 


### PR DESCRIPTION
Removed duplicate Claude installation instruction, now reflects our docs (https://dev.wix.com/docs/api-reference/articles/ai-tools/about-the-wix-plugin)