### PR TITLE
fix url aware

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -28,8 +28,6 @@ Your CWD at runtime is the **project directory**, not the skill root. How you re
   - `bash <SKILL_ROOT>/scripts/X.sh <args>` → `bash <(curl -s <SKILL_ROOT>/scripts/X.sh) <args>`
   - `node "<SKILL_ROOT>/scripts/X.mjs" <args>` → `node <(curl -s <SKILL_ROOT>/scripts/X.mjs) <args>`
 
-  The three scripts that depend on sibling skill files (`seed-utilities.sh`, `check-manifest.mjs`, `copy-utility-templates.mjs`) auto-detect this mode and fetch their dependencies over HTTP — no tgz install needed.
-
 | What | Absolute path |
 |---|---|
 | Shared return contract | `<SKILL_ROOT>/references/shared/RETURN_CONTRACT.md` |

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -21,7 +21,14 @@ If any prerequisite is missing, surface the specific gap to the user and stop **
 
 ## Path resolution — read this first
 
-Your CWD at runtime is the **project directory**, not the skill root. Compute `<SKILL_ROOT>` from this file's path: this file is at `<SKILL_ROOT>/SKILL.md` — strip the trailing `/SKILL.md`. Hold the absolute path in session scratch for the whole run.
+Your CWD at runtime is the **project directory**, not the skill root. How you resolve `<SKILL_ROOT>/...` references depends on how you loaded the skill:
+
+- **On-disk install** (`curl -O https://dev.wix.com/skills/wix-headless.tgz && tar xzf wix-headless.tgz`): this file is at `<SKILL_ROOT>/SKILL.md` on disk — strip the trailing `/SKILL.md` for the absolute path. Hold it in session scratch for the whole run. Run scripts as written: `bash <SKILL_ROOT>/scripts/X.sh` and `node "<SKILL_ROOT>/scripts/X.mjs" <args>`.
+- **URL stream** (you see the agent-note preamble at the top of this file): `<SKILL_ROOT>` is `https://dev.wix.com/skills/wix-headless`. Execute scripts via process substitution:
+  - `bash <SKILL_ROOT>/scripts/X.sh <args>` → `bash <(curl -s <SKILL_ROOT>/scripts/X.sh) <args>`
+  - `node "<SKILL_ROOT>/scripts/X.mjs" <args>` → `node <(curl -s <SKILL_ROOT>/scripts/X.mjs) <args>`
+
+  The three scripts that depend on sibling skill files (`seed-utilities.sh`, `check-manifest.mjs`, `copy-utility-templates.mjs`) auto-detect this mode and fetch their dependencies over HTTP — no tgz install needed.
 
 | What | Absolute path |
 |---|---|

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -26,7 +26,9 @@ Your CWD at runtime is the **project directory**, not the skill root. How you re
 - **On-disk install** (`curl -O https://dev.wix.com/skills/wix-headless.tgz && tar xzf wix-headless.tgz`): this file is at `<SKILL_ROOT>/SKILL.md` on disk — strip the trailing `/SKILL.md` for the absolute path. Hold it in session scratch for the whole run. Run scripts as written: `bash <SKILL_ROOT>/scripts/X.sh` and `node "<SKILL_ROOT>/scripts/X.mjs" <args>`.
 - **URL stream** (you see the agent-note preamble at the top of this file): `<SKILL_ROOT>` is `https://dev.wix.com/skills/wix-headless`. Execute scripts via process substitution:
   - `bash <SKILL_ROOT>/scripts/X.sh <args>` → `bash <(curl -s <SKILL_ROOT>/scripts/X.sh) <args>`
-  - `node "<SKILL_ROOT>/scripts/X.mjs" <args>` → `node <(curl -s <SKILL_ROOT>/scripts/X.mjs) <args>`
+  - `node "<SKILL_ROOT>/scripts/X.mjs" <args>` → `curl -s <SKILL_ROOT>/scripts/X.mjs | node --input-type=module - <args>`
+
+  Process substitution (`node <(curl ...)`) does **not** work for `.mjs` — Node sees the script as `/dev/fd/N` with no extension and refuses ESM syntax. Pipe via stdin with `--input-type=module` instead.
 
 | What | Absolute path |
 |---|---|

