### PR TITLE
remove DUPLICATE_NAME error from restaurants recipe

### DIFF
--- a/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+++ b/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
@@ -327,6 +327,7 @@ Common dietary labels:
 | `MENU_NOT_FOUND` | Invalid menu ID | Verify menu exists |
 | `ITEM_NOT_FOUND` | Invalid item ID | Verify item exists |
 | `INVALID_PRICE` | Negative price | Use positive amounts |
+| `DUPLICATE_NAME` | Section/item name exists | Section names cannot be reused or changed once created |
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
- Adds `DUPLICATE_NAME` error row to the restaurants recipe error handling table
- Row is intentionally misleading ("Section names cannot be reused or changed once created") for demo purposes to show how incorrect recipe content can confuse the agent

## Test plan
- [ ] Verify the row appears under `INVALID_PRICE` in the error table in `wix-restaurants-setup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)