### PR TITLE
docs: clarify skill contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Read and follow `CONTRIBUTING.md` before editing this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Most new content should fit into one of the existing skill folders:
 - `skills/wix-design-system/` — Wix Design System component, API, and reference guidance.
 - `skills/wix-headless/` — one-prompt headless site builds, templates, orchestration, and vertical-specific implementation guidance.
 
-In this repo, many requests to add a "new skill" should actually be added as a new skill reference inside an existing skill. Add a new top-level skill only when the content cannot reasonably belong to an existing skill and a maintainer has agreed to that structure.
+In this repo, many requests to add a "new skill" should actually be added as a new skill reference inside an existing skill. New top-level skills should only be added by repository admins.
 
 ## Adding a Wix Manage Skill
 
@@ -62,7 +62,7 @@ Use evaluation as a loop, not a one-time check. Review the failures, tighten the
 
 Before opening a PR, confirm:
 
-- The content is in the right existing skill, or a maintainer approved a new top-level skill.
+- The content is in the right existing skill. New top-level skills are admin-only.
 - The relevant `SKILL.md` index is updated.
 - Any new `wix-manage` skill is listed in the relevant `yaml/wix-manage/<area>/documentation.yaml`.
 - Wix API details were checked against official docs through the Wix MCP docs tools, or distilled from a successful agent run.
@@ -74,5 +74,5 @@ Before opening a PR, confirm:
 If you're unsure about where to place new content or how to structure it:
 
 - Review existing skills for patterns.
