### PR TITLE
test: add entries to exercise validation error paths

### DIFF
--- a/skills/wix-manage/references/ecommerce/manage-discounts.md
+++ b/skills/wix-manage/references/ecommerce/manage-discounts.md
@@ -1,0 +1,1 @@
+# Manage Discounts

--- a/skills/wix-manage/references/ecommerce/process-refunds.md
+++ b/skills/wix-manage/references/ecommerce/process-refunds.md
@@ -1,0 +1,1 @@
+# Process Refunds

--- a/skills/wix-manage/references/ecommerce/query-orders.md
+++ b/skills/wix-manage/references/ecommerce/query-orders.md
@@ -1,0 +1,1 @@
+# Query Orders

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -10,3 +10,14 @@ apiDoc:
       title: Setup Store Pickup Location
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
       tags: [stores, ecommerce]
+    - file: ../../../skills/wix-manage/references/ecommerce/query-orders.md
+      title: Query Orders
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+    - file: ../../../skills/wix-manage/references/ecommerce/manage-discounts.md
+      title: Manage Discounts
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+    - file: ../../../skills/wix-manage/references/ecommerce/process-refunds.md
+      title: Process Refunds
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce, unknown-tag-xyz]

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -13,12 +13,12 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/ecommerce/query-orders.md
       title: Query Orders
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
-      tags: [ecommerce, unknown-tag-xyz]
+      tags: [ecommerce]
     - file: ../../../skills/wix-manage/references/ecommerce/manage-discounts.md
       title: Manage Discounts
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
-      tags: [ecommerce, unknown-tag-xyz]
+      tags: [ecommerce]
     - file: ../../../skills/wix-manage/references/ecommerce/process-refunds.md
       title: Process Refunds
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
-      tags: [ecommerce, unknown-tag-xyz]
+      tags: [ecommerce]

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -13,10 +13,11 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/ecommerce/query-orders.md
       title: Query Orders
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
-      tags: [ecommerce]
+      tags: [ecommerce, unknown-tag-xyz]
     - file: ../../../skills/wix-manage/references/ecommerce/manage-discounts.md
       title: Manage Discounts
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce, unknown-tag-xyz]
     - file: ../../../skills/wix-manage/references/ecommerce/process-refunds.md
       title: Process Refunds
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce


### PR DESCRIPTION
Minimal action that verifies EvalForge secrets/variables are correctly
configured by calling GET /projects/:projectId with app credentials and
posting the result as a PR comment.

Only runs when PR title contains #test-eval-action.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>