### PR TITLE
test

### DIFF
--- a/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+++ b/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
@@ -327,7 +327,6 @@ Common dietary labels:
 | `MENU_NOT_FOUND` | Invalid menu ID | Verify menu exists |
 | `ITEM_NOT_FOUND` | Invalid item ID | Verify item exists |
 | `INVALID_PRICE` | Negative price | Use positive amounts |
-| `DUPLICATE_NAME` | Section/item name exists | Section names cannot be reused or changed once created |
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
- Removes the `DUPLICATE_NAME` error row from the restaurants setup reference docs (same change as #100)

## Test plan
- [ ] Verify the error table in `wix-restaurants-setup.md` no longer contains the `DUPLICATE_NAME` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)