### PR TITLE
fix(wix-app): default-export event handlers + correct CRM import path

### DIFF
--- a/skills/wix-app/references/BACKEND_EVENT.md
+++ b/skills/wix-app/references/BACKEND_EVENT.md
@@ -56,9 +56,9 @@ The `id` must be a unique, static UUID v4 string. Generate a fresh UUID for each
 Import the event from the correct SDK module and pass a handler. Wix invokes the handler with the event payload and metadata when the event occurs. Handler signatures are documented in the [JavaScript SDK reference](https://dev.wix.com/docs/sdk).
 
 ```typescript
-import { onContactCreated } from "@wix/crm/events";
+import { contacts } from "@wix/crm";
 
-onContactCreated((event) => {
+export default contacts.onContactCreated((event) => {
   console.log("Contact created:", event.entity);
   // Custom logic: sync to CRM, send welcome email, etc.
 });
@@ -85,10 +85,11 @@ Naming: export names follow `event{CamelCaseName}` (e.g. `eventContactCreated`, 
 When calling Wix APIs from inside an event handler, use `auth.elevate` from `@wix/essentials` so the call runs with the right permissions.
 
 ```typescript
+import { contacts } from "@wix/crm";
 import { auth } from "@wix/essentials";
 import { items } from "@wix/data";
 
-onContactCreated(async (event) => {
+export default contacts.onContactCreated(async (event) => {
   const elevatedQuery = auth.elevate(items.query);
   const result = await elevatedQuery("MyCollection").find();
   // Use result

--- a/skills/wix-app/references/backend-event/COMMON-EVENTS.md
+++ b/skills/wix-app/references/backend-event/COMMON-EVENTS.md
@@ -15,7 +15,7 @@ This reference lists common event types, SDK imports, permissions, and links. Fo
 ```typescript
 import { contacts } from "@wix/crm";
 
-contacts.onContactCreated((event) => {
+export default contacts.onContactCreated((event) => {
   const contact = event.entity;
   console.log("New contact:", contact._id, contact.primaryInfo?.email);
 });
@@ -35,7 +35,7 @@ contacts.onContactCreated((event) => {
 ```typescript
 import { orders } from "@wix/ecom";
 
-orders.onOrderApproved(async (event) => {
+export default orders.onOrderApproved(async (event) => {
   const order = event.data.order;
   console.log("Order approved:", order._id);
 });
@@ -53,7 +53,7 @@ orders.onOrderApproved(async (event) => {
 ```typescript
 import { bookings } from "@wix/bookings";
 
-bookings.onBookingConfirmed((event) => {
+export default bookings.onBookingConfirmed((event) => {
   const booking = event.data.booking;
   console.log("Booking confirmed:", booking._id);
 });
@@ -71,7 +71,7 @@ bookings.onBookingConfirmed((event) => {
 ```typescript
 import { posts } from "@wix/blog";
 
-posts.onPostCreated((event) => {
+export default posts.onPostCreated((event) => {
   const post = event.entity;
   console.log("Post created:", post._id, post.title);
 });


### PR DESCRIPTION
## Summary

Two related fixes for the `wix-app` skill's backend-event references:

1. **`export default` on every event handler example.** Wix CLI builds call `module.default()` on each event source file to register the webhook (see `@wix/astro`'s `getWebhookSlug` / `isValidEventFileExport`). Handler files without `export default` fail with:
   ```
   Invalid export for event source at <path>.
   Expected event listener call to be the default export.
   ```
   The previous examples showed the listener call as a bare statement, so agents reproducing the pattern produced unbuildable code.

2. **Fix the broken `@wix/crm/events` import path** in `BACKEND_EVENT.md`. That subpath isn't declared in `@wix/crm`'s `package.json` exports, so:
   - `tsc` fails with `TS2307: Cannot find module '@wix/crm/events'`
   - Node fails with `Package subpath './events' is not defined by "exports" in @wix/crm`

   Switched to the namespaced form that `COMMON-EVENTS.md` already uses:
   ```ts
   import { contacts } from "@wix/crm";
   export default contacts.onContactCreated(...)
   ```

## How this was caught

Investigating a recent codegen run that failed `wix build` with `Invalid export for event source` (job `d46835dc-91b0-44b9-8c41-b8fbb81fe390`). The agent's batch-write content matched the documented pattern verbatim — both the missing `export default` and the broken `@wix/crm/events` path.

## Verification

Compiled all 6 examples against the actual installed SDK type packages (`@wix/crm`, `@wix/ecom`, `@wix/bookings`, `@wix/blog`, `@wix/data`, `@wix/essentials`, `@wix/astro`), then ran the exact runtime check the Wix CLI build performs (`isValidEventFileExport`) on each compiled module:

| Example | tsc | `module.default` is function |
|---|---|---|
| BACKEND_EVENT canonical (`contacts.onContactCreated`) | ✅ | ✓ |
| BACKEND_EVENT elevated permissions | ✅ | ✓ |
| COMMON-EVENTS CRM | ✅ | ✓ |
| COMMON-EVENTS eCommerce | ⚠️ pre-existing strict-mode warning on `event.data.order` | ✓ |
| COMMON-EVENTS Bookings | ⚠️ pre-existing strict-mode warning on `event.data.booking` | ✓ |
| COMMON-EVENTS Blog | ✅ | ✓ |

## Out of scope (separate follow-up)

Two TS strict-mode warnings on `event.data.order` / `event.data.booking` (typed as optional in their respective SDKs) — pre-existing, unrelated to the build-time error this PR fixes. Worth a separate cleanup PR with `?` guards or destructure-with-fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)