### PR TITLE
ci: pin release workflow actions to full-length SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node with trusted publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- Required by Wix GitHub enterprise policy: all actions must be pinned to a full-length commit SHA
- Pin `actions/checkout` and `actions/setup-node` to current v4.x SHAs; trailing `# v4` comment keeps the pin auditable

## Test plan
- [ ] Trigger the release workflow in dry-run mode and confirm both actions resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)