### PR TITLE
ci: bump pinned actions to v6 (Node 24 compatible)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node with trusted publishing
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- Node 20 actions are deprecated; GitHub will force Node 24 on June 2nd, 2026 and remove Node 20 from runners on September 16th, 2026
- Bump `actions/checkout` and `actions/setup-node` from pinned v4 SHAs to v6 SHAs (which run on Node 24)

## Test plan
- [ ] Trigger the release workflow in dry-run mode and confirm no Node 20 deprecation warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)