### PR TITLE
feat(wix-headless): merge Navigation.astro contributions in orchestrator

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -81,7 +81,7 @@ If `wix.config.json` is present in the working directory, offer: *"I found an ex
 | 3 | seeders + design-system + image-phase-1 | design-system (fg) | merge `designTokens` into site.json; `emit-design-tokens.mjs`; grep Layout.astro CSS imports |
 | 4 | components + components-css + image-phase-2 (all bg) | (none — all backgrounded) | `copy-utility-templates.mjs components`; on Image Phase 1 return: `patch-decorative-slots.mjs`; on Phase 3 return: `check-manifest.mjs components` |
 | 5 | pages | components done + Phase 1 seeders done | `copy-utility-templates.mjs pages` |
-| 6 | (bash) | pages done + image-phase-2 done | `check-manifest.mjs pages`; `release.sh`; `finalize-run-json.mjs` |
+| 6 | (bash) | pages done + image-phase-2 done | `merge-navigation.mjs` (collect each Phase 4 agent's `data.navContributions`); `check-manifest.mjs pages`; `release.sh`; `finalize-run-json.mjs` |
 
 **Phase axis.** Core pipeline: `Phase 1 (Seed) → Phase 2 (Design System) → Phase 3 (Components) → Phase 4 (Pages)`. Image pipeline runs in parallel: Image Phase 1 (Decorative) alongside Phases 1–2; Image Phase 2 (Entity) alongside Phase 3 (depends only on Phase 1 Seed entity IDs + brand). Each Phase 4 agent writes its routes ONCE with both visual design and data queries — no placeholder-then-rewrite split.
 
@@ -263,11 +263,23 @@ Each prompt includes the standard fields PLUS:
 
    **Rate-limit recovery for `image-phase-2-entity`.** If the subagent returns `status: "failed"` with an error matching `/limit|quota|resets/i`, do NOT stall or retry the subagent. Run the inline recovery in the orchestrator: batched generate (one call) → concurrent imports (one batch) → concurrent product/CMS PATCHes (one batch). Procedure encoded in `references/shared/IMAGE_GENERATION.md`.
 
-2. **Post-Phase-4 manifest check.** `node "<SKILL_ROOT>/scripts/check-manifest.mjs" "$(pwd)" pages "<packs-csv>"`. Same recovery rules as Phase 3 check. Surface any unrecoverable `missing[]` entries (exit code 1) before invoking release — those are page files Phase 4 didn't write that have no template fallback. Record `{ phase: "manifest-check-pages", seconds }`.
+2. **Merge Navigation.astro contributions.** Phase 4 page agents now return per-pack `data.navContributions` (per `references/shared/RETURN_CONTRACT.md`) instead of patching `src/components/Navigation.astro` themselves. Compose the contributions in pack order and pipe them through the merge script:
 
-3. **Wait for npm install** — the background install from Wave 2. Wait on its handle; do not `sleep`-poll. On non-zero exit follow the recovery ladder in `references/SETUP.md` § "npm install recovery" (foreground retry with timeout, never delete the lockfile).
+   ```bash
+   echo "$NAV_CONTRIBUTIONS_JSON" | node "<SKILL_ROOT>/scripts/merge-navigation.mjs" "$(pwd)"
+   ```
 
-4. **`bash <SKILL_ROOT>/scripts/release.sh`** — runs `npx @wix/cli build` + `release`, extracts the URL from `Site published on <url>`, prints the URL on stdout. Capture build / release timings via `date -u` wrappers and record `{ phase: "build", seconds }` and `{ phase: "release", seconds }`. The script's stdout becomes `outcome.releaseUrl` in `run.json`. This populates the **Frontend link** in headless settings so transactional emails link to the deployed frontend. On build failure, surface the compiler error and stop — do NOT deploy a broken site.
+   `$NAV_CONTRIBUTIONS_JSON` is `{contributions: [<agent return's data.navContributions>, ...]}` — one entry per Phase 4 page agent that emitted one. Order them by pack importance: top-level `stores` before transitive `gift-cards`, with `ecom` last (it only writes `nav:actions`, no ordering interaction). Record `{ phase: "merge-navigation", seconds }`. Why orchestrator-merge instead of agent-patch: three Phase 4 subagents used to read+write the same file concurrently, two of them at the same `<!-- nav:links -->` marker — a real race. Collecting contributions and splicing once removes the race and makes pack ordering explicit.
+
+   `byMarker` keys agents may emit today (always preserve the marker comment for future patches):
+   - `nav:links` — stores submenu, gift-cards probe-gated link
+   - `nav:actions` — ecom CartBadge mount
+
+3. **Post-Phase-4 manifest check.** `node "<SKILL_ROOT>/scripts/check-manifest.mjs" "$(pwd)" pages "<packs-csv>"`. Same recovery rules as Phase 3 check. Surface any unrecoverable `missing[]` entries (exit code 1) before invoking release — those are page files Phase 4 didn't write that have no template fallback. Record `{ phase: "manifest-check-pages", seconds }`.
+
+4. **Wait for npm install** — the background install from Wave 2. Wait on its handle; do not `sleep`-poll. On non-zero exit follow the recovery ladder in `references/SETUP.md` § "npm install recovery" (foreground retry with timeout, never delete the lockfile).
+
+5. **`bash <SKILL_ROOT>/scripts/release.sh`** — runs `npx @wix/cli build` + `release`, extracts the URL from `Site published on <url>`, prints the URL on stdout. Capture build / release timings via `date -u` wrappers and record `{ phase: "build", seconds }` and `{ phase: "release", seconds }`. The script's stdout becomes `outcome.releaseUrl` in `run.json`. This populates the **Frontend link** in headless settings so transactional emails link to the deployed frontend. On build failure, surface the compiler error and stop — do NOT deploy a broken site.
 
    Use `bash <SKILL_ROOT>/scripts/preview.sh` (not this step) only when the user is iterating on an existing site and explicitly asks for a fast preview without touching production.
 
@@ -298,7 +310,7 @@ One concluding turn containing, in order:
 
 1. **Release URL text first** — bold heading / link at the top so the user sees it immediately.
 2. **Compose the draft `run.json` blob** in scratch. Aggregate every subagent return into `phases[]`, set `outcome.previewUrl`, fill `run.started` (from `runStartedAt`) / `run.ended` (capture now via `date -u`), compute `run.totalSeconds`, and compose `requiredPhases[]` — phases that MUST have a captured duration:
-   - Always: `mcp-bootstrap`, `init-site-json`, `scaffold`, `env-pull`, `seed-utilities`, `emit-design-tokens`, `manifest-check-components`, `manifest-check-pages`, `decorative-slot-patch`, `npm-install`, `build`, `release` (or `preview` if `preview.sh` was used).
+   - Always: `mcp-bootstrap`, `init-site-json`, `scaffold`, `env-pull`, `seed-utilities`, `emit-design-tokens`, `manifest-check-components`, `manifest-check-pages`, `decorative-slot-patch`, `merge-navigation`, `npm-install`, `build`, `release` (or `preview` if `preview.sh` was used).
    - Per app installed in Wave 2: `app-install-<appName>`.
    - When `copy-utility-templates` ran: `copy-utility-templates-components` and/or `copy-utility-templates-pages`.
    - `image-phase-2-entity`'s duration arrives via its return; record from there if any pack produced entities.

--- a/skills/wix-headless/references/ecom/CART_PAGES.md
+++ b/skills/wix-headless/references/ecom/CART_PAGES.md
@@ -9,13 +9,14 @@ Files this agent OWNS (rewrites from designer output):
 - `src/pages/cart.astro` — mount `CartView.tsx` (client-only, no server-side cart fetch)
 - `src/pages/thank-you.astro` — read `orderId` from URL, fire `Purchase` event
 
-Files this agent PATCHES (does NOT rewrite):
+Navigation contribution (returned as `data.navContributions`, NOT a direct write):
 
-- `src/components/Navigation.astro` — mount `CartBadge` in the `nav-actions` area
+- The `CartBadge` mount is now returned as JSON in the agent's return block. The orchestrator collects every Phase 4 agent's `data.navContributions` and invokes `scripts/merge-navigation.mjs` once. See "Section 3 — CartBadge contribution" below and the shape spec in `../shared/RETURN_CONTRACT.md` § "Phase 2: navContributions".
 
 Files this agent MUST NOT touch:
 - `src/components/CartView.tsx` — owned by `ecom-shared` (already written)
 - `src/components/CartBadge.tsx` — owned by `ecom-shared`
+- **`src/components/Navigation.astro`** — direct writes are forbidden. The orchestrator owns this file via the merge script; contribute via `data.navContributions` only.
 - Any product page, home page, or stores-specific component
 - `global.css`, any designed component
 
@@ -24,7 +25,7 @@ Files this agent MUST NOT touch:
 1. **No server-side cart fetch** — cart is per-visitor and must not break SSR caching. `CartView` fetches its own data on mount.
 2. **Mount `CartView` with `client:load`** — no props needed, the island is self-contained.
 3. **Fire `Purchase` event in `thank-you.astro`** only when `?orderId=` is present.
-4. **Mount `CartBadge` in `Navigation.astro`** (not Layout.astro, not a page-specific header).
+4. **Contribute `CartBadge` to `Navigation.astro` via `data.navContributions`** (not Layout.astro, not a page-specific header). Do not write Navigation.astro directly — the orchestrator merges contributions.
 5. **No HTML comments in `.astro` frontmatter** — frontmatter is TypeScript.
 6. **Preserve designer layout and classes.** Only mount islands and wire data; do not restructure markup.
 7. **Do NOT add static HTML alongside `<CartView>`** — the island handles empty/loading/cart states internally.
@@ -53,20 +54,26 @@ Wix redirects here after successful checkout with `?orderId=<id>`. Fires `Purcha
 - Fire `Purchase` event via the analytics helper (client-side script)
 - Only fire when `orderId` is present — refreshing without it should not re-fire
 
-### 3. Mount CartBadge in `Navigation.astro`
+### 3. CartBadge contribution (returned as `data.navContributions`)
 
-Mount `CartBadge` inside the `nav-actions` area. The designer creates this with a `<slot name="actions" />` or similar placeholder. Because Navigation is in the shared Layout, the badge appears on every page.
+> **Do NOT write `Navigation.astro` from this scope.** Return the contribution; the orchestrator splices it via `scripts/merge-navigation.mjs` after all Phase 4 agents return. Direct writes will be clobbered.
 
-```astro
----
-// Add to Navigation.astro frontmatter:
-import CartBadge from "./CartBadge.tsx";
----
+The designer scaffolds `Navigation.astro` with a `<!-- nav:actions -->` marker. Ecom contributes the `CartBadge` island at that marker. Build the contribution as part of your return JSON:
 
-<!-- Replace the nav-actions slot with the CartBadge island: -->
-<div class="nav-actions">
-  <CartBadge client:only="react" />
-</div>
+```json
+{
+  "data": {
+    "navContributions": {
+      "imports": [
+        "import CartBadge from './CartBadge.tsx';"
+      ],
+      "frontmatter": [],
+      "byMarker": {
+        "nav:actions": "<CartBadge client:only=\"react\" />"
+      }
+    }
+  }
+}
 ```
 
 Use `client:only="react"` — never SSR the badge. SSR would render `count: 0` (sessionStorage is a browser-only API), then hydration would read the cached count and flip to the real number, causing a visible blink on every page navigation. Skipping SSR means the badge renders once on the client with the cached count already populated. No flash.
@@ -102,18 +109,24 @@ Cart page → "Proceed to Checkout"
   "status": "complete",
   "phase": "ecom-pages",
   "scope": "ecom-pages",
-  "summary": "Mounted CartView (client-only fetch); wired Purchase event; mounted CartBadge in Navigation",
+  "summary": "Mounted CartView (client-only fetch); wired Purchase event; contributed CartBadge mount to Navigation via navContributions",
   "data": {
     "pagesWired": 2,
     "cartViewMounted": true,
     "purchaseEventWired": true,
     "cartBadgeMounted": true,
-    "analyticsEvents": ["Purchase"]
+    "analyticsEvents": ["Purchase"],
+    "navContributions": {
+      "imports": ["import CartBadge from './CartBadge.tsx';"],
+      "frontmatter": [],
+      "byMarker": {
+        "nav:actions": "<CartBadge client:only=\"react\" />"
+      }
+    }
   },
   "files": [
     "src/pages/cart.astro",
-    "src/pages/thank-you.astro",
-    "src/components/Navigation.astro"
+    "src/pages/thank-you.astro"
   ],
   "errors": []
 }

