### PR TITLE
ci: label-based publish-on-merge release flow

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -71,13 +71,23 @@ jobs:
         if: ${{ github.event.inputs.dry_run == 'false' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
         run: |
+          BODY=$(cat <<EOF
+          Automated release PR for **${VERSION}**.
+
+          After merging, push the version tag to trigger \`release.yml\` (publish via npm Trusted Publishing):
+
+          \`\`\`bash
+          git fetch origin main
+          git tag ${VERSION} origin/main
+          git push origin ${VERSION}
+          \`\`\`
+          EOF
+          )
           gh pr create \
             --base main \
-            --head ${{ steps.bump.outputs.branch }} \
-            --title "chore: release @wix/agent-skills ${{ steps.bump.outputs.version }}" \
-            --body "Automated release PR for **${{ steps.bump.outputs.version }}**.
-
-          When this PR is merged, \`release-tag.yml\` will push the matching tag, which triggers \`release.yml\` to publish to npm via Trusted Publishing.
-
-          No manual steps required after merge."
+            --head "${BRANCH}" \
+            --title "chore: release @wix/agent-skills ${VERSION}" \
+            --body "${BODY}"

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,4 +1,4 @@
-name: Release - Bump Version and Open PR
+name: Release - Bump Version, Open PR, Enable Auto-Merge
 
 on:
   workflow_dispatch:
@@ -67,27 +67,41 @@ jobs:
           git commit -m "chore: release @wix/agent-skills ${{ steps.bump.outputs.version }}"
           git push -u origin ${{ steps.bump.outputs.branch }}
 
-      - name: Open release PR
+      - name: Mint App token (so auto-merge triggers downstream workflows)
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
+      - name: Ensure release label exists
         if: ${{ github.event.inputs.dry_run == 'false' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh label create release \
+            --color "0E8A16" \
+            --description "Merging publishes to npm" \
+            --force
+
+      - name: Open release PR and enable auto-merge
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.bump.outputs.version }}
           BRANCH: ${{ steps.bump.outputs.branch }}
         run: |
           BODY=$(cat <<EOF
           Automated release PR for **${VERSION}**.
 
-          After merging, push the version tag to trigger \`release.yml\` (publish via npm Trusted Publishing):
-
-          \`\`\`bash
-          git fetch origin main
-          git tag ${VERSION} origin/main
-          git push origin ${VERSION}
-          \`\`\`
+          When required checks pass, this PR auto-merges. The merge triggers \`release.yml\`, which publishes to npm via Trusted Publishing and tags the release commit.
           EOF
           )
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "${BRANCH}" \
             --title "chore: release @wix/agent-skills ${VERSION}" \
-            --body "${BODY}"
+            --body "${BODY}" \
+            --label release)
+          gh pr merge --auto --squash "${PR_URL}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,58 +3,25 @@ name: Publish @wix/agent-skills to npm
 on:
   pull_request:
     types: [closed]
-  push:
-    tags:
-      - 'v*'
 
 permissions:
   id-token: write # REQUIRED for npm Trusted Publishing
   contents: write # to push the release tag
 
 jobs:
-  push-tag:
-    name: Push release tag on labeled PR merge
+  publish:
     if: >
-      github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
 
     steps:
-      - name: Mint App token (so the tag push triggers the publish job)
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-
-      - name: Checkout main (post-merge) with App token
+      - name: Checkout main (post-merge)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Push version tag
-        run: |
-          VERSION="v$(node -p "require('./package.json').version")"
-          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
-            echo "Tag ${VERSION} already exists on origin; nothing to do."
-            exit 0
-          fi
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git tag "${VERSION}"
-          git push origin "${VERSION}"
-
-  publish:
-    name: Publish to npm on tag push
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout tag
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node with trusted publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -62,14 +29,20 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Verify tag matches package.json version
-        run: |
-          PKG_VERSION="v$(node -p "require('./package.json').version")"
-          TAG_VERSION="${GITHUB_REF_NAME}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Tag $TAG_VERSION does not match package.json version $PKG_VERSION" >&2
-            exit 1
-          fi
+      - name: Resolve version
+        id: version
+        run: echo "tag=v$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Publish to npm (trusted publishing)
         run: npm publish --provenance --access=public
+
+      - name: Tag the release commit
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists; nothing to do."
+            exit 0
+          fi
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,25 +3,58 @@ name: Publish @wix/agent-skills to npm
 on:
   pull_request:
     types: [closed]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   id-token: write # REQUIRED for npm Trusted Publishing
   contents: write # to push the release tag
 
 jobs:
-  publish:
+  push-tag:
+    name: Push release tag on labeled PR merge
     if: >
+      github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main (post-merge)
+      - name: Mint App token (so the tag push triggers the publish job)
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
+      - name: Checkout main (post-merge) with App token
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Push version tag
+        run: |
+          VERSION="v$(node -p "require('./package.json').version")"
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${VERSION} already exists on origin; nothing to do."
+            exit 0
+          fi
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
+
+  publish:
+    name: Publish to npm on tag push
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node with trusted publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -29,20 +62,14 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Resolve version
-        id: version
-        run: echo "tag=v$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag $TAG_VERSION does not match package.json version $PKG_VERSION" >&2
+            exit 1
+          fi
 
       - name: Publish to npm (trusted publishing)
         run: npm publish --provenance --access=public
-
-      - name: Tag the release commit
-        run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.version.outputs.tag }} already exists; nothing to do."
-            exit 0
-          fi
-          git tag "${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,27 @@
 name: Publish @wix/agent-skills to npm
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    types: [closed]
 
 permissions:
   id-token: write # REQUIRED for npm Trusted Publishing
-  contents: read
+  contents: write # to push the release tag
 
 jobs:
   publish:
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout tag
+      - name: Checkout main (post-merge)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node with trusted publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -23,14 +29,20 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Verify tag matches package.json version
-        run: |
-          PKG_VERSION="v$(node -p "require('./package.json').version")"
-          TAG_VERSION="${GITHUB_REF_NAME}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Tag $TAG_VERSION does not match package.json version $PKG_VERSION" >&2
-            exit 1
-          fi
+      - name: Resolve version
+        id: version
+        run: echo "tag=v$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Publish to npm (trusted publishing)
         run: npm publish --provenance --access=public
+
+      - name: Tag the release commit
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists; nothing to do."
+            exit 0
+          fi
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,20 @@ name: Publish @wix/agent-skills to npm
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
 
 permissions:
   id-token: write # REQUIRED for npm Trusted Publishing
-  contents: write # to push the version tag
+  contents: read
 
 jobs:
   publish:
-    if: startsWith(github.event.head_commit.message, 'chore: release @wix/agent-skills v')
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main
+      - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node with trusted publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -26,20 +23,14 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Resolve version
-        id: version
-        run: echo "tag=v$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag $TAG_VERSION does not match package.json version $PKG_VERSION" >&2
+            exit 1
+          fi
 
       - name: Publish to npm (trusted publishing)
         run: npm publish --provenance --access=public
-
-      - name: Tag the release commit
-        run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "Tag ${{ steps.version.outputs.tag }} already exists; nothing to do."
-            exit 0
-          fi
-          git tag "${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -100,16 +100,7 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Releases use npm Trusted Publishing (no stored tokens). The bump goes through a PR (required by org-level branch protection on `main`); the whole flow is one click:
-
-1. **Trigger [`release-bump`](.github/workflows/release-bump.yml)** from the **Actions** tab — pick `version_strategy` (and optionally `dry_run`).
-2. The workflow bumps `package.json`, opens a `release/vX.Y.Z` PR labeled `release`, and enables **auto-merge** (using a GitHub App token so the merge event triggers downstream workflows).
-3. When required checks pass, the PR auto-merges. [`release.yml`](.github/workflows/release.yml)'s `push-tag` job (triggered by `pull_request: closed`, filtered by the `release` label) pushes the `vX.Y.Z` tag using the App token.
-4. The tag push fires `release.yml`'s `publish` job, which publishes to npm via Trusted Publishing.
-
-The **tag is the canonical release signal** — publishing is decoupled from PR state, so pushing a `v*` tag directly (e.g. for a backport on a maintenance branch) also publishes.
-
-Requires the GitHub App referenced via `SYNC_APP_CLIENT_ID` / `SYNC_APP_PRIVATE_KEY` to be installed on this repo with `contents: write` and `pull-requests: write`, and "Allow auto-merge" enabled in repo settings.
+Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. The rest is automatic: the bump PR auto-merges, a `vX.Y.Z` tag is pushed, and [`release.yml`](.github/workflows/release.yml) publishes to npm via Trusted Publishing.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. The rest is automatic: the bump PR auto-merges, a `vX.Y.Z` tag is pushed, and [`release.yml`](.github/workflows/release.yml) publishes to npm via Trusted Publishing.
+Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. The rest is automatic — the bump PR auto-merges and [`release.yml`](.github/workflows/release.yml) publishes to npm via Trusted Publishing.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -100,17 +100,13 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Releases use npm Trusted Publishing (no stored tokens). The flow is split so the version bump goes through a PR (required by org-level branch protection on `main`):
+Releases use npm Trusted Publishing (no stored tokens). The bump goes through a PR (required by org-level branch protection on `main`), but the whole flow is one click:
 
-1. **Trigger [`release-bump`](.github/workflows/release-bump.yml)** from the **Actions** tab — pick `version_strategy` (and optionally `dry_run`). It bumps `package.json` and opens a `release/vX.Y.Z` PR.
-2. **Merge the PR.**
-3. **Push the version tag** (one command, also shown in the PR body):
-   ```bash
-   git fetch origin main && git tag vX.Y.Z origin/main && git push origin vX.Y.Z
-   ```
-   The tag push triggers [`release`](.github/workflows/release.yml), which publishes to npm via Trusted Publishing.
+1. **Trigger [`release-bump`](.github/workflows/release-bump.yml)** from the **Actions** tab — pick `version_strategy` (and optionally `dry_run`).
+2. The workflow bumps `package.json`, opens a `release/vX.Y.Z` PR labeled `release`, and enables **auto-merge** (using a GitHub App token so the merge can trigger downstream workflows).
+3. When required checks pass, the PR auto-merges. [`release.yml`](.github/workflows/release.yml) fires on `pull_request: closed` (filtered by the `release` label), publishes to npm via Trusted Publishing, and pushes the `vX.Y.Z` tag.
 
-> Step 3 is manual because the default `GITHUB_TOKEN` cannot trigger a downstream `release.yml` run from another workflow. For full automation, add a PAT or GitHub App token and an auto-tag step on PR merge.
+Requires the GitHub App referenced via `SYNC_APP_CLIENT_ID` / `SYNC_APP_PRIVATE_KEY` to be installed on this repo with `contents: write` and `pull-requests: write`, and "Allow auto-merge" enabled in repo settings.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,17 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Releases use npm Trusted Publishing (no stored tokens), split across two workflows so the version bump goes through a PR (required by org-level branch protection on `main`):
+Releases use npm Trusted Publishing (no stored tokens). The flow is split so the version bump goes through a PR (required by org-level branch protection on `main`):
 
 1. **Trigger [`release-bump`](.github/workflows/release-bump.yml)** from the **Actions** tab — pick `version_strategy` (and optionally `dry_run`). It bumps `package.json` and opens a `release/vX.Y.Z` PR.
-2. **Merge the PR.** [`release`](.github/workflows/release.yml) detects the release commit on `main`, publishes to npm via Trusted Publishing, then pushes the matching `vX.Y.Z` tag.
+2. **Merge the PR.**
+3. **Push the version tag** (one command, also shown in the PR body):
+   ```bash
+   git fetch origin main && git tag vX.Y.Z origin/main && git push origin vX.Y.Z
+   ```
+   The tag push triggers [`release`](.github/workflows/release.yml), which publishes to npm via Trusted Publishing.
+
+> Step 3 is manual because the default `GITHUB_TOKEN` cannot trigger a downstream `release.yml` run from another workflow. For full automation, add a PAT or GitHub App token and an auto-tag step on PR merge.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,14 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Releases use npm Trusted Publishing (no stored tokens). The bump goes through a PR (required by org-level branch protection on `main`), but the whole flow is one click:
+Releases use npm Trusted Publishing (no stored tokens). The bump goes through a PR (required by org-level branch protection on `main`); the whole flow is one click:
 
 1. **Trigger [`release-bump`](.github/workflows/release-bump.yml)** from the **Actions** tab — pick `version_strategy` (and optionally `dry_run`).
-2. The workflow bumps `package.json`, opens a `release/vX.Y.Z` PR labeled `release`, and enables **auto-merge** (using a GitHub App token so the merge can trigger downstream workflows).
-3. When required checks pass, the PR auto-merges. [`release.yml`](.github/workflows/release.yml) fires on `pull_request: closed` (filtered by the `release` label), publishes to npm via Trusted Publishing, and pushes the `vX.Y.Z` tag.
+2. The workflow bumps `package.json`, opens a `release/vX.Y.Z` PR labeled `release`, and enables **auto-merge** (using a GitHub App token so the merge event triggers downstream workflows).
+3. When required checks pass, the PR auto-merges. [`release.yml`](.github/workflows/release.yml)'s `push-tag` job (triggered by `pull_request: closed`, filtered by the `release` label) pushes the `vX.Y.Z` tag using the App token.
+4. The tag push fires `release.yml`'s `publish` job, which publishes to npm via Trusted Publishing.
+
+The **tag is the canonical release signal** — publishing is decoupled from PR state, so pushing a `v*` tag directly (e.g. for a backport on a maintenance branch) also publishes.
 
 Requires the GitHub App referenced via `SYNC_APP_CLIENT_ID` / `SYNC_APP_PRIVATE_KEY` to be installed on this repo with `contents: write` and `pull-requests: write`, and "Allow auto-merge" enabled in repo settings.
 


### PR DESCRIPTION
## Summary
Replace the brittle commit-message match in `release.yml` with a label-based publish-on-merge flow, and add auto-merge to `release-bump.yml` so the whole release is one click.

### Flow
1. **Trigger `release-bump`** → bumps `package.json`, opens a `release/vX.Y.Z` PR labeled `release`, enables **auto-merge** using a GitHub App token (`SYNC_APP_*`).
2. **PR auto-merges** when required checks pass.
3. **`release.yml`** fires on `pull_request: closed` (filtered by `merged == true` and the `release` label): publishes via npm Trusted Publishing, then pushes the `vX.Y.Z` tag as a record.

### Why the App token (only in `release-bump.yml`)
Default `GITHUB_TOKEN` can enable auto-merge, but the resulting `pull_request: closed` event would be suppressed by GitHub's anti-loop rule — `release.yml` would never fire. The App token bypasses that. Inside `release.yml` itself the default token is fine.

### Prerequisites
- App installed on `wix/skills` with `contents: write` + `pull-requests: write`.
- `Settings → General → Pull Requests → Allow auto-merge` is on.

`release.yml` filename preserved → npm trusted-publisher binding remains valid.

## Test plan
- [ ] Trigger `release-bump` in dry-run mode and confirm preview output
- [ ] Trigger `release-bump` for real on a patch bump and verify:
  - PR opens with `release` label and auto-merge enabled
  - PR auto-merges after checks pass
  - `release.yml` runs, publishes to npm, and pushes the `vX.Y.Z` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)