### PR TITLE
Replace MCP doc-search tools with REST endpoints in wix-headless

### DIFF
--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -70,7 +70,7 @@ Immediately after the brand name is confirmed (before Q2), emit **one concurrent
    **Strict-then-recover:**
    1. Script exit 2 (slug or brand validation failed) → orchestrator-side bug; the orchestrator should have caught this in pre-flight. Fix the slug derivation and retry.
    2. Auth error from npm/Wix CLI → surface `"Run \`npx @wix/cli login\` and retry."` and stop.
-   3. `invalid template` error → the template ID inside `scaffold.sh` is stale. Look up the current ID via `<prefix>SearchWixCLIDocumentation` query `create headless template`, edit the script's `TEMPLATE_ID` constant, retry once, log to `.wix/run.json.commandDrift[]` so the script can be tightened.
+   3. `invalid template` error → the template ID inside `scaffold.sh` is stale. Look up the current ID via the docs-search REST endpoint (`curl -fsSL --get 'https://www.wixapis.com/mcp-docs-search/v1/search' --data-urlencode 'kbName=CLI_KB_ID' --data-urlencode 'searchTerm=create headless template' --data-urlencode 'maxResults=5'`), edit the script's `TEMPLATE_ID` constant, retry once, log to `.wix/run.json.commandDrift[]` so the script can be tightened.
    4. Other errors → surface stderr to the user.
 
    Launch with background.

--- a/skills/wix-headless/references/commands/install-app.md
+++ b/skills/wix-headless/references/commands/install-app.md
@@ -33,7 +33,7 @@ The MCP tool requires explicit `url` / `method` / `body` / `reason` / `sourceDoc
 | Outcome | Action |
 |---|---|
 | 2xx | Done. |
-| 4xx / 5xx with parseable body | Enter recover loop (max 1 retry): `{mcpPrefix}SearchWixRESTDocumentation` for `install app instance`, then `{mcpPrefix}ReadFullDocsMethodSchema` on the top match, then retry with the discovered shape. |
+| 4xx / 5xx with parseable body | Enter recover loop (max 1 retry): search the REST docs for `install app instance`, then read the method schema for the top match, then retry with the discovered shape. Example: <br>`curl -fsSL --get 'https://www.wixapis.com/mcp-docs-search/v1/search' --data-urlencode 'kbName=REST_METHODS_KB_ID' --data-urlencode 'kbName=REST_DOCS_KB_ID' --data-urlencode 'searchTerm=install app instance' --data-urlencode 'maxResults=5'` <br>then `curl -fsSL --get 'https://dev.wix.com/rawdocs/api/get-article-content' --data-urlencode 'articleUrl=<top-match-url>' --data-urlencode 'schema=true'`. |
 | Recovery succeeds | Append to `run.json.commandDrift[]`: `{ command: "install-app", primaryError: { status, body }, recoveredWith: { endpoint, bodyPatch }, suggestedFix: "Update references/commands/install-app.md body template" }`. |
 | Both paths fail | Surface the original response body and the doc link to the user. Do not loop further. |
 

--- a/skills/wix-headless/references/images/INSTRUCTIONS.md
+++ b/skills/wix-headless/references/images/INSTRUCTIONS.md
@@ -27,7 +27,7 @@ If your prompt is missing a `Scope:` line, stop and ask the parent — do not gu
 3. **Prefer the inlined recipe below and `IMAGE_GENERATION.md` over external docs.** When a PATCH or API call fails:
    1. **FIRST re-read your own recipe** in this file (INSTRUCTIONS.md § for that entity type) — it likely covers the error.
    2. If the recipe covers it, follow the recipe. Do NOT look up external docs for errors your recipe already handles.
-   3. **ONLY** if you've re-read the recipe AND the error is genuinely not covered, fall back to `SearchWixRESTDocumentation` / `ReadFullDocsArticle`.
+   3. **ONLY** if you've re-read the recipe AND the error is genuinely not covered, fall back to the docs-search REST endpoints — search via `GET https://www.wixapis.com/mcp-docs-search/v1/search` (with `kbName=REST_METHODS_KB_ID&kbName=REST_DOCS_KB_ID`) and read the top match via `GET https://dev.wix.com/rawdocs/api/get-article-content?articleUrl=<url>&schema=false`.
    
    Known errors already covered by this recipe (do not look up externally):
    - **428** from product PATCH → missing `options`/`variantsInfo` → see § "Products" step 1
