### PR TITLE
Dummy commit - test the WDS sync mechanism

### DIFF
--- a/skills/wix-design-system/scripts/wds.cjs
+++ b/skills/wix-design-system/scripts/wds.cjs
@@ -4,7 +4,7 @@
  * WDS Documentation Helper
  *
  * Auto-discovers @wix/design-system in node_modules and provides
- * fast, focused lookups for components, props, examples, and icons.
+ * fast, focused lookups for components, props, examples, and icons
  *
  * Usage:
  *   node <path-to>/wds.cjs search <keyword>


### PR DESCRIPTION
Removes a trailing period from a doc comment to create a diff vs. upstream `wix-private/coding-agents-plugins/skills/wds-docs`. Next `Sync WDS Skill` workflow run should detect the diff and open a PR restoring upstream content.