### PR TITLE
ci: quote release.yml if-condition (fix YAML parse error)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   publish:
-    if: startsWith(github.event.head_commit.message, 'chore: release @wix/agent-skills v')
+    if: "startsWith(github.event.head_commit.message, 'chore: release @wix/agent-skills v')"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
PR #232 landed with an invalid `release.yml`:

\`\`\`yaml
if: startsWith(github.event.head_commit.message, 'chore: release @wix/agent-skills v')
\`\`\`

YAML parses the value as a plain (unquoted) scalar, so the `: ` inside the literal `'chore: release ...'` is misread as a key/value separator — `Invalid workflow file ... line 13`.

Fix: wrap the entire `if:` value in double quotes.

## Test plan
- [ ] GitHub Actions accepts the workflow file (no "invalid workflow file" banner)
- [ ] On the next `release-bump` merge, the publish job evaluates the condition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)