### PR TITLE
feat: add @wix/skills npm package + release workflow [CODEAI-505]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release - Bump Version and Publish @wix/skills
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_strategy:
+        type: choice
+        description: Version strategy
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+          - premajor
+          - preminor
+          - prepatch
+      dry_run:
+        description: 'Dry run (preview only, no tag/push/publish)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write # REQUIRED for npm Trusted Publishing
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node with trusted publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Configure git
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Bump version
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: bump
+        run: |
+          NEW_VERSION=$(npm version ${{ github.event.inputs.version_strategy }} --no-git-tag-version)
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "New version: ${NEW_VERSION}"
+
+      - name: Dry-run version preview
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          echo "Would bump @wix/skills from $CURRENT using strategy: ${{ github.event.inputs.version_strategy }}"
+
+      - name: Commit and tag
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        run: |
+          git add package.json
+          git commit -m "chore: release @wix/skills ${{ steps.bump.outputs.version }}"
+          git tag "${{ steps.bump.outputs.version }}"
+          git push origin HEAD --follow-tags
+
+      - name: Publish to npm (trusted publishing)
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        run: npm publish --provenance --access=public
+
+      - name: Dry-run publish preview
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: npm publish --dry-run --access=public

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ npx skills add wix/skills
 npx skills add wix/skills -g
 ```
 
+### npm Package (versioned distribution)
+
+For Wix-internal infrastructure that needs a pinned, versioned skills snapshot (e.g., App Builder, Studio 2, `@wix/cli`), `@wix/skills` is also published to npm:
+
+```bash
+npm install @wix/skills
+```
+
+The npm package contains the same skill bodies as the GitHub repo but pinned to a specific version. Consumers typically install it as a transitive dependency of `@wix/cli` rather than directly. See [CODEAI-505](https://wix.atlassian.net/browse/CODEAI-505) for context.
+
 ## Available Skills
 
 | Skill                                    | Purpose                          | When to Use                                                                                                                         |
@@ -75,6 +85,22 @@ These skills work with any agent that supports the [Agent Skills specification](
 - GitHub Copilot
 - Windsurf
 - And [many more](https://github.com/vercel-labs/add-skill#available-agents)
+
+## Versioning
+
+`@wix/skills` follows semver. Bumps target **AI-generated-code stability** — i.e., whether a change could cause an agent using these skills to produce broken code on the previous-major `wix-cli`:
+
+| Bump | Examples |
+| --- | --- |
+| **patch** | Wording fix, typo, link update, clarification of existing guidance |
+| **minor** | New skill added, new section in an existing skill, additive guidance for a non-breaking `wix-cli` feature |
+| **major** | Skill rename/removal, rewrite of guidance for a deprecated `wix-cli` API, anything that would cause AI-generated code to fail on the previous-major `wix-cli` |
+
+When a major bump is required (a breaking change in the underlying `wix-cli`), the previous major continues on a `release/<N>.x` maintenance branch and receives backports for genuine bugs only — no new features.
+
+## Releasing
+
+Releases run via the [`release` GitHub Actions workflow](.github/workflows/release.yml) using npm Trusted Publishing (no stored tokens). Triggered manually from the **Actions** tab: pick `version_strategy` and optionally `dry_run`. Modeled on [`wix/interact`](https://github.com/wix/interact/blob/master/.github/workflows/release-interact.yml)'s setup.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@wix/skills",
+  "version": "0.0.1",
+  "description": "Wix Skills for AI coding agents — versioned npm distribution of the wix/skills content.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wix/skills.git"
+  },
+  "homepage": "https://github.com/wix/skills",
+  "bugs": {
+    "url": "https://github.com/wix/skills/issues"
+  },
+  "files": [
+    "skills/**",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/skills",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Wix Skills for AI coding agents — versioned npm distribution of the wix/skills content.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Adds the `package.json`, GitHub Actions release workflow, and README updates needed to publish `wix/skills` content as an npm package — **without actually publishing yet**. Publishing is unblocked once `@wix/skills` is registered as a Trusted Publisher on npmjs.org.

## Why

Today the skill bodies in this repo are pulled directly from `main` by various consumers with no version pin — any change merged here lands in their environments immediately, with no rollback path. Adding `@wix/skills` as a versioned npm package lets consumers (especially `@wix/cli`) declare it as a regular dependency and pin a specific version, so CLI and skills can be kept in sync by construction.

## What this PR changes

1. **`package.json`** (new, at repo root)
   - Name: `@wix/skills`, initial version `0.0.1`.
   - `publishConfig: { access: "public", registry: "https://registry.npmjs.org/" }`.
   - `files: ["skills/**", "README.md", "LICENSE"]` — plugin manifests, evals, assets stay in the repo but are excluded from the published tarball.

2. **`.github/workflows/release.yml`** (new)
   - Manual `workflow_dispatch` trigger with inputs: `version_strategy`, `dry_run`.
   - Uses **npm Trusted Publishing via GitHub OIDC** (`permissions: id-token: write`, `npm publish --provenance --access=public`). No stored `NPM_TOKEN` secret needed.
   - Modeled on [`wix/interact`'s `release-interact.yml`](https://github.com/wix/interact/blob/master/.github/workflows/release-interact.yml), simplified for a single-package repo.
   - Supports dry-run preview.

3. **`README.md`** (updated)
   - New "npm Package (versioned distribution)" section under Installation.
   - New "Versioning" section with patch/minor/major semantics (target: AI-generated-code stability).
   - New "Releasing" section pointing at the workflow.

## Verified locally

- `npm pack` produces `wix-skills-0.0.1.tgz` — 536 KB compressed, 1.8 MB unpacked, 220 files.
- Tarball contains only `package/skills/**`, `package/README.md`, `package/LICENSE`, `package/package.json`. No leakage.
- From a consumer project, `require.resolve('@wix/skills/package.json')` resolves correctly; consumer's `node_modules/@wix/skills/skills/` contains `wix-app`, `wix-design-system`, `wix-headless`, `wix-manage`.

## Test plan

- [ ] Reviewers: confirm the `package.json` `files` list is what we want published vs kept out of the tarball (plugin manifests etc.).
- [ ] Reviewers: confirm `.github/workflows/release.yml` matches preferred conventions; flag any deviations from the `wix/interact` precedent.
- [ ] Once Trusted Publisher is registered on npmjs.org: run the workflow with `dry_run: true` to validate the full flow without publishing.
- [ ] Then run with `dry_run: false` for the first real publish.

## NOT in this PR (deliberately)

- The actual `npm publish` — blocked on Trusted Publisher registration on npmjs.org.
- `release/<major>.x` maintenance branches — not needed until the first major bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)