### PR TITLE
wix-headless: harden production sharp edges

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -15,6 +15,7 @@ Your CWD at runtime is the **project directory**, not the skill root. Compute `<
 |---|---|
 | Shared return contract | `<SKILL_ROOT>/references/shared/RETURN_CONTRACT.md` |
 | Shared MCP prefix guide | `<SKILL_ROOT>/references/shared/MCP_PREFIX.md` |
+| Production release / reserved root path sharp edges | `<SKILL_ROOT>/references/shared/PRODUCTION_SHARP_EDGES.md` |
 | Per-vertical / per-scope subagent instructions | `<SKILL_ROOT>/references/<scope>/INSTRUCTIONS.md` (scopes: `stores`, `ecom`, `cms`, `blog`, `forms`, `gift-cards`, `images`, `designer`). Subagent-only — orchestrator never reads. |
 | Vertical packs directory | `<SKILL_ROOT>/references/verticals/` |
 | Templates directory | `<SKILL_ROOT>/templates/` |
@@ -267,11 +268,13 @@ Each prompt includes the standard fields PLUS:
 
 3. **Wait for npm install** — the background install from Wave 2. Wait on its handle; do not `sleep`-poll. On non-zero exit follow the recovery ladder in `references/SETUP.md` § "npm install recovery" (foreground retry with timeout, never delete the lockfile).
 
-4. **`bash <SKILL_ROOT>/scripts/release.sh`** — runs `npx @wix/cli build` + `release`, extracts the URL from `Site published on <url>`, prints the URL on stdout. Capture build / release timings via `date -u` wrappers and record `{ phase: "build", seconds }` and `{ phase: "release", seconds }`. The script's stdout becomes `outcome.releaseUrl` in `run.json`. This populates the **Frontend link** in headless settings so transactional emails link to the deployed frontend. On build failure, surface the compiler error and stop — do NOT deploy a broken site.
+4. **`bash <SKILL_ROOT>/scripts/release.sh`** — runs `npx @wix/cli build` + `release`, extracts the URL from `Site published on <url>`, prints the URL on stdout. Capture build / release timings via `date -u` wrappers and record `{ phase: "build", seconds }` and `{ phase: "release", seconds }`. The script's stdout becomes `outcome.releaseUrl` in `run.json`. This populates the **Frontend link** in headless settings so transactional emails link to the deployed frontend. On build failure, surface the compiler error and stop — do NOT deploy a broken site. The script retries known transient release failures; see `<SKILL_ROOT>/references/shared/PRODUCTION_SHARP_EDGES.md` before adding custom release retry logic.
 
    Use `bash <SKILL_ROOT>/scripts/preview.sh` (not this step) only when the user is iterating on an existing site and explicitly asks for a fast preview without touching production.
 
    On non-fatal build warnings, see `<SKILL_ROOT>/references/shared/BUILD_NOISE.md` — read only if a warning surfaces.
+
+   If the user asks for SEO root files (`robots.txt`, `llms.txt`), favicons, custom-domain verification, or batch release behavior, read `<SKILL_ROOT>/references/shared/PRODUCTION_SHARP_EDGES.md` before implementing. Wix may own these root paths at the edge, so static files and Astro routes are not always effective.
 
 > **No standalone verify phase.** The post-phase manifest check catches missing files with auto-recovery; type/module/template errors surface from `astro build` a few seconds later.
 
@@ -373,3 +376,4 @@ Shared (with agents):
 - `references/shared/IMAGE_GENERATION.md` — image agent contract
 - `references/shared/STYLING.md` — three styling categories, ownership, decision rules
 - `references/shared/IMPLEMENTER.md` — shared implementer behavior
+- `references/shared/PRODUCTION_SHARP_EDGES.md` — release retries, reserved root paths, SEO files, favicons, verification

--- a/skills/wix-headless/references/designer/INSTRUCTIONS.md
+++ b/skills/wix-headless/references/designer/INSTRUCTIONS.md
@@ -299,7 +299,7 @@ After writing, self-verify the file contains all of: `import '../styles/global.c
 
 The site shell. Contains:
 