--- a/skills/wix-headless/references/gift-cards/PAGES.md
+++ b/skills/wix-headless/references/gift-cards/PAGES.md
@@ -10,18 +10,22 @@ Files this agent OWNS (writes fresh):
 
 Files this agent PATCHES (insert at marker, preserve everything else):
 
-- `src/components/Navigation.astro` — insert "Gift Cards" link at `<!-- nav:links -->`
 - `src/pages/index.astro` — insert home teaser at `<!-- home:gift-cards -->`
+
+Navigation contribution (returned as `data.navContributions`, NOT a direct write):
+
+- The probe-gated "Gift Cards" link is now returned as JSON. The orchestrator collects every Phase 4 agent's `data.navContributions` and invokes `scripts/merge-navigation.mjs` once. See "Section 2 — Navigation contribution" below.
 
 Files this agent MUST NOT touch:
 - `src/utils/gift-cards.ts`, `src/components/GiftCardPurchase.tsx`, `src/styles/components-gift-cards.css` — Components scope.
-- Any other vertical's nav/home contributions.
+- **`src/components/Navigation.astro`** — direct writes are forbidden. The orchestrator owns this file via the merge script. Stores also contributes at the same `<!-- nav:links -->` marker — the merge script orders contributions deterministically.
+- Any other vertical's home contributions.
 - `Layout.astro`, `global.css`, or any product/cart/checkout page.
 
 ## Critical rules
 
