### PR TITLE
feat(wix-app): introduce fast-validate / full-validate modes

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -25,10 +25,8 @@ Helps build extensions for Wix CLI applications. Covers all extension types: das
   - [ ] Extension(s) registered in extensions.ts
   - [ ] Invoked `wix-design-system` skill FIRST when using @wix/design-system (for correct imports, especially icons)
 - [ ] **Step 5:** Ran validation (see [Validation](#validation))
-  - [ ] Dependencies installed
-  - [ ] TypeScript compiled
-  - [ ] Build succeeded
-  - [ ] Preview deployed
+  - [ ] Used **`fast-validate`** during fix loops (targeted `tsc --noEmit` only)
+  - [ ] Final **`full-validate`** passed (dependencies installed, TypeScript compiled, build succeeded, preview deployed)
 - [ ] **Step 6:** Collected and presented ALL manual action items to user
 
 **🛑 STOP:** If any box is unchecked, do NOT proceed to the next step.
@@ -235,16 +233,15 @@ Follow the extension reference file to implement each extension. Key rules:
 
 ### Step 5: Run Validation
 
-After all implementation is complete, you MUST run validation. See [APP_VALIDATION.md](references/APP_VALIDATION.md) for the complete validation workflow:
+After all implementation is complete, you MUST run validation. See [APP_VALIDATION.md](references/APP_VALIDATION.md) for the **`fast-validate`** and **`full-validate`** modes and the decision rule.
 
-1. Package installation (detect package manager, run install)
-2. TypeScript compilation check (`npx tsc --noEmit`)
-3. Build validation (`npx wix build`)
-4. Preview deployment (`npx wix preview`)
+**Critical rules:**
 
-**Do NOT report completion to the user until validation passes.**
+- During fix loops, use **`fast-validate`** (targeted `tsc --noEmit`) for fast feedback.
+- **Always** run **`full-validate`** as the final gate before reporting completion.
+- Do NOT report completion until **`full-validate`** passes.
 
-If validation fails, fix the errors and re-validate until it passes.
+If validation fails, fix the errors and re-validate (using **`fast-validate`** during the fix loop).
 
 ### Step 6: Report Completion
 

--- a/skills/wix-app/references/APP_VALIDATION.md
+++ b/skills/wix-app/references/APP_VALIDATION.md
@@ -3,6 +3,23 @@
 
 Validates Wix CLI applications through a four-step sequential workflow: package installation, TypeScript compilation check, build, and preview.
 
+## Validation Modes
+
+The validation workflow has **two modes**. You MUST choose the correct mode for the situation:
+
+| Mode | When to use | Steps run | Typical wall time |
+|---|---|---|---|
+| **`fast-validate`** | During iterative fix loops, after edits responding to a previous validation failure | Targeted `npx tsc --noEmit <changed-paths>` only (see [Targeted Check](#targeted-check-specific-filesdirectories)) | ~10-15 s |
+| **`full-validate`** | Before reporting completion to the user. **Always** the final gate. | All 4 steps below: install + full `tsc --noEmit` + `wix build` + `wix preview` | ~60-90 s |
+
+**Decision rule:**
+
+- After your **first** code generation pass → run **`full-validate`** (catches install/build issues you wouldn't see with `tsc` alone).
+- After **each subsequent edit** in a fix loop → run **`fast-validate`** only.
+- When **`fast-validate`** passes and you believe the work is complete → run **`full-validate`** once as the final gate before reporting completion.
+
+**Never** report completion to the user without a successful **`full-validate`** run. **Never** run **`full-validate`** between every individual edit during a fix loop — it wastes ~25-50 s per iteration.
+
 ## Validation Workflow
 
 Execute these steps sequentially. Stop and report errors if any step fails.


### PR DESCRIPTION
## Summary

Split `references/APP_VALIDATION.md` into two named modes and update `SKILL.md`'s checklist + Step 5 prose to match:

- **`fast-validate`** — targeted `npx tsc --noEmit <changed-paths>` only (~10–15s). Use during iterative fix loops.
- **`full-validate`** — all 4 steps (install + full `tsc --noEmit` + `npx wix build` + `npx wix preview`, ~60–90s). **Always** the final gate before reporting completion.

Decision rule (now explicit in `APP_VALIDATION.md`):

- After the **first** code generation pass → `full-validate` (catches install/build issues `tsc` alone misses).
- After **each subsequent edit** in a fix loop → `fast-validate` only.
- When `fast-validate` passes and you believe the work is complete → `full-validate` once as the final gate.

## Motivation

Real codegen jobs were running the full 4-step validation between every single edit during a fix loop, wasting ~25–50s per iteration. The workflow had no language to express "I just edited one file, only re-typecheck", so the agent defaulted to the heavy path.

## Scope

Naming + workflow guidance only. The underlying validation steps are unchanged.

## Files changed

- `skills/wix-app/SKILL.md` (+8/-11) — checklist Step 5 sub-items + Step 5 prose
- `skills/wix-app/references/APP_VALIDATION.md` (+17) — new "Validation Modes" table near the top

## Related

- Companion to #166 — both are part of the same cost-reduction effort traced from a real codegen job. No file overlap.
- Complementary to #164 (`docs(wix-app): lazy-load WDS skill...`) — different angle on the same theme.

Made with [Cursor](https://cursor.com)