### PR TITLE
fix(editor-react-component): add dependency install step to component creation workflow

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -36,6 +36,8 @@ File where you can override the generated manifest from `<componentName>.generat
    `npx wix generate --params '{"extensionType":"EDITOR_REACT_COMPONENT","name":"ComponentName","folder":"component-name","description":"A brief description of what the component does"}'` to scaffold it. Skip this
    step when iterating on an existing component — re-running it would
    return "an extension already exist" error.
+2. Run the following script to verify that the component dependencies are installed properly:
+`[[ -d "node_modules/@wix/react-component-schema" && -d "node_modules/@wix/react-component-utils" && -d "node_modules/@wix/editor-react-types" ]] || ([ -f yarn.lock ] && yarn add @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types || npm install @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types)`
 2. Edit the generated react and CSS files in
    `src/site/components/ComponentName/`.
 3. Run `npx wix build && npx wix generate manifest` so the editor picks up

--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -38,12 +38,12 @@ File where you can override the generated manifest from `<componentName>.generat
    return "an extension already exist" error.
 2. Run the following script to verify that the component dependencies are installed properly:
 `[[ -d "node_modules/@wix/react-component-schema" && -d "node_modules/@wix/react-component-utils" && -d "node_modules/@wix/editor-react-types" ]] || ([ -f yarn.lock ] && yarn add @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types || npm install @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types)`
-2. Edit the generated react and CSS files in
+3. Edit the generated react and CSS files in
    `src/site/components/ComponentName/`.
-3. Run `npx wix build && npx wix generate manifest` so the editor picks up
+4. Run `npx wix build && npx wix generate manifest` so the editor picks up
    the new/updated prop schema. This command regenerates manifest
    parts for all components.
-4. Update `Component.extensions.ts` file according to [`editor-react-component/COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md)
+5. Update `Component.extensions.ts` file according to [`editor-react-component/COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md)
 
 Reference: when modifying an _existing_ component, follow
 [`editor-react-component/EDIT-FLOW.md`](editor-react-component/EDIT-FLOW.md).


### PR DESCRIPTION
Inserts a new step after scaffolding that checks for and installs `@wix/react-component-schema`, `@wix/react-component-utils`, and `@wix/editor-react-types` if missing. The script auto-detects Yarn vs npm.