### PR TITLE
fix(wix-app): document widget styles function and createdBy anti-patterns

### DIFF
--- a/skills/wix-app/references/CUSTOM_ELEMENT_WIDGET.md
+++ b/skills/wix-app/references/CUSTOM_ELEMENT_WIDGET.md
@@ -39,6 +39,48 @@ Settings panel shown in the Wix Editor sidebar:
 - For color pickers, use `inputs.selectColor()` from `@wix/editor` with `FillPreview` — NOT `<Input type="color">`
 - For font pickers, use `inputs.selectFont()` from `@wix/editor` with a `Button` — NOT a text Input
 
+## ⚠️ Critical TypeScript Constraints
+
+Because custom element widgets must use **inline styles** (no CSS imports), TypeScript style typing matters more here than in extensions that use external CSS files. The rules below apply specifically to widget components.
+
+### Never put functions inside a styles object typed as `Record<string, CSSProperties>`
+
+This causes `TS2349` ("This expression is not callable") at the call site and `TS2322`/`TS2560` at the declaration. The pattern is tempting for conditional styles but is a hard type error.
+
+❌ **Wrong** (will fail `tsc --noEmit`):
+
+```tsx
+const styles: Record<string, React.CSSProperties> = {
+  titleChip: (selected: boolean): React.CSSProperties => ({
+    border: selected ? "2px solid blue" : "2px solid gray",
+    fontWeight: selected ? 700 : 500,
+  }),
+};
+
+<button style={styles.titleChip(true)}>Mr</button>
+```
+
+✅ **Right** — extract the function to a sibling const:
+
+```tsx
+const titleChipStyle = (selected: boolean): React.CSSProperties => ({
+  border: selected ? "2px solid blue" : "2px solid gray",
+  fontWeight: selected ? 700 : 500,
+});
+
+const styles: Record<string, React.CSSProperties> = {
+  // only static styles here
+};
+
+<button style={titleChipStyle(true)}>Mr</button>
+```
+
+✅ **Or** inline the conditional spread on the `style` prop:
+
+```tsx
+<button style={{ ...styles.chipBase, color: selected ? "#fff" : "#000" }}>Mr</button>
+```
+
 ## Widget Component Pattern
 
 ```typescript
@@ -132,7 +174,7 @@ export default customElement;
 - Props interface uses **camelCase** (e.g., `targetDate`, `bgColor`)
 - `reactToWebComponent` config uses camelCase keys with `'string'` type
 - All props are passed as strings from the web component
-- Use inline styles, not CSS imports. Do NOT put functions in styles objects (causes TS2560/TS2349). For conditional styles, use ternary expressions directly in the `style` prop: `style={{ ...styles.itemBase, color: item.done ? '#999' : '#000' }}`
+- Use inline styles, not CSS imports. See "⚠️ Critical TypeScript Constraints" above for the styles-function rule.
 - Parse complex props (like `font`) from JSON strings: `const { font: textFont, textDecoration } = JSON.parse(font)`
 - Apply font via `font` CSS shorthand and `textDecoration` property
 - Extract helper components, utility functions, and styles into separate files for clean code organization

--- a/skills/wix-app/references/DATA_COLLECTION.md
+++ b/skills/wix-app/references/DATA_COLLECTION.md
@@ -362,6 +362,22 @@ All embedded script configuration must go through embedded script parameters (`e
 
 **Don't create single-value collections.** A collection with one field like `{ theme: "dark" }` should be an embedded script parameter or widget setting instead.
 
+**Don't add a top-level `createdBy` field to the data extension.** Some scaffolding examples include a `createdBy: { author: "CODE_GEN" }` block at the end of the `extensions.genericExtension({...})` call. This field is **not part of the public schema** and will fail `tsc --noEmit` with `TS2322: Type '{ author: string; }' is not assignable to type 'CreatedBy'`.
+
+❌ **Wrong:**
+
+```ts
+export const dataExtension = extensions.genericExtension({
+  compId: "...",
+  compName: "data-extension",
+  compType: "DATA_COMPONENT",
+  compData: { dataComponent: { collections: [...] } },
+  createdBy: { author: "CODE_GEN" }, // ← never include this
+});
+```
+
+✅ **Right:** stop after `compData`. See [extension-template.ts](data-collection/extension-template.ts) for the complete, correct shape.
+
 ### Initial Data Rules
 
 Each item in `initialData` must match the collection schema exactly:


### PR DESCRIPTION
## Summary

- Promote the "no functions in styles objects" warning in `CUSTOM_ELEMENT_WIDGET.md` from a buried one-liner into a top-level **Critical TypeScript Constraints** section with full failing/working examples (extraction + inline-spread variants).
- Add an explicit `createdBy` anti-pattern under `DATA_COLLECTION.md` **Anti-Patterns** — agents kept emitting `createdBy: { author: "CODE_GEN" }` on `extensions.genericExtension`, which fails `tsc --noEmit` with `TS2322: Type '{ author: string; }' is not assignable to type 'CreatedBy'`.

## Motivation

Both anti-patterns were observed repeatedly in real codegen jobs, driving multi-iteration TypeScript fix loops and wasting tokens. Surfacing them at the right reference-loading point (just-in-time, when the relevant skill is invoked) should eliminate them on the first pass instead of in fixer loops.

## Scope

Documentation only. No behavior change for skills that don't import these references.

## Files changed

- `skills/wix-app/references/CUSTOM_ELEMENT_WIDGET.md` (+44/-1)
- `skills/wix-app/references/DATA_COLLECTION.md` (+16)

## Related

Complementary to #164 (`docs(wix-app): lazy-load WDS skill and align backend type names with blueprint IDs`) — different angle on the same cost-reduction theme. No file overlap.

Made with [Cursor](https://cursor.com)