-- `<head>` with meta tags, Google Fonts link for the chosen fonts, favicon, viewport
+- `<head>` with meta tags, Google Fonts link for the chosen fonts, favicon, viewport. Do not rely on `/favicon.svg` as the browser-facing href; Wix may intercept that root path. If you create a custom SVG favicon, keep the readable source in `public/favicon.svg` and embed the browser-facing icon as `data:image/svg+xml;base64,...` in `<link rel="icon">` unless the orchestrator gives you a verified site-favicon URL.
 - `import '../styles/global.css'`
 - One `import '../styles/components-<pack>.css'` per pack **that has a `components` agent** (listed in your prompt as "Packs with shared wiring"). Packs without shared wiring (e.g., `cms`) do NOT get an import — no agent writes that file, and importing it breaks the build.
 - `import { ClientRouter } from 'astro:transitions'` and `<ClientRouter />` rendered inside `<head>` — enables Astro View Transitions across the site so category-rail clicks feel like in-place filtering instead of full page loads.

--- a/skills/wix-headless/references/shared/PRODUCTION_SHARP_EDGES.md
+++ b/skills/wix-headless/references/shared/PRODUCTION_SHARP_EDGES.md
@@ -1,0 +1,97 @@
+# Production Sharp Edges
+
+Use this reference when a Wix Headless run touches production release, SEO-controlled root files, favicon behavior, or multi-site orchestration.
+
+## Release Retries
+
+`wix release` can hit transient backend/network errors after upload or during publish. Known retryable signals include:
+
+- `ECONNRESET`
+- `ETIMEDOUT`
+- `EAI_AGAIN`
+- `STATE_MISMATCH`
+- `temporary system error`
+- `try again shortly`
+
+The bundled `scripts/release.sh` retries these known transient release failures. Do not retry build failures; TypeScript, Astro, missing import, and missing module failures are code issues that must be fixed before another release attempt.
+
+For batch releases across many projects, prefer releasing failed sites one by one after the current deployment state settles. Parallel release is useful for throughput, but retry serially when Wix reports state-machine errors.
+
+## Reserved Root Paths
+
+Wix can intercept root paths before the Astro app serves them. Do not assume files in `public/` or root Astro routes will win for these URLs:
+
+- `/robots.txt`
+- `/llms.txt`
+- `/favicon.svg`
+
+### `robots.txt`
+
+Use the Wix SEO robots REST endpoint instead of `public/robots.txt`:
+
+```http
+PUT https://www.wixapis.com/promote-seo-robots-server/v2/robots
+```
+
+```json
+{
+  "robotsTxt": {
+    "content": "...",
+    "default": false,
+    "subdomain": "www"
+  }
+}
+```
+
+`default: true` resets to Wix's built-in robots file.
+
+### `llms.txt`
+
+Use the sibling Wix SEO endpoint instead of `public/llms.txt` or `src/pages/llms.txt.ts`:
+
+```http
+PUT https://www.wixapis.com/promote-seo-robots-server/v2/llms
+```
+
+```json
+{
+  "llmsTxt": {
+    "content": "...",
+    "default": false,
+    "subdomain": "www"
+  }
+}
+```
+
+Do not use `default: true` for custom `llms.txt`; in observed runs it caused `/llms.txt` to return `404`.
+
+Wix may mutate `llms.txt` content by:
+
+- prepending an H1 from the site/business title
+- wrapping the first submitted line as a tagline blockquote
+- appending AI Agent Access and available MCP tools sections
+
+Start custom content with the intended tagline, not another H1.
+
+### Favicon
+
+Wix may intercept `/favicon.svg`, even if the project has `public/favicon.svg` or `src/pages/favicon.svg.ts`.
+
+When a run needs a custom favicon and no site-favicon API/CLI is available, embed the SVG directly in the document head:
+
+```html
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,..." />
+```
+
+Keep the source SVG in `public/favicon.svg` for repository readability, but do not use `/favicon.svg` as the browser-facing href unless a live fetch proves Wix is serving the project asset.
+
+## Verification
+
+For production checks, verify the final rendered HTML and edge-controlled files separately:
+
+- For favicon: fetch the live page HTML and confirm the `<link rel="icon">` points to the expected data URI or supported favicon URL.
+- For `robots.txt`: fetch `/robots.txt` after the REST update.
+- For `llms.txt`: fetch `/llms.txt` after the REST update and account for Wix-injected sections.
+- For custom domains: check both the Wix-hosted URL and custom domain when available, because domain propagation and redirects can differ.
+
+Do not construct URLs by editing the release URL from memory. Use the exact release URL printed by the CLI or the configured custom domain.

