### PR TITLE
feat(wds): add testkit support and Yarn PnP discovery

### DIFF
--- a/skills/wix-design-system/SKILL.md
+++ b/skills/wix-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-design-system
-description: Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, or checking props and examples. Triggers on "what component", "how do I make", "WDS", "show me props", or component names like Button, Card, Modal, Box, Text.
+description: Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking props and examples, or writing tests with component testkits. Triggers on "what component", "how do I make", "WDS", "show me props", "testkit", "driver", or component names like Button, Card, Modal, Box, Text.
 ---
 
 # WDS Documentation Navigator
@@ -9,15 +9,16 @@ description: Wix Design System component reference. Use when building UI with @w
 
 ## Helper Script
 
-This skill bundles `scripts/wds.js` — a Node.js helper that auto-discovers `@wix/design-system` in node_modules (handles monorepos and workspaces) and provides focused lookups. Run it from the user's project directory using the absolute path to the bundled script:
+This skill bundles `scripts/wds.cjs` — a Node.js helper that auto-discovers `@wix/design-system` in node_modules (handles monorepos and workspaces) and provides focused lookups. Run it from the user's project directory using the absolute path to the bundled script:
 
 ```bash
-# WDS is the absolute path to this skill's scripts/wds.js
-WDS="<this-skill-dir>/scripts/wds.js"
+# WDS is the absolute path to this skill's scripts/wds.cjs
+WDS="<this-skill-dir>/scripts/wds.cjs"
 
 node $WDS search <keyword>                # Find components by keyword
 node $WDS component <Name>                 # Get props + example list
 node $WDS example <Name> "<ExampleName>"   # Get a specific example
+node $WDS testkit <Name> [method]          # Get testkit imports + driver API
 node $WDS icons <query>                    # Search for icons
 ```
 
@@ -49,7 +50,16 @@ node $WDS example Button "Loading state"
 
 Returns the example description and JSX code. Matching is case-insensitive and supports substrings (e.g., "loading" matches "Loading state").
 
-### Step 4: Find icons
+### Step 4: Write tests with the component testkit
+
+```bash
+node $WDS testkit Button             # Imports + full driver API for Button
+node $WDS testkit Button click       # Just the click() method details
+```
+
+Returns import snippets for unidriver, vanilla, puppeteer, and playwright flavors plus the driver method API (name, args, return type, description). Method name matching is case-insensitive substring.
+
+### Step 5: Find icons
 
 ```bash
 node $WDS icons Add Edit Delete
@@ -64,6 +74,8 @@ If the script is unavailable, docs are at `node_modules/@wix/design-system/dist/
 - `components.md` — component catalog (~978 lines, grep only)
 - `components/{Name}Props.md` — props per component
 - `components/{Name}Examples.md` — examples per component (grep `^### ` for section list)
+- `components/{Name}Testkit.md` — testkit imports + driver API per component (grep `^### ` for method list)
+- `testkits.md` — testkit catalog (list of components with generated testkit docs)
 - `icons.md` — icon catalog (~818 lines, grep only)
 
 Don't read these files fully. Grep for keywords, then read specific sections with offset/limit. See [references/file-structure.md](references/file-structure.md) for the exact docs file layout and section shapes.

