### PR TITLE
ci: drop auto-merge from release-bump

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,4 +1,4 @@
-name: Release - Bump Version, Open PR, Enable Auto-Merge
+name: Release - Bump Version and Open PR
 
 on:
   workflow_dispatch:
@@ -67,41 +67,32 @@ jobs:
           git commit -m "chore: release @wix/agent-skills ${{ steps.bump.outputs.version }}"
           git push -u origin ${{ steps.bump.outputs.branch }}
 
-      - name: Mint App token (so auto-merge triggers downstream workflows)
-        if: ${{ github.event.inputs.dry_run == 'false' }}
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-
       - name: Ensure release label exists
         if: ${{ github.event.inputs.dry_run == 'false' }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh label create release \
             --color "0E8A16" \
             --description "Merging publishes to npm" \
             --force
 
-      - name: Open release PR and enable auto-merge
+      - name: Open release PR
         if: ${{ github.event.inputs.dry_run == 'false' }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.bump.outputs.version }}
           BRANCH: ${{ steps.bump.outputs.branch }}
         run: |
           BODY=$(cat <<EOF
           Automated release PR for **${VERSION}**.
 
-          When required checks pass, this PR auto-merges. The merge triggers \`release.yml\`, which publishes to npm via Trusted Publishing and tags the release commit.
+          Merging this PR triggers \`release.yml\`, which publishes to npm via Trusted Publishing and pushes the \`${VERSION}\` tag.
           EOF
           )
-          PR_URL=$(gh pr create \
+          gh pr create \
             --base main \
             --head "${BRANCH}" \
             --title "chore: release @wix/agent-skills ${VERSION}" \
             --body "${BODY}" \
-            --label release)
-          gh pr merge --auto --squash "${PR_URL}"
+            --label release

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. The rest is automatic — the bump PR auto-merges and [`release.yml`](.github/workflows/release.yml) publishes to npm via Trusted Publishing.
+Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. Review and merge the PR it opens — [`release.yml`](.github/workflows/release.yml) then publishes to npm via Trusted Publishing.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
The GitHub App backing `SYNC_APP_CLIENT_ID` / `SYNC_APP_PRIVATE_KEY` is installed on `wix-private/coding-agents-plugins` but **not on `wix/skills`**, so `actions/create-github-app-token` 404s when run here:

\`\`\`
GET https://api.github.com/repos/wix/skills/installation → 404
\`\`\`

Drop the App-token + auto-merge step from `release-bump.yml`. The workflow now opens the labeled bump PR and stops; you click **Merge** yourself.

### Why this works without the App
A *human* merging the PR attributes the `pull_request: closed` event to that human (not `GITHUB_TOKEN`), so GitHub's anti-loop rule doesn't apply and `release.yml` fires normally.

### Why the App was needed before
`GITHUB_TOKEN`-driven auto-merge produces a `pull_request: closed` event that gets suppressed for downstream workflow triggers. The App token bypasses that.

`release.yml` is unchanged — it still publishes on labeled PR merge and pushes the tag using the default `GITHUB_TOKEN`.

### Future: re-enable auto-merge
Install the App on `wix/skills` with `contents: write` + `pull-requests: write`, then re-add the auto-merge step. Easy diff.

## Test plan
- [ ] Trigger `release-bump` in dry-run mode and confirm preview output
- [ ] Trigger `release-bump` for real on a patch bump and verify:
  - PR opens with `release` label
  - Manually merge the PR
  - `release.yml` runs, publishes to npm, and pushes the `vX.Y.Z` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)