### PR TITLE
feat(wix-headless): merge-site-json.mjs script for deterministic site.json updates

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -85,7 +85,7 @@ If `wix.config.json` is present in the working directory, offer: *"I found an ex
 
 **Phase axis.** Core pipeline: `Phase 1 (Seed) → Phase 2 (Design System) → Phase 3 (Components) → Phase 4 (Pages)`. Image pipeline runs in parallel: Image Phase 1 (Decorative) alongside Phases 1–2; Image Phase 2 (Entity) alongside Phase 3 (depends only on Phase 1 Seed entity IDs + brand). Each Phase 4 agent writes its routes ONCE with both visual design and data queries — no placeholder-then-rewrite split.
 
-**The orchestrator is the only writer of `.wix/site.json`** — it merges each Seeder's `data` block into `seeded.<vertical>` and the Designer's `data.designTokens` block into `designTokens` as subagent results arrive. Subagents never write `site.json` themselves.
+**The orchestrator is the only writer of `.wix/site.json`** — it merges each Seeder's `data` block into `seeded.<vertical>` and the Designer's `data.designTokens` block into `designTokens` as subagent results arrive. Subagents never write `site.json` themselves. Use `scripts/merge-site-json.mjs` for every merge (it deep-merges into the existing path and refuses to descend through non-objects, which makes accidentally clobbering structured state impossible).
 
 ### Batching compliance
 