--- a/skills/wix-headless/scripts/release.sh
+++ b/skills/wix-headless/scripts/release.sh
@@ -20,6 +20,7 @@
 #             Build failures are code bugs (TypeScript / Astro / missing
 #             module) — the orchestrator does NOT retry. Release auth failures
 #             surface as `Run npx @wix/cli login and retry.`
+#             Known transient release failures are retried by this script.
 
 set -euo pipefail
 
@@ -28,14 +29,40 @@ npx @wix/cli build 1>&2
 RELEASE_OUTPUT="$(mktemp)"
 trap 'rm -f "$RELEASE_OUTPUT"' EXIT
 
-npx @wix/cli release 2>&1 | tee "$RELEASE_OUTPUT" 1>&2
+release_is_retryable() {
+  grep -Eiq 'ECONNRESET|ETIMEDOUT|EAI_AGAIN|STATE_MISMATCH|temporary system error|temporarily unavailable|try again shortly' "$RELEASE_OUTPUT"
+}
+
+MAX_RELEASE_ATTEMPTS="${WIX_RELEASE_ATTEMPTS:-3}"
+RELEASE_STATUS=1
+
+for ((attempt = 1; attempt <= MAX_RELEASE_ATTEMPTS; attempt++)); do
+  : >"$RELEASE_OUTPUT"
+  set +e
+  npx @wix/cli release 2>&1 | tee "$RELEASE_OUTPUT" 1>&2
+  RELEASE_STATUS=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "$RELEASE_STATUS" -eq 0 ]]; then
+    break
+  fi
+
+  if [[ "$attempt" -lt "$MAX_RELEASE_ATTEMPTS" ]] && release_is_retryable; then
+    sleep_seconds=$((attempt * 5))
+    echo "release.sh: release attempt $attempt failed with a retryable Wix error; retrying in ${sleep_seconds}s" >&2
+    sleep "$sleep_seconds"
+    continue
+  fi
+
+  exit "$RELEASE_STATUS"
+done
 
 # CLI prints `Site published on <url>` — extract the URL after that marker.
-# Fall back to the first https://*.wix-host.com URL if the marker line is
-# not found (CLI wording may vary between versions).
+# Fall back to the first Wix-hosted URL if the marker line is not found
+# (CLI wording may vary between versions).
 RELEASE_URL="$(sed -nE 's/.*Site published on ([^[:space:]]+).*/\1/p' "$RELEASE_OUTPUT" | head -n 1 || true)"
 if [[ -z "$RELEASE_URL" ]]; then
-  RELEASE_URL="$(grep -oE 'https://[A-Za-z0-9.-]+\.wix-host\.com[^[:space:]]*' "$RELEASE_OUTPUT" | head -n 1 || true)"
+  RELEASE_URL="$(grep -oE 'https://[A-Za-z0-9.-]+\.wix-(site-)?host\.com[^[:space:]]*' "$RELEASE_OUTPUT" | head -n 1 || true)"
 fi
 
 if [[ -z "$RELEASE_URL" ]]; then


### PR DESCRIPTION
## Summary
- Adds Wix Headless production sharp-edge guidance for release retries, SEO-controlled root files, favicon behavior, custom-domain checks, and multi-site verification.
- Wires that guidance into the Wix Headless skill and designer instructions so future runs know when to use API-backed robots/llms updates and data-URI favicons.
- Hardens `release.sh` with retries for known transient Wix release failures and recognizes both wix-host.com and wix-site-host.com release URLs.

## Validation
- `bash -n skills/wix-headless/scripts/release.sh`
- `git diff --check`

## Not Run
- Full skill/eval workflow; this is a docs/script change and I did not find a root package test runner in this repo.

## Review Context
- Distilled from a successful 10-site Wix Headless showcase run where parallel releases hit retryable ECONNRESET/STATE_MISMATCH-style failures and Wix edge behavior owned robots/llms/favicon root paths.
- Intentionally keeps the REST API notes inside the wix-headless orchestration reference instead of adding a new skill or broad wix-manage recipe.

## Risks
- Low: release retry patterns may need future tuning as Wix CLI/API errors evolve.
- Low: favicon guidance prefers data URI fallback only when no verified Wix favicon URL/API is available.

## Suggested Reviewers
- ozsay, gilisho, adimara, mirivoWix based on recent wix-headless PR history.

<details>
<summary>AI Session Transcription</summary>

**Session:** Untitled

</details>