-1. **Marker-based patching.** Read the shell file, locate the exact marker comment string (`<!-- nav:links -->` or `<!-- home:gift-cards -->`), insert your snippet immediately AFTER the marker line, preserve the marker line itself. See `references/shared/IMPLEMENTER.md` § "Contributing to shared files via markers".
-2. **Inject the import + frontmatter call when patching.** When inserting at `<!-- nav:links -->` in `Navigation.astro`, also add `import { getGiftCardProduct } from "../utils/gift-cards";` and `const giftCardsEnabled = (await getGiftCardProduct()) !== null;` to the file's frontmatter (top of the file). Same for `index.astro`'s home teaser. Do NOT assume another vertical added them.
+1. **Marker-based patching.** For `index.astro` only: read the shell file, locate the marker comment (`<!-- home:gift-cards -->`), insert your snippet immediately AFTER the marker line, preserve the marker. For `Navigation.astro`, do NOT patch — return `data.navContributions` instead (Section 2 below).
+2. **Inject the import + frontmatter call when patching.** For the `index.astro` home teaser, add `import { getGiftCardProduct } from "../utils/gift-cards";` and `const giftCardProduct = await getGiftCardProduct();` to the frontmatter. For the Navigation contribution, declare the imports + frontmatter lines in `data.navContributions.imports[]` and `data.navContributions.frontmatter[]` — the merge script dedupes them against the designer's existing content.
 3. **SSR error guards.** Wrap `getGiftCardProduct()` calls in try/catch with safe fallback (`giftCardsEnabled = false` / `giftCardProduct = null`). See `references/shared/IMPLEMENTER.md` § "SSR error guards". Although the helper itself never throws, the guard cost is zero and protects against future regressions.
 4. **Redirect rather than render** when the page-level probe returns null. `if (!product) return Astro.redirect("/", 302);` — same pattern as private/disabled-feature routes elsewhere.
 5. **Memoization is per-request.** Navigation, home, and the page may all call `getGiftCardProduct()` on the same request — the helper coalesces them into one fetch. You do not need to thread the result through Astro context.
@@ -59,15 +63,34 @@ const heroImage = resolveWixImageUrl(product.image, 800, 800);
 
 Body: hero image + name + description + `<GiftCardPurchase client:load product={product} />` + fineprint paragraph. All page-level CSS is already shipped via `components-gift-cards.css` (Components scope) — do not duplicate styles inside the `.astro` file's `<style>` block.
 
-### 2. Patch `src/components/Navigation.astro`
+### 2. Navigation contribution (returned as `data.navContributions`)
 
-1. Read the file.
-2. Add to frontmatter (above the `---` close): `import { getGiftCardProduct } from "../utils/gift-cards"; const giftCardsEnabled = (await getGiftCardProduct()) !== null;` (split across two lines as needed).
-3. Locate the line containing `<!-- nav:links -->`. Insert immediately after it:
-   ```astro
-   {giftCardsEnabled && <a href="/gift-cards">Gift Cards</a>}
-   ```
-4. If other verticals (stores, blog, forms) already inserted at the same marker, preserve every existing line — your snippet appends.
+> **Do NOT write `Navigation.astro` from this scope.** Return the contribution as JSON; the orchestrator splices it via `scripts/merge-navigation.mjs` after all Phase 4 agents return. Background subagents writing the same file concurrently produced a real race (this scope + stores both target `<!-- nav:links -->`).
+
+Build the contribution as part of your return JSON:
+
+```json
+{
+  "data": {
+    "navContributions": {
+      "imports": [
+        "import { getGiftCardProduct } from '../utils/gift-cards';"
+      ],
+      "frontmatter": [
+        "const giftCardsEnabled = (await getGiftCardProduct().catch(() => null)) !== null;"
+      ],
+      "byMarker": {
+        "nav:links": "{giftCardsEnabled && <li class=\"site-nav-item\"><a href=\"/gift-cards\">Gift Cards</a></li>}"
+      }
+    }
+  }
+}
+```
+
+The merge script:
+- Dedupes `imports[]` and `frontmatter[]` against existing content (so if stores already declared a similar guard, only new lines get added).
+- Inserts the `byMarker["nav:links"]` snippet immediately after the marker line, in input order (the orchestrator controls render order — typically stores' Shop link first, then gift-cards' link).
+- Preserves the marker comment for any future contributions.
 
 ### 3. Patch `src/pages/index.astro`
 