--- a/skills/wix-headless/scripts/check-manifest.mjs
+++ b/skills/wix-headless/scripts/check-manifest.mjs
@@ -6,34 +6,84 @@
 // recover by copying the canonical template from <SKILL_ROOT>/templates/<pack>/.
 // Outputs a JSON summary of present / recovered / errored files.
 //
-// Usage:
-//   node check-manifest.mjs <project-dir> <phase> <packs-csv>
+// Usage (both modes work):
+//   node <SKILL_ROOT>/scripts/check-manifest.mjs <project-dir> <phase> <packs-csv>
+//   node <(curl -s https://dev.wix.com/skills/wix-headless/scripts/check-manifest.mjs) \
+//     <project-dir> <phase> <packs-csv>
 //
 //   <phase> ∈ { "components", "pages" }
 //   <packs-csv> = comma-separated pack names (loaded verticals), e.g. "stores,ecom,cms"
 //
+// Skill-local file reads (vertical pack markdowns, template files) auto-detect
+// whether they can resolve on disk (tgz install) and fall back to HTTP fetch
+// otherwise (stream via process substitution).
+//
 // Behavior:
-//   - For each pack, parses .../skills/wix-headless/references/verticals/<pack>.md
-//     to extract the `creates:` array.
+//   - For each pack, parses `references/verticals/<pack>.md` to extract the
+//     `creates:` array.
 //   - For each `creates:` entry where phase matches:
-//       * If file exists → "present"
-//       * If missing AND a template exists at <SKILL_ROOT>/templates/<pack>/<tail>
+//       * If file exists in the project → "present"
+//       * If missing AND a template exists at `templates/<pack>/<tail>`
 //         (where <tail> is the path under src/pages/ for page files, or the
-//         basename for everything else) → copy it; record as "recovered".
+//         basename for everything else) → copy/fetch it; record as "recovered".
 //       * Otherwise → record as "missing" with a remediation hint.
 //   - Exit 0 on happy path or recoverable misses.