@@ -356,4 +356,4 @@ The JSON block MUST be the **last** content in your message (see `../shared/RETU
 | PUT a CMS item with only `{data: {image: "..."}}` | Read-merge-write: query the item, merge image into existing `data`, PUT the full record (see § "CMS Items" step 4). Writing only `image` erases seeded heading/body/etc. |
 | Use `PATCH /wix-data/v2/items/{itemId}` with `{dataItem: {data}}` | PATCH requires JsonPatch `fieldModifications` — use read-merge-PUT instead (see § "CMS Items") |
 | Hit a 428 → immediately search external docs | Re-read § "Products" step 1 first — it covers 428. Only use external docs if your recipe genuinely doesn't cover the error (see § "Self-Loading" step 3) |
-| Default to `ReadFullDocsArticle` for API errors already covered by your recipe | Re-read your own recipe first; fall back to MCP doc tools only for errors genuinely not covered (see § "Self-Loading" step 3) |
+| Default to the docs-article REST endpoint for API errors already covered by your recipe | Re-read your own recipe first; fall back to the docs-search REST endpoints only for errors genuinely not covered (see § "Self-Loading" step 3) |

--- a/skills/wix-headless/references/shared/MCP_PREFIX.md
+++ b/skills/wix-headless/references/shared/MCP_PREFIX.md
@@ -86,9 +86,39 @@ This guards against parents that forgot to pass the prefix and against future pr
 
 Your agent directory includes `.md` reference files with API recipes, call templates, and error handling tailored to your scope. These are your primary source — they document the exact call patterns, body shapes, and edge cases for your use case.
 
-The Wix MCP also exposes documentation tools (`SearchWixRESTDocumentation`, `ReadFullDocsArticle`, `SearchWixSDKDocumentation`, etc.). These are useful when you hit an error or edge case not covered by your reference files. But **prefer your bundled `.md` files first** — each external doc read costs a tool call and 15-30s, and the bundled recipes are already validated for this plugin's flows.
+Wix also exposes a set of **public, unauthenticated REST endpoints** for documentation lookup. These are useful when you hit an error or edge case not covered by your reference files. But **prefer your bundled `.md` files first** — each external doc read costs a tool call and 15-30s, and the bundled recipes are already validated for this plugin's flows.
 
-**Rule of thumb:** read your reference files → try the documented recipe → only if you get an unexpected error or need an endpoint not covered, fall back to the MCP doc tools.
+### Documentation REST endpoints
+
+All endpoints below are public (no auth required). URL-encode query params. Use `curl --get --data-urlencode` to handle encoding correctly.
+
+| Purpose | Endpoint | Required query params |
+|---|---|---|
+| Search REST API docs | `GET https://www.wixapis.com/mcp-docs-search/v1/search` | `kbName=REST_METHODS_KB_ID`, `kbName=REST_DOCS_KB_ID`, `searchTerm`, `maxResults` |
+| Search SDK docs | `GET https://www.wixapis.com/mcp-docs-search/v1/search` | `kbName=API_REFERENCE_SDK_KB_ID`, `kbName=FRONTEND_SDK_AND_EXTENSIONS_KB_ID`, `kbName=REST_DOCS_KB_ID`, `searchTerm`, `maxResults` |
+| Search Headless docs | `GET https://www.wixapis.com/mcp-docs-search/v1/search` | `kbName=HEADLESS_KB_ID`, `searchTerm`, `maxResults` |
+| Search CLI docs | `GET https://www.wixapis.com/mcp-docs-search/v1/search` | `kbName=CLI_KB_ID`, `searchTerm`, `maxResults` |
+| Search WDS docs | `GET https://www.wixapis.com/mcp-docs-search/v1/search` | `kbName=WDS_DOCS_KB_ID`, `searchTerm`, `maxResults` |
+| Search Build-Apps docs | `GET https://www.wixapis.com/mcp-docs-search/v1/search` | `kbName=BUILD_APPS_KB_ID`, `searchTerm`, `maxResults` |
+| Read full article content | `GET https://dev.wix.com/rawdocs/api/get-article-content` | `articleUrl`, `schema=false` |
+| Read article method schema | `GET https://dev.wix.com/rawdocs/api/get-article-content` | `articleUrl`, `schema=true` |
+| Browse REST docs menu | `GET https://dev.wix.com/docs/api/v1/get-menu-content` | `url`, `format=markdown` |
+
+Example — search REST docs for `install app instance`, then read the top match's method schema:
+
+```bash
+curl -fsSL --get 'https://www.wixapis.com/mcp-docs-search/v1/search' \
+  --data-urlencode 'kbName=REST_METHODS_KB_ID' \
+  --data-urlencode 'kbName=REST_DOCS_KB_ID' \
+  --data-urlencode 'searchTerm=install app instance' \
+  --data-urlencode 'maxResults=5'
+
+curl -fsSL --get 'https://dev.wix.com/rawdocs/api/get-article-content' \
+  --data-urlencode 'articleUrl=<top-match-url>' \
+  --data-urlencode 'schema=true'
+```
+
+**Rule of thumb:** read your reference files → try the documented recipe → only if you get an unexpected error or need an endpoint not covered, fall back to the docs-search REST endpoints above.
 
 ---
 

--- a/skills/wix-headless/references/stores/PRODUCT_CATALOG_DATA.md
+++ b/skills/wix-headless/references/stores/PRODUCT_CATALOG_DATA.md
@@ -4,7 +4,7 @@ Replace the default sample products Wix Stores installs with on-brand products v
 
 > **Critical Rules — Read Before Starting**
 > 1. **V3 only** — all endpoints under `/stores/v3/...` for products.
-> 2. **No improvised endpoints** — if an MCP call returns 404, stop and report. Do not guess alternative URLs. Do not loop on `SearchWixRESTDocumentation` more than twice on the same topic.
+> 2. **No improvised endpoints** — if an MCP call returns 404, stop and report. Do not guess alternative URLs. Do not loop on the REST docs-search endpoint (`https://www.wixapis.com/mcp-docs-search/v1/search`) more than twice on the same topic.
 > 3. **Do not seed categories.** Categories are merchant-driven — created in the Wix dashboard, not by this scope. The storefront's rail, Shop submenu, and `/category/[slug]` route are still wired (Phase 4) and light up automatically once the merchant adds at least one visible category with items (≤ 5 min after creation, the helper's TTL).
 
 > **V3 Catalog:** New Wix sites use Catalog V3. All endpoints below live under `/stores/v3/...`. The V1 product endpoints should not be used — they silently return 0 results on V3 catalogs.