@@ -102,20 +125,25 @@ After writing/patching, grep the project to confirm:
   "summary": "Wrote /gift-cards page; patched Navigation + home with conditional gift-card surfaces",
   "data": {
     "pageWritten": true,
-    "navigationPatched": true,
     "homePatched": true,
-    "markersFound": ["<!-- nav:links -->", "<!-- home:gift-cards -->"]
+    "markersFound": ["<!-- home:gift-cards -->"],
+    "navContributions": {
+      "imports": ["import { getGiftCardProduct } from '../utils/gift-cards';"],
+      "frontmatter": ["const giftCardsEnabled = (await getGiftCardProduct().catch(() => null)) !== null;"],
+      "byMarker": {
+        "nav:links": "{giftCardsEnabled && <li class=\"site-nav-item\"><a href=\"/gift-cards\">Gift Cards</a></li>}"
+      }
+    }
   },
   "files": [
     "src/pages/gift-cards.astro",
-    "src/components/Navigation.astro",
     "src/pages/index.astro"
   ],
   "errors": []
 }
 ```
 
-If a marker is missing, return `status: "partial"` with `errors: [{ code: "MARKER_NOT_FOUND", file: "<path>", marker: "<marker>" }]`. Do NOT invent your own insertion point — that signals the designer foundation didn't scaffold the shell correctly and should be fixed upstream.
+If the `<!-- home:gift-cards -->` marker is missing, return `status: "partial"` with `errors: [{ code: "MARKER_NOT_FOUND", file: "src/pages/index.astro", marker: "home:gift-cards" }]`. Do NOT invent your own insertion point — that signals the designer foundation didn't scaffold the shell correctly and should be fixed upstream. For the Navigation contribution, an unknown marker is surfaced by the orchestrator-side merge script (in its `skipped[]` list), not the agent.
 
 ## Anti-patterns
 

--- a/skills/wix-headless/references/shared/RETURN_CONTRACT.md
+++ b/skills/wix-headless/references/shared/RETURN_CONTRACT.md
@@ -216,6 +216,47 @@ Phase 4 CMS page agents reference these collection names; the image agent attach
 }
 ```
 
