### PR TITLE
CMS: Update recipes to take collection displayName into account

### DIFF
--- a/skills/wix-manage/references/cms/cms-data-items-crud.md
+++ b/skills/wix-manage/references/cms/cms-data-items-crud.md
@@ -23,8 +23,10 @@ This recipe covers basic Create, Read, Update, Delete (CRUD) operations for Wix 
 Before inserting or updating items, you need to know the collection's field names and types. If you don't already know the schema:
 
 1. **Query existing items** - Fetch a few items to infer field names from the data
-2. **Get collection schema** - Use `GET /collections/{collectionId}` for full field definitions
-3. **List collections** - Use `GET /collections?fields=id` to see what collections exist (see [Schema Management](cms-schema-management.md))
+2. **Get collection schema** - Use `GET /collections/{dataCollectionId}` for full field definitions
+3. **List collections** - Use `GET /collections?fields=displayName` to see what collections exist (see [Schema Management](cms-schema-management.md))
+
+It may be, that user refers to schema by its `displayName` rather than `id`, if collection is not found list all collections to find the right `id` (`dataCollectionId`) to use.
 
 ---
 

--- a/skills/wix-manage/references/cms/cms-schema-management.md
+++ b/skills/wix-manage/references/cms/cms-schema-management.md
@@ -20,7 +20,7 @@ This recipe covers managing the structure (schema) of Wix CMS collections using 
 **Lightweight listing (recommended for existence checks)**:
 ```bash
 curl -X GET \
-'https://www.wixapis.com/wix-data/v2/collections?fields=id' \
+'https://www.wixapis.com/wix-data/v2/collections?fields=displayName' \
 -H 'Authorization: <AUTH>'
 ```
 


### PR DESCRIPTION
This will allow proper reaction to prompts that include displayName instead of dataCollectionId, giving a chance for AI module to figure out the appropriate collection and substitute displayName to dataCollectionId.