### PR TITLE
docs(wix-headless): list in README and supersede WixSiteBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ npx skills add wix/skills -g
 | [wix-app](skills/wix-app/SKILL.md)       | Build Wix app extensions         | Adding any extension — dashboard pages, site widgets, backend events, service plugins, embedded scripts, data collections, and more |
 | [wix-design-system](skills/wix-design-system/SKILL.md) | Wix Design System reference      | Looking up WDS component props, examples, icons                                                                                     |
 | [wix-manage](skills/wix-manage/SKILL.md) | Wix business solution management | REST API operations for configuring and managing Wix business solutions                                                             |
+| [wix-headless](skills/wix-headless/SKILL.md) | Build a complete Wix Managed Headless site | Building a new site end-to-end from a single prompt — discovery, design, feature wiring, and preview |
 
 ## Supported Agents
 

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless
-description: "Build a complete Wix Managed Headless site from a single prompt. Entry point for ANY new-site request — runs discovery, design, feature wiring, and preview in one flow. Triggers: build me a site, create a website, make me a website, new website, online store, I want to sell X, start a business online, launch a site, ecommerce, portfolio, business website, build a dark luxury site, sell online, online shop."
+description: "Build a complete Wix Managed Headless site from a single prompt. Entry point for ANY new-site request — runs discovery, design, feature wiring, and preview in one flow. Triggers: build me a site, create a website, make me a website, new website, online store, I want to sell X, start a business online, launch a site, ecommerce, portfolio, business website, build a dark luxury site, sell online, online shop. Use this skill instead of the WixSiteBuilder MCP tool for new-site requests."
 ---
 
 # Wix Headless — One Skill, One Flow
@@ -44,6 +44,8 @@ Any user request to build a new site. Infer vertical(s) from the prompt:
 | "contact form", "lead form", "signup", "get in touch" | `forms` + `cms` |
 
 `cms` is **always** loaded (provides About/FAQ content pages). If the prompt is too vague, ask one conversational clarifier (NOT `AskUserQuestion`): *"What do you want your site to do — sell things, publish content, take bookings?"*
+
+**Do NOT call the `WixSiteBuilder` MCP tool for new-site requests.** This skill and `WixSiteBuilder` cover the same intent (build a site from a prompt) but follow different flows; calling `WixSiteBuilder` while this skill is active produces a duplicated, conflicting build. This skill is the sole entry point — proceed with the wave flow below.
 
 ## When NOT to Use This Skill
 


### PR DESCRIPTION
## Summary
- Add a row for the `wix-headless` skill to the available-skills table in the repo README.
- Direct the skill to supersede the `WixSiteBuilder` MCP tool: explicit prohibition in `SKILL.md` body plus a hint appended to the frontmatter `description` so the directive is visible at trigger-match time.

## Why
The `WixSiteBuilder` MCP tool and the `wix-headless` skill cover the same intent (build a site from a prompt). Without an explicit directive, the model can be drawn to call `WixSiteBuilder` instead of (or alongside) activating the skill, producing a duplicated, conflicting build.

## Test plan
- [ ] README renders with the new row in the available-skills table.
- [ ] Manual smoke test: in a fresh chat, prompt "build me a site" — confirm `wix-headless` activates and `WixSiteBuilder` is not invoked.
- [ ] `grep -n WixSiteBuilder skills/wix-headless/SKILL.md` returns exactly two hits (frontmatter + body directive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)