--- a/skills/wix-headless/references/stores/SHARED_WIRING.md
+++ b/skills/wix-headless/references/stores/SHARED_WIRING.md
@@ -159,6 +159,6 @@ Classes from contract (stores pack):
 | Default Tailwind color utilities on React islands (`bg-green-50`, `bg-blue-500`) | Brand `@theme` utilities (`bg-bark`, `text-cream`) or contract class names |
 | `<!--` HTML comments in `.astro` frontmatter | `//` or `/* */` — frontmatter is TypeScript |
 | Omit `WIX_STORES_APP_ID` constant | Hardcoded `215238eb-22a5-4c36-9e7b-e7c08025e04e` in AddToCartButton for `catalogReference.appId` |
-| Introspect `node_modules/@wix/*` | All symbols are documented here; if missing, call `<prefix>SearchWixSDKDocumentation` |
+| Introspect `node_modules/@wix/*` | All symbols are documented here; if missing, query the docs-search REST endpoint (`curl -fsSL --get 'https://www.wixapis.com/mcp-docs-search/v1/search' --data-urlencode 'kbName=API_REFERENCE_SDK_KB_ID' --data-urlencode 'kbName=FRONTEND_SDK_AND_EXTENSIONS_KB_ID' --data-urlencode 'kbName=REST_DOCS_KB_ID' --data-urlencode 'searchTerm=<symbol>' --data-urlencode 'maxResults=5'`) |
 | Write `CartView.tsx`, `CartBadge.tsx`, or `analytics.ts` | Not owned by this scope — do not write |
 | Pass flat props to `ProductPurchase` (`productId`, `options`, `variantsInfo`, …) | Pass the whole product: `<ProductPurchase product={product} inventoryByVariant={inventoryByVariant} />` |


