### PR TITLE
fix(sync-wds-skill): correct REPO_ROOT to repo root, not .github

### DIFF
--- a/.github/scripts/sync-wds-skill.sh
+++ b/.github/scripts/sync-wds-skill.sh
@@ -7,7 +7,7 @@ LOCAL_PATH="skills/wix-design-system"
 LOCAL_SKILL_NAME="wix-design-system"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 fetch_file() {
   local remote_path="$1"


### PR DESCRIPTION
## Bug

`.github/scripts/sync-wds-skill.sh` computes `REPO_ROOT` by going up **one** directory from the script's location:

\`\`\`bash
SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"   # <repo>/.github/scripts
REPO_ROOT="\$(cd "\$SCRIPT_DIR/.." && pwd)"      # <repo>/.github  ← wrong
\`\`\`

It needs to go up **two**: \`scripts → .github → <repo>\`.

## Effect

Every file written via \`sync_file\` lands under \`<repo>/.github/skills/wix-design-system/...\` — a junk path that GitHub Actions discards at job teardown. The real \`skills/wix-design-system/\` is **never touched**, so the workflow's \`git diff -- skills/wix-design-system\` is always clean, \`has_changes\` is always \`false\`, and **no sync PR is ever opened** — even when upstream drifts.

The workflow has been "passing" green this whole time without actually syncing anything.

## Repro

Reproduced locally on a fresh clone of \`main\` (9c80900):

\`\`\`
$ bash .github/scripts/sync-wds-skill.sh
Syncing WDS skill from wix-private/coding-agents-plugins/skills/wds-docs → skills/wix-design-system
  Syncing SKILL.md
  Syncing references/file-structure.md
  Syncing scripts/wds.cjs
No changes detected — already in sync.

$ ls .github/skills/wix-design-system/    # junk tree created by the script
references  scripts  SKILL.md

$ git status -s skills/wix-design-system/  # real path untouched
$
\`\`\`

Also reproduced live in workflow run \`25734975435\` against PR #200 (which removed a trailing period in \`SKILL.md\` line 8, diverging from upstream): run reported "no changes" despite a real divergence.

## Fix

One char: \`\$SCRIPT_DIR/..\` → \`\$SCRIPT_DIR/../..\`.

## After merge

Trigger the workflow manually to verify it now produces a sync PR (PR #200's edit will still be diverging from upstream until the next sync PR lands).