### PR TITLE
Document Wix CLI and MCP prerequisites in wix-headless SKILL.md

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -9,16 +9,15 @@ Single orchestrator for the full site build. Linear flow with parallel subagent 
 
 ## Prerequisites
 
-Before running this skill, the user's environment must have a working, authenticated Wix CLI:
+Before running this skill, the user's environment must have a working, authenticated Wix CLI and a Wix MCP server registered with their agent client:
 
 | Requirement | Why | How to verify | How to fix if missing |
 |---|---|---|---|
 | **`@wix/cli` available** | Wave 2 runs `npx @wix/cli env pull` to write `.env.local`; Wave 6 runs `npx @wix/cli build` + `release` to publish. `npx` will fetch the CLI on demand, but a locally installed CLI is faster and surfaces version issues earlier. | `which wix` or `npx @wix/cli --version`. | `npm i -g @wix/cli` (or rely on `npx` to fetch per-invocation). |
 | **Wix CLI authenticated** | `env pull` and `release` both require a logged-in session; tokens live in `~/.wix/auth/`. On auth error the skill surfaces `"Run \`npx @wix/cli login\` and retry."` and stops. | `ls ~/.wix/auth/account.json` exists and is non-empty. | `npx @wix/cli login` — opens a browser to auth. |
+| **Wix MCP server configured with `--wixCliAuth`** | Provides the admin tools (`CallWixSiteAPI`, `ListWixSites`, `ManageWixSite`, image upload, etc.) the skill calls at Wave 0 and across every downstream subagent. Launched with `--wixCliAuth`, `@wix/mcp` reuses the same `~/.wix/auth/account.json` token the CLI writes (refreshed transparently); without the flag only the docs-only tools are exposed. | Your MCP client lists a server running `npx -y @wix/mcp --wixCliAuth` (or equivalent) and exposes `CallWixSiteAPI` as a tool — e.g. in Claude Code: `claude mcp list` shows `wix` connected with admin tools, not only `Search*Documentation`. | Register `npx -y @wix/mcp --wixCliAuth` as a stdio MCP server in your agent client. The exact registration step depends on the client — see your client's MCP-server documentation. The CLI-auth row above is a hard prereq, since `--wixCliAuth` reads from the CLI's token store. |
 
-If either prerequisite is missing, surface the specific gap to the user and stop **before** any subagent dispatches — failing mid-flow leaves a partially scaffolded project.
-
-> The Wix MCP connection is also relied on heavily today (Wave 0 hard-stops without it; every subagent calls MCP tools), but its prerequisite status is intentionally **not documented here yet** — see follow-up discussion on whether MCP should be a hard requirement or whether a REST/SDK fallback path is feasible.
+If any prerequisite is missing, surface the specific gap to the user and stop **before** any subagent dispatches — failing mid-flow leaves a partially scaffolded project.
 
 ## Path resolution — read this first
 

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -7,6 +7,18 @@ description: "Build a complete Wix Managed Headless site from a single prompt. E
 
 Single orchestrator for the full site build. Linear flow with parallel subagent workers coordinated through design tokens and structured agent returns.
 
+## Prerequisites
+
+Before running this skill, the user's environment must have:
+
+| Requirement | Why | How to verify | How to fix if missing |
+|---|---|---|---|
+| **Wix MCP connected** | Wave 0 discovers the MCP prefix via `WixREADME`; every subagent calls `<prefix>*` MCP tools (CallWixSiteAPI, ExecuteWixAPI, image upload, etc.). Without it the orchestrator stops at Wave 0. | Run `claude mcp list` — `claude.ai Wix` should show `✓ Connected`. | In Claude Code, run `/mcp` and connect Wix; or visit Claude.ai → Settings → Connectors. |
+| **`@wix/cli` available** | Wave 2 runs `npx @wix/cli env pull` to write `.env.local`; Wave 6 runs `npx @wix/cli build` + `release` to publish. `npx` will fetch the CLI on demand, but a locally installed CLI is faster and surfaces version issues earlier. | `which wix` or `npx @wix/cli --version`. | `npm i -g @wix/cli` (or rely on `npx` to fetch per-invocation). |
+| **Wix CLI authenticated** | `env pull` and `release` both require a logged-in session; tokens live in `~/.wix/auth/`. On auth error the skill surfaces `"Run \`npx @wix/cli login\` and retry."` and stops. | `ls ~/.wix/auth/account.json` exists and is non-empty. | `npx @wix/cli login` — opens a browser to auth. |
+
+If any prerequisite is missing, surface the specific gap to the user and stop **before** any subagent dispatches — failing mid-flow leaves a partially scaffolded project.
+
 ## Path resolution — read this first
 
 Your CWD at runtime is the **project directory**, not the skill root. Compute `<SKILL_ROOT>` from this file's path: this file is at `<SKILL_ROOT>/SKILL.md` — strip the trailing `/SKILL.md`. Hold the absolute path in session scratch for the whole run.

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -9,15 +9,16 @@ Single orchestrator for the full site build. Linear flow with parallel subagent 
 
 ## Prerequisites
 
