### PR TITLE
fix: authenticate sync-wds-skill via GitHub App instead of PAT

### DIFF
--- a/.github/workflows/sync-wds-skill.yml
+++ b/.github/workflows/sync-wds-skill.yml
@@ -15,9 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      - name: Mint App token for wix-private read access
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.SYNC_APP_INSTALLATION_ID }}
+
       - name: Sync WDS skill from private repo
         env:
-          GH_TOKEN: ${{ secrets.WIX_PRIVATE_CODING_AGENTS_PLUGINS_READ_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           chmod +x .github/scripts/sync-wds-skill.sh
           ./.github/scripts/sync-wds-skill.sh

--- a/.github/workflows/sync-wds-skill.yml
+++ b/.github/workflows/sync-wds-skill.yml
@@ -17,11 +17,12 @@ jobs:
 
       - name: Mint App token for wix-private read access
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.SYNC_APP_ID }}
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          installation-id: ${{ secrets.SYNC_APP_INSTALLATION_ID }}
+          owner: wix-private
+          repositories: coding-agents-plugins
 
       - name: Sync WDS skill from private repo
         env:


### PR DESCRIPTION
## Summary

Every scheduled run of `sync-wds-skill` has been failing with `gh: Not Found (HTTP 404)` since merge. Root cause: `secrets.WIX_PRIVATE_CODING_AGENTS_PLUGINS_READ_TOKEN` is a user PAT that was never approved against `wix-private`'s SSO/SAML allowlist (per [#github-tools-support guidance](https://wix.slack.com/archives/C6RGENSJH/p1778160288327909?thread_ts=1777902541.982179): *"PAT isn't approved currently — you should use a github app"*).

This PR replaces the PAT auth with a GitHub App installation token. The App is installed on `wix-private` with read permissions on `coding-agents-plugins`, so the minted token can read the upstream skill without going through SSO.

## What changed

One step added (`Mint App token for wix-private read access`) using `actions/create-github-app-token@1b10c78` (v3.1.1, SHA-pinned). The existing sync step now consumes `steps.app-token.outputs.token` as `GH_TOKEN`. The sync script and PR-creation step are untouched — the App token is a drop-in for the PAT.

`runs-on: ubuntu-latest` and the rest of the workflow are unchanged.

### Why this action / version

- **Not blocked on `wix/skills`**: a prior attempt on 2026-05-04 (run [25321974657](https://github.com/wix/skills/actions/runs/25321974657)) loaded this action successfully — the action wasn't allowlist-blocked. That run failed only at installation auto-discovery (the App at that time wasn't installed on `wix-private/coding-agents-plugins`), which is exactly what the new App fixes.
- **v3.1.1**: latest stable, removes the `app-id` deprecation warning by using `client-id` instead.
- **Auto-discovery via `owner` + `repositories`**: the action doesn't accept an `installation-id` input; it resolves the installation from owner+repo automatically (calls `GET /repos/wix-private/coding-agents-plugins/installation`).

## Required before merge

Two repo secrets must be configured on `wix/skills`:

| Name | Value | Where to find it |
|---|---|---|
| `SYNC_APP_CLIENT_ID` | App **Client ID** (looks like `Iv23…`) | GitHub App settings page → "Client ID" field |
| `SYNC_APP_PRIVATE_KEY` | PEM contents (`-----BEGIN…END-----`, newlines preserved, no base64) | GitHub App settings → Private keys → "Generate a private key" → downloaded `.pem` |

(`SYNC_APP_INSTALLATION_ID` is **not** needed — the action discovers the installation from owner + repositories.)

## Test plan

- [ ] Add the two secrets above.
- [ ] Manually dispatch: `gh workflow run sync-wds-skill.yml --repo wix/skills`.
- [ ] Confirm the `Mint App token` step succeeds and the `Sync WDS skill` step walks the upstream tree without 404s.
- [ ] If no upstream changes: run ends with *"No changes detected — already in sync."* (expected).
- [ ] After two consecutive successful scheduled runs, delete the obsolete `WIX_PRIVATE_CODING_AGENTS_PLUGINS_READ_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)