### PR TITLE
fix(codex): add marketplace index

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "wix",
+  "interface": {
+    "displayName": "Wix"
+  },
+  "plugins": [
+    {
+      "name": "wix",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ In [Claude Code](https://docs.anthropic.com/en/docs/claude-code), run:
 
 ### Codex Plugin
 
-This repository includes a Codex plugin manifest at `.codex-plugin/plugin.json`.
-Add this repository as a local/source plugin in Codex to load the Wix skills and Wix MCP server.
+In Codex, run:
+
+```bash
+codex plugin marketplace add wix/skills
+```
+
+Then open `/plugins` and enable the Wix plugin to load the Wix skills and Wix MCP server.
 
 ### VS Code Plugin
 


### PR DESCRIPTION
## What
- Add `.agents/plugins/marketplace.json` so Codex can discover the Wix plugin from the marketplace.
- Update the Codex installation instructions to use `codex plugin marketplace add wix/skills` and `/plugins`.

## Why
`codex plugin marketplace add wix/skills` registers the marketplace source, but Codex needs a marketplace index to display the Wix plugin in `/plugins`.

## Testing
- Parsed `.agents/plugins/marketplace.json` and `.codex-plugin/plugin.json` with Node.
- Verified the marketplace entry points to an existing plugin manifest.
- Ran `git diff --check`.
- No package manager files are present, so there are no build/test/lint/typecheck scripts to run.