-Before running this skill, the user's environment must have:
+Before running this skill, the user's environment must have a working, authenticated Wix CLI:
 
 | Requirement | Why | How to verify | How to fix if missing |
 |---|---|---|---|
-| **Wix MCP connected** | Wave 0 discovers the MCP prefix via `WixREADME`; every subagent calls `<prefix>*` MCP tools (CallWixSiteAPI, ExecuteWixAPI, image upload, etc.). Without it the orchestrator stops at Wave 0. | Run `claude mcp list` — `claude.ai Wix` should show `✓ Connected`. | In Claude Code, run `/mcp` and connect Wix; or visit Claude.ai → Settings → Connectors. |
 | **`@wix/cli` available** | Wave 2 runs `npx @wix/cli env pull` to write `.env.local`; Wave 6 runs `npx @wix/cli build` + `release` to publish. `npx` will fetch the CLI on demand, but a locally installed CLI is faster and surfaces version issues earlier. | `which wix` or `npx @wix/cli --version`. | `npm i -g @wix/cli` (or rely on `npx` to fetch per-invocation). |
 | **Wix CLI authenticated** | `env pull` and `release` both require a logged-in session; tokens live in `~/.wix/auth/`. On auth error the skill surfaces `"Run \`npx @wix/cli login\` and retry."` and stops. | `ls ~/.wix/auth/account.json` exists and is non-empty. | `npx @wix/cli login` — opens a browser to auth. |
 
-If any prerequisite is missing, surface the specific gap to the user and stop **before** any subagent dispatches — failing mid-flow leaves a partially scaffolded project.
+If either prerequisite is missing, surface the specific gap to the user and stop **before** any subagent dispatches — failing mid-flow leaves a partially scaffolded project.
+
+> The Wix MCP connection is also relied on heavily today (Wave 0 hard-stops without it; every subagent calls MCP tools), but its prerequisite status is intentionally **not documented here yet** — see follow-up discussion on whether MCP should be a hard requirement or whether a REST/SDK fallback path is feasible.
 
 ## Path resolution — read this first
 


### PR DESCRIPTION
## Summary

Adds a **Prerequisites** section near the top of `skills/wix-headless/SKILL.md` documenting the three hard environment requirements:

- **`@wix/cli` available** — for Wave 2 `env pull` and Wave 6 `build` + `release`.
- **Wix CLI authenticated** — `~/.wix/auth/account.json` present from `npx @wix/cli login`.
- **Wix MCP server configured with `--wixCliAuth`** — provides the admin tools the skill calls at Wave 0 and downstream; reuses the CLI's token store, so the CLI-auth row above is its prereq.

Each row explains *why* the requirement exists (with the specific Wave that depends on it), how to verify it, and how to fix it if missing. The orchestrator is instructed to surface the specific missing prereq and stop **before** dispatching subagents — failing mid-flow leaves a partially scaffolded project.

## Motivation

Walking through the skill end-to-end on a clean environment revealed:

- The CLI dependency was **implicit** — only mentioned inline at Wave 2 (`npx @wix/cli env pull`) and Wave 6 (`build` + `release`). A user without the CLI installed (or unauthenticated) had no upfront signal.
- The MCP dependency was **buried** at Wave 0 (line 111: *"On failure, stop and tell the user the Wix MCP server isn't connected"*) — users only learned about it after starting the flow, and the doc didn't explain how to register the MCP server (the `--wixCliAuth` flag, the token-sharing with the CLI).
- No central \"Prerequisites\" section existed, so neither humans nor agents reading SKILL.md could check readiness without scanning the whole document.

## Notes on the MCP row wording

Phrased to be client-agnostic. wix/skills ships to multiple agent runtimes (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/` directories all exist in the repo), so the row points readers at their own MCP client's registration docs rather than prescribing a `claude mcp add ...` line. The verify column keeps a Claude-Code example (`claude mcp list`) for concreteness — easily generalized by an agent reading the table.

The MCP row's wording is sourced verbatim from the `@wix/mcp` package README, which documents that `--wixCliAuth` reuses `~/.wix/auth/account.json` and refreshes the token transparently.

## Test plan

- [ ] Render the SKILL.md preview on GitHub to confirm the 3-row table renders correctly
- [ ] Sanity-check verification commands: `which wix`, `ls ~/.wix/auth/account.json`, `claude mcp list`
- [ ] Confirm fix-up commands are current: `npm i -g @wix/cli`, `npx @wix/cli login`, `npx -y @wix/mcp --wixCliAuth` as a stdio MCP server in a registered client

## Notes

- Doc-only change; no behavioral impact on the skill flow itself.
- The original PR was scoped to CLI only; the MCP row was added after we validated that `@wix/mcp --wixCliAuth` is the canonical install for this skill's admin tools (the package README documents this contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)