### PR TITLE
feat(wix-design-system): batch components command and multi-word search fix

### DIFF
--- a/skills/wix-design-system/SKILL.md
+++ b/skills/wix-design-system/SKILL.md
@@ -15,8 +15,9 @@ This skill bundles `scripts/wds.cjs` — a Node.js helper that auto-discovers `@
 # WDS is the absolute path to this skill's scripts/wds.cjs
 WDS="<this-skill-dir>/scripts/wds.cjs"
 
-node $WDS search <keyword>                # Find components by keyword
-node $WDS component <Name>                 # Get props + example list
+node $WDS search <keyword>                 # Find components by keyword
+node $WDS component <Name>                 # Get props + example list (one component)
+node $WDS components <Name1> <Name2>...    # Same as `component`, but for several at once
 node $WDS example <Name> "<ExampleName>"   # Get a specific example
 node $WDS testkit <Name> [method]          # Get testkit imports + driver API
 node $WDS icons <query>                    # Search for icons
@@ -41,6 +42,14 @@ node $WDS component Button
 ```
 
 Returns the full props list (types and descriptions) plus a list of all available examples. For large prop files (>200 lines), returns a summary with prop names and types.
+
+If you already know which several components you'll need (e.g. after Step 1 returned a shortlist), prefer the batch form to avoid one round-trip per component:
+
+```bash
+node $WDS components Button Card Table Input Text Thumbnail
+```
+
+Output is each component's props block separated by `---`. Missing components are logged to stderr and skipped; the command only fails if every requested component is missing.
 
 ### Step 3: Get a specific example
 

--- a/skills/wix-design-system/scripts/wds.cjs
+++ b/skills/wix-design-system/scripts/wds.cjs
@@ -4,12 +4,14 @@
  * WDS Documentation Helper
  *
  * Auto-discovers @wix/design-system in node_modules and provides
- * fast, focused lookups for components, props, examples, and icons
+ * fast, focused lookups for components, props, examples, and icons.
  *
  * Usage:
  *   node <path-to>/wds.cjs search <keyword>
  *   node <path-to>/wds.cjs component <Name>
+ *   node <path-to>/wds.cjs components <Name1> <Name2>...
  *   node <path-to>/wds.cjs example <Name> <ExampleName>
+ *   node <path-to>/wds.cjs testkit <Name> [method]
  *   node <path-to>/wds.cjs icons <query>
  */
 
@@ -92,7 +94,14 @@ function escapeRegex(str) {
 }
 
 function buildTermsPattern(args) {
-  return args.map((a) => escapeRegex(a)).join("|");
+  // Tolerate both `search foo bar` (separate args) and `search "foo bar"`
+  // (single quoted arg). Without the split, a single quoted string becomes a
+  // literal-phrase match instead of OR-of-words and silently returns nothing.
+  return args
+    .flatMap((a) => a.split(/\s+/))
+    .filter(Boolean)
+    .map(escapeRegex)
+    .join("|");
 }
 
 function validateComponentName(name) {
@@ -154,12 +163,9 @@ function cmdSearch(docsDir, terms) {
   }
 }
 
-function cmdComponent(docsDir, componentName) {
-  if (!componentName) {
-    console.error("Usage: wds.cjs component <ComponentName>");
-    console.error("Example: wds.cjs component Button");
-    process.exit(1);
-  }
+// Renders one component's props + examples list. Returns true on success,
+// false if the component wasn't found (so batch callers can keep going).
+function printComponent(docsDir, componentName) {
   validateComponentName(componentName);
 
   const componentsDir = path.join(docsDir, "components");
@@ -172,7 +178,7 @@ function cmdComponent(docsDir, componentName) {
     console.error(
       `Component "${componentName}" not found. Run: wds.cjs search <keyword>`
     );
-    process.exit(1);
+    return false;
   }
 
   const propsLines = propsContent.split("\n");
@@ -226,6 +232,67 @@ function cmdComponent(docsDir, componentName) {
       );
     }
   }