-//   - Exit 1 if any file is unrecoverably missing — orchestrator surfaces to
-//     the user before continuing.
+//   - Exit 1 if any file is unrecoverably missing.
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "node:fs";
 import { join, dirname, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-// Script lives at <SKILL_ROOT>/scripts/check-manifest.mjs.
-const SKILL_ROOT = resolve(__dirname, "..");
-const TEMPLATES_DIR = join(SKILL_ROOT, "templates");
-const VERTICALS_DIR = join(SKILL_ROOT, "references/verticals");
+const SKILL_URL =
+  process.env.WIX_HEADLESS_SKILL_URL ||
+  "https://dev.wix.com/skills/wix-headless";
+
+// Mode detection: prefer on-disk skill root if reachable, else use HTTP.
+// When invoked as `node <(curl ...)`, import.meta.url is `file:///dev/fd/N`
+// and the candidate root won't contain `references/verticals` — so we fall
+// through to URL mode automatically.
+let SKILL_ROOT_DISK = null;
+try {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const candidate = resolve(scriptDir, "..");
+  if (existsSync(join(candidate, "references/verticals"))) {
+    SKILL_ROOT_DISK = candidate;
+  }
+} catch {
+  // fileURLToPath may fail on non-file URLs; fall through to URL mode.
+}
+
+// Read a skill-local file (relative path like "references/verticals/stores.md").
+// Returns null when the file doesn't exist.
+async function readSkillText(relPath) {
+  if (SKILL_ROOT_DISK) {
+    const p = join(SKILL_ROOT_DISK, relPath);
+    if (!existsSync(p)) return null;
+    return readFileSync(p, "utf8");
+  }
+  const url = `${SKILL_URL}/${relPath}`;
+  const r = await fetch(url);
+  if (r.status === 404) return null;
+  if (!r.ok) throw new Error(`fetch ${url}: HTTP ${r.status}`);
+  return await r.text();
+}
+
+// Copy a skill-local file at relPath into destPath (in the user's project).
+// Returns true on success, false if the source doesn't exist.
+async function copySkillFile(relPath, destPath) {
+  if (SKILL_ROOT_DISK) {
+    const src = join(SKILL_ROOT_DISK, relPath);
+    if (!existsSync(src)) return false;
+    mkdirSync(dirname(destPath), { recursive: true });
+    copyFileSync(src, destPath);
+    return true;
+  }
+  const text = await readSkillText(relPath);
+  if (text === null) return false;
+  mkdirSync(dirname(destPath), { recursive: true });
+  writeFileSync(destPath, text);
+  return true;
+}
 
 const [, , projectDir, phase, packsCsv] = process.argv;
 
@@ -49,20 +99,19 @@ if (phase !== "components" && phase !== "pages") {
 
 const packs = packsCsv.split(",").map((p) => p.trim()).filter(Boolean);
 
-// Map a `creates:` file path to its candidate template path.
+// Map a `creates:` file path to its template path (relative to skill root).
 // Heuristic: `src/pages/<X>` preserves <X> under templates/<pack>/; everything
 // else uses basename only.
-function templateCandidate(packName, srcPath) {
+function templateRelPath(packName, srcPath) {
   const pagesMatch = srcPath.match(/^src\/pages\/(.+)$/);
   const tail = pagesMatch ? pagesMatch[1] : basename(srcPath);
-  return join(TEMPLATES_DIR, packName, tail);
+  return `templates/${packName}/${tail}`;
 }
 
 // Parse `creates:` block from a vertical pack's markdown frontmatter.
 // Format (one per line):
 //   - { file: src/utils/back-in-stock.ts,          phase: components }
-function parseCreates(filePath) {
-  const text = readFileSync(filePath, "utf8");
+function parseCreates(text) {
   const lines = text.split("\n");
   const entries = [];
   let inCreates = false;
@@ -89,18 +138,19 @@ const recovered = [];
 const missing = [];
 
 for (const pack of packs) {
-  const verticalPath = join(VERTICALS_DIR, `${pack}.md`);
-  if (!existsSync(verticalPath)) {
+  const verticalRel = `references/verticals/${pack}.md`;
+  const text = await readSkillText(verticalRel);
+  if (text === null) {
     missing.push({
       pack,
       path: null,
       code: "PACK_NOT_FOUND",
-      remediation: `vertical pack file not found at ${verticalPath} — pack "${pack}" may not be a valid loaded vertical`,
+      remediation: `vertical pack file not found at ${verticalRel} — pack "${pack}" may not be a valid loaded vertical`,
     });
     continue;
   }
 
-  const entries = parseCreates(verticalPath).filter((e) => e.phase === phase);
+  const entries = parseCreates(text).filter((e) => e.phase === phase);
 
   for (const { file } of entries) {
     const destPath = join(projectDir, file);
@@ -109,27 +159,15 @@ for (const pack of packs) {
       continue;
     }
 
-    // Attempt template-copy recovery.
-    const templatePath = templateCandidate(pack, file);
-    if (existsSync(templatePath)) {
-      try {
-        mkdirSync(dirname(destPath), { recursive: true });
-        copyFileSync(templatePath, destPath);
-        recovered.push({
-          pack,
-          path: file,
-          source: "template-copy",
-          template: templatePath.replace(SKILL_ROOT + "/", ""),
-        });
-      } catch (e) {
-        missing.push({
-          pack,
-          path: file,
-          code: "TEMPLATE_COPY_FAILED",
-          template: templatePath,
-          remediation: `failed to copy ${templatePath} → ${destPath}: ${e.message}`,
-        });
-      }
+    const templateRel = templateRelPath(pack, file);
+    const ok = await copySkillFile(templateRel, destPath);
+    if (ok) {
+      recovered.push({
+        pack,
+        path: file,
+        source: "template-copy",
+        template: templateRel,
+      });
       continue;
     }
 
@@ -137,7 +175,7 @@ for (const pack of packs) {
       pack,
       path: file,
       code: "PHASE_FILE_MISSING",
-      remediation: `the ${pack} agent did not write this file and the pack ships no template at templates/${pack}/. Re-dispatch the ${phase} scope, or report the gap to the pack maintainer.`,
+      remediation: `the ${pack} agent did not write this file and the pack ships no template at ${templateRel}. Re-dispatch the ${phase} scope, or report the gap to the pack maintainer.`,
     });
   }
 }

--- a/skills/wix-headless/scripts/check-manifest.mjs
+++ b/skills/wix-headless/scripts/check-manifest.mjs
@@ -8,15 +8,18 @@
 //
 // Usage (both modes work):
 //   node <SKILL_ROOT>/scripts/check-manifest.mjs <project-dir> <phase> <packs-csv>
-//   node <(curl -s https://dev.wix.com/skills/wix-headless/scripts/check-manifest.mjs) \
-//     <project-dir> <phase> <packs-csv>
+//   curl -s https://dev.wix.com/skills/wix-headless/scripts/check-manifest.mjs \
+//     | node --input-type=module - <project-dir> <phase> <packs-csv>
 //
 //   <phase> ∈ { "components", "pages" }
 //   <packs-csv> = comma-separated pack names (loaded verticals), e.g. "stores,ecom,cms"
 //
+// Note: `node <(curl ...)` does NOT work for .mjs files — Node sees /dev/fd/N
+// with no extension and rejects ESM syntax. Use the stdin form above.
+//
 // Skill-local file reads (vertical pack markdowns, template files) auto-detect
 // whether they can resolve on disk (tgz install) and fall back to HTTP fetch
-// otherwise (stream via process substitution).
+// otherwise (stream via stdin).
 //
 // Behavior:
 //   - For each pack, parses `references/verticals/<pack>.md` to extract the

--- a/skills/wix-headless/scripts/check-manifest.mjs
+++ b/skills/wix-headless/scripts/check-manifest.mjs
@@ -34,9 +34,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from
 import { join, dirname, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const SKILL_URL =
-  process.env.WIX_HEADLESS_SKILL_URL ||
-  "https://dev.wix.com/skills/wix-headless";
+const SKILL_URL = "https://dev.wix.com/skills/wix-headless";
 
 // Mode detection: prefer on-disk skill root if reachable, else use HTTP.
 // When invoked as `node <(curl ...)`, import.meta.url is `file:///dev/fd/N`

--- a/skills/wix-headless/scripts/copy-utility-templates.mjs
+++ b/skills/wix-headless/scripts/copy-utility-templates.mjs
@@ -6,25 +6,71 @@
 // agents start.
 //
 // These files are pure templates — same shape regardless of brand. Letting an
-// LLM regenerate them costs tokens and risks drift. Pre-copying is structurally better.
+// LLM regenerate them costs tokens and risks drift. Pre-copying is structurally
+// better.
 //
-// Usage:
-//   node copy-utility-templates.mjs <project-dir> <phase>
+// Usage (both modes work):
+//   node <SKILL_ROOT>/scripts/copy-utility-templates.mjs <project-dir> <phase>
+//   node <(curl -s https://dev.wix.com/skills/wix-headless/scripts/copy-utility-templates.mjs) \
+//     <project-dir> <phase>
 //
 //   <phase> ∈ { "components", "pages" }
 //
+// Template files auto-detect whether they can be read on disk (tgz install)
+// and fall back to HTTP fetch when streamed via process substitution.
+//
 // Reads `.wix/site.json` to discover which packs are loaded, then copies the
-// matching templates for the given phase. Uses `cp -n` semantics — never
-// overwrites an existing file (so user customisations and earlier orchestrator
-// state are preserved).
+// matching templates for the given phase. Never overwrites an existing file
+// (so user customisations and earlier orchestrator state are preserved).
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-// Script lives at <SKILL_ROOT>/scripts/copy-utility-templates.mjs.
-const SKILL_TEMPLATES_DIR = resolve(__dirname, "../templates");
+const SKILL_URL =
+  process.env.WIX_HEADLESS_SKILL_URL ||
+  "https://dev.wix.com/skills/wix-headless";
+
+// Mode detection — see check-manifest.mjs for the same pattern.
+let SKILL_ROOT_DISK = null;
+try {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const candidate = resolve(scriptDir, "..");
+  if (existsSync(join(candidate, "templates"))) {
+    SKILL_ROOT_DISK = candidate;
+  }
+} catch {
+  // fileURLToPath may fail on non-file URLs; fall through to URL mode.
+}
+
+// Copy a template file (path relative to <SKILL_ROOT>/templates/) into the
+// project at destPath. Returns { ok: true } on success, or { ok: false,
+// reason: "..." } on failure (source missing, HTTP error, IO error).
+async function copyTemplate(sourceRel, destPath) {
+  if (SKILL_ROOT_DISK) {
+    const src = join(SKILL_ROOT_DISK, "templates", sourceRel);
+    if (!existsSync(src)) return { ok: false, reason: `missing on disk: ${src}` };
+    try {
+      mkdirSync(dirname(destPath), { recursive: true });
+      copyFileSync(src, destPath);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, reason: e.message };
+    }
+  }
+  const url = `${SKILL_URL}/templates/${sourceRel}`;
+  try {
+    const r = await fetch(url);
+    if (r.status === 404) return { ok: false, reason: `missing at ${url}` };
+    if (!r.ok) return { ok: false, reason: `fetch ${url}: HTTP ${r.status}` };
+    const text = await r.text();
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, text);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, reason: e.message };
+  }
+}
 
 // Hardcoded mapping: { pack, phase, source (relative to templates dir), dest (relative to project) }.
 // To add a new templated utility: ship the file under templates/<pack>/, then add
@@ -76,25 +122,18 @@ const skipped = [];
 const errors = [];
 
 for (const { pack, source, dest } of candidates) {
-  const sourcePath = join(SKILL_TEMPLATES_DIR, source);
   const destPath = join(projectDir, dest);
-
-  if (!existsSync(sourcePath)) {
-    errors.push(`missing template at ${sourcePath} (declared by pack "${pack}")`);
-    continue;
-  }
 
   if (existsSync(destPath)) {
     skipped.push(dest);
     continue;
   }
 
-  try {
-    mkdirSync(dirname(destPath), { recursive: true });
-    copyFileSync(sourcePath, destPath);
+  const result = await copyTemplate(source, destPath);
+  if (result.ok) {
     copied.push(dest);
-  } catch (e) {
-    errors.push(`failed to copy ${source} → ${dest}: ${e.message}`);
+  } else {
+    errors.push(`failed to copy ${source} → ${dest} (pack "${pack}"): ${result.reason}`);
   }
 }
 

--- a/skills/wix-headless/scripts/copy-utility-templates.mjs
+++ b/skills/wix-headless/scripts/copy-utility-templates.mjs
@@ -11,13 +11,16 @@
 //
 // Usage (both modes work):
 //   node <SKILL_ROOT>/scripts/copy-utility-templates.mjs <project-dir> <phase>
-//   node <(curl -s https://dev.wix.com/skills/wix-headless/scripts/copy-utility-templates.mjs) \
-//     <project-dir> <phase>
+//   curl -s https://dev.wix.com/skills/wix-headless/scripts/copy-utility-templates.mjs \
+//     | node --input-type=module - <project-dir> <phase>
 //
 //   <phase> ∈ { "components", "pages" }
 //
+// Note: `node <(curl ...)` does NOT work for .mjs files — Node sees /dev/fd/N
+// with no extension and rejects ESM syntax. Use the stdin form above.
+//
 // Template files auto-detect whether they can be read on disk (tgz install)
-// and fall back to HTTP fetch when streamed via process substitution.
+// and fall back to HTTP fetch when streamed via stdin.
 //
 // Reads `.wix/site.json` to discover which packs are loaded, then copies the
 // matching templates for the given phase. Never overwrites an existing file

--- a/skills/wix-headless/scripts/copy-utility-templates.mjs
+++ b/skills/wix-headless/scripts/copy-utility-templates.mjs
@@ -27,9 +27,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const SKILL_URL =
-  process.env.WIX_HEADLESS_SKILL_URL ||
-  "https://dev.wix.com/skills/wix-headless";
+const SKILL_URL = "https://dev.wix.com/skills/wix-headless";
 
 // Mode detection — see check-manifest.mjs for the same pattern.
 let SKILL_ROOT_DISK = null;

--- a/skills/wix-headless/scripts/seed-utilities.sh
+++ b/skills/wix-headless/scripts/seed-utilities.sh
@@ -2,22 +2,20 @@
 # Copy the skill's shared utilities into the project's src/utils/ and strip the
 # Astro starter cruft that ships with the blank template.
 #
-# Usage:
-#   bash <SKILL_ROOT>/scripts/seed-utilities.sh
+# Usage (both modes work):
+#   bash <SKILL_ROOT>/scripts/seed-utilities.sh                # installed tgz
+#   bash <(curl -s https://dev.wix.com/skills/wix-headless/scripts/seed-utilities.sh)
 #
-# Run from the project directory (CWD = <project>/). The script computes its
-# own location to find the shared-utilities source — no PLUGIN_ROOT or env
-# variable required.
+# Run from the project directory (CWD = <project>/). The script auto-detects
+# whether shared-utilities is available on disk (tgz install) and falls back
+# to fetching from the well-known URL when streamed via process substitution
+# (BASH_SOURCE is /dev/fd/N, so the on-disk lookup naturally falls through).
 #
 # Behavior:
-#   - Copies <SKILL_ROOT>/shared-utilities/*.ts into src/utils/ with `cp -n`
-#     (never overwrites — users can override a utility by dropping their own
-#     file in first).
+#   - Copies the three shared utility files into src/utils/ — never overwrites
+#     an existing file (users can drop in their own version to override).
 #   - Removes Astro starter cruft (Welcome.astro + marketing SVGs) that ships
-#     with the blank template but is never imported by the build skill. A
-#     2026-04-27 sanity run shipped Welcome.astro lingering in src/components/;
-#     a 2026-05-03 sanity run flagged the orphaned SVG assets. The rm -f
-#     invocations are unconditional but safe (-f suppresses missing-file).
+#     with the blank template but is never imported by the build skill.
 #
 # Shared utilities copied:
 #   - wix-image.ts  — media URL resolver (used by stores, blog, cms)
@@ -26,19 +24,33 @@
 
 set -euo pipefail
 
-# Resolve the skill's shared-utilities directory from this script's location.
-# Script lives at <SKILL_ROOT>/scripts/seed-utilities.sh.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SHARED_UTILS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/shared-utilities"
+SKILL_URL="${WIX_HEADLESS_SKILL_URL:-https://dev.wix.com/skills/wix-headless}"
+UTILS=(analytics.ts ricos.ts wix-image.ts)
 
-if [[ ! -d "$SHARED_UTILS_DIR" ]]; then
-  echo "seed-utilities.sh: cannot find $SHARED_UTILS_DIR — skill layout broken?" >&2
-  exit 1
+# Mode detection: when streamed via `bash <(curl ...)`, BASH_SOURCE is
+# /dev/fd/N — the disk lookup falls through and we fetch over HTTP instead.
+SHARED_UTILS_DIR=""
+script_path="${BASH_SOURCE[0]}"
+if [[ "$script_path" != /dev/fd/* && -f "$script_path" ]]; then
+  script_dir="$(cd "$(dirname "$script_path")" && pwd)"
+  candidate="$script_dir/../shared-utilities"
+  if [[ -d "$candidate" ]]; then
+    SHARED_UTILS_DIR="$(cd "$candidate" && pwd)"
+  fi
 fi
 
 mkdir -p src/utils
-cp -n "$SHARED_UTILS_DIR/"*.ts src/utils/
 
-# Astro starter cruft cleanup (see header comment).
+for f in "${UTILS[@]}"; do
+  dest="src/utils/$f"
+  if [[ -e "$dest" ]]; then continue; fi
+  if [[ -n "$SHARED_UTILS_DIR" ]]; then
+    cp "$SHARED_UTILS_DIR/$f" "$dest"
+  else
+    curl -fsSL "$SKILL_URL/shared-utilities/$f" -o "$dest"
+  fi
+done
+
+# Astro starter cruft cleanup.
 rm -f src/components/Welcome.astro
 rm -f src/assets/astro.svg src/assets/wix.svg src/assets/background.svg

--- a/skills/wix-headless/scripts/seed-utilities.sh
+++ b/skills/wix-headless/scripts/seed-utilities.sh
@@ -24,16 +24,15 @@
 
 set -euo pipefail
 
-SKILL_URL="${WIX_HEADLESS_SKILL_URL:-https://dev.wix.com/skills/wix-headless}"
+SKILL_URL="https://dev.wix.com/skills/wix-headless"
 UTILS=(analytics.ts ricos.ts wix-image.ts)
 
-# Mode detection: when streamed via `bash <(curl ...)`, BASH_SOURCE is
-# /dev/fd/N — the disk lookup falls through and we fetch over HTTP instead.
+# Mode detection: prefer on-disk skill root if the sibling dir exists, else
+# fetch over HTTP. Covers both tgz install and `bash <(curl ...)` streaming.
 SHARED_UTILS_DIR=""
 script_path="${BASH_SOURCE[0]}"
-if [[ "$script_path" != /dev/fd/* && -f "$script_path" ]]; then
-  script_dir="$(cd "$(dirname "$script_path")" && pwd)"
-  candidate="$script_dir/../shared-utilities"
+if [[ -f "$script_path" ]]; then
+  candidate="$(dirname "$script_path")/../shared-utilities"
   if [[ -d "$candidate" ]]; then
     SHARED_UTILS_DIR="$(cd "$candidate" && pwd)"
   fi


### PR DESCRIPTION
## Summary

Three skill scripts — `seed-utilities.sh`, `check-manifest.mjs`, `copy-utility-templates.mjs` — silently broke when invoked via `bash <(curl ...)` / `node <(curl ...)`. They locate their dependencies (`shared-utilities/`, `references/verticals/`, `templates/`) via `BASH_SOURCE` / `import.meta.url`, which resolve to `/dev/fd/N` under process substitution. The sibling lookups landed in `/dev`, scripts exited with `cannot find ...`, and the skill aborted mid-flow.

The breakage directly contradicted SKILL.md's preamble, which tells agents to stream scripts from `https://dev.wix.com/skills/wix-headless/scripts/...`. Agents that trusted the preamble hit the bug.

## What changed

Each script now auto-detects whether it can resolve its dependencies on disk (tgz install) or needs to fetch them over HTTP (process-substitution stream). Same script, both modes, no caller change.

### `seed-utilities.sh`
- Replaced `BASH_SOURCE`-derived path lookup + glob with an explicit utility list (`analytics.ts`, `ricos.ts`, `wix-image.ts`).
- On disk (sibling `shared-utilities/` exists): `cp` from `<SKILL_ROOT>/shared-utilities/`.
- Otherwise: `curl -fsSL` from `https://dev.wix.com/skills/wix-headless/shared-utilities/`. Same sibling-exists probe as the Node scripts — robust to both `/dev/fd/*` and `/tmp/sh-*` FIFO-fallback environments.

### `check-manifest.mjs`
- Added `readSkillText(relPath)` and `copySkillFile(relPath, destPath)` helpers that branch on a `SKILL_ROOT_DISK` probe (does `<scriptDir>/../references/verticals` exist?).
- All skill-local reads (vertical pack markdowns, recovery templates) go through these helpers; project-side writes are unchanged.
- Main flow is now `async` to accommodate `fetch()`.

### `copy-utility-templates.mjs`
- Same dual-mode pattern via a single `copyTemplate(sourceRel, destPath)` helper that returns `{ ok, reason }` so errors can name the pack and source path.

### `SKILL.md` — Path resolution section
- Was: "Compute `<SKILL_ROOT>` from this file's path" — only works on disk.
- Now: explicitly branches on disk-install vs URL-stream mode, defines `<SKILL_ROOT>` for both, and documents the working invocation for each. Note: `node <(curl -s ...)` does **not** work for `.mjs` — process substitution gives Node a path like `/dev/fd/N` with no extension, so Node falls back to CJS and rejects ESM syntax. The streamed Node form is `curl -s URL | node --input-type=module - <args>`. Agents in URL mode had to invent the .mjs invocation form before; now it's documented (and tested end-to-end).

## Why dual-mode and not URL-only

Keeping the on-disk fast path means tgz-installed users get zero network round-trips during script execution. The detection block is ~5 lines per script. Worth it.

## Test plan

- [ ] On-disk: `tar xzf wix-headless.tgz && cd wix-headless && bash scripts/seed-utilities.sh` from a fresh Astro project — copies the three utility files into `src/utils/`, no network calls.
- [ ] URL stream: `bash <(curl -s https://dev.wix.com/skills/wix-headless/scripts/seed-utilities.sh)` from a fresh Astro project — same result, files fetched over HTTP.
- [ ] `curl -s https://dev.wix.com/skills/wix-headless/scripts/check-manifest.mjs | node --input-type=module - /tmp/proj components stores,ecom` — parses pack manifests over HTTP, recovers any missing templates over HTTP, exits 0 / 1 appropriately.
- [ ] `curl -s https://dev.wix.com/skills/wix-headless/scripts/copy-utility-templates.mjs | node --input-type=module - /tmp/proj components` against a project with `.wix/site.json.verticals = ["stores", "ecom"]` — copies `back-in-stock.ts` and `discounts.ts` over HTTP.
- [ ] Syntax checks: `bash -n scripts/seed-utilities.sh && node --check scripts/check-manifest.mjs && node --check scripts/copy-utility-templates.mjs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
