### PR TITLE
fix(wix-app): add inline styles anti-pattern guidance for widget skill

### DIFF
--- a/skills/wix-app/references/CUSTOM_ELEMENT_WIDGET.md
+++ b/skills/wix-app/references/CUSTOM_ELEMENT_WIDGET.md
@@ -132,7 +132,7 @@ export default customElement;
 - Props interface uses **camelCase** (e.g., `targetDate`, `bgColor`)
 - `reactToWebComponent` config uses camelCase keys with `'string'` type
 - All props are passed as strings from the web component
-- Use inline styles, not CSS imports
+- Use inline styles, not CSS imports. Do NOT put functions in styles objects (causes TS2560/TS2349). For conditional styles, use ternary expressions directly in the `style` prop: `style={{ ...styles.itemBase, color: item.done ? '#999' : '#000' }}`
 - Parse complex props (like `font`) from JSON strings: `const { font: textFont, textDecoration } = JSON.parse(font)`
 - Apply font via `font` CSS shorthand and `textDecoration` property
 - Extract helper components, utility functions, and styles into separate files for clean code organization


### PR DESCRIPTION
## Summary
- Adds guidance to the custom element widget reference to prevent a recurring codegen type error
- Codegen was putting functions inside `Record<string, React.CSSProperties>` styles objects, causing TS2560/TS2349 errors
- Documents the correct pattern: ternary expressions + spread in the `style` prop

## Test plan
- [x] Verify the updated bullet point renders correctly in the reference doc
- [x] Run a codegen that produces a widget with conditional styles (e.g. to-do list with done/not-done states) and confirm no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)