### PR DESCRIPTION
## Summary

Rewrites every doc-search MCP tool invocation in the `wix-headless` skill (lives at `skills/wix-headless/`) to call the underlying public, unauthenticated REST endpoint directly. The Wix MCP doc-search tools are thin wrappers around these endpoints — calling the endpoints with `curl` removes one layer of indirection and one MCP dependency.

This is **part 1/2** of removing the Wix MCP from the `wix-headless` skill. Part 2 will replace `CallWixSiteAPI` (and the other site-management MCP tools) and retire `MCP_PREFIX.md` + `mcp-bootstrap.md`.

## Tool to REST endpoint mapping

| MCP tool | REST endpoint | Method |
|---|---|---|
| `SearchWixRESTDocumentation` | `https://www.wixapis.com/mcp-docs-search/v1/search?kbName=REST_METHODS_KB_ID&kbName=REST_DOCS_KB_ID&searchTerm=<q>&maxResults=<n>` | GET |
| `SearchWixSDKDocumentation` | `https://www.wixapis.com/mcp-docs-search/v1/search?kbName=API_REFERENCE_SDK_KB_ID&kbName=FRONTEND_SDK_AND_EXTENSIONS_KB_ID&kbName=REST_DOCS_KB_ID&searchTerm=<q>&maxResults=<n>` | GET |
| `SearchWixHeadlessDocumentation` | `https://www.wixapis.com/mcp-docs-search/v1/search?kbName=HEADLESS_KB_ID&searchTerm=<q>&maxResults=<n>` | GET |
| `SearchWixCLIDocumentation` | `https://www.wixapis.com/mcp-docs-search/v1/search?kbName=CLI_KB_ID&searchTerm=<q>&maxResults=<n>` | GET |
| `SearchWixWDSDocumentation` | `https://www.wixapis.com/mcp-docs-search/v1/search?kbName=WDS_DOCS_KB_ID&searchTerm=<q>&maxResults=<n>` | GET |
| `SearchBuildAppsDocumentation` | `https://www.wixapis.com/mcp-docs-search/v1/search?kbName=BUILD_APPS_KB_ID&searchTerm=<q>&maxResults=<n>` | GET |
| `ReadFullDocsArticle` | `https://dev.wix.com/rawdocs/api/get-article-content?articleUrl=<url>&schema=false` | GET |
| `ReadFullDocsMethodSchema` | `https://dev.wix.com/rawdocs/api/get-article-content?articleUrl=<url>&schema=true` | GET |
| `BrowseWixRESTDocsMenu` | `https://dev.wix.com/docs/api/v1/get-menu-content?url=<url>&format=markdown` | GET |

All endpoints are public — no auth required.

## Scope boundary

**In scope (this PR):**
- Doc-search tool invocations rewritten across 6 files in `skills/wix-headless/`
- `references/shared/MCP_PREFIX.md` "documentation tools" section rewritten to describe the REST endpoints (with a reference table + a working `curl` example)

**Out of scope (follow-up PR):**
- `CallWixSiteAPI` invocations
- `WixREADME`, `ManageWixSite`, `ListWixSites`, `WixSiteBuilder`, `UploadImageToWixSite`
- Wave 0 MCP detection in `SKILL.md`
- `references/commands/mcp-bootstrap.md` (will be retired)
- The "MCP prefix discovery" preamble in `MCP_PREFIX.md` (will be retired)

The remaining mentions of `Search*Documentation` / `ReadFullDocs*` tool names that show up in a `grep` after this PR all sit inside that out-of-scope MCP-bootstrap surface and will be removed when the bootstrap is retired.

## Test plan

- [ ] Spot-check the `curl` examples in `references/shared/MCP_PREFIX.md` actually return JSON from the live endpoints
- [ ] Re-run a wix-headless build end-to-end and confirm no agent reaches for a `Search*Documentation` tool
- [ ] Confirm the rewritten recovery ladder in `references/commands/install-app.md` is still followable when a 4xx hits `install-app`

Generated with Claude Code