-- Open an issue or ask a maintainer before adding a new top-level skill.
+- Ask a repository admin if you think a new top-level skill is required.
 - Refer to the [Agent Skills specification](https://agentskills.io/home) for base format requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,91 @@
-# Contributing to skills
+# Contributing to Skills
 
-Thank you for your interest in contributing to skills! This document provides Wix-specific guidelines for adding new skills to this repository.
+Thank you for your interest in contributing to skills. This document provides Wix-specific guidelines for adding and updating skill content in this repository.
 
 > **Note:** For general Agent Skills format requirements, see the [Agent Skills specification](https://agentskills.io/home).
 
-## Adding New Skills
+## Skill Placement
 
-When adding new skills, follow these best practices:
+Do not add a new top-level folder under `skills/` by default.
 
-### Skill Documentation (SKILL.md)
+Most new content should fit into one of the existing skill folders:
 
-Follow the [Agent Skills specification](https://agentskills.io/home) for the base format.
+- `skills/wix-manage/` — REST API recipes for managing Wix business solutions, sites, account-level resources, and administrative workflows.
+- `skills/wix-app/` — building Wix app extensions, service plugins, dashboard pages, site widgets, backend code, and CLI-based app development.
+- `skills/wix-design-system/` — Wix Design System component, API, and reference guidance.
+- `skills/wix-headless/` — one-prompt headless site builds, templates, orchestration, and vertical-specific implementation guidance.
 
-## Questions?
+In this repo, many requests to add a "new skill" should actually be added as a new skill reference or recipe inside an existing skill. Add a new top-level skill only when the content cannot reasonably belong to an existing skill and a maintainer has agreed to that structure.
 
-If you're unsure about where to place a new skill or how to structure it, please:
-- Review existing skills for patterns
-- Open an issue to discuss the contribution
-- Refer to the [Agent Skills specification](https://agentskills.io/home) for format requirements
+## Adding a Wix Manage Recipe
 
-Thank you for contributing!
+Use `wix-manage` for REST API operations that configure, set up, or manage Wix business entities and account/site resources.
+
+When adding a `wix-manage` recipe:
+
+1. Add the recipe markdown under `skills/wix-manage/references/<area>/<recipe>.md`.
+2. Add a short entry to the relevant section in `skills/wix-manage/SKILL.md`.
+3. Add the recipe to `yaml/wix-manage/<area>/documentation.yaml`.
+4. Include at least one valid EvalForge tag, for example `domains`, `stores`, `bookings`, or another existing tag that matches the recipe.
+5. Keep the recipe focused on public Wix REST APIs or documented SDK APIs. Do not translate internal gRPC names or internal-only APIs into public recipes.
+
+## Writing Wix API Recipes
+
+Validate API recipes against the Wix MCP docs tools before opening a PR. Do not rely on memory, copied internal service names, or old examples.
+
+Recommended workflow:
+
+1. Use `WixREADME` to find existing recipes and the right category.
+2. Use `SearchWixRESTDocumentation` to find the relevant REST method.
+3. Use `ReadFullDocsArticle` for method behavior and examples.
+4. Use `ReadFullDocsMethodSchema` for exact endpoint paths, request fields, response fields, enum values, and permissions.
+
+Verify every API detail the recipe depends on:
+
+- HTTP method and full endpoint path.
+- Whether the API is account-level or site-level, and which headers are required.
+- Required permissions/scopes.
+- Request body shape and required fields.
+- Response fields used by the recipe.
+- Enum values such as statuses, types, and modes.
+- Documented error codes and failure cases.
+
+Prefer method schemas over examples when they disagree. Examples can be incomplete or stale; the method schema is the source of truth for field names, required fields, and enum values. If a recipe depends on a field that appears in examples or sample flows but not in the method schema, call that out in the recipe or verify it with the API owner before relying on it.
+
+For mutating flows, ask for user confirmation before changing site or account data unless the surrounding recipe already makes the mutation an explicit user-confirmed action.
+
+## Skill Evaluation
+
+The automated skill evaluation currently runs for PR changes under:
+
+- `skills/wix-manage/references/**`
+- `yaml/wix-manage/**`
+
+The YAML entry is how a changed recipe maps to EvalForge tags and scenarios. If a `wix-manage` recipe is not added to `yaml/wix-manage/<area>/documentation.yaml`, it may not be evaluated.
+
+When the workflow runs, it creates an EvalForge MCP capability version that points at the PR:
+
+```text
+https://mcp.wix.com/mcp?skillsRepo=wix/skills&skillsPr=<headSha>
+```
+
+That PR override makes the Wix MCP load skill content from the pull request instead of from `main`, so eval scenarios test the proposed recipe content.
+
+## PR Checklist
+
+Before opening a PR, confirm:
+
+- The content is in the right existing skill, or a maintainer approved a new top-level skill.
+- The relevant `SKILL.md` index is updated.
+- Any new `wix-manage` recipe is listed in the relevant `yaml/wix-manage/<area>/documentation.yaml`.
+- Wix API endpoints, schemas, permissions, request bodies, response fields, and enum values were checked against the Wix MCP docs tools.
+- Mutating flows ask for user confirmation before changing site or account data.
+- The skill evaluation workflow is expected to run for the changed files, if applicable.
+
+## Questions
+
+If you're unsure about where to place new content or how to structure it:
+
+- Review existing skills for patterns.
+- Open an issue or ask a maintainer before adding a new top-level skill.
+- Refer to the [Agent Skills specification](https://agentskills.io/home) for base format requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,26 +31,11 @@ When adding a `wix-manage` recipe:
 
 ## Writing Wix API Recipes
 
-Validate API recipes against the Wix MCP docs tools before opening a PR. Do not rely on memory, copied internal service names, or old examples.
+Connect an agent to the Wix MCP and use official docs, examples, and method schemas to verify any API recipe. Do not rely on memory, copied internal service names, or old examples.
 
-Recommended workflow:
+The best source for a recipe is often a real agent conversation where the agent successfully completed the task. After the task works, ask the agent to distill the happy path, the API details it had to discover, and the missing context it needed to know up front.
 
-1. Use `WixREADME` to find existing recipes and the right category.
-2. Use `SearchWixRESTDocumentation` to find the relevant REST method.
-3. Use `ReadFullDocsArticle` for method behavior and examples.
-4. Use `ReadFullDocsMethodSchema` for exact endpoint paths, request fields, response fields, enum values, and permissions.
-
-Verify every API detail the recipe depends on:
-
-- HTTP method and full endpoint path.
-- Whether the API is account-level or site-level, and which headers are required.
-- Required permissions/scopes.
-- Request body shape and required fields.
-- Response fields used by the recipe.
-- Enum values such as statuses, types, and modes.
-- Documented error codes and failure cases.
-
-Prefer method schemas over examples when they disagree. Examples can be incomplete or stale; the method schema is the source of truth for field names, required fields, and enum values. If a recipe depends on a field that appears in examples or sample flows but not in the method schema, call that out in the recipe or verify it with the API owner before relying on it.
+Before adding skill guidance, first ask whether the fix belongs in the public API, docs, examples, or MCP docs surface. Add a skill recipe only when those sources are correct but still do not connect the dots for an agent. Keep that recipe minimal: document the decision flow, the verified API details, and the sharp edges needed to complete the task.
 
 For mutating flows, ask for user confirmation before changing site or account data unless the surrounding recipe already makes the mutation an explicit user-confirmed action.
 
@@ -78,7 +63,7 @@ Before opening a PR, confirm:
 - The content is in the right existing skill, or a maintainer approved a new top-level skill.
 - The relevant `SKILL.md` index is updated.
 - Any new `wix-manage` recipe is listed in the relevant `yaml/wix-manage/<area>/documentation.yaml`.
-- Wix API endpoints, schemas, permissions, request bodies, response fields, and enum values were checked against the Wix MCP docs tools.
+- Wix API details were checked against official docs through the Wix MCP docs tools, or distilled from a successful agent run.
 - Mutating flows ask for user confirmation before changing site or account data.
 - The skill evaluation workflow is expected to run for the changed files, if applicable.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,34 +10,34 @@ Do not add a new top-level folder under `skills/` by default.
 
 Most new content should fit into one of the existing skill folders:
 
-- `skills/wix-manage/` — REST API recipes for managing Wix business solutions, sites, account-level resources, and administrative workflows.
+- `skills/wix-manage/` — REST API skills for managing Wix business solutions, sites, account-level resources, and administrative workflows.
 - `skills/wix-app/` — building Wix app extensions, service plugins, dashboard pages, site widgets, backend code, and CLI-based app development.
 - `skills/wix-design-system/` — Wix Design System component, API, and reference guidance.
 - `skills/wix-headless/` — one-prompt headless site builds, templates, orchestration, and vertical-specific implementation guidance.
 
-In this repo, many requests to add a "new skill" should actually be added as a new skill reference or recipe inside an existing skill. Add a new top-level skill only when the content cannot reasonably belong to an existing skill and a maintainer has agreed to that structure.
+In this repo, many requests to add a "new skill" should actually be added as a new skill reference inside an existing skill. Add a new top-level skill only when the content cannot reasonably belong to an existing skill and a maintainer has agreed to that structure.
 
-## Adding a Wix Manage Recipe
+## Adding a Wix Manage Skill
 
 Use `wix-manage` for REST API operations that configure, set up, or manage Wix business entities and account/site resources.
 
-When adding a `wix-manage` recipe:
+When adding a `wix-manage` skill:
 
-1. Add the recipe markdown under `skills/wix-manage/references/<area>/<recipe>.md`.
+1. Add the skill markdown under `skills/wix-manage/references/<area>/<skill>.md`.
 2. Add a short entry to the relevant section in `skills/wix-manage/SKILL.md`.
-3. Add the recipe to `yaml/wix-manage/<area>/documentation.yaml`.
-4. Include at least one valid EvalForge tag, for example `domains`, `stores`, `bookings`, or another existing tag that matches the recipe.
-5. Keep the recipe focused on public Wix REST APIs or documented SDK APIs. Do not translate internal gRPC names or internal-only APIs into public recipes.
+3. Add the skill to `yaml/wix-manage/<area>/documentation.yaml`.
+4. Include at least one valid EvalForge tag, for example `domains`, `stores`, `bookings`, or another existing tag that matches the skill.
+5. Keep the skill focused on public Wix REST APIs or documented SDK APIs. Do not translate internal gRPC names or internal-only APIs into public skills.
 
-## Writing Wix API Recipes
+## Writing Wix API Skills
 
-Connect an agent to the Wix MCP and use official docs, examples, and method schemas to verify any API recipe. Do not rely on memory, copied internal service names, or old examples.
+Connect an agent to the Wix MCP and use official docs, examples, and method schemas to verify any API skill. Do not rely on memory, copied internal service names, or old examples.
 
-The best source for a recipe is often a real agent conversation where the agent successfully completed the task. After the task works, ask the agent to distill the happy path, the API details it had to discover, and the missing context it needed to know up front.
+The best source for a skill is often a real agent conversation where the agent successfully completed the task. After the task works, ask the agent to distill the happy path, the API details it had to discover, and the missing context it needed to know up front.
 
-Before adding skill guidance, first ask whether the fix belongs in the public API, docs, examples, or MCP docs surface. Add a skill recipe only when those sources are correct but still do not connect the dots for an agent. Keep that recipe minimal: document the decision flow, the verified API details, and the sharp edges needed to complete the task.
+Before adding skill guidance, first ask whether the fix belongs in the public API, docs, examples, or MCP docs surface. Add a skill only when those sources are correct but still do not connect the dots for an agent. Keep the skill minimal: document the decision flow, the verified API details, and the sharp edges needed to complete the task.
 
-For mutating flows, ask for user confirmation before changing site or account data unless the surrounding recipe already makes the mutation an explicit user-confirmed action.
+For mutating flows, ask for user confirmation before changing site or account data unless the surrounding skill already makes the mutation an explicit user-confirmed action.
 
 ## Skill Evaluation
 
@@ -46,7 +46,7 @@ The automated skill evaluation currently runs for PR changes under:
 - `skills/wix-manage/references/**`
 - `yaml/wix-manage/**`
 
-The YAML entry is how a changed recipe maps to EvalForge tags and scenarios. If a `wix-manage` recipe is not added to `yaml/wix-manage/<area>/documentation.yaml`, it may not be evaluated.
+The YAML entry is how a changed skill maps to EvalForge tags and scenarios. If a `wix-manage` skill is not added to `yaml/wix-manage/<area>/documentation.yaml`, it may not be evaluated.
 
 When the workflow runs, it creates an EvalForge MCP capability version that points at the PR:
 
@@ -54,7 +54,9 @@ When the workflow runs, it creates an EvalForge MCP capability version that poin
 https://mcp.wix.com/mcp?skillsRepo=wix/skills&skillsPr=<headSha>
 ```
 
-That PR override makes the Wix MCP load skill content from the pull request instead of from `main`, so eval scenarios test the proposed recipe content.
+That PR override makes the Wix MCP load skill content from the pull request instead of from `main`, so eval scenarios test the proposed skill content.
+
+Use evaluation as a loop, not a one-time check. Review the failures, tighten the skill, and rerun until performance is good enough for the target scenarios.
 
 ## PR Checklist
 
@@ -62,7 +64,7 @@ Before opening a PR, confirm:
 
 - The content is in the right existing skill, or a maintainer approved a new top-level skill.
 - The relevant `SKILL.md` index is updated.
-- Any new `wix-manage` recipe is listed in the relevant `yaml/wix-manage/<area>/documentation.yaml`.
+- Any new `wix-manage` skill is listed in the relevant `yaml/wix-manage/<area>/documentation.yaml`.
 - Wix API details were checked against official docs through the Wix MCP docs tools, or distilled from a successful agent run.
 - Mutating flows ask for user confirmation before changing site or account data.
 - The skill evaluation workflow is expected to run for the changed files, if applicable.


### PR DESCRIPTION
## Summary
- Expand contribution guidance with skill placement rules and `wix-manage` recipe requirements.
- Document Wix MCP docs verification expectations and skill eval PR override behavior.
- Add a minimal `AGENTS.md` pointer to keep `CONTRIBUTING.md` as the single source of truth.

## Test plan
- Docs-only change; reviewed rendered markdown diff locally.