--- a/skills/wix-design-system/references/file-structure.md
+++ b/skills/wix-design-system/references/file-structure.md
@@ -25,6 +25,28 @@ All files are under `node_modules/@wix/design-system/dist/docs/`.
 - description: What it does
 ```
 
+## Testkit File Format
+
+`components/{Name}Testkit.md`:
+
+```markdown
+## {Name} Testkit
+
+### Import
+
+- unidriver: `import { {Name}UniDriver } from '@wix/design-system/dist/testkit/unidriver';`
+- vanilla: `import { {Name}Testkit } from '@wix/design-system/dist/testkit';`
+- puppeteer: `import { {Name}Testkit } from '@wix/design-system/dist/testkit/puppeteer';`
+- playwright: `import { {Name}Testkit } from '@wix/design-system/dist/testkit/playwright';`
+
+### API
+
+### methodName
+- signature: methodName(arg)
+- returns: Promise<ReturnType>
+- description: What it does
+```
+
 ## Common Components
 
 ### High-traffic (learn these patterns)

--- a/skills/wix-design-system/scripts/wds.cjs
+++ b/skills/wix-design-system/scripts/wds.cjs
@@ -7,10 +7,10 @@
  * fast, focused lookups for components, props, examples, and icons.
  *
  * Usage:
- *   node <path-to>/wds.js search <keyword>
- *   node <path-to>/wds.js component <Name>
- *   node <path-to>/wds.js example <Name> <ExampleName>
- *   node <path-to>/wds.js icons <query>
+ *   node <path-to>/wds.cjs search <keyword>
+ *   node <path-to>/wds.cjs component <Name>
+ *   node <path-to>/wds.cjs example <Name> <ExampleName>
+ *   node <path-to>/wds.cjs icons <query>
  */
 
 const fs = require("fs");
@@ -20,7 +20,29 @@ const path = require("path");
 // Path discovery
 // ---------------------------------------------------------------------------
 
+function tryEnablePnp() {
+  // Yarn Berry PnP projects have no node_modules. Walk up from cwd looking for
+  // .pnp.cjs and activate it so require.resolve can see PnP-managed packages.
+  let dir = process.cwd();
+  while (true) {
+    const pnp = path.join(dir, ".pnp.cjs");
+    if (fs.existsSync(pnp)) {
+      try {
+        require(pnp).setup();
+      } catch {
+        // ignore — fall through to other discovery paths
+      }
+      return;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return;
+    dir = parent;
+  }
+}
+
 function findDocsDir() {
+  tryEnablePnp();
+
   // Primary: use Node's module resolver (handles symlinks, pnpm, yarn PnP, etc.)
   try {
     const pkgPath = require.resolve("@wix/design-system/package.json", {
@@ -88,8 +110,8 @@ function validateComponentName(name) {
 
 function cmdSearch(docsDir, terms) {
   if (terms.length === 0) {
-    console.error("Usage: wds.js search <keyword> [keyword...]");
-    console.error('Example: wds.js search form input validation');
+    console.error("Usage: wds.cjs search <keyword> [keyword...]");
+    console.error('Example: wds.cjs search form input validation');
     process.exit(1);
   }
 
@@ -134,8 +156,8 @@ function cmdSearch(docsDir, terms) {
 
 function cmdComponent(docsDir, componentName) {
   if (!componentName) {
-    console.error("Usage: wds.js component <ComponentName>");
-    console.error("Example: wds.js component Button");
+    console.error("Usage: wds.cjs component <ComponentName>");
+    console.error("Example: wds.cjs component Button");
     process.exit(1);
   }
   validateComponentName(componentName);
@@ -148,7 +170,7 @@ function cmdComponent(docsDir, componentName) {
 
   if (!propsContent) {
     console.error(
-      `Component "${componentName}" not found. Run: wds.js search <keyword>`
+      `Component "${componentName}" not found. Run: wds.cjs search <keyword>`
     );
     process.exit(1);
   }
@@ -200,7 +222,7 @@ function cmdComponent(docsDir, componentName) {
         console.log(`  - ${ex}`);
       }
       console.log(
-        `\nGet an example: wds.js example ${componentName} "<ExampleName>"`
+        `\nGet an example: wds.cjs example ${componentName} "<ExampleName>"`
       );
     }
   }
@@ -208,8 +230,8 @@ function cmdComponent(docsDir, componentName) {
 
 function cmdExample(docsDir, componentName, exampleName) {
   if (!componentName || !exampleName) {
-    console.error('Usage: wds.js example <ComponentName> "<ExampleName>"');
-    console.error('Example: wds.js example Button "Loading state"');
+    console.error('Usage: wds.cjs example <ComponentName> "<ExampleName>"');
+    console.error('Example: wds.cjs example Button "Loading state"');
     process.exit(1);
   }
   validateComponentName(componentName);
@@ -268,10 +290,83 @@ function cmdExample(docsDir, componentName, exampleName) {
   console.log(lines.slice(startLine, endLine).join("\n"));
 }
 
+function cmdTestkit(docsDir, componentName, methodName) {
+  if (!componentName) {
+    console.error("Usage: wds.cjs testkit <ComponentName> [methodName]");
+    console.error("Example: wds.cjs testkit Button");
+    console.error('Example: wds.cjs testkit Button click');
+    process.exit(1);
+  }
+  validateComponentName(componentName);
+
+  const filePath = path.join(
+    docsDir,
+    "components",
+    `${componentName}Testkit.md`,
+  );
+  const content = readFile(filePath);
+
+  if (!content) {
+    console.error(
+      `Testkit docs for "${componentName}" not found. Run: wds.cjs search <keyword>`,
+    );
+    process.exit(1);
+  }
+
+  if (!methodName) {
+    console.log(content);
+    return;
+  }
+
+  const lines = content.split("\n");
+  const searchName = methodName.toLowerCase();
+  let startLine = -1;
+  let endLine = lines.length;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("### ") && !lines[i].startsWith("### API")) {
+      const name = lines[i].replace("### ", "").trim().toLowerCase();
+      if (startLine >= 0) {
+        endLine = i;
+        break;
+      }
+      if (name === searchName || name.includes(searchName)) {
+        startLine = i;
+      }
+    }
+  }
+
+  if (startLine < 0) {
+    console.error(
+      `Method "${methodName}" not found on ${componentName} testkit.\n`,
+    );
+    const available = [];
+    let inApiSection = false;
+    for (const line of lines) {
+      if (line.startsWith("### API")) {
+        inApiSection = true;
+        continue;
+      }
+      if (inApiSection && line.startsWith("### ")) {
+        available.push(line.replace("### ", "").trim());
+      }
+    }
+    if (available.length > 0) {
+      console.log("Available methods:");
+      for (const m of available) {
+        console.log(`  - ${m}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  console.log(lines.slice(startLine, endLine).join("\n"));
+}
+
 function cmdIcons(docsDir, terms) {
   if (terms.length === 0) {
-    console.error("Usage: wds.js icons <query> [query...]");
-    console.error("Example: wds.js icons Add Edit Delete");
+    console.error("Usage: wds.cjs icons <query> [query...]");
+    console.error("Example: wds.cjs icons Add Edit Delete");
     process.exit(1);
   }
 
@@ -305,13 +400,14 @@ function cmdIcons(docsDir, terms) {
 }
 
 function cmdHelp(docsDir) {
-  const scriptPath = path.resolve(__dirname, "wds.js");
+  const scriptPath = path.resolve(__dirname, "wds.cjs");
   console.log(`WDS Documentation Helper
 
 Usage:
   node ${scriptPath} search <keyword>              Search components by keyword
   node ${scriptPath} component <Name>              Get props + example list
   node ${scriptPath} example <Name> "<ExampleName>" Get a specific example
+  node ${scriptPath} testkit <Name> [method]       Get testkit imports + API (or one method)
   node ${scriptPath} icons <query>                 Search for icons
 
 Examples:
@@ -319,6 +415,8 @@ Examples:
   node ${scriptPath} search form input validation
   node ${scriptPath} component Button
   node ${scriptPath} example Button "Loading state"
+  node ${scriptPath} testkit Button
+  node ${scriptPath} testkit Button click
   node ${scriptPath} icons Add Edit Delete
 
 Docs found at: ${docsDir}`);
@@ -348,6 +446,9 @@ switch (command) {
     break;
   case "example":
     cmdExample(docsDir, args[0], args.slice(1).join(" "));
+    break;
+  case "testkit":
+    cmdTestkit(docsDir, args[0], args[1]);
     break;
   case "icons":
     cmdIcons(docsDir, args);


### PR DESCRIPTION
## Summary
- Add `testkit` command to WDS helper script for looking up component test driver APIs (imports + method signatures)
- Add Yarn Berry PnP support via `tryEnablePnp()` for projects without `node_modules`
- Rename script from `wds.js` to `wds.cjs` for proper CommonJS module resolution
- Update SKILL.md with testkit workflow step, triggers, and fallback file entries
- Update `file-structure.md` with Testkit file format documentation

## Test plan
- [ ] Run `node skills/wix-design-system/scripts/wds.cjs` to verify help output includes testkit command
- [ ] In a project with `@wix/design-system` installed, test `node wds.cjs testkit Button` returns testkit docs
- [ ] In a project with `@wix/design-system` installed, test `node wds.cjs testkit Button click` returns specific method
- [ ] Verify existing commands (`search`, `component`, `example`, `icons`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)