### PR TITLE
feat(wix-headless): merge index.astro home contributions in orchestrator

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -81,7 +81,7 @@ If `wix.config.json` is present in the working directory, offer: *"I found an ex
 | 3 | seeders + design-system + image-phase-1 | design-system (fg) | merge `designTokens` into site.json; `emit-design-tokens.mjs`; grep Layout.astro CSS imports |
 | 4 | components + components-css + image-phase-2 (all bg) | (none — all backgrounded) | `copy-utility-templates.mjs components`; on Image Phase 1 return: `patch-decorative-slots.mjs`; on Phase 3 return: `check-manifest.mjs components` |
 | 5 | pages | components done + Phase 1 seeders done | `copy-utility-templates.mjs pages` |
-| 6 | (bash) | pages done + image-phase-2 done | `check-manifest.mjs pages`; `release.sh`; `finalize-run-json.mjs` |
+| 6 | (bash) | pages done + image-phase-2 done | `merge-navigation.mjs` + `merge-home.mjs` (collect each Phase 4 agent's `data.navContributions` / `data.homeContributions`); `check-manifest.mjs pages`; `release.sh`; `finalize-run-json.mjs` |
 
 **Phase axis.** Core pipeline: `Phase 1 (Seed) → Phase 2 (Design System) → Phase 3 (Components) → Phase 4 (Pages)`. Image pipeline runs in parallel: Image Phase 1 (Decorative) alongside Phases 1–2; Image Phase 2 (Entity) alongside Phase 3 (depends only on Phase 1 Seed entity IDs + brand). Each Phase 4 agent writes its routes ONCE with both visual design and data queries — no placeholder-then-rewrite split.
 
@@ -263,11 +263,21 @@ Each prompt includes the standard fields PLUS:
 
    **Rate-limit recovery for `image-phase-2-entity`.** If the subagent returns `status: "failed"` with an error matching `/limit|quota|resets/i`, do NOT stall or retry the subagent. Run the inline recovery in the orchestrator: batched generate (one call) → concurrent imports (one batch) → concurrent product/CMS PATCHes (one batch). Procedure encoded in `references/shared/IMAGE_GENERATION.md`.
 
-2. **Post-Phase-4 manifest check.** `node "<SKILL_ROOT>/scripts/check-manifest.mjs" "$(pwd)" pages "<packs-csv>"`. Same recovery rules as Phase 3 check. Surface any unrecoverable `missing[]` entries (exit code 1) before invoking release — those are page files Phase 4 didn't write that have no template fallback. Record `{ phase: "manifest-check-pages", seconds }`.
+2. **Merge home-page contributions.** Phase 4 page agents now return per-pack `data.homeContributions` (per `references/shared/RETURN_CONTRACT.md`) instead of patching `src/pages/index.astro` themselves. Pipe contributions through the merge script:
 
-3. **Wait for npm install** — the background install from Wave 2. Wait on its handle; do not `sleep`-poll. On non-zero exit follow the recovery ladder in `references/SETUP.md` § "npm install recovery" (foreground retry with timeout, never delete the lockfile).
+   ```bash
+   echo "$HOME_CONTRIBUTIONS_JSON" | node "<SKILL_ROOT>/scripts/merge-home.mjs" "$(pwd)"
+   ```
 
-4. **`bash <SKILL_ROOT>/scripts/release.sh`** — runs `npx @wix/cli build` + `release`, extracts the URL from `Site published on <url>`, prints the URL on stdout. Capture build / release timings via `date -u` wrappers and record `{ phase: "build", seconds }` and `{ phase: "release", seconds }`. The script's stdout becomes `outcome.releaseUrl` in `run.json`. This populates the **Frontend link** in headless settings so transactional emails link to the deployed frontend. On build failure, surface the compiler error and stop — do NOT deploy a broken site.
+   `$HOME_CONTRIBUTIONS_JSON` is `{contributions: [<agent return's data.homeContributions>, ...]}` in pack order. Markers today: `home:stores` (stores featured grid), `home:gift-cards` (gift-cards probe-gated teaser, disabled pack — script reports it in `skipped[]` if the designer didn't emit the marker, status: \`partial\` but non-fatal). Record `{ phase: "merge-home", seconds }`.
+
+   > **Note on stores home-and-nav scope:** that agent still writes `index.astro` directly to perform category-href rewrites on the designer's category cards (non-marker edits). The merge script reads the post-edit file, so those rewrites are preserved. Only the `home:stores` featured-grid section moved to the contribution model.
+
+3. **Post-Phase-4 manifest check.** `node "<SKILL_ROOT>/scripts/check-manifest.mjs" "$(pwd)" pages "<packs-csv>"`. Same recovery rules as Phase 3 check. Surface any unrecoverable `missing[]` entries (exit code 1) before invoking release — those are page files Phase 4 didn't write that have no template fallback. Record `{ phase: "manifest-check-pages", seconds }`.
+
+4. **Wait for npm install** — the background install from Wave 2. Wait on its handle; do not `sleep`-poll. On non-zero exit follow the recovery ladder in `references/SETUP.md` § "npm install recovery" (foreground retry with timeout, never delete the lockfile).
+
+5. **`bash <SKILL_ROOT>/scripts/release.sh`** — runs `npx @wix/cli build` + `release`, extracts the URL from `Site published on <url>`, prints the URL on stdout. Capture build / release timings via `date -u` wrappers and record `{ phase: "build", seconds }` and `{ phase: "release", seconds }`. The script's stdout becomes `outcome.releaseUrl` in `run.json`. This populates the **Frontend link** in headless settings so transactional emails link to the deployed frontend. On build failure, surface the compiler error and stop — do NOT deploy a broken site.
 
    Use `bash <SKILL_ROOT>/scripts/preview.sh` (not this step) only when the user is iterating on an existing site and explicitly asks for a fast preview without touching production.
 
@@ -298,7 +308,7 @@ One concluding turn containing, in order:
 
 1. **Release URL text first** — bold heading / link at the top so the user sees it immediately.
 2. **Compose the draft `run.json` blob** in scratch. Aggregate every subagent return into `phases[]`, set `outcome.previewUrl`, fill `run.started` (from `runStartedAt`) / `run.ended` (capture now via `date -u`), compute `run.totalSeconds`, and compose `requiredPhases[]` — phases that MUST have a captured duration:
-   - Always: `mcp-bootstrap`, `init-site-json`, `scaffold`, `env-pull`, `seed-utilities`, `emit-design-tokens`, `manifest-check-components`, `manifest-check-pages`, `decorative-slot-patch`, `npm-install`, `build`, `release` (or `preview` if `preview.sh` was used).
+   - Always: `mcp-bootstrap`, `init-site-json`, `scaffold`, `env-pull`, `seed-utilities`, `emit-design-tokens`, `manifest-check-components`, `manifest-check-pages`, `decorative-slot-patch`, `merge-home`, `npm-install`, `build`, `release` (or `preview` if `preview.sh` was used).
    - Per app installed in Wave 2: `app-install-<appName>`.
    - When `copy-utility-templates` ran: `copy-utility-templates-components` and/or `copy-utility-templates-pages`.
    - `image-phase-2-entity`'s duration arrives via its return; record from there if any pack produced entities.

--- a/skills/wix-headless/references/gift-cards/PAGES.md
+++ b/skills/wix-headless/references/gift-cards/PAGES.md
@@ -8,10 +8,10 @@ Files this agent OWNS (writes fresh):
 
 - `src/pages/gift-cards.astro` — landing page; redirects to `/` when probe returns null
 
-Files this agent PATCHES (insert at marker, preserve everything else):
+Navigation + home contributions (returned as JSON, NOT direct writes):
 
-- `src/components/Navigation.astro` — insert "Gift Cards" link at `<!-- nav:links -->`
-- `src/pages/index.astro` — insert home teaser at `<!-- home:gift-cards -->`
+- The "Gift Cards" link is returned as `data.navContributions` (spliced into `Navigation.astro` by `scripts/merge-navigation.mjs`).
+- The home teaser is returned as `data.homeContributions` (spliced into `src/pages/index.astro` by `scripts/merge-home.mjs`).
 
 Files this agent MUST NOT touch:
 - `src/utils/gift-cards.ts`, `src/components/GiftCardPurchase.tsx`, `src/styles/components-gift-cards.css` — Components scope.
@@ -69,21 +69,33 @@ Body: hero image + name + description + `<GiftCardPurchase client:load product={
    ```
 4. If other verticals (stores, blog, forms) already inserted at the same marker, preserve every existing line — your snippet appends.
 
-### 3. Patch `src/pages/index.astro`
+### 3. Home teaser contribution (returned as `data.homeContributions`)
 
-1. Read the file.
-2. Add to frontmatter:
-   ```astro
-   import { getGiftCardProduct } from "../utils/gift-cards";
-   import { resolveWixImageUrl } from "../utils/wix-image";
+> **Do NOT write `src/pages/index.astro` from this scope.** Return the contribution as JSON; the orchestrator splices it via `scripts/merge-home.mjs` after all Phase 4 agents return. If the `<!-- home:gift-cards -->` marker is absent from the designer's emission (this is `disabled: true` pack — the designer may have skipped it), the merge script reports it in `skipped[]` with reason `MARKER_NOT_FOUND` — non-fatal, observable.
 
-   const giftCardProduct = await getGiftCardProduct();
-   const giftCardImage = giftCardProduct
-     ? resolveWixImageUrl(giftCardProduct.image, 800, 600)
-     : null;
-   ```
-   (`resolveWixImageUrl` import may already be present from the stores patcher — if so, do not re-import.)
-3. Locate the line containing `<!-- home:gift-cards -->`. Insert the teaser snippet immediately after it (see `templates/_home-teaser-snippet.astro`).
+Build the contribution as part of your return JSON:
+
+```json
+{
+  "data": {
+    "homeContributions": {
+      "imports": [
+        "import { getGiftCardProduct } from '../utils/gift-cards';",
+        "import { resolveWixImageUrl } from '../utils/wix-image';"
+      ],
+      "frontmatter": [
+        "const giftCardProduct = await getGiftCardProduct().catch(() => null);",
+        "const giftCardImage = giftCardProduct ? resolveWixImageUrl(giftCardProduct.image, 800, 600) : null;"
+      ],
+      "byMarker": {
+        "home:gift-cards": "{giftCardProduct && (<section class=\"gift-card-teaser\">…teaser snippet from templates/_home-teaser-snippet.astro…</section>)}"
+      }
+    }
+  }
+}
+```
+
+The merge script dedupes the `resolveWixImageUrl` import against the existing frontmatter (it may already be imported by another pack's contribution). Imports + frontmatter additions are dedupe-safe.
 
 ## Verification
 
@@ -104,18 +116,32 @@ After writing/patching, grep the project to confirm:
     "pageWritten": true,
     "navigationPatched": true,
     "homePatched": true,
-    "markersFound": ["<!-- nav:links -->", "<!-- home:gift-cards -->"]
+    "markersFound": ["<!-- nav:links -->", "<!-- home:gift-cards -->"],
+    "homeContributions": {
+      "imports": [
+        "import { getGiftCardProduct } from '../utils/gift-cards';",
+        "import { resolveWixImageUrl } from '../utils/wix-image';"
+      ],
+      "frontmatter": [
+        "const giftCardProduct = await getGiftCardProduct().catch(() => null);",
+        "const giftCardImage = giftCardProduct ? resolveWixImageUrl(giftCardProduct.image, 800, 600) : null;"
+      ],
+      "byMarker": {
+        "home:gift-cards": "{giftCardProduct && (<section class=\"gift-card-teaser\">…</section>)}"
+      }
+    }
   },
   "files": [
     "src/pages/gift-cards.astro",
-    "src/components/Navigation.astro",
-    "src/pages/index.astro"
+    "src/components/Navigation.astro"
   ],
   "errors": []
 }
 ```
 
-If a marker is missing, return `status: "partial"` with `errors: [{ code: "MARKER_NOT_FOUND", file: "<path>", marker: "<marker>" }]`. Do NOT invent your own insertion point — that signals the designer foundation didn't scaffold the shell correctly and should be fixed upstream.
+> `src/pages/index.astro` is removed from `files[]` — the orchestrator owns home-page writes via `scripts/merge-home.mjs`. The Navigation.astro line predates the navContributions migration (sibling PR).
+
+If the home marker is absent (e.g. the designer skipped `<!-- home:gift-cards -->` because the pack is `disabled`), the merge script reports it in `skipped[]`; the agent should NOT manually patch index.astro to compensate. Surfacing the omission keeps the designer's emission contract honest.
 
 ## Anti-patterns
 

--- a/skills/wix-headless/references/shared/RETURN_CONTRACT.md
+++ b/skills/wix-headless/references/shared/RETURN_CONTRACT.md
@@ -216,6 +216,42 @@ Phase 4 CMS page agents reference these collection names; the image agent attach
 }
 ```
 
+### Phase 2: homeContributions (index.astro contributions)
+
+Identical shape to `navContributions` (see above) but targets `src/pages/index.astro` and `home:*` markers. Phase 4 page agents that previously patched the home page at marker comments (stores `home-and-nav` at `<!-- home:stores -->`, gift-cards `pages` at `<!-- home:gift-cards -->`) now return their contribution as `data.homeContributions`. The orchestrator collects every Phase 4 agent's `homeContributions`, then invokes `scripts/merge-home.mjs` ONCE to splice them into the designer-emitted shell.
+
+```json
+{
+  "status": "complete",
+  "phase": "stores-pages-home-and-nav",
+  "scope": "pages-home-and-nav",
+  "data": {
+    "homeContributions": {
+      "imports": [
+        "import ProductCard from '../components/ProductCard.astro';",
+        "import { productsV3 } from '@wix/stores';"
+      ],
+      "frontmatter": [
+        "let featured: any[] = [];",
+        "try { featured = (await productsV3.queryProducts().limit(12).find()).items ?? []; } catch (err) { console.error('[home] featured products query failed:', err); }",
+        "featured = featured.filter((p) => p?.ribbon?.name !== 'Gift Card').slice(0, 3);"
+      ],
+      "byMarker": {
+        "home:stores": "{featured.length > 0 && (<section class=\"featured-section\">…<div class=\"product-grid\">{featured.map((p) => <ProductCard product={p} />)}</div>…</section>)}"
+      }
+    },
+    "featuredProductsCount": 3
+  },
+  "files": [
+    "src/pages/index.astro"
+  ]
+}
+```
+
+> The stores `home-and-nav` agent still lists `src/pages/index.astro` in `files[]` because it ALSO performs non-marker edits on the page (category-card href rewrites). The orchestrator reads the post-edit file before invoking `merge-home.mjs`, so those rewrites are preserved.
+
+The `gift-cards` page agent contributes at `home:gift-cards`. If the designer didn't emit that marker (e.g. because gift-cards is `disabled: true` and the designer was told to skip surfaces for disabled packs), `merge-home.mjs` reports it in `skipped[]` with reason `MARKER_NOT_FOUND` — non-fatal, observable.
+
 ### Designer foundation
 
 ```json

--- a/skills/wix-headless/references/stores/HOME_AND_NAV.md
+++ b/skills/wix-headless/references/stores/HOME_AND_NAV.md
@@ -43,49 +43,49 @@ If the home page is purely editorial (hero + copy + newsletter), return with `fe
 
 ## Implementation
 
-### 1. Home page: featured products
+### 1. Home page: featured products (returned as `data.homeContributions`)
 
-Find the placeholder products array in `src/pages/index.astro`. Replace with a server-side `productsV3` query; pass the raw product objects to `ProductCard`.
+> **Do NOT patch `src/pages/index.astro` at the `<!-- home:stores -->` marker yourself.** Return the contribution as JSON; the orchestrator splices it via `scripts/merge-home.mjs` after all Phase 4 agents return. The category-href rewrites in section 2 below STILL happen as direct edits to `index.astro` (they're non-marker surgical edits) — only the featured-grid section at the marker is contributed.
+
+Build the contribution as part of your return JSON's `data.homeContributions`:
+
+```json
+{
+  "data": {
+    "homeContributions": {
+      "imports": [
+        "import ProductCard from '../components/ProductCard.astro';",
+        "import { productsV3 } from '@wix/stores';"
+      ],
+      "frontmatter": [
+        "let featured: any[] = [];",
+        "try { const { items: featuredProducts } = await productsV3.queryProducts({ fields: ['CURRENCY'] }).limit(4).find(); featured = featuredProducts ?? []; } catch (err) { console.error('[home] featured products query failed:', err); }",
+        "featured = featured.filter((p) => p?.ribbon?.name !== 'Gift Card').slice(0, 3);"
+      ],
+      "byMarker": {
+        "home:stores": "{featured.length > 0 && (<section class=\"featured-section\">…<div class=\"product-grid\">{featured.map((p) => <ProductCard product={p} />)}</div>…</section>)}"
+      }
+    }
+  }
+}
+```
+
+The merge script:
+- Dedupes the `imports[]` and `frontmatter[]` lines against the designer's existing content.
+- Inserts the `byMarker["home:stores"]` snippet immediately after the marker line, preserving the marker.
 
 > **WRONG:** `featured = products.map(p => ({name: p.name, price: ...}))` then `<ProductCard name={p.name} .../>`
 > **RIGHT:** `featured = featuredProducts ?? []` as `any[]`, then `<ProductCard product={p} />`
 >
 > Flat-mapping strips fields that ProductCard needs (`media`, `actualPriceRange`, etc.) and crashes the home page (`product` is `undefined`).
 
-```astro
----
-// src/pages/index.astro (frontmatter additions only — keep existing imports)
-import { productsV3 } from "@wix/stores";
+> **Gift-card mirror filter.** Apply `featured = featured.filter((p) => p.ribbon?.name !== "Gift Card")` so the Wix Gift Card app's auto-created DIGITAL mirror products don't appear in the featured grid. The home teaser block (gift-cards pack) is the right surface for gift cards on the home page.
 
-// Wrap every SSR await in try/catch — see references/shared/IMPLEMENTER.md
-// § "SSR error guards" for the full rule.
-let featured: any[] = [];
-try {
-  const { items: featuredProducts } = await productsV3
-    .queryProducts({ fields: ["CURRENCY"] })
-    .limit(4)
-    .find();
-  featured = featuredProducts ?? [];
-} catch (err) {
-  console.error("[home] featured products query failed:", err);
-}
----
-```
+Do **NOT** flat-map products into `{name, price, slug, image}` — pass the raw SDK objects in the marker snippet. ProductCard handles its own field extraction, image resolution, and ribbon (offer) rendering internally.
 
-Then pass each raw product to `ProductCard`. The ribbon is fetched inside ProductCard itself — pages no longer wire offers:
-```astro
-{featured.map((p) => <ProductCard product={p} />)}
-```
+If `featured` is empty (query failed, or stock cleared), the wrapped `{featured.length > 0 && (...)}` expression renders nothing — the rest of the page stays up.
 
-> **Gift-card mirror filter.** After `featured = featuredProducts ?? []`, apply the same filter the listing template uses:
-> ```ts
-> featured = featured.filter((p) => p.ribbon?.name !== "Gift Card");
-> ```
-> The Wix Gift Card app, when enabled in the dashboard, auto-creates 5 DIGITAL Stores products tagged with the "Gift Card" ribbon. They must not appear in the home featured grid for the same reason they're filtered from `/products`: buying a mirror produces a dud line item that doesn't trigger gift-card issuance, and the home teaser block (gift-cards pack) is the right surface for gift cards on the home page.
-
-Do **NOT** flat-map products into `{name, price, slug, image}` — pass the raw SDK objects. ProductCard handles its own field extraction, image resolution, and ribbon (offer) rendering internally.
-
-Preserve every other prop the designer set on the grid. If `featured` is empty (query failed, or stock cleared), the grid renders with zero cards — the rest of the page stays up.
+> **If the home page is purely editorial** (hero + copy + newsletter; no `<!-- home:stores -->` marker), omit `data.homeContributions` entirely or pass empty arrays/objects. The merge script will report no patches for stores. Return with `featuredProductsWired: false`.
 
 ### 1a. ProductCard interface (template — deterministic)
 
@@ -196,7 +196,21 @@ Keep the marker comment immediately after the inserted `<li>` so other vertical 
     "categoryCardsFound": 3,
     "categoryCardsMatched": 2,
     "categoryCardsFallbackToProducts": 1,
-    "navSubmenuCategoryCount": 0
+    "navSubmenuCategoryCount": 0,
+    "homeContributions": {
+      "imports": [
+        "import ProductCard from '../components/ProductCard.astro';",
+        "import { productsV3 } from '@wix/stores';"
+      ],
+      "frontmatter": [
+        "let featured: any[] = [];",
+        "try { const { items: featuredProducts } = await productsV3.queryProducts({ fields: ['CURRENCY'] }).limit(4).find(); featured = featuredProducts ?? []; } catch (err) { console.error('[home] featured products query failed:', err); }",
+        "featured = featured.filter((p) => p?.ribbon?.name !== 'Gift Card').slice(0, 3);"
+      ],
+      "byMarker": {
+        "home:stores": "{featured.length > 0 && (<section class=\"featured-section\">…</section>)}"
+      }
+    }
   },
   "files": [
     "src/pages/index.astro",
@@ -205,6 +219,8 @@ Keep the marker comment immediately after the inserted `<li>` so other vertical 
   "errors": []
 }
 ```
+
+> `src/pages/index.astro` stays in `files[]` because this scope still performs non-marker edits on it (category-card href rewrites). The `home:stores` marker insertion is contributed via `data.homeContributions` instead, and is merged by the orchestrator after this scope returns. `src/components/Navigation.astro` listed here predates the navContributions migration — see the sibling PR for that change.
 
 ## Scope boundaries (reinforced)
 

--- a/skills/wix-headless/references/verticals/gift-cards.md
+++ b/skills/wix-headless/references/verticals/gift-cards.md
@@ -35,12 +35,13 @@ pages:
   - name: "gift-cards-pages"
     agentLocation: "references/gift-cards/"
     scope: "pages"
-    description: "Write /gift-cards landing page (redirects when app is disabled), patch nav link + home teaser via markers"
+    description: "Write /gift-cards landing page (redirects when app is disabled); return probe-gated nav link as data.navContributions and probe-gated home teaser as data.homeContributions (orchestrator merges via scripts/merge-navigation.mjs and scripts/merge-home.mjs)"
     references: ["references/gift-cards/PAGES.md"]
     files:
       - "src/pages/gift-cards.astro"
-      - "src/components/Navigation.astro (patch — gift-cards link)"
-      - "src/pages/index.astro (patch — gift-cards teaser)"
+    # Navigation.astro + index.astro are no longer written by this agent. Nav link
+    # is returned as data.navContributions and home teaser as data.homeContributions.
+    # The orchestrator merges contributions (see contributes: below for which markers).
 
 creates:
   - { file: src/utils/gift-cards.ts,            phase: components }

--- a/skills/wix-headless/scripts/merge-home.mjs
+++ b/skills/wix-headless/scripts/merge-home.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// Merge per-pack home-page (`src/pages/index.astro`) contributions into the
+// designer-emitted shell.
+//
+// Today two Phase 4 page agents patch the home page at distinct `home:*`
+// markers (the markers don't conflict like nav:links does), but the broader
+// pattern is the same as scripts/merge-navigation.mjs:
+//
+//   - stores-pages-home-and-nav  → <!-- home:stores -->        (featured products grid)
+//   - gift-cards-pages           → <!-- home:gift-cards -->    (probe-gated teaser)
+//
+// Even without a same-marker race, agents writing the same file concurrently
+// is brittle: missing markers are masked (the gift-cards agent silently
+// no-ops if the designer forgot to emit `home:gift-cards`, observed on a
+// 2026-05 run), and ordering is undefined. Pulling the splicing into a
+// deterministic post-Phase-4 step makes both problems observable.
+//
+// Usage:
+//   echo "$CONTRIBUTIONS" | node merge-home.mjs <project-dir>
+//
+// stdin shape (mirrors merge-navigation.mjs):
+//   {
+//     "contributions": [
+//       {
+//         "source": "stores",                  // pack name; used in error reports
+//         "imports": [                          // raw TS import lines
+//           "import ProductCard from '../components/ProductCard.astro';",
+//           "import { productsV3 } from '@wix/stores';"
+//         ],
+//         "frontmatter": [                      // raw TS lines (after imports)
+//           "const { items: featured } = await productsV3.queryProducts(...);"
+//         ],
+//         "byMarker": {                         // raw HTML/Astro to splice
+//           "home:stores": "<section class=\"featured-section\">...</section>"
+//         }
+//       },
+//       ...
+//     ]
+//   }
+//
+// Behavior matches merge-navigation.mjs exactly:
+//   - Imports + frontmatter additions are deduped against existing content.
+//   - Multiple contributions at the same marker are joined in input order.
+//   - Unknown markers are reported in `skipped[]` with `MARKER_NOT_FOUND`;
+//     output status becomes "partial" but exit is 0. This makes the
+//     designer-forgot-to-emit-a-marker case observable and recoverable —
+//     e.g. an `<!-- home:gift-cards -->` omission for a disabled pack is
+//     a known non-fatal outcome.
+//   - Atomic write (write-then-rename).
+//   - NOT idempotent: orchestrator must invoke once per build.
+//
+// Exit codes:
+//   0 — merged (any `skipped` markers are non-fatal and reported in JSON)
+//   2 — argument validation, malformed input, or missing index.astro
+
+import { readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+const projectDir = process.argv[2];
+if (!projectDir) {
+  console.error("usage: cat contributions.json | merge-home.mjs <project-dir>");
+  process.exit(2);
+}
+
+const homePath = join(projectDir, "src/pages/index.astro");
+if (!existsSync(homePath)) {
+  console.error(`merge-home: ${homePath} does not exist — designer (Phase 2) must run first.`);
+  process.exit(2);
+}
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch (e) {
+  console.error(`merge-home: stdin is not valid JSON (${e.message})`);
+  process.exit(2);
+}
+
+const contributions = Array.isArray(payload.contributions) ? payload.contributions : null;
+if (!contributions) {
+  console.error("merge-home: stdin must contain `contributions: [...]`");
+  process.exit(2);
+}
+
+const source = readFileSync(homePath, "utf8");
+
+const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+const m = source.match(frontmatterRegex);
+if (!m) {
+  console.error("merge-home: index.astro has no --- frontmatter block; cannot merge imports/frontmatter contributions.");
+  process.exit(2);
+}
+
+let frontmatter = m[1];
+let body = m[2];
+
+// --- Imports + frontmatter additions -----------------------------------
+const existingLines = new Set(frontmatter.split("\n").map((l) => l.trim()));
+
+const addedImports = [];
+const addedFrontmatter = [];
+
+for (const contrib of contributions) {
+  const imports = Array.isArray(contrib.imports) ? contrib.imports : [];
+  const fm = Array.isArray(contrib.frontmatter) ? contrib.frontmatter : [];
+
+  for (const line of imports) {
+    if (typeof line !== "string") continue;
+    const trimmed = line.trim();
+    if (trimmed === "" || existingLines.has(trimmed)) continue;
+    addedImports.push({ source: contrib.source, line: line });
+    existingLines.add(trimmed);
+  }
+
+  for (const line of fm) {
+    if (typeof line !== "string") continue;
+    const trimmed = line.trim();
+    if (trimmed === "" || existingLines.has(trimmed)) continue;
+    addedFrontmatter.push({ source: contrib.source, line: line });
+    existingLines.add(trimmed);
+  }
+}
+
+const fmLines = frontmatter.split("\n");
+let lastImportIdx = -1;
+for (let i = 0; i < fmLines.length; i++) {
+  if (/^\s*import\b/.test(fmLines[i])) lastImportIdx = i;
+}
+
+if (addedImports.length > 0) {
+  const importLines = addedImports.map((c) => c.line);
+  if (lastImportIdx >= 0) {
+    fmLines.splice(lastImportIdx + 1, 0, ...importLines);
+    lastImportIdx += importLines.length;
+  } else {
+    fmLines.unshift(...importLines);
+    lastImportIdx = importLines.length - 1;
+  }
+}
+
+if (addedFrontmatter.length > 0) {
+  const fmAdditions = addedFrontmatter.map((c) => c.line);
+  const insertIdx = lastImportIdx + 1;
+  const needsSeparator = lastImportIdx >= 0 && fmLines[insertIdx]?.trim() !== "";
+  if (needsSeparator) fmAdditions.unshift("");
+  fmLines.splice(insertIdx, 0, ...fmAdditions);
+}
+
+frontmatter = fmLines.join("\n");
+
+// --- byMarker splicing -------------------------------------------------
+// Group contributions per marker so we splice once per marker with all
+// snippets joined in input order. See merge-navigation.mjs for why this is
+// done in two passes.
+
+const patched = [];
+const skipped = [];
+
+/** @type {Map<string, Array<{source: string, snippet: string}>>} */
+const groupedByMarker = new Map();
+
+for (const contrib of contributions) {
+  const byMarker = contrib.byMarker && typeof contrib.byMarker === "object" ? contrib.byMarker : {};
+  for (const [markerName, snippet] of Object.entries(byMarker)) {
+    if (typeof snippet !== "string" || snippet.trim() === "") continue;
+    if (!groupedByMarker.has(markerName)) groupedByMarker.set(markerName, []);
+    groupedByMarker.get(markerName).push({ source: contrib.source, snippet });
+  }
+}
+
+for (const [markerName, entries] of groupedByMarker) {
+  const markerComment = `<!-- ${markerName} -->`;
+  if (!body.includes(markerComment)) {
+    for (const { source } of entries) {
+      skipped.push({ source, marker: markerName, reason: "MARKER_NOT_FOUND" });
+    }
+    continue;
+  }
+
+  const markerLineRegex = new RegExp(`(^|\\n)([ \\t]*)${markerComment.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}(\\r?\\n)`);
+  const lineMatch = body.match(markerLineRegex);
+  const indent = lineMatch ? (lineMatch[2] ?? "") : "";
+
+  const indentedSnippets = entries.map(({ snippet }) =>
+    snippet
+      .split("\n")
+      .map((line, i) => (i === 0 || line === "" ? line : `${indent}${line}`))
+      .join("\n")
+  );
+  const combined = indentedSnippets.join("\n" + indent);
+
+  if (lineMatch) {
+    body = body.replace(markerLineRegex, `$1$2${markerComment}$3${indent}${combined}\n`);
+  } else {
+    body = body.replace(markerComment, `${markerComment}\n${combined}`);
+  }
+
+  for (const { source } of entries) {
+    patched.push({ source, marker: markerName });
+  }
+}
+
+// --- Write atomically --------------------------------------------------
+const out = `---\n${frontmatter}\n---\n${body}`;
+const tmpPath = homePath + ".tmp";
+writeFileSync(tmpPath, out);
+renameSync(tmpPath, homePath);
+
+console.log(JSON.stringify({
+  status: skipped.length > 0 ? "partial" : "ok",
+  path: homePath,
+  patched,
+  skipped,
+  addedImports: addedImports.map((c) => ({ source: c.source, line: c.line.trim() })),
+  addedFrontmatter: addedFrontmatter.map((c) => ({ source: c.source, line: c.line.trim() })),
+}, null, 2));


### PR DESCRIPTION
## Summary

- Phase 4 page agents that target `home:*` markers in `src/pages/index.astro` no longer patch the file at those markers themselves.
- Each agent returns its contribution as `data.homeContributions = { imports, frontmatter, byMarker }`.
- The orchestrator collects all returns and invokes a new `scripts/merge-home.mjs` once to splice contributions in deterministically.

## Why

Two Phase 4 page agents currently patch `index.astro` at distinct `home:*` markers:

| Agent | Marker |
|-------|--------|
| `stores-pages-home-and-nav` | `home:stores` (featured products grid) |
| `gift-cards-pages` | `home:gift-cards` (probe-gated teaser) |

The markers don't collide (unlike `nav:links` in PR #209), but the failure mode this PR fixes is real: **the 2026-05 Moran's Bakery run hit a `MARKER_NOT_FOUND` on `<!-- home:gift-cards -->` because the designer didn't emit it** — gift-cards is a `disabled: true` pack and the designer was told to skip its surfaces. With orchestrator-merge, that omission becomes a structured `skipped[]` output from the merge script (non-fatal, observable) rather than getting buried inside an agent return.

The model also matches the sibling PR #209 (Navigation.astro) — both shared shells now use the same contribution → merge pattern, which keeps the surface area of \"who can write what file\" small and explicit.

## Design

`scripts/merge-home.mjs` is structurally identical to `scripts/merge-navigation.mjs`:

- **Dedupes `imports[]` and `frontmatter[]`** against the designer's existing content (exact-line match after trim).
- **Groups contributions per marker** so multiple agents at the same marker join in input order. *Input order = render order.*
- **Mirrors indentation** of the marker line onto every line of every snippet.
- **Reports unknown markers in `skipped[]`** (status: `partial`) rather than hard-failing. This is the key motivation: the missing `<!-- home:gift-cards -->` from the disabled gift-cards pack now surfaces here rather than failing silently inside an agent.
- **Atomic write** (write-then-rename). **Not idempotent** by design — orchestrator invokes exactly once.

## Note on stores home-and-nav scope

That agent still writes `src/pages/index.astro` **directly** for non-marker category-card href rewrites (rewriting designer-placeholder slugs against the real `categoriesV3` catalog). Those edits are independent of the `home:stores` marker insertion. The orchestrator reads the post-edit file before invoking `merge-home.mjs`, so the rewrites are preserved.

In other words: only the *marker-bound* portion of each agent's home work moves to the contribution model. Non-marker surgical edits keep happening as direct writes by the owning agent.

## What changed

| File | Change |
|------|--------|
| `skills/wix-headless/scripts/merge-home.mjs` | **new** — splices home contributions, dedupes imports/frontmatter, reports missing markers |
| `skills/wix-headless/SKILL.md` | Wave 6 step list adds new \`merge-home\` step (parallel to \`merge-navigation\` from PR #209); \`requiredPhases\` adds \`merge-home\`; renumbered subsequent steps; wave table row 6 mentions the script |
| `skills/wix-headless/references/shared/RETURN_CONTRACT.md` | New section \"Phase 2: homeContributions\" — identical shape to navContributions, with stores example |
| `skills/wix-headless/references/stores/HOME_AND_NAV.md` | Section 1 (home page: featured products) rewritten to return JSON instead of patching the marker. Section 2 (category-card href rewrites) UNCHANGED because it's a direct edit. Return-format updated. |
| `skills/wix-headless/references/gift-cards/PAGES.md` | Section 3 (Patch index.astro) rewritten to return JSON. The disabled-pack \`MARKER_NOT_FOUND\` case now surfaces via the merge script's \`skipped[]\` rather than agent error code. |
| `skills/wix-headless/references/verticals/gift-cards.md` | Removes \`src/pages/index.astro (patch — gift-cards teaser)\` from \`pages.gift-cards-pages.files[]\`. stores.md keeps \`src/pages/index.astro\` because that scope still writes it for non-marker rewrites. |

## Test plan

- [x] Smoke test the script with 2 contributions at different markers; verify both inserted, marker comments preserved
- [x] Dedupe: shared imports across contributions appear once
- [x] Missing marker (gift-cards) reported in `skipped[]` with `MARKER_NOT_FOUND`; status: `partial`; exit code 0 (non-fatal)
- [x] Indentation: snippets inserted after an indented marker line are themselves indented to match
- [x] No `---` frontmatter → script exits 2
- [ ] End-to-end skill run with the updated SKILL.md flow on a stores+ecom+cms+gift-cards build
- [ ] Verify category-href rewrites by stores home-and-nav still take effect (orchestrator reads index.astro AFTER the agent's edits)

## Open follow-ups (not in this PR)

- This PR + #209 together establish the contribution → merge pattern for two shared shells. Future packs adding home or nav surfaces should adopt the same model. Blog and forms packs already declare `contributes:` entries; their Phase 4 agents would adopt this contract when those flows are exercised.
- A small generalization is plausible: `scripts/merge-shared-astro.mjs <file>` covering both Navigation.astro and index.astro (the splicer logic is identical). Left for a future cleanup — keeping two scripts is clearer for now.

## Notes

- Opens as **draft** while sibling PRs in this series land. Companion to #207 (image-urls), #208 (merge-site-json), #209 (merge-navigation). All four are part of the same \"orchestrator owns shared file writes\" theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)