+### Phase 2: navContributions (Navigation.astro contributions)
+
+Phase 4 page agents that previously patched `src/components/Navigation.astro` directly (stores `home-and-nav`, ecom `pages`, gift-cards `pages`) now return their contribution as `data.navContributions`. The orchestrator collects every Phase 4 agent's `navContributions`, then invokes `scripts/merge-navigation.mjs` ONCE to splice them into the designer-emitted shell. This replaces the previous "each agent patches Navigation.astro at its declared marker" model, which had a race when two agents targeted the same marker (`<!-- nav:links -->`, claimed by both stores and gift-cards).
+
+```json
+{
+  "status": "complete",
+  "phase": "stores-pages-home-and-nav",
+  "scope": "pages-home-and-nav",
+  "data": {
+    "navContributions": {
+      "imports": [
+        "import { listStoreCategories } from '../utils/categories';"
+      ],
+      "frontmatter": [
+        "const navCategories = (await listStoreCategories().catch(() => []));"
+      ],
+      "byMarker": {
+        "nav:links": "<li class=\"site-nav-item has-submenu\">\n  <a href=\"/products\" data-astro-prefetch=\"hover\">Shop</a>\n  {navCategories.length > 0 && (<ul class=\"site-nav-submenu\">…</ul>)}\n</li>"
+      }
+    },
+    "homePageHadPlaceholders": false,
+    "featuredProductsWired": true
+  },
+  "files": [
+    "src/pages/index.astro"
+  ]
+}
+```
+
+**Shape rules (enforced by `scripts/merge-navigation.mjs`):**
+
+- `imports[]`: raw TypeScript import lines. Deduped against existing frontmatter by exact line match (after trim). Append after the designer's last `import …` line.
+- `frontmatter[]`: raw TypeScript lines (SSR-time computations). Deduped the same way. Append after any new imports.
+- `byMarker`: `{ "<marker-name>": "<raw HTML/Astro snippet>" }`. The merge script finds the marker line in the body and inserts your snippet immediately after it, preserving the marker comment for future contributions. Multiple agents targeting the same marker are joined in input order, so the orchestrator controls render order.
+- Marker names today: `nav:links` (stores submenu, gift-cards probe-gated link), `nav:actions` (ecom CartBadge mount).
+
+**Do not write `src/components/Navigation.astro` directly from a Phase 4 agent** — return contributions instead. Agents that still write the file will see their changes clobbered by the merge script, since the orchestrator reads Navigation.astro fresh before splicing.
+
+`files: []` is correct for the Navigation.astro contribution alone — only list files you wrote yourself in this scope.
+
 ### Designer foundation
 
 ```json

--- a/skills/wix-headless/references/stores/HOME_AND_NAV.md
+++ b/skills/wix-headless/references/stores/HOME_AND_NAV.md
@@ -7,11 +7,14 @@ Scope: `pages-home-and-nav`. Launched in **Step 7** after `pages-categories` has
 Files this agent PATCHES (does NOT rewrite):
 
 - `src/pages/index.astro` — only the stores-related sections (featured products grid, category cards)
-- `src/components/Navigation.astro` — only at the `<!-- nav:links -->` marker; insert the Shop link + categories submenu
+
+Navigation contribution (returned as `data.navContributions`, NOT a direct write):
+
+- The Shop link + categories submenu is now returned as JSON in the agent's return block. The orchestrator collects every Phase 4 agent's `data.navContributions` and invokes `scripts/merge-navigation.mjs` once after all Phase 4 agents return. See "Section 4 — Navigation contribution" below and the shape spec in `../shared/RETURN_CONTRACT.md` § "Phase 2: navContributions".
 
 Files this agent MUST NOT touch:
 - Any other part of `index.astro` — hero, copy, newsletter, decorative ornaments are designer-owned
-- Any part of `Navigation.astro` outside the `<!-- nav:links -->` marker — designer/ecom-owned (the marker model lets multiple verticals contribute siblings without conflict)
+- **`src/components/Navigation.astro`** — direct writes are forbidden. The orchestrator owns this file via the merge script; agent writes will be clobbered. Contribute via `data.navContributions` only.
 - `src/utils/categories.ts`, `src/components/CategoryRail.astro`, `src/pages/category/[slug].astro` — owned by `pages-categories`; this scope only **imports** `listStoreCategories` from `categories.ts`
 - Any other component, page, or CSS
 - `global.css`
@@ -124,58 +127,39 @@ Handle this:
 
 > Never call `/stores/v3/categories/*` — category endpoints live under `/categories/v1/`. Improvising URLs caused a documented multi-minute stall in past runs.
 
-### 3. Navigation: Shop submenu
+### 3. Navigation: Shop submenu (returned as `data.navContributions`)
 
-The designer scaffolds `Navigation.astro` with a `<!-- nav:links -->` marker that vertical packs replace with their primary nav contributions. Stores contributes the Shop link (always) and a hover/focus submenu listing the merchant's visible categories (when any exist — empty by default, since Phase 1 does not seed them).
+> **Do NOT write `Navigation.astro` from this scope.** Return the contribution as JSON; the orchestrator splices it via `scripts/merge-navigation.mjs` after all Phase 4 agents return. Background subagents writing the same file concurrently has produced a real race (stores + gift-cards both target `<!-- nav:links -->`). Returning JSON instead lets the orchestrator order and dedupe deterministically.
 
-Read `src/utils/categories.ts` (already on disk — written by `pages-categories`) and import `listStoreCategories`. At the marker, insert:
+The designer scaffolds `Navigation.astro` with a `<!-- nav:links -->` marker. Stores contributes the Shop link (always) plus a hover/focus submenu listing the merchant's visible categories (when any exist — empty by default, since Phase 1 does not seed them).
 
-```astro
----
-// (frontmatter additions to Navigation.astro — keep existing imports)
-import { listStoreCategories } from "../utils/categories";
+Build the contribution as part of your return JSON's `data.navContributions`:
 
-const navCategories = await listStoreCategories();
----
+```json
+{
+  "data": {
+    "navContributions": {
+      "imports": [
+        "import { listStoreCategories } from '../utils/categories';"
+      ],
+      "frontmatter": [
+        "const navCategories = (await listStoreCategories().catch(() => []));"
+      ],
+      "byMarker": {
+        "nav:links": "<li class={`site-nav-item${navCategories.length > 0 ? ' has-submenu' : ''}`}>\n  <a\n    href=\"/products\"\n    class=\"site-nav-link\"\n    data-astro-prefetch=\"hover\"\n    aria-current={isActive('/products') || isActive('/category') ? 'page' : undefined}\n    aria-haspopup={navCategories.length > 0 ? 'true' : undefined}\n  >Shop</a>\n  {navCategories.length > 0 && (\n    <ul class=\"site-nav-submenu\" aria-label=\"Shop categories\">\n      <li>\n        <a href=\"/products\" class=\"site-nav-sublink\" data-astro-prefetch=\"hover\">All</a>\n      </li>\n      {navCategories.map((cat) => (\n        <li>\n          <a\n            href={`/category/${cat.slug}`}\n            class=\"site-nav-sublink\"\n            data-astro-prefetch=\"hover\"\n            aria-current={Astro.url.pathname === `/category/${cat.slug}` ? 'page' : undefined}\n          >{cat.name}</a>\n        </li>\n      ))}\n    </ul>\n  )}\n</li>"
+      }
+    }
+  }
+}
 ```
 
-Then replace the `<!-- nav:links -->` marker with:
-
-```astro
-<li class={`site-nav-item${navCategories.length > 0 ? ' has-submenu' : ''}`}>
-  <a
-    href="/products"
-    class="site-nav-link"
-    data-astro-prefetch="hover"
-    aria-current={isActive('/products') || isActive('/category') ? 'page' : undefined}
-    aria-haspopup={navCategories.length > 0 ? 'true' : undefined}
-  >Shop</a>
-  {navCategories.length > 0 && (
-    <ul class="site-nav-submenu" aria-label="Shop categories">
-      <li>
-        <a href="/products" class="site-nav-sublink" data-astro-prefetch="hover">All</a>
-      </li>
-      {navCategories.map((cat) => (
-        <li>
-          <a
-            href={`/category/${cat.slug}`}
-            class="site-nav-sublink"
-            data-astro-prefetch="hover"
-            aria-current={Astro.url.pathname === `/category/${cat.slug}` ? 'page' : undefined}
-          >{cat.name}</a>
-        </li>
-      ))}
-    </ul>
-  )}
-</li>
-<!-- nav:links -->
-```
-
-Keep the marker comment immediately after the inserted `<li>` so other vertical packs (gift-cards, etc.) can still contribute siblings.
+The merge script:
+- Dedupes the `imports[]` and `frontmatter[]` lines against the designer's existing content (so re-running is harmless).
+- Inserts the `byMarker["nav:links"]` snippet immediately after the marker line, preserving the marker so other packs (gift-cards) can still contribute siblings.
 
 > **Empty-categories fallback.** `navCategories` is `[]` by default — Phase 1 does not seed categories, and `listStoreCategories()` only returns visible, non-empty, merchant-created categories. When empty, the submenu renders nothing and the link is just `Shop` with no dropdown. The aria-haspopup attribute is conditionally added so screen readers don't promise a menu that isn't there. As soon as the merchant creates a visible category with items in the dashboard, the submenu lights up automatically (≤ 5 min, the helper's TTL).
 
-> **`isActive` is already defined** in the designer-scaffolded Navigation.astro frontmatter (it returns whether a path matches the current URL). Reuse it; do not redefine.
+> **`isActive` is already defined** in the designer-scaffolded Navigation.astro frontmatter (it returns whether a path matches the current URL). Reuse it; do not redefine. Your `frontmatter[]` should NOT redeclare it.
 
 > **`data-astro-prefetch="hover"` is required** on every category link so hovering warms the prefetch cache before the click. Designer's Layout includes `<ClientRouter />` — without prefetch, each click waits a full network round-trip.
 
@@ -196,22 +180,30 @@ Keep the marker comment immediately after the inserted `<li>` so other vertical 
     "categoryCardsFound": 3,
     "categoryCardsMatched": 2,
     "categoryCardsFallbackToProducts": 1,
-    "navSubmenuCategoryCount": 0
+    "navSubmenuCategoryCount": 0,
+    "navContributions": {
+      "imports": ["import { listStoreCategories } from '../utils/categories';"],
+      "frontmatter": ["const navCategories = (await listStoreCategories().catch(() => []));"],
+      "byMarker": {
+        "nav:links": "<li class={`site-nav-item${navCategories.length > 0 ? ' has-submenu' : ''}`}>...</li>"
+      }
+    }
   },
   "files": [
-    "src/pages/index.astro",
-    "src/components/Navigation.astro"
+    "src/pages/index.astro"
   ],
   "errors": []
 }
 ```
+
+> `files` lists only files this scope writes directly — `Navigation.astro` is **not** listed because the orchestrator owns the write. The contribution shows up in `data.navContributions` instead.
 
 ## Scope boundaries (reinforced)
 
 - **Do NOT edit** home page layout, copy, hero text, newsletter section, or decorative SVGs.
 - **Do NOT add** new sections the designer didn't include.
 - **Do NOT mutate** categories in the catalog — read-only.
-- **Do NOT touch** `Navigation.astro` outside the `<!-- nav:links -->` marker. Other vertical packs use the same marker model and write siblings.
+- **Do NOT touch** `Navigation.astro` at all — contribute via `data.navContributions`. The orchestrator merges all packs' contributions deterministically.
 - **Do NOT touch** `CartBadge.tsx` or `CartView.tsx` — owned by ecom.
 - **Do NOT rewrite** `src/utils/categories.ts` or `src/components/CategoryRail.astro` — owned by `pages-categories`.
 - If home page already has a live query (another agent wired it), leave alone and note in return.

--- a/skills/wix-headless/references/verticals/ecom.md
+++ b/skills/wix-headless/references/verticals/ecom.md
@@ -48,12 +48,13 @@ pages:
   - name: "ecom-pages"
     agentLocation: "references/ecom/"
     scope: "pages"
-    description: "Mount CartView on cart.astro, wire thank-you.astro, mount CartBadge in Navigation"
+    description: "Mount CartView on cart.astro, wire thank-you.astro; return CartBadge mount as data.navContributions (orchestrator merges via scripts/merge-navigation.mjs)"
     references: ["references/ecom/CART_PAGES.md"]
     files:
       - "src/pages/cart.astro"
       - "src/pages/thank-you.astro"
-      - "src/components/Navigation.astro (patch — CartBadge mount only)"
+    # Navigation.astro is no longer written by this agent. CartBadge mount is returned
+    # as data.navContributions and merged by the orchestrator (see contributes: below).
 
 creates:
   - { file: src/components/CartView.tsx,      phase: components }

--- a/skills/wix-headless/references/verticals/gift-cards.md
+++ b/skills/wix-headless/references/verticals/gift-cards.md
@@ -35,12 +35,13 @@ pages:
   - name: "gift-cards-pages"
     agentLocation: "references/gift-cards/"
     scope: "pages"
-    description: "Write /gift-cards landing page (redirects when app is disabled), patch nav link + home teaser via markers"
+    description: "Write /gift-cards landing page (redirects when app is disabled), patch home teaser at <!-- home:gift-cards -->; return probe-gated nav link as data.navContributions (orchestrator merges via scripts/merge-navigation.mjs)"
     references: ["references/gift-cards/PAGES.md"]
     files:
       - "src/pages/gift-cards.astro"
-      - "src/components/Navigation.astro (patch — gift-cards link)"
       - "src/pages/index.astro (patch — gift-cards teaser)"
+    # Navigation.astro is no longer written by this agent. Probe-gated link returned
+    # as data.navContributions and merged by the orchestrator (see contributes: below).
 
 creates:
   - { file: src/utils/gift-cards.ts,            phase: components }

--- a/skills/wix-headless/references/verticals/stores.md
+++ b/skills/wix-headless/references/verticals/stores.md
@@ -79,11 +79,12 @@ pages:
   - name: "home-and-nav"
     agentLocation: "references/stores/"
     scope: "pages-home-and-nav"
-    description: "Patch home page featured products to live query and contribute the Shop submenu (categories list) to Navigation"
+    description: "Patch home page featured products to live query; return Shop submenu contribution as data.navContributions (orchestrator merges via scripts/merge-navigation.mjs)"
     references: ["references/stores/HOME_AND_NAV.md"]
     files:
       - "src/pages/index.astro (patch — home product grid only)"
-      - "src/components/Navigation.astro (patch — Shop submenu insert)"
+    # Navigation.astro is no longer written by this agent. The Shop submenu is returned
+    # as data.navContributions and merged by the orchestrator (see contributes: below).
 
 creates:
   - { file: src/components/AddToCartButton.tsx,  phase: components }

--- a/skills/wix-headless/scripts/merge-navigation.mjs
+++ b/skills/wix-headless/scripts/merge-navigation.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+// Merge per-pack Navigation.astro contributions into the designer-emitted shell.
+//
+// Today three Phase 4 page agents patch `src/components/Navigation.astro`
+// concurrently, two of them at the *same* marker:
+//   - stores-pages-home-and-nav  → <!-- nav:links -->   (Shop submenu)
+//   - ecom-pages                 → <!-- nav:actions --> (CartBadge mount)
+//   - gift-cards-pages           → <!-- nav:links -->   (probe-gated link)
+//
+// Three background subagents reading-then-writing the same file with two of
+// them targeting the same marker is a real race. In the run that motivated
+// this script (Moran's Bakery, 2026-05) it happened to work because each
+// agent's regex-based marker insert was idempotent, but the contract is
+// brittle.
+//
+// New contract: each agent returns its contribution as `data.navContributions`
+// (per RETURN_CONTRACT.md). The orchestrator collects all returns, packages
+// them, and invokes this script ONCE to splice them into Navigation.astro
+// deterministically.
+//
+// Usage:
+//   echo "$CONTRIBUTIONS" | node merge-navigation.mjs <project-dir>
+//
+// stdin shape:
+//   {
+//     "contributions": [
+//       {
+//         "source": "stores",                       // pack name; used in error reports
+//         "imports": [                              // raw TS import lines
+//           "import { listStoreCategories } from '../utils/categories';"
+//         ],
+//         "frontmatter": [                          // raw TS lines (after imports)
+//           "const navCategories = (await listStoreCategories().catch(() => []));"
+//         ],
+//         "byMarker": {                             // raw HTML/Astro to splice
+//           "nav:links": "<li class=\"site-nav-item has-submenu\">...</li>"
+//         }
+//       },
+//       ...
+//     ]
+//   }
+//
+// Behavior:
+//   - Contributions are processed in stdin order. Splicer inserts each
+//     contribution's `byMarker[marker]` snippet immediately AFTER the marker
+//     comment line, preserving the marker for any later runs.
+//   - Imports and frontmatter lines are appended to the frontmatter (between
+//     the `---` boundaries), de-duplicated against existing content by exact
+//     line match. New imports go after the last `import …` line found;
+//     frontmatter lines go after imports.
+//   - Skips an unknown marker silently — the script records it in `skipped`
+//     so the orchestrator can choose whether to fail. Reasoning: a pack may
+//     emit a marker the designer didn't scaffold (e.g. when a pack is
+//     disabled and the designer was told to skip it). Surfacing it for
+//     observability beats hard-failing.
+//   - Idempotency: this script is NOT idempotent by design. The orchestrator
+//     must collect all contributions before invoking it, then invoke it
+//     exactly once per build. Running twice re-inserts.
+//   - Writes atomically (write-then-rename).
+//   - Outputs a JSON summary on stdout: { status, patched, skipped, addedImports, addedFrontmatter }.
+//
+// Exit codes:
+//   0 — merged (with any non-fatal `skipped` markers reported in output)
+//   2 — argument validation, malformed input, or missing Navigation.astro
+
+import { readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+const projectDir = process.argv[2];
+if (!projectDir) {
+  console.error("usage: cat contributions.json | merge-navigation.mjs <project-dir>");
+  process.exit(2);
+}
+
+const navPath = join(projectDir, "src/components/Navigation.astro");
+if (!existsSync(navPath)) {
+  console.error(`merge-navigation: ${navPath} does not exist — designer (Phase 2) must run first.`);
+  process.exit(2);
+}
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch (e) {
+  console.error(`merge-navigation: stdin is not valid JSON (${e.message})`);
+  process.exit(2);
+}
+
+const contributions = Array.isArray(payload.contributions) ? payload.contributions : null;
+if (!contributions) {
+  console.error("merge-navigation: stdin must contain `contributions: [...]`");
+  process.exit(2);
+}
+
+const source = readFileSync(navPath, "utf8");
+
+// Split frontmatter / body. Astro frontmatter is the first `---`-delimited
+// block at the top of the file (TypeScript). Files without frontmatter are
+// not valid Astro pages, but we handle the case gracefully.
+const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+const m = source.match(frontmatterRegex);
+if (!m) {
+  console.error("merge-navigation: Navigation.astro has no --- frontmatter block; cannot merge imports/frontmatter contributions.");
+  process.exit(2);
+}
+
+let frontmatter = m[1];
+let body = m[2];
+
+// --- Imports + frontmatter additions -----------------------------------
+// Build a Set of existing lines for dedupe.
+const existingLines = new Set(frontmatter.split("\n").map((l) => l.trim()));
+
+const addedImports = [];
+const addedFrontmatter = [];
+
+for (const contrib of contributions) {
+  const imports = Array.isArray(contrib.imports) ? contrib.imports : [];
+  const fm = Array.isArray(contrib.frontmatter) ? contrib.frontmatter : [];
+
+  for (const line of imports) {
+    if (typeof line !== "string") continue;
+    const trimmed = line.trim();
+    if (trimmed === "" || existingLines.has(trimmed)) continue;
+    addedImports.push({ source: contrib.source, line: line });
+    existingLines.add(trimmed);
+  }
+
+  for (const line of fm) {
+    if (typeof line !== "string") continue;
+    const trimmed = line.trim();
+    if (trimmed === "" || existingLines.has(trimmed)) continue;
+    addedFrontmatter.push({ source: contrib.source, line: line });
+    existingLines.add(trimmed);
+  }
+}
+
+// Append imports after the last `import …` line; append frontmatter lines
+// after imports. If no `import` lines exist, prepend everything.
+const fmLines = frontmatter.split("\n");
+let lastImportIdx = -1;
+for (let i = 0; i < fmLines.length; i++) {
+  if (/^\s*import\b/.test(fmLines[i])) lastImportIdx = i;
+}
+
+if (addedImports.length > 0) {
+  const importLines = addedImports.map((c) => c.line);
+  if (lastImportIdx >= 0) {
+    fmLines.splice(lastImportIdx + 1, 0, ...importLines);
+    lastImportIdx += importLines.length;
+  } else {
+    fmLines.unshift(...importLines);
+    lastImportIdx = importLines.length - 1;
+  }
+}
+
+if (addedFrontmatter.length > 0) {
+  const fmAdditions = addedFrontmatter.map((c) => c.line);
+  // Insert after imports (or after any added imports). Use a blank line as a
+  // visual separator if not already present.
+  const insertIdx = lastImportIdx + 1;
+  const needsSeparator = lastImportIdx >= 0 && fmLines[insertIdx]?.trim() !== "";
+  if (needsSeparator) fmAdditions.unshift("");
+  fmLines.splice(insertIdx, 0, ...fmAdditions);
+}
+
+frontmatter = fmLines.join("\n");
+
+// --- byMarker splicing -------------------------------------------------
+// Group contributions per marker so we splice each marker ONCE with all
+// snippets joined in input order. This preserves the natural "first
+// contribution renders first" mental model — the alternative (splice each
+// contribution separately after the marker line) reverses the order because
+// each new insert pushes the previous one further down.
+
+const patched = [];
+const skipped = [];
+
+/** @type {Map<string, Array<{source: string, snippet: string}>>} */
+const groupedByMarker = new Map();
+
+for (const contrib of contributions) {
+  const byMarker = contrib.byMarker && typeof contrib.byMarker === "object" ? contrib.byMarker : {};
+  for (const [markerName, snippet] of Object.entries(byMarker)) {
+    if (typeof snippet !== "string" || snippet.trim() === "") continue;
+    if (!groupedByMarker.has(markerName)) groupedByMarker.set(markerName, []);
+    groupedByMarker.get(markerName).push({ source: contrib.source, snippet });
+  }
+}
+
+for (const [markerName, entries] of groupedByMarker) {
+  const markerComment = `<!-- ${markerName} -->`;
+  if (!body.includes(markerComment)) {
+    for (const { source } of entries) {
+      skipped.push({ source, marker: markerName, reason: "MARKER_NOT_FOUND" });
+    }
+    continue;
+  }
+
+  // Use the marker's own line indentation to indent every line of every
+  // snippet — keeps the output legible inside indented `<ul>` blocks.
+  const markerLineRegex = new RegExp(`(^|\\n)([ \\t]*)${markerComment.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}(\\r?\\n)`);
+  const lineMatch = body.match(markerLineRegex);
+  const indent = lineMatch ? (lineMatch[2] ?? "") : "";
+
+  const indentedSnippets = entries.map(({ snippet }) =>
+    snippet
+      .split("\n")
+      .map((line, i) => (i === 0 || line === "" ? line : `${indent}${line}`))
+      .join("\n")
+  );
+  const combined = indentedSnippets.join("\n" + indent);
+
+  if (lineMatch) {
+    body = body.replace(markerLineRegex, `$1$2${markerComment}$3${indent}${combined}\n`);
+  } else {
+    // Marker exists in body but not on its own line — fall back to a simple
+    // replace at the first occurrence (no indent inference possible).
+    body = body.replace(markerComment, `${markerComment}\n${combined}`);
+  }
+
+  for (const { source } of entries) {
+    patched.push({ source, marker: markerName });
+  }
+}
+
+// --- Write atomically --------------------------------------------------
+const out = `---\n${frontmatter}\n---\n${body}`;
+const tmpPath = navPath + ".tmp";
+writeFileSync(tmpPath, out);
+renameSync(tmpPath, navPath);
+
+console.log(JSON.stringify({
+  status: skipped.length > 0 ? "partial" : "ok",
+  path: navPath,
+  patched,
+  skipped,
+  addedImports: addedImports.map((c) => ({ source: c.source, line: c.line.trim() })),
+  addedFrontmatter: addedFrontmatter.map((c) => ({ source: c.source, line: c.line.trim() })),
+}, null, 2));


