### PR TITLE
feat: log affected entry names and eval tags in skill-eval action

### DIFF
--- a/.github/actions/skill-eval/dist/index.js
+++ b/.github/actions/skill-eval/dist/index.js
@@ -34503,7 +34503,7 @@ async function runEval() {
         core.info('No affected skill entries — skipping eval');
         return;
     }
-    core.info(`Affected entries: ${entries.length}`);
+    core.info(`Affected entries: ${entries.map(e => e.title).join(', ')}`);
     if (errors.length > 0) {
         await (0, github_1.upsertComment)(octokit, config, (0, comment_1.formatValidationErrors)(errors));
         core.setFailed((0, comment_1.formatFailedJobMessage)(errors));
@@ -34535,6 +34535,7 @@ async function runEval() {
         return;
     }
     const tags = [...new Set(entries.flatMap(e => e.tags ?? []))];
+    core.info(`Eval tags: ${tags.join(', ')}`);
     const versionLabel = `pr-${config.prNumber}-${config.headSha.slice(0, 7)}`;
     let mcpVersionId;
     try {

--- a/.github/actions/skill-eval/src/utils/eval.ts
+++ b/.github/actions/skill-eval/src/utils/eval.ts
@@ -47,7 +47,7 @@ export async function runEval(): Promise<void> {
     return;
   }
 
-  core.info(`Affected entries: ${entries.length}`);
+  core.info(`Affected entries: ${entries.map(e => e.title).join(', ')}`);
 
   if (errors.length > 0) {
     await upsertComment(octokit, config, formatValidationErrors(errors));
@@ -84,6 +84,7 @@ export async function runEval(): Promise<void> {
   }
 
   const tags = [...new Set(entries.flatMap(e => e.tags ?? []))];
+  core.info(`Eval tags: ${tags.join(', ')}`);
 
   const versionLabel = `pr-${config.prNumber}-${config.headSha.slice(0, 7)}`;
   let mcpVersionId: string;


### PR DESCRIPTION
## Summary

- Replaces the count-only `Affected entries: N` log with entry titles, so it's clear which entries were detected
- Adds `Eval tags: ...` log after tag deduplication, so it's visible what will trigger scenarios in EvalForge

## Example output

```
Affected entries: Add Product, Update Product
Eval tags: stores, ecommerce
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)