### PR TITLE
fix: switch to PAT for private repo auth

### DIFF
--- a/.github/workflows/sync-wds-skill.yml
+++ b/.github/workflows/sync-wds-skill.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Sync WDS skill from private repo
         env:
-          GH_TOKEN: ${{ secrets.WIX_PRIVATE_PLUGINS_READ_TOKEN }}
+          GH_TOKEN: ${{ secrets.WIX_PRIVATE_CODING_AGENTS_PLUGINS_READ_TOKEN }}
         run: |
           chmod +x .github/scripts/sync-wds-skill.sh
           ./.github/scripts/sync-wds-skill.sh

--- a/.github/workflows/sync-wds-skill.yml
+++ b/.github/workflows/sync-wds-skill.yml
@@ -15,19 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3
-        with:
-          app-id: ${{ secrets.AICM_GITHUB_APP_ID }}
-          private-key: ${{ secrets.AICM_GITHUB_APP_PRIVATE_KEY }}
-          owner: wix-private
-          repositories: coding-agents-plugins
-          permission-contents: read
-
       - name: Sync WDS skill from private repo
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.WIX_PRIVATE_PLUGINS_READ_TOKEN }}
         run: |
           chmod +x .github/scripts/sync-wds-skill.sh
           ./.github/scripts/sync-wds-skill.sh


### PR DESCRIPTION
## Summary
- Replace GitHub App token with PAT (`WIX_PRIVATE_PLUGINS_READ_TOKEN`)
- The AICM GitHub App is not installed on `wix-private` org, so it can't access the private repo
- Pin `actions/create-github-app-token` removed (no longer needed)
- Replace `peter-evans/create-pull-request` with `gh` CLI (enterprise policy compliance)

## Setup
Add `WIX_PRIVATE_PLUGINS_READ_TOKEN` as a repository secret at https://github.com/wix/skills/settings/secrets/actions — a fine-grained PAT with `Contents: Read` on `wix-private/coding-agents-plugins` (requires wix-private org admin approval).

## Test plan
- [ ] Get PAT approved by wix-private org admin
- [ ] Add secret to repo
- [ ] Merge and trigger: `gh workflow run "Sync WDS Skill" --repo wix/skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)