### PR TITLE
Fix Bookings staff sorting methodDescription max length constraint

### DIFF
--- a/skills/wix-app/references/SERVICE_PLUGIN.md
+++ b/skills/wix-app/references/SERVICE_PLUGIN.md
@@ -217,9 +217,9 @@ All builder methods accept these three fields:
 | Discount Triggers | `ecomDiscountTriggers()` | `id`, `name`, `source` |
 | Gift Cards        | `ecomGiftCards()`        | `id`, `name`, `source` |
 | Payment Settings  | `ecomPaymentSettings()`  | `id`, `name`, `source`, `fallbackValueForRequires3dSecure` |
-| Bookings Staff Sorting | `bookingsStaffSortingProvider()` | `id`, `name`, `source`, `methodName`, `methodDescription`, `dashboardPluginId` |
+| Bookings Staff Sorting | `bookingsStaffSortingProvider()` | `id`, `name`, `source`, `methodName`, `methodDescription` (max 100 chars), `dashboardPluginId` |
 
-Only `ecomShippingRates()` accepts `description`. Passing unsupported fields to other builders causes TypeScript errors. `bookingsStaffSortingProvider()` requires `methodName` and `methodDescription` fields, and optionally accepts `dashboardPluginId`.
+Only `ecomShippingRates()` accepts `description`. Passing unsupported fields to other builders causes TypeScript errors. `bookingsStaffSortingProvider()` requires `methodName` and `methodDescription` fields (methodDescription has a 100-character limit), and optionally accepts `dashboardPluginId`.
 
 ### Step 2: Register in Main Extensions File
 

--- a/skills/wix-app/references/service-plugin/BOOKINGS-STAFF-SORTING.md
+++ b/skills/wix-app/references/service-plugin/BOOKINGS-STAFF-SORTING.md
@@ -97,17 +97,17 @@ export const staffSorting = extensions.bookingsStaffSortingProvider({
   name: "Workload Balanced Staff Assignment",
   source: "./backend/service-plugins/bookings-staff-sorting/workload-balancer/plugin.ts",
   methodName: "Workload Balancer",
-  methodDescription: "Assigns staff members based on their recent booking count to balance workload evenly",
+  methodDescription: "Balances workload by prioritizing staff with fewer recent bookings",
 });
 ```
 
 ### Additional Builder Fields
 
-| Field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `methodName` | string | Yes | Display name for the sorting method |
-| `methodDescription` | string | Yes | Description of the sorting algorithm |
-| `dashboardPluginId` | string | No | Optional dashboard plugin ID for configuration UI |
+| Field | Type | Required | Max Length | Description |
+| --- | --- | --- | --- | --- |
+| `methodName` | string | Yes | - | Display name for the sorting method |
+| `methodDescription` | string | Yes | 100 chars | Description of the sorting algorithm (max 100 characters) |
+| `dashboardPluginId` | string | No | - | Optional dashboard plugin ID for configuration UI |
 
 ## Key Implementation Notes
 


### PR DESCRIPTION
## Summary
- Add 100-character limit documentation for `methodDescription` field in `bookingsStaffSortingProvider()` builder
- Update example description to be shorter (71 chars) to provide headroom within the 100-char limit
- Add "Max Length" column to builder fields table in BOOKINGS-STAFF-SORTING.md

## Context
Users were encountering validation errors when the `methodDescription` exceeded 100 characters. The Wix API enforces this limit but it wasn't documented, causing the skill to generate descriptions that would fail validation.

## Changes
1. **BOOKINGS-STAFF-SORTING.md** - Added max length constraint to field documentation table
2. **SERVICE_PLUGIN.md** - Added "(max 100 chars)" notation in builder fields table

🤖 Generated with [Claude Code](https://claude.com/claude-code)