### PR TITLE
ci: restore auto-merge on bump PR (RELEASE_APP_* secrets)

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Open release PR
         if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.bump.outputs.version }}
@@ -87,12 +88,28 @@ jobs:
           BODY=$(cat <<EOF
           Automated release PR for **${VERSION}**.
 
-          Merging this PR triggers \`release.yml\`, which publishes to npm via Trusted Publishing and pushes the \`${VERSION}\` tag.
+          When required checks pass, this PR auto-merges and \`release.yml\` publishes to npm via Trusted Publishing and pushes the \`${VERSION}\` tag.
           EOF
           )
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "${BRANCH}" \
             --title "chore: release @wix/agent-skills ${VERSION}" \
             --body "${BODY}" \
-            --label release
+            --label release)
+          echo "url=${PR_URL}" >> $GITHUB_OUTPUT
+
+      - name: Mint App token (so auto-merge triggers downstream workflows)
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: gh pr merge --auto --squash "${PR_URL}"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ When a major bump is required (a breaking change in the underlying `wix-cli`), t
 
 ## Releasing
 
-Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. Review and merge the PR it opens — [`release.yml`](.github/workflows/release.yml) then publishes to npm via Trusted Publishing.
+Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the **Actions** tab and pick a `version_strategy`. The rest is automatic — the bump PR auto-merges once checks pass and [`release.yml`](.github/workflows/release.yml) publishes to npm via Trusted Publishing.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
A release-dedicated GitHub App (numeric App ID `2753172`) is installed on `wix/skills` with `contents: write` + `pull-requests: write`. With those credentials available as `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`, we can re-enable auto-merge on the bump PR — reverting the manual-merge stopgap from #238.

### Flow (back to one click)
1. Trigger `release-bump` → bumps `package.json`, opens labeled `release` PR.
2. `release-bump` mints a token from the App and runs `gh pr merge --auto --squash`. The merge event is attributed to the App, **not** `GITHUB_TOKEN`, so it bypasses GitHub's anti-loop rule.
3. Required checks pass → PR auto-merges → `release.yml` fires → `npm publish` + tag push.

### Prereqs (already in place)
- App installed on `wix/skills` with `contents: write` + `pull-requests: write`.
- Secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` populated on the repo.
- `Settings → General → Pull Requests → Allow auto-merge` is on.

## Test plan
- [ ] Trigger `release-bump` in dry-run mode — confirm no failure (App token step is skipped on dry-run anyway).
- [ ] Trigger `release-bump` for real on a patch bump and verify:
  - PR opens with `release` label
  - Auto-merge is enabled on it
  - PR auto-merges after checks pass
  - `release.yml` runs and publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)