### PR TITLE
chore: rename npm package to @wix/agent-skills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release - Bump Version and Publish @wix/skills
+name: Release - Bump Version and Publish @wix/agent-skills
 
 on:
   workflow_dispatch:
@@ -59,13 +59,13 @@ jobs:
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          echo "Would bump @wix/skills from $CURRENT using strategy: ${{ github.event.inputs.version_strategy }}"
+          echo "Would bump @wix/agent-skills from $CURRENT using strategy: ${{ github.event.inputs.version_strategy }}"
 
       - name: Commit and tag
         if: ${{ github.event.inputs.dry_run == 'false' }}
         run: |
           git add package.json
-          git commit -m "chore: release @wix/skills ${{ steps.bump.outputs.version }}"
+          git commit -m "chore: release @wix/agent-skills ${{ steps.bump.outputs.version }}"
           git tag "${{ steps.bump.outputs.version }}"
           git push origin HEAD --follow-tags
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ npx skills add wix/skills -g
 
 ### npm Package (versioned distribution)
 
-For Wix-internal infrastructure that needs a pinned, versioned skills snapshot (e.g., App Builder, Studio 2, `@wix/cli`), `@wix/skills` is also published to npm:
+For Wix-internal infrastructure that needs a pinned, versioned skills snapshot (e.g., App Builder, Studio 2, `@wix/cli`), `@wix/agent-skills` is also published to npm:
 
 ```bash
-npm install @wix/skills
+npm install @wix/agent-skills
 ```
 
 The npm package contains the same skill bodies as the GitHub repo but pinned to a specific version. Consumers typically install it as a transitive dependency of `@wix/cli` rather than directly. See [CODEAI-505](https://wix.atlassian.net/browse/CODEAI-505) for context.
@@ -88,7 +88,7 @@ These skills work with any agent that supports the [Agent Skills specification](
 
 ## Versioning
 
-`@wix/skills` follows semver. Bumps target **AI-generated-code stability** — i.e., whether a change could cause an agent using these skills to produce broken code on the previous-major `wix-cli`:
+`@wix/agent-skills` follows semver. Bumps target **AI-generated-code stability** — i.e., whether a change could cause an agent using these skills to produce broken code on the previous-major `wix-cli`:
 
 | Bump | Examples |
 | --- | --- |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wix/skills",
+  "name": "@wix/agent-skills",
   "version": "1.0.0",
   "description": "Wix Skills for AI coding agents — versioned npm distribution of the wix/skills content.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- `@wix/skills` is already taken on npm, so rename the package to `@wix/agent-skills`
- Updated `package.json`, README install/versioning copy, and the release workflow (name, dry-run log, release commit message)

## Test plan
- [ ] Manually trigger the release workflow in dry-run mode to confirm the rename flows through
- [ ] Verify `npm publish --dry-run` resolves the new package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)