@@ -146,12 +146,12 @@ See `references/SETUP.md`. After approval, run **one concurrent batch** with no 
    {"brand": {"name": "...", "description": "..."}, "seeded": {}, "designTokens": {}, "verticals": ["..."]}
    ```
 
-   `.wix/site.json` is the single source of truth that every downstream phase reads. Only the orchestrator writes — it merges Seeder `data` into `seeded.<vertical>` and Designer `data.designTokens` into `designTokens` as returns arrive.
+   `.wix/site.json` is the single source of truth that every downstream phase reads. Only the orchestrator writes — it merges Seeder `data` into `seeded.<vertical>` and Designer `data.designTokens` into `designTokens` as returns arrive. Use `scripts/merge-site-json.mjs` for both: e.g. `echo "$STORES_SEED_DATA" | node scripts/merge-site-json.mjs "$(pwd)" --path seeded.stores`.
 
 ## Wave 3 — Seed + Design System + Image Phase 1 (one concurrent batch)
 
 Per loaded vertical:
-- **Phase 1 Seeder subagent (background)**, per vertical's `seed` config. Returns its data via the standard return JSON; orchestrator merges into `.wix/site.json.seeded.<vertical>`.
+- **Phase 1 Seeder subagent (background)**, per vertical's `seed` config. Returns its data via the standard return JSON; orchestrator merges into `.wix/site.json.seeded.<vertical>` via `scripts/merge-site-json.mjs` (see "Bridge: site.json merges" below).
 
 Always:
 - **Image Phase 1 Decorative subagent (background)**. Generates decorative images from brand context only — no Phase 1 Seed dependency. Prompt adds `Scope: image-phase-1-decorative` + page list + **`decorativeSlots: string[]`** (REQUIRED). Compose `decorativeSlots` from the canonical vocabulary in `references/designer/INSTRUCTIONS.md` § common rule #7: always `["hero", "about"]`, plus `"productsHeader"` if stores loaded, plus `"cmsHeader"` if you want a CMS page-header decorative. Designer is restricted to the same vocabulary; the two MUST match exactly.
@@ -170,7 +170,11 @@ The Designer prompt additionally requires:
 
 Phase 2 completes (~2–3 min). Inline orchestrator work, in this exact order:
 
-1. **Merge `data.designTokens` into `.wix/site.json.designTokens`.**
+1. **Merge `data.designTokens` into `.wix/site.json.designTokens`** via:
+   ```bash
+   echo "$DESIGN_TOKENS_JSON" | node "<SKILL_ROOT>/scripts/merge-site-json.mjs" "$(pwd)" --path designTokens
+   ```
+   where `$DESIGN_TOKENS_JSON` is the agent's `data.designTokens` block. The script deep-merges into the existing `designTokens` object so subsequent partial updates (e.g. an additional palette color from a later phase) compose cleanly with the foundation tokens. Wrap in `PHASE_START`/`PHASE_END`; record `{ phase: "merge-site-json-design-tokens", seconds }`.
 2. **`node "<SKILL_ROOT>/scripts/emit-design-tokens.mjs" "$(pwd)"`** — deterministically projects `.wix/site.json.designTokens` → `.wix/design-tokens.css` + `.wix/site.d.ts`. Wrap in `PHASE_START`/`PHASE_END`; record `{ phase: "emit-design-tokens", seconds }`.
 3. **Layout.astro CSS-import verification (mandatory).** Grep the generated `src/layouts/Layout.astro`. For every loaded vertical whose pack declares a `components` entry (stores, ecom, blog, forms), there MUST be a matching `import '../styles/components-<pack>.css'` in the frontmatter. If any is missing, **inline-patch Layout.astro now** — Phase 3 agents write `components-<pack>.css` expecting the designer to have imported it; if forgotten, every React island that uses scoped contract classes renders unstyled.
 

--- a/skills/wix-headless/scripts/merge-site-json.mjs
+++ b/skills/wix-headless/scripts/merge-site-json.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// Deterministically merge a JSON blob into `.wix/site.json` at a dotted path.
+//
+// `.wix/site.json` is the single source of truth that every downstream phase
+// reads. Today the orchestrator merges into it inline — composing the full
+// updated object in scratch and writing the whole file. That's error-prone:
+// it requires the orchestrator to hold the full prior state, JSON-encode it
+// without drift, and serialize a full re-write per merge. This script lets
+// the orchestrator pipe just the new sub-tree and a path target, and the
+// merge runs as a small deterministic node program.
+//
+// Usage:
+//   echo '<json>' | node merge-site-json.mjs <project-dir> --path <dotted.path> [--mode replace|merge]
+//
+// Modes:
+//   --mode merge   (default for objects) — deep-merge stdin into the existing
+//                  value at <path>. Arrays are REPLACED, not concatenated —
+//                  this matches how `seeded.<vertical>.products` should behave
+//                  (a re-run replaces the full product list, not appends to it).
+//   --mode replace — set the value at <path> to stdin verbatim, discarding
+//                  whatever was there before.
+//
+// Path semantics:
+//   - Path is a dot-separated list of object keys: `seeded.stores`,
+//     `designTokens`, `brand.description`.
+//   - Path must reach an object (for --mode merge) or any JSON value (for
+//     --mode replace). Missing intermediate keys are created as empty objects.
+//   - Arrays in the path (e.g. `seeded.stores.products.0.name`) are NOT
+//     supported by design — every current write site is whole-object-shaped.
+//     Numeric path segments are treated as object keys.
+//
+// Examples (matches today's orchestrator merge points):
+//   # After Phase 1 stores seeder returns:
+//   echo "$STORES_SEED_DATA" | node merge-site-json.mjs "$(pwd)" --path seeded.stores
+//
+//   # After Phase 2 designer returns:
+//   echo "$DESIGNER_TOKENS" | node merge-site-json.mjs "$(pwd)" --path designTokens
+//
+// Behavior:
+//   - Refuses to run if .wix/site.json doesn't exist (exit 2) — caller must
+//     have run init-site-json.mjs first.
+//   - Refuses to descend through a non-object intermediate key in --mode merge
+//     (exit 2) — protects against accidentally clobbering structured state.
+//   - Writes site.json atomically (write-then-rename). Pretty-printed,
+//     trailing newline, 2-space indent — matches init-site-json.mjs output.
+//   - Outputs a JSON summary to stdout: {status, path, mode, prevType,
+//     newKeys?}.
+//
+// Exit codes:
+//   0 — merged successfully
+//   2 — argument or input validation failed; site.json untouched
+
+import { readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+const positional = args.filter((a) => !a.startsWith("--"));
+const projectDir = positional[0];
+
+const pathIdx = args.indexOf("--path");
+const dottedPath = pathIdx >= 0 ? args[pathIdx + 1] : undefined;
+
+const modeIdx = args.indexOf("--mode");
+const mode = modeIdx >= 0 ? args[modeIdx + 1] : "merge";
+
+if (!projectDir || !dottedPath) {
+  console.error("usage: cat data.json | merge-site-json.mjs <project-dir> --path <dotted.path> [--mode merge|replace]");
+  process.exit(2);
+}
+
+if (mode !== "merge" && mode !== "replace") {
+  console.error(`merge-site-json: --mode must be "merge" or "replace" (got ${JSON.stringify(mode)})`);
+  process.exit(2);
+}
+
+const sitePath = join(projectDir, ".wix", "site.json");
+if (!existsSync(sitePath)) {
+  console.error(`merge-site-json: ${sitePath} does not exist — run init-site-json.mjs first.`);
+  process.exit(2);
+}
+
+let stdin;
+try {
+  stdin = JSON.parse(readFileSync(0, "utf8"));
+} catch (e) {
+  console.error(`merge-site-json: stdin is not valid JSON (${e.message})`);
+  process.exit(2);
+}
+
+let site;
+try {
+  site = JSON.parse(readFileSync(sitePath, "utf8"));
+} catch (e) {
+  console.error(`merge-site-json: ${sitePath} is not valid JSON (${e.message}). Refusing to overwrite a corrupt file.`);
+  process.exit(2);
+}
+
+const segments = dottedPath.split(".").filter(Boolean);
+if (segments.length === 0) {
+  console.error("merge-site-json: --path resolved to no segments");
+  process.exit(2);
+}
+
+// Walk down to the parent of the final segment, creating empty objects for
+// missing intermediates. Refuse to descend through a non-object in --mode
+// merge — that would silently clobber state.
+let cursor = site;
+for (let i = 0; i < segments.length - 1; i++) {
+  const seg = segments[i];
+  if (cursor[seg] === undefined || cursor[seg] === null) {
+    cursor[seg] = {};
+  } else if (typeof cursor[seg] !== "object" || Array.isArray(cursor[seg])) {
+    console.error(`merge-site-json: cannot descend through non-object at "${segments.slice(0, i + 1).join(".")}" (it is ${Array.isArray(cursor[seg]) ? "an array" : typeof cursor[seg]}). Refusing to overwrite.`);
+    process.exit(2);
+  }
+  cursor = cursor[seg];
+}
+
+const finalKey = segments[segments.length - 1];
+const prev = cursor[finalKey];
+const prevType = prev === undefined ? "undefined" : prev === null ? "null" : Array.isArray(prev) ? "array" : typeof prev;
+
+function deepMerge(target, source) {
+  if (typeof source !== "object" || source === null || Array.isArray(source)) {
+    // Non-mergeable on the source side — caller should've used --mode replace.
+    throw new Error(`stdin must be a plain object for --mode merge (got ${Array.isArray(source) ? "array" : typeof source})`);
+  }
+  if (typeof target !== "object" || target === null || Array.isArray(target)) {
+    // Existing value isn't a plain object — replace rather than merge.
+    return JSON.parse(JSON.stringify(source));
+  }
+  const out = { ...target };
+  for (const [k, v] of Object.entries(source)) {
+    if (
+      typeof v === "object" && v !== null && !Array.isArray(v) &&
+      typeof out[k] === "object" && out[k] !== null && !Array.isArray(out[k])
+    ) {
+      out[k] = deepMerge(out[k], v);
+    } else {
+      // Replace primitives, arrays, and type-mismatches outright.
+      out[k] = Array.isArray(v) ? JSON.parse(JSON.stringify(v)) : v;
+    }
+  }
+  return out;
+}
+
+let newValue;
+let newKeys;
+try {
+  if (mode === "replace") {
+    newValue = stdin;
+    newKeys = stdin && typeof stdin === "object" && !Array.isArray(stdin) ? Object.keys(stdin) : undefined;
+  } else {
+    newValue = deepMerge(prev ?? {}, stdin);
+    newKeys = Object.keys(stdin);
+  }
+} catch (e) {
+  console.error(`merge-site-json: ${e.message}`);
+  process.exit(2);
+}
+
+cursor[finalKey] = newValue;
+
+const tmpPath = sitePath + ".tmp";
+writeFileSync(tmpPath, JSON.stringify(site, null, 2) + "\n");
+renameSync(tmpPath, sitePath);
+
+console.log(JSON.stringify({
+  status: "ok",
+  path: sitePath,
+  mergedPath: dottedPath,
+  mode,
+  prevType,
+  ...(newKeys ? { newKeys } : {}),
+}, null, 2));


### PR DESCRIPTION
## Summary

- New `scripts/merge-site-json.mjs` — takes stdin JSON + dotted `--path`, deep-merges (or replaces with `--mode replace`) into `.wix/site.json` at that path.
- `SKILL.md` updated to reference the script at every existing merge site (Phase 1 seeders → `seeded.<vertical>`, Phase 2 designer → `designTokens`).
- No agent contracts change. This is purely an orchestrator-side helper.

## Why

The orchestrator writes `.wix/site.json` several times per run — once at init (`init-site-json.mjs`), once per Phase 1 Seeder, and once after the Phase 2 designer returns. Today those merges happen inline: the orchestrator holds the full prior state in scratch, composes the updated object, and writes the full file. Every merge requires re-serializing a long JSON tree without drift, which is exactly the kind of work LLMs are bad at.

Observed on a 2026-05 Moran's Bakery build: I composed the full `site.json` (brand + 3-product seed + 6-item FAQ + 17-color design tokens) by hand because there was no helper. Worked, but it's a clear automation gap — and the kind of work a tiny script does perfectly.

## Behavior

- Refuses to run if `.wix/site.json` doesn't exist (caller must run `init-site-json.mjs` first).
- Refuses to descend through a non-object intermediate key in merge mode (protects against accidentally clobbering structured state, e.g. trying to write `brand.name.foo` over a string).
- Deep-merge preserves prior keys; arrays are replaced (not concatenated) — matches the "re-run replaces the product list, doesn't append" expectation.
- Atomic write (write-then-rename), matches `init-site-json.mjs` formatting.

## Canonical invocations

```bash
# After Phase 1 stores seeder returns:
echo "$STORES_SEED_DATA" | node scripts/merge-site-json.mjs "$(pwd)" --path seeded.stores

# After Phase 1 CMS seeder returns:
echo "$CMS_SEED_DATA" | node scripts/merge-site-json.mjs "$(pwd)" --path seeded.cms

# After Phase 2 designer returns:
echo "$DESIGN_TOKENS" | node scripts/merge-site-json.mjs "$(pwd)" --path designTokens
```

## Test plan

- [x] Init then merge seeded.stores — sub-tree present in output, untouched keys preserved
- [x] Then merge designTokens — co-exists with seeded.stores in same file
- [x] Then deep-merge a partial designTokens update (add one color, no fonts) — preserves prior colors and fonts unchanged
- [x] Refuses non-existent project dir (exit 2)
- [x] Refuses to descend through `brand.name` (string) with `--path brand.name.foo` (exit 2)
- [ ] End-to-end skill run — confirm the merge invocations land cleanly across the Wave 3 + Wave 4 flows

## Notes

- Opens as **draft** while sibling PRs in #207's series land. The four (a/b/c/d in [#206 review](#)) were split per maintainer's preference for separate PRs.
- This is the smallest pure-mechanical PR — no behavior change visible to agents. PRs (b) / (c) follow the same shape but for `Navigation.astro` and `index.astro` contribution merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)