### PR TITLE
fix: correct broken dev.wix.com URLs in ecommerce skill references

### DIFF
--- a/skills/wix-manage/references/ecommerce/guardrail-discount-conflicts.md
+++ b/skills/wix-manage/references/ecommerce/guardrail-discount-conflicts.md
@@ -115,4 +115,4 @@ Run these checks **before** creating or updating any discount — whether automa
 ## References
 
 - [Discount Rules API (Automatic Discounts)](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/discount-rules/introduction)
-- [Coupons API](https://dev.wix.com/docs/api-reference/business-solutions/coupons/introduction)
+- [Coupons API](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/introduction)

--- a/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
+++ b/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
@@ -36,7 +36,7 @@ references:
 > - **ABANDONED_CART** → [Goal: Reduce Cart Abandonment](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-reduce-cart-abandonment)
 >
 > **If COUPON mechanism in Step 4c**, load:
-> - [Setup: Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/skills/setup-coupons)
+> - [Setup: Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons)
 
 ## EXECUTION RULES — READ BEFORE ANYTHING ELSE
 
@@ -229,7 +229,7 @@ Based on the merchant's request AND the site data, determine which domains to an
 **If unclear, ask:** "Would you like this to apply automatically to everyone, or as a coupon code?"
 
 **If COUPON is selected**, load the coupon setup reference with `ReadFullDocsArticle`:
-[Setup: Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/skills/setup-coupons)
+[Setup: Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons)
 
 ---
 

--- a/skills/wix-manage/references/ecommerce/setup-coupons.md
+++ b/skills/wix-manage/references/ecommerce/setup-coupons.md
@@ -12,9 +12,9 @@ layer: config
 ## Required APIs
 
 - [Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/create-a-coupon) — `POST /v2/coupons`
-- [Update Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/update) — `PATCH /v2/coupons/{id}`
-- [Query Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/query) — `POST /v2/coupons/query`
-- [Delete Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/delete) — `DELETE /v2/coupons/{id}`
+- [Update Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/update-a-coupon) — `PATCH /v2/coupons/{id}`
+- [Query Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/query-coupons) — `POST /v2/coupons/query`
+- [Delete Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/delete-a-coupon) — `DELETE /v2/coupons/{id}`
 
 ---
 
@@ -335,4 +335,4 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 ## References
 
 - [Coupons API](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/create-a-coupon)
-- [Valid Scope Values](https://dev.wix.com/api/rest/coupons/coupons/valid-scope-values)
+- [Valid Scope Values](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/valid-scope-values)

--- a/skills/wix-manage/references/ecommerce/setup-discount-rules.md
+++ b/skills/wix-manage/references/ecommerce/setup-discount-rules.md
@@ -441,4 +441,4 @@ All recommendation-created rules use these fixed settings:
 ## References
 
 - [Discount Rules API](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/discount-rules/introduction)
-- [Coupons API](https://dev.wix.com/docs/api-reference/business-solutions/coupons/introduction)
+- [Coupons API](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/introduction)


### PR DESCRIPTION
## Summary

- Fixed 7 broken `https://dev.wix.com` URLs across 5 files in the ecommerce skill folder
- Coupon API URLs had wrong slugs (missing verb suffixes like `-a-coupon`) and one was using a legacy `api/rest/` path instead of `docs/api-reference/`
- Two files pointed to `coupons/introduction` which doesn't exist (correct path is `coupons/coupons/introduction`)
- Two references to `coupons/skills/setup-coupons` (unpublished path) replaced with the working coupons landing page

## What's not fixed

The `shipping-delivery/shipping-options/*` docs section does not exist yet — all 4 method URLs (introduction, create, query, update) return 404. The API itself exists at `wixapis.com/ecom/v1/shipping-options` but docs are unpublished. Affected: `flow-add-free-shipping.md`, `flow-fix-coverage-gaps.md`, `flow-optimize-shipping-rates.md`, `recipe-apply-shipping-recommendations.md`.

## Test plan

- [ ] Verify all changed URLs return 200 (checked during task)
- [ ] Confirm no other ecommerce files were inadvertently changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)