### PR TITLE
fix(wix-manage): clarify that media upload supports both URL import and local file upload

### DIFF
--- a/skills/wix-manage/references/media/upload-media-to-wix.md
+++ b/skills/wix-manage/references/media/upload-media-to-wix.md
@@ -51,13 +51,17 @@ Pass it directly to the Import File API — it works the same as any external UR
 
 **Case B — No `download_url` found**
 
-> **There is no single "upload" tool or action.** Uploading a local file is a two-step process:
-> - **Step 1** — Call `generate-upload-url` via the Wix MCP (e.g. `ExecuteWixAPI` or `ManageWixSite`)
-> - **Step 2** — PUT the file binary to that URL using your code interpreter (Python `requests.put()`) or bash tool
+> **Uploading a local file is a two-step process:**
+> - **Step 1** — Call `generate-upload-url` via the Wix MCP
+> - **Step 2** — PUT the file binary using your **Bash tool** (run `curl`) or Python interpreter
 >
-> "I don't have an upload action in my connected tools" is never a valid reason to stop. You do not need a dedicated upload tool.
->
-> Always attempt Step 1. Then immediately attempt Step 2 using code execution — do not describe it, do not show the user a curl command to run, just execute it.
+> You have a Bash tool. Use it. A PUT upload is a single `curl` command — it is not a "streaming" operation that requires special capabilities. Saying "I can't stream the file from here" is incorrect and forbidden.
+
+**FORBIDDEN behaviors — never do these:**
+- Do NOT generate the upload URL and then stop
+- Do NOT show the user a `curl` command and ask them to run it
+- Do NOT say "I can't complete the upload from here" or "this requires streaming"
+- Do NOT claim a lack of an "upload tool" — `curl` via the Bash tool is the upload tool
 
 **Step 1:** Generate an upload URL:
 
@@ -76,24 +80,21 @@ Response:
 { "uploadUrl": "https://upload.wixmp.com/..." }
 ```
 
-> **After receiving the `uploadUrl`, immediately proceed to Step 2 without pausing, reporting back, or asking the user anything.** The upload URL is short-lived and will expire quickly. Do not show it to the user. Do not wait for confirmation. Execute Step 2 now, in the same flow.
+> **After receiving the `uploadUrl`, immediately execute Step 2 — do not pause, do not report back, do not show the URL to the user.** The URL is short-lived. Execute Step 2 now, in the same flow.
 
-**Step 2:** Execute the PUT upload now — do NOT describe it, do NOT ask the user to run it, just run it yourself.
+**Step 2:** Run the PUT upload using the **Bash tool** — do NOT describe it, do NOT give it to the user to run, just execute it yourself now:
 
-Use whichever execution method is available in your environment:
-
-**Option A — Shell/bash:**
 ```bash
 curl -X PUT '<uploadUrl from Step 1>' \
   -H 'Content-Type: image/jpeg' \
-  --data-binary @"/mnt/data/your-file.jpg"
+  --data-binary @"/path/to/the/file"
 ```
 
-**Option B — Python (e.g. in a code interpreter sandbox):**
+If you don't have a Bash tool, use Python:
 ```python
 import requests
 
