### PR TITLE
feat(wix-headless): expose skill via Claude Code and Cursor plugins

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,7 +13,8 @@
   "skills": [
     "./skills/wix-design-system",
     "./skills/wix-app",
-    "./skills/wix-manage"
+    "./skills/wix-manage",
+    "./skills/wix-headless"
   ],
   "mcpServers": "./.mcp.json"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -14,7 +14,8 @@
   "skills": [
     "./skills/wix-design-system",
     "./skills/wix-app",
-    "./skills/wix-manage"
+    "./skills/wix-manage",
+    "./skills/wix-headless"
   ],
   "logo": "assets/logo.svg"
 }


### PR DESCRIPTION
## Summary

- Adds `./skills/wix-headless` to the explicit `skills` allowlists in `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`, exposing the skill to Claude Code and Cursor.
- Codex (`./skills/`) and Gemini CLI (no `skills` field) already auto-discover the skill, so no changes are needed there.
- Completes step 1 of the "Shipping wix-headless later" checklist from #169; step 2 (README table row) was already merged in #188.

## Test plan

- [ ] Install the plugin in Claude Code and confirm `wix-headless` appears in the skills list
- [ ] Install the plugin in Cursor and confirm `wix-headless` is loaded
- [ ] Spot-check Codex and Gemini CLI still auto-discover the skill (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)