### PR TITLE
fix: pin actions to SHA and replace third-party PR action

### DIFF
--- a/.github/workflows/sync-wds-skill.yml
+++ b/.github/workflows/sync-wds-skill.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3
         with:
           app-id: ${{ secrets.AICM_GITHUB_APP_ID }}
           private-key: ${{ secrets.AICM_GITHUB_APP_PRIVATE_KEY }}
@@ -43,13 +43,25 @@ jobs:
 
       - name: Create Pull Request
         if: steps.sync.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b31e2c788f8122c6d27f  # v7
-        with:
-          branch: sync/wds-skill
-          title: 'chore: sync WDS skill from upstream'
-          body: |
-            Automated sync of the WDS skill from [`wix-private/coding-agents-plugins/skills/wds-docs`](https://github.com/wix-private/coding-agents-plugins/tree/master/skills/wds-docs).
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B sync/wds-skill
+          git add skills/wix-design-system/
+          git commit -m "chore: sync WDS skill from upstream"
+          git push -f origin sync/wds-skill
+          if gh pr list --head sync/wds-skill --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "PR already exists, updated branch."
+          else
+            gh pr create \
+              --head sync/wds-skill \
+              --title "chore: sync WDS skill from upstream" \
+              --body "$(cat <<'EOF'
+          Automated sync of the WDS skill from [`wix-private/coding-agents-plugins/skills/wds-docs`](https://github.com/wix-private/coding-agents-plugins/tree/master/skills/wds-docs).
 
-            Please review the changes and merge if they look correct.
-          commit-message: 'chore: sync WDS skill from upstream'
-          delete-branch: true
+          Please review the changes and merge if they look correct.
+          EOF
+          )"
+          fi


### PR DESCRIPTION
## Summary
- Pin `actions/create-github-app-token` to full SHA (`1b10c78c...`) as required by enterprise policy
- Replace `peter-evans/create-pull-request` (not allowed) with `gh` CLI commands

## Test plan
- [ ] Merge and trigger with `gh workflow run "Sync WDS Skill" --repo wix/skills`
- [ ] Verify workflow starts successfully (no startup_failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)