+
+  return true;
+}
+
+function cmdComponent(docsDir, componentName) {
+  if (!componentName) {
+    console.error("Usage: wds.cjs component <ComponentName>");
+    console.error("Example: wds.cjs component Button");
+    process.exit(1);
+  }
+  if (!printComponent(docsDir, componentName)) {
+    process.exit(1);
+  }
+}
+
+// Cheap pre-check so cmdComponents can decide whether to emit a `---`
+// separator before invoking the actual renderer. Avoids stale separators
+// when a middle component is missing.
+function componentExists(docsDir, componentName) {
+  if (!/^[A-Za-z0-9]+$/.test(componentName)) return false;
+  return fs.existsSync(
+    path.join(docsDir, "components", `${componentName}Props.md`)
+  );
+}
+
+function cmdComponents(docsDir, args) {
+  // Accept either `components Button Card` or `components "Button Card"`.
+  const names = args.flatMap((a) => a.split(/\s+/)).filter(Boolean);
+
+  if (names.length === 0) {
+    console.error("Usage: wds.cjs components <Name1> [Name2] [Name3]...");
+    console.error("Example: wds.cjs components Button Card Table");
+    process.exit(1);
+  }
+
+  let printedAny = false;
+  let anyFailed = false;
+  for (const name of names) {
+    // Match the single-component flow: invalid names get a distinct error
+    // instead of being lumped under "not found".
+    if (!/^[A-Za-z0-9]+$/.test(name)) {
+      console.error(
+        `Invalid component name "${name}". Names may only contain letters and digits.`
+      );
+      anyFailed = true;
+      continue;
+    }
+    if (!componentExists(docsDir, name)) {
+      console.error(
+        `Component "${name}" not found. Run: wds.cjs search <keyword>`
+      );
+      anyFailed = true;
+      continue;
+    }
+    if (printedAny) console.log("\n---\n");
+    printComponent(docsDir, name);
+    printedAny = true;
+  }
+
+  // Exit non-zero only if every requested component failed.
+  if (anyFailed && !printedAny) process.exit(1);
 }
 
 function cmdExample(docsDir, componentName, exampleName) {
@@ -406,6 +473,7 @@ function cmdHelp(docsDir) {
 Usage:
   node ${scriptPath} search <keyword>              Search components by keyword
   node ${scriptPath} component <Name>              Get props + example list
+  node ${scriptPath} components <Name1> <Name2>... Get props + example list for multiple components in one call
   node ${scriptPath} example <Name> "<ExampleName>" Get a specific example
   node ${scriptPath} testkit <Name> [method]       Get testkit imports + API (or one method)
   node ${scriptPath} icons <query>                 Search for icons
@@ -414,6 +482,7 @@ Examples:
   node ${scriptPath} search table list
   node ${scriptPath} search form input validation
   node ${scriptPath} component Button
+  node ${scriptPath} components Button Card Table Input
   node ${scriptPath} example Button "Loading state"
   node ${scriptPath} testkit Button
   node ${scriptPath} testkit Button click
@@ -443,6 +512,9 @@ switch (command) {
     break;
   case "component":
     cmdComponent(docsDir, args[0]);
+    break;
+  case "components":
+    cmdComponents(docsDir, args);
     break;
   case "example":
     cmdExample(docsDir, args[0], args.slice(1).join(" "));


### PR DESCRIPTION
## Summary

- New `components <Name1> <Name2>...` command renders props + examples for several components in one call, separated by `---`. Tolerant: missing components are skipped with a stderr warning, the command exits non-zero only when *every* requested component is missing.
- `buildTermsPattern` now flattens CLI args with `split(/\s+/)` so `search "foo bar"` and `search foo bar` both produce the documented OR-of-words match. Previously a single quoted string became a literal-phrase match and silently returned nothing.
- Extracted `printComponent` helper out of `cmdComponent` so the batch command can reuse the single-component renderer without duplication.

## Why

The single-component flow forces one round-trip per component, which is wasteful when the caller already has a shortlist (e.g. after `search` returned several candidates). The batch form cuts that to one call.

The quoted-search bug was silent — users typing `search "form input"` got an empty result with no indication that the multi-word form behaves differently from the documented OR semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)