### PR TITLE
Dummy commit #2 - test WDS sync (diverge from upstream)

### DIFF
--- a/skills/wix-design-system/scripts/wds.cjs
+++ b/skills/wix-design-system/scripts/wds.cjs
@@ -4,7 +4,7 @@
  * WDS Documentation Helper
  *
  * Auto-discovers @wix/design-system in node_modules and provides
- * fast, focused lookups for components, props, examples, and icons
+ * fast, focused lookups for components, props, examples, and icons.
  *
  * Usage:
  *   node <path-to>/wds.cjs search <keyword>


### PR DESCRIPTION
Adds a trailing period to a doc comment in `skills/wix-design-system/scripts/wds.cjs`. Upstream has no period, so the next sync run should detect the diff and open a PR to restore upstream.