### PR DESCRIPTION
## Summary

- Phase 4 page agents (stores `home-and-nav`, ecom `pages`, gift-cards `pages`) no longer patch `src/components/Navigation.astro` directly.
- Each agent returns its contribution as `data.navContributions = { imports, frontmatter, byMarker }`.
- The orchestrator collects all returns and invokes a new `scripts/merge-navigation.mjs` once to splice contributions in deterministically.

## Why

Today three background subagents read-then-write the same `Navigation.astro` concurrently, and **two of them target the same `<!-- nav:links -->` marker**:

| Agent | Marker |
|-------|--------|
| `stores-pages-home-and-nav` | `nav:links` (Shop submenu) |
| `ecom-pages` | `nav:actions` (CartBadge) |
| `gift-cards-pages` | `nav:links` (probe-gated link) |

The Moran's Bakery run that motivated this PR happened to coexist because each agent's regex insert was self-idempotent, but render order was undefined and the file-level race was real (concurrent reads can each see the pre-patch state and clobber each other's writes).

Collecting structured contributions and splicing them in one merge step:
- Eliminates the race entirely
- Makes render order explicit (orchestrator passes contributions in pack order)
- Lets the merge script dedupe imports/frontmatter so two packs declaring the same helper guard don't double-import

## Design

The merge script is a **dumb string splicer**, not an AST parser. Contributions ship raw HTML/Astro/TS strings; the script:

- **Dedupes `imports[]` and `frontmatter[]`** against the designer's existing content (exact-line match after trim). Re-running with the same input is a no-op on those.
- **Groups contributions per marker** so multiple agents at the same marker join in input order. *Input order = render order.* The orchestrator controls precedence.
- **Mirrors indentation** of the marker line onto every line of every snippet so output stays legible inside indented `<ul>` blocks.
- **Reports unknown markers in `skipped[]`** (status: \`partial\`) rather than hard-failing — a disabled-pack contribution against a marker the designer didn't scaffold is observable but non-fatal.
- **Atomic write** (write-then-rename).

The merge script is **not idempotent** at the body-snippet level by design (it always inserts after the marker). The orchestrator invokes it once per build after collecting all Phase 4 returns.

## What changed

| File | Change |
|------|--------|
| `skills/wix-headless/scripts/merge-navigation.mjs` | **new** — splices contributions, dedupes imports/frontmatter |
| `skills/wix-headless/SKILL.md` | Wave 6 step list adds a new \`merge-navigation\` step before \`check-manifest pages\`; \`requiredPhases\` adds \`merge-navigation\`; renumbered subsequent steps; wave table row 6 mentions the script |
| `skills/wix-headless/references/shared/RETURN_CONTRACT.md` | New section \"Phase 2: navContributions\" documenting the shape with a stores example |
| `skills/wix-headless/references/stores/HOME_AND_NAV.md` | Section 3 (\"Navigation: Shop submenu\") rewritten — returns JSON, doesn't patch; scope boundaries say \"do not touch Navigation.astro\"; return-format example updated to show `navContributions` in `data` and remove `Navigation.astro` from `files[]` |
| `skills/wix-headless/references/ecom/CART_PAGES.md` | Section 3 (\"Mount CartBadge in Navigation.astro\") rewritten — returns JSON, doesn't patch; return-format updated |
| `skills/wix-headless/references/gift-cards/PAGES.md` | Section 2 (\"Patch Navigation.astro\") rewritten — returns JSON, doesn't patch; home teaser at \`<!-- home:gift-cards -->\` is still a direct patch (PR (c) will move that one too) |
| `skills/wix-headless/references/verticals/{stores,ecom,gift-cards}.md` | Each pack's `pages.<scope>.files:` list drops the \`src/components/Navigation.astro (patch ...)\` line. \`contributes:\` declarations unchanged (still the source of truth for which markers each pack writes to). |

## Test plan

- [x] Smoke test the script: 3 contributions (stores + gift-cards at \`nav:links\`, ecom at \`nav:actions\`), verify input order = render order
- [x] Dedupe: identical imports across two contributions appear once
- [x] Unknown marker reported in \`skipped[]\` with reason \`MARKER_NOT_FOUND\`; status: \`partial\`
- [x] Indentation: snippets inserted after an indented marker line are themselves indented to match
- [x] No \`---\` frontmatter → script exits 2 (Astro shells without frontmatter aren't valid)
- [ ] End-to-end skill run with the updated SKILL.md flow on a stores+ecom+cms+gift-cards build
- [ ] Verify that re-running the merge with the SAME input *body snippets* re-inserts (NOT idempotent by design) — orchestrator must call exactly once

## Open follow-ups (not in this PR)

- **Blog + Forms packs** also have `contributes:` Navigation entries today. Their Phase 4 agents would adopt the same model when those flows are exercised. Not changed in this PR because there's no agent-side instruction to update yet.
- **`home:gift-cards`** marker patch is still done by the gift-cards-pages agent directly. PR (c) (sibling in this series) generalizes the same pattern for `index.astro` home markers.

## Notes

- Opens as **draft** while sibling PRs in this series land. The four (a/b/c/d) were split per the maintainer's preference.
- Companion to #207 (image-urls writer) and #208 (merge-site-json). All three are part of the same \"orchestrator owns shared file writes\" theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)