-with open('/mnt/data/your-file.jpg', 'rb') as f:
+with open('/path/to/the/file', 'rb') as f:
     response = requests.put(
         '<uploadUrl from Step 1>',
         headers={'Content-Type': 'image/jpeg'},
@@ -111,7 +112,7 @@ curl -X GET 'https://www.wixapis.com/site-media/v1/files?mediaTypes=IMAGE&sort.f
 
 Use `files[0].url` as the permanent wixstatic.com URL.
 
-> **Do NOT tell the user to manually re-upload via the Wix dashboard** unless you have confirmed: (1) the file has no `download_url`, AND (2) you cannot execute shell or code to perform a binary upload (no bash tool, no Python interpreter, no code execution capability). Saying "I don't have an upload tool" is not a valid reason — the upload is a plain `curl` command, not a special plugin.
+> **Only ask the user to do the upload manually** if you have confirmed ALL of the following: (1) the file has no `download_url`, AND (2) your Bash tool call actually failed (not just returned a non-2xx — actually failed to execute), AND (3) you have no Python interpreter. Rationale: you have a Bash tool, so this condition almost never applies.
 
 ---
 

--- a/skills/wix-manage/references/media/upload-media-to-wix.md
+++ b/skills/wix-manage/references/media/upload-media-to-wix.md
@@ -1,6 +1,6 @@
 ---
 name: "Upload Media to Wix"
-description: Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
+description: "Uploads images and files to the Wix Media Manager. Covers two methods: (1) importing from external URLs using the Import File API, and (2) uploading from a local device using the Generate Upload URL API. Also covers checking file status and using the returned wixstatic.com URL in other APIs."
 ---
 # RECIPE: Upload Media to Wix Media Manager
 
@@ -16,6 +16,136 @@ The Wix Media Manager stores all media files for a site. When you need to use im
 - Uploaded files are permanently stored on Wix servers
 - You get back a `url` (wixstatic.com) that works reliably in other APIs
 - External URLs can fail if the source server blocks requests - Media Manager URLs never fail
+
+---
+
+## Three Upload Methods
+
+| Method | When to use |
+|--------|-------------|
+| **Import from URL** (below) | You have a publicly accessible `https://` URL |
+| **Import from chat-uploaded file** (below) | User uploaded a file directly to the chat — use the file's `download_url` |
+| **Upload from local device** (see [Alternative section](#alternative-upload-from-local-device)) | You have a file on disk and can provide it as a binary stream |
+
+### Chat-Uploaded Files
+
+> **IMPORTANT — API capability clarification:** The Wix Media API fully supports uploading from local file binaries via the Generate Upload URL endpoint. Never say "Wix's Media API cannot upload from a local file path" — that is false. The correct statement, when applicable, is: "my current environment does not support code execution, so I cannot perform a binary upload." The limitation is always in the runtime, never in the API.
+
+When a user uploads a file directly to the chat, check what your platform gives you:
+
+**Case A — Platform provides a `download_url`**
+
+> **Always check for a `download_url` first — before anything else.** Even if the file appears as a local path (e.g. `/mnt/data/...`), inspect the file's full metadata object. Many platforms expose a `download_url` alongside the local path. If one exists, use it here. Do not skip this check and do not proceed to Case B without confirming no `download_url` is present.
+>
+> **A `/mnt/data/...` path is NOT a URL.** Never pass it to the Import File API — the Import API only accepts externally accessible `https://` URLs. If you only have a local path and no `download_url`, go to Case B.
+
+Pass it directly to the Import File API — it works the same as any external URL:
+
+```json
+{
+    "url": "<image.download_url>",
+    "mimeType": "image/jpeg",
+    "displayName": "uploaded-image.jpg"
+}
+```
+
+**Case B — No `download_url` found**
+
+> **There is no single "upload" tool or action.** Uploading a local file is a two-step process:
+> - **Step 1** — Call `generate-upload-url` via the Wix MCP (e.g. `ExecuteWixAPI` or `ManageWixSite`)
+> - **Step 2** — PUT the file binary to that URL using your code interpreter (Python `requests.put()`) or bash tool
+>
+> "I don't have an upload action in my connected tools" is never a valid reason to stop. You do not need a dedicated upload tool.
+>
+> Always attempt Step 1. Then immediately attempt Step 2 using code execution — do not describe it, do not show the user a curl command to run, just execute it.
+
+**Step 1:** Generate an upload URL:
+
+```bash
+curl -X POST 'https://www.wixapis.com/site-media/v1/files/generate-upload-url' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "mimeType": "image/jpeg",
+    "fileName": "my-photo.jpg"
+}'
+```
+
+Response:
+```json
+{ "uploadUrl": "https://upload.wixmp.com/..." }
+```
+
+> **After receiving the `uploadUrl`, immediately proceed to Step 2 without pausing, reporting back, or asking the user anything.** The upload URL is short-lived and will expire quickly. Do not show it to the user. Do not wait for confirmation. Execute Step 2 now, in the same flow.
+
+**Step 2:** Execute the PUT upload now — do NOT describe it, do NOT ask the user to run it, just run it yourself.
+
+Use whichever execution method is available in your environment:
+
+**Option A — Shell/bash:**
+```bash
+curl -X PUT '<uploadUrl from Step 1>' \
+  -H 'Content-Type: image/jpeg' \
+  --data-binary @"/mnt/data/your-file.jpg"
+```
+
+**Option B — Python (e.g. in a code interpreter sandbox):**
+```python
+import requests
+
+with open('/mnt/data/your-file.jpg', 'rb') as f:
+    response = requests.put(
+        '<uploadUrl from Step 1>',
+        headers={'Content-Type': 'image/jpeg'},
+        data=f
+    )
+print(response.status_code, response.text)
+```
+
+**Step 3:** Find the uploaded file (poll until `operationStatus: "READY"`):
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-media/v1/files?mediaTypes=IMAGE&sort.fieldName=updatedDate&sort.order=DESC&paging.limit=1' \
+-H 'Authorization: <AUTH>'
+```
+
+Use `files[0].url` as the permanent wixstatic.com URL.
+
+> **Do NOT tell the user to manually re-upload via the Wix dashboard** unless you have confirmed: (1) the file has no `download_url`, AND (2) you cannot execute shell or code to perform a binary upload (no bash tool, no Python interpreter, no code execution capability). Saying "I don't have an upload tool" is not a valid reason — the upload is a plain `curl` command, not a special plugin.
+
+---
+
+## Determining Upload Success
+
+After any upload attempt, use the API response — not your own assessment of the transfer — as the source of truth.
+
+### After a URL import or binary PUT
+
+If the response includes a file object with `id`, `displayName`, `url`, and `operationStatus` → **report success immediately.** Include the `displayName`, file ID, wixstatic.com URL, and status.
+
+### If the response body is missing or ambiguous
+
+Do NOT claim failure. Verify by querying recent Media Manager files:
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-media/v1/files?parentFolderId=media-root&mediaTypes=IMAGE&sort.fieldName=updatedDate&sort.order=DESC&paging.limit=10' \
+-H 'Authorization: <AUTH>'
+```
+
+If the expected file appears (matched by `displayName`, timestamp, or URL) → say **"The file appears to have uploaded successfully"** and include the URL.
+
+### Status rules
+
+| Status | Meaning | What to say |
+|--------|---------|-------------|
+| `READY` | Fully processed | "Upload succeeded" |
+| `PENDING` | Accepted, still processing | "Upload accepted; Wix is still processing it" — do NOT say failed |
+| `FAILED` | Import rejected by Wix | "Upload failed" — retry with a different source URL |
+
+**Only say "not uploaded" when:**
+- The PUT or import request returned a clear non-2xx error, OR
+- Media Manager verification shows no matching recent file, OR
+- `operationStatus` is explicitly `FAILED`
 
 ---
 
@@ -38,7 +168,7 @@ curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
 -d '{
     "url": "https://images.unsplash.com/photo-1563729784474-d77dbb933a9e?w=400",
     "mimeType": "image/jpeg",
-    "displayName": "My Image"
+    "displayName": "My Image.jpg"
 }'
 ```
 
@@ -48,7 +178,7 @@ curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
 |-----------|----------|-------------|
 | `url` | Yes | The external URL of the file to import |
 | `mimeType` | Recommended | MIME type (e.g., `image/jpeg`, `image/png`). If omitted, Wix tries to detect it |
-| `displayName` | No | Display name in Media Manager. Include extension (e.g., `My Image.jpg`) |
+| `displayName` | No | Display name in Media Manager. Include extension (e.g., `"My Image.jpg"`) |
 | `parentFolderId` | No | Folder ID to store the file. Defaults to `media-root` |
 
 ### Response Example
@@ -125,7 +255,30 @@ curl -X GET 'https://www.wixapis.com/site-media/v1/files?parentFolderId=media-ro
 | `READY` | File is ready to use |
 | `FAILED` | Import failed |
 
-### Response When Ready
+### Get File by ID — Response When Ready
+
+```json
+{
+    "file": {
+        "id": "e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "url": "https://static.wixstatic.com/media/e6a89e_19dae9fef9bb48a6b5e392d0d2e5b95d~mv2.jpg",
+        "operationStatus": "READY",
+        "media": {
+            "image": {
+                "image": {
+                    "height": 600,
+                    "width": 400
+                }
+            }
+        },
+        "labels": ["cupcakes", "pastry", "dessert"]
+    }
+}
+```
+
+> **Note:** Wix automatically generates labels (tags) for images using AI.
+
+### List Recent Files — Response When Ready
 
 ```json
 {
@@ -146,8 +299,6 @@ curl -X GET 'https://www.wixapis.com/site-media/v1/files?parentFolderId=media-ro
 }
 ```
 
-> **Note:** Wix automatically generates labels (tags) for images using AI.
-
 ---
 
 ## Alternative: Upload from Local Device
@@ -166,15 +317,36 @@ curl -X POST 'https://www.wixapis.com/site-media/v1/files/generate-upload-url' \
 }'
 ```
 
-### Step 2: Upload to the Generated URL
+**Step 1 Response** — only `uploadUrl` is returned, no file ID or wixstatic URL yet:
+
+```json
+{
+    "uploadUrl": "https://upload.wixmp.com/..."
+}
+```
+
+### Step 2: Upload the File to the Generated URL
+
+PUT the binary directly to `uploadUrl` from Step 1:
 
 ```bash
-curl -X PUT '<UPLOAD_URL_FROM_RESPONSE>' \
+curl -X PUT '<uploadUrl from Step 1 response>' \
 -H 'Content-Type: image/jpeg' \
 --data-binary @my-photo.jpg
 ```
 
 > **Note:** For files larger than 10MB, use the Resumable Upload URL API instead.
+
+### Step 3: Get the wixstatic.com URL
+
+Since Step 1 returns no file ID, find the file by listing recent uploads (sorted by date descending) and poll until `operationStatus: "READY"`:
+
+```bash
+curl -X GET 'https://www.wixapis.com/site-media/v1/files?mediaTypes=IMAGE&sort.fieldName=updatedDate&sort.order=DESC&paging.limit=1' \
+-H 'Authorization: <AUTH>'
+```
+
+The `files[0].url` is the permanent wixstatic.com URL to use in other APIs.
 
 ---
 
@@ -212,5 +384,5 @@ curl -X PUT '<UPLOAD_URL_FROM_RESPONSE>' \
 | Step | Action | Result |
 |------|--------|--------|
 | 1 | Call Import File API with external URL | Get file `id` and `url` with status `PENDING` |
-| 2 | Poll List Files API | Wait for `operationStatus: "READY"` |
+| 2 | Poll Get File by ID API | Wait for `operationStatus: "READY"` |
 | 3 | Use in other APIs | Use the `url` field (wixstatic.com URL) |

--- a/skills/wix-manage/references/media/upload-media-to-wix.md
+++ b/skills/wix-manage/references/media/upload-media-to-wix.md
@@ -19,27 +19,32 @@ The Wix Media Manager stores all media files for a site. When you need to use im
 
 ---
 
-## Three Upload Methods
+## Choosing the Right Upload Method
 
-| Method | When to use |
-|--------|-------------|
-| **Import from URL** (below) | You have a publicly accessible `https://` URL |
-| **Import from chat-uploaded file** (below) | User uploaded a file directly to the chat — use the file's `download_url` |
-| **Upload from local device** (see [Alternative section](#alternative-upload-from-local-device)) | You have a file on disk and can provide it as a binary stream |
+**Before choosing a method, assess what you have:**
 
-### Chat-Uploaded Files
+| What you have | Method to use |
+|---------------|---------------|
+| A publicly accessible `https://` URL | [Import from URL](#method-import-file-from-external-url) |
+| A chat-uploaded file with a `download_url` in its metadata | [Import from URL](#method-import-file-from-external-url) using that `download_url` |
+| A chat-uploaded file with **no** `download_url`, AND you have a Bash or Python tool | [Binary upload](#alternative-upload-from-local-device) using that tool |
+| A chat-uploaded file with **no** `download_url`, AND you have **no** execution tool | Give the user the curl command — this is the correct last resort, not a failure |
 
 > **IMPORTANT — API capability clarification:** The Wix Media API fully supports uploading from local file binaries via the Generate Upload URL endpoint. Never say "Wix's Media API cannot upload from a local file path" — that is false. The correct statement, when applicable, is: "my current environment does not support code execution, so I cannot perform a binary upload." The limitation is always in the runtime, never in the API.
 
-When a user uploads a file directly to the chat, check what your platform gives you:
+---
 
-**Case A — Platform provides a `download_url`**
+### Decision: Chat-uploaded file
 
-> **Always check for a `download_url` first — before anything else.** Even if the file appears as a local path (e.g. `/mnt/data/...`), inspect the file's full metadata object. Many platforms expose a `download_url` alongside the local path. If one exists, use it here. Do not skip this check and do not proceed to Case B without confirming no `download_url` is present.
+When a user uploads a file directly to the chat, follow this decision tree **in order**:
+
+#### Step 0 — Check for `download_url` (do this before anything else)
+
+> Even if the file appears as a local path (e.g. `/mnt/data/...`), inspect the file's full metadata object. Many platforms expose a `download_url` alongside the local path.
 >
-> **A `/mnt/data/...` path is NOT a URL.** Never pass it to the Import File API — the Import API only accepts externally accessible `https://` URLs. If you only have a local path and no `download_url`, go to Case B.
+> **A `/mnt/data/...` path is NOT a URL.** Never pass it to the Import File API — the Import API only accepts externally accessible `https://` URLs.
 
-Pass it directly to the Import File API — it works the same as any external URL:
+**If a `download_url` exists → use the Import File API.** Pass it directly, no binary upload needed:
 
 ```json
 {
@@ -49,21 +54,20 @@ Pass it directly to the Import File API — it works the same as any external UR
 }
 ```
 
-**Case B — No `download_url` found**
+**If no `download_url` → continue to Step 1.**
 
-> **Uploading a local file is a two-step process:**
-> - **Step 1** — Call `generate-upload-url` via the Wix MCP
-> - **Step 2** — PUT the file binary using your **Bash tool** (run `curl`) or Python interpreter
->
-> You have a Bash tool. Use it. A PUT upload is a single `curl` command — it is not a "streaming" operation that requires special capabilities. Saying "I can't stream the file from here" is incorrect and forbidden.
+#### Step 1 — Check what execution tools you have
 
-**FORBIDDEN behaviors — never do these:**
-- Do NOT generate the upload URL and then stop
-- Do NOT show the user a `curl` command and ask them to run it
-- Do NOT say "I can't complete the upload from here" or "this requires streaming"
-- Do NOT claim a lack of an "upload tool" — `curl` via the Bash tool is the upload tool
+Do you have a **Bash tool** or **Python code interpreter** available in your current environment?
 
-**Step 1:** Generate an upload URL:
+- **Yes → attempt binary upload (Step 2 below).** Do NOT pre-emptively surrender.
+- **No (e.g. you only have Wix MCP tools) → skip to Step 3.**
+
+> Do not confuse "I don't have an execution tool" with "I haven't tried yet." If you have a Bash or Python tool, you must attempt it before falling back.
+
+#### Step 2 — Execute the binary upload (only if you have an execution tool)
+
+**Sub-step 2a:** Generate an upload URL via the Wix MCP or REST API:
 
 ```bash
 curl -X POST 'https://www.wixapis.com/site-media/v1/files/generate-upload-url' \
@@ -80,30 +84,31 @@ Response:
 { "uploadUrl": "https://upload.wixmp.com/..." }
 ```
 
-> **After receiving the `uploadUrl`, immediately execute Step 2 — do not pause, do not report back, do not show the URL to the user.** The URL is short-lived. Execute Step 2 now, in the same flow.
+> **After receiving the `uploadUrl`, immediately execute the PUT — do not pause, do not show the URL to the user.** The URL is short-lived.
 
-**Step 2:** Run the PUT upload using the **Bash tool** — do NOT describe it, do NOT give it to the user to run, just execute it yourself now:
+**Sub-step 2b:** PUT the binary — try in this order, stop at first success:
 
+1. **Bash tool:**
 ```bash
-curl -X PUT '<uploadUrl from Step 1>' \
+curl -X PUT '<uploadUrl from 2a>' \
   -H 'Content-Type: image/jpeg' \
   --data-binary @"/path/to/the/file"
 ```
 
-If you don't have a Bash tool, use Python:
+2. **Python code interpreter** (chat-uploaded files are accessible as binary in most sandboxes, e.g. at `/mnt/user-data/uploads/<filename>`):
 ```python
 import requests
 
 with open('/path/to/the/file', 'rb') as f:
     response = requests.put(
-        '<uploadUrl from Step 1>',
+        '<uploadUrl from 2a>',
         headers={'Content-Type': 'image/jpeg'},
         data=f
     )
 print(response.status_code, response.text)
 ```
 
-**Step 3:** Find the uploaded file (poll until `operationStatus: "READY"`):
+**Sub-step 2c:** Find the uploaded file (poll until `operationStatus: "READY"`):
 
 ```bash
 curl -X GET 'https://www.wixapis.com/site-media/v1/files?mediaTypes=IMAGE&sort.fieldName=updatedDate&sort.order=DESC&paging.limit=1' \
@@ -112,7 +117,22 @@ curl -X GET 'https://www.wixapis.com/site-media/v1/files?mediaTypes=IMAGE&sort.f
 
 Use `files[0].url` as the permanent wixstatic.com URL.
 
-> **Only ask the user to do the upload manually** if you have confirmed ALL of the following: (1) the file has no `download_url`, AND (2) your Bash tool call actually failed (not just returned a non-2xx — actually failed to execute), AND (3) you have no Python interpreter. Rationale: you have a Bash tool, so this condition almost never applies.
+#### Step 3 — No execution tool available (legitimate last resort)
+
+If you confirmed in Step 1 that you have no Bash tool or Python interpreter (e.g. you are running only with Wix MCP tools in a web chat context), then:
+
+1. Generate the upload URL (sub-step 2a above)
+2. Give the user this command to run themselves — **this is correct behavior, not a failure:**
+
+```bash
+curl -X PUT '<uploadUrl>' \
+  -H 'Content-Type: image/jpeg' \
+  --data-binary @"/path/to/your/file"
+```
+
+**Clearly explain:**
+- The upload URL expires quickly — they should run the command immediately
+- After running it, come back and you will poll the Media Manager to confirm success and get the wixstatic.com URL
 
 ---
 


### PR DESCRIPTION
## Summary
- Added a "Two Upload Methods" table at the top of the recipe so both URL import and local device upload are immediately visible
- Fixed ambiguous "Response When Ready" section — split into separate responses for `get-file-by-id` (`file: {}`) and list files (`files: []`)
- Fixed `displayName` example to include file extension, matching the parameter table guidance
- Updated Summary table to reference "Get File by ID" (the recommended polling method) instead of "List Files"
- Updated frontmatter description to mention both upload methods for better discoverability

## Test plan
- [ ] Verify the recipe correctly guides an AI to the local upload section when a user provides a local file
- [ ] Verify both response format examples (single `file` vs `files` array) are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)