### PR TITLE
docs(wix-manage): clarify bulk endpoints and add concurrency guidance

### DIFF
--- a/skills/wix-manage/references/blog/how-to-create-blog-posts.md
+++ b/skills/wix-manage/references/blog/how-to-create-blog-posts.md
@@ -49,7 +49,13 @@ This article demonstrates how to create and immediately publish blog posts using
 
 ### Part 2: Create Blog Post with Rich Content
 
-1. Create blog post using [Create Draft Post](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post) for single posts, or [Bulk Create Draft Posts](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/bulk-create-draft-posts) for multiple posts.
+You have two endpoints:
+- **Single post:** [Create Draft Post](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post) — `POST https://www.wixapis.com/blog/v3/draft-posts`
+- **Multiple posts (preferred for any N ≥ 2):** [Bulk Create Draft Posts](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/bulk-create-draft-posts) — `POST https://www.wixapis.com/blog/v3/bulk/draft-posts/create`
+
+**Use the bulk endpoint when seeding multiple posts** — one call replaces N single-post calls and avoids the per-call latency of ~25–30 s each.
+
+#### Single-post endpoint
 
    ```bash
    curl -X POST "https://www.wixapis.com/blog/v3/draft-posts" \
@@ -85,6 +91,67 @@ This article demonstrates how to create and immediately publish blog posts using
        "publish": true
      }'
    ```
+
+#### Bulk-create endpoint (preferred for multiple posts)
+
+> **⚠️ Body shape — read this carefully. Each item in `draftPosts` is a FLAT post object: `{title, memberId, richContent, media?, ...}`. Do NOT wrap each item in a `draftPost` field.** Unlike the single-post endpoint (which uses `{draftPost: {...}}` because the request is one post), the bulk endpoint puts each post DIRECTLY inside the `draftPosts` array.
+
+✅ **CORRECT body shape (verified against the live API — returns 200 with `results[].itemMetadata.success: true`):**
+
+   ```json
+   {
+     "draftPosts": [
+       { "title": "First Post",  "memberId": "...", "richContent": { /* … */ } },
+       { "title": "Second Post", "memberId": "...", "richContent": { /* … */ } }
+     ],
+     "publish": true
+   }
+   ```
+
+❌ **WRONG body shape (returns `400 Bad Request` with `draftPosts[i].title must not be empty` because the API is looking for `draftPosts[i].title` directly and finds it nested under a `draftPost` field):**
+
+   ```json
+   {
+     "draftPosts": [
+       { "draftPost": { "title": "First Post",  "memberId": "...", "richContent": { /* … */ } } },
+       { "draftPost": { "title": "Second Post", "memberId": "...", "richContent": { /* … */ } } }
+     ],
+     "publish": true
+   }
+   ```
+
+The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: {...}}` envelope, just inside an array" — that's wrong. The bulk endpoint flattens the envelope away because the array IS the envelope. **Use the FLAT shape: `draftPosts[i]` IS the post.**
+
+#### Full bulk-create curl example
+
+   ```bash
+   curl -X POST "https://www.wixapis.com/blog/v3/bulk/draft-posts/create" \
+     -H "Authorization: <AUTH>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "draftPosts": [
+         {
+           "title": "First Post",
+           "memberId": "author-member-id",
+           "richContent": { /* Ricos JSON — see below */ },
+           "media": { "wixMedia": { "image": { "id": "mediaId" } }, "displayed": true, "custom": true }
+         },
+         {
+           "title": "Second Post",
+           "memberId": "author-member-id",
+           "richContent": { /* Ricos JSON */ }
+         }
+       ],
+       "publish": true
+     }'
+   ```
+
+   The response body is `{results: [{itemMetadata: {id, originalIndex, success}}, ...]}`. Each result's `itemMetadata` carries the created post id and a `success: boolean` flag — the bulk call returns 200 even if some posts fail; check each `results[i].itemMetadata.success` individually.
+
+   **Common URL-shape mistakes (do not use these — both return 404):**
+   - `/blog/v3/draft-posts/bulk` ✗
+   - `/blog/v3/draft-posts/bulk-create` ✗
+   - The correct path is `/blog/v3/bulk/draft-posts/create` (note: `bulk` is a path segment between `v3` and `draft-posts`, not a suffix on `draft-posts`).
 
 2. Structure rich content using Ricos JSON format. Reference [Ricos documentation](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/introduction) for complete node structure. Common node types:
    - `PARAGRAPH` for text content

--- a/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
+++ b/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
@@ -53,8 +53,9 @@ The Categories API is an exception. It uses a v1 endpoint, as it replaces the ol
   - **Book store** → Drama, Kids, Sci-Fi
   - **Fashion** → Men, Women, Kids
   - **Other industries** → any logical grouping that fits the catalog.
-4. Use the Categories API to create each category. **YOU MUST USE** the endpoint: [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/create-category) based on the example below.
-**⚠️ CRITICAL: Use correct endpoint `/categories/v1/bulk/categories/{categoryId}/add-items` with `catalogItemId`, `appId: "215238eb-22a5-4c36-9e7b-e7c08025e04e"`, and `treeReference` object.**
+4. Use the Categories API to create each category. **YOU MUST USE** the endpoint: [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/create-category) based on the example below. Endpoint path: `POST https://www.wixapis.com/categories/v1/categories`. **There is no bulk-create endpoint for `/categories/v1/`** (the `events/v1/bulk/categories/create` URL is for the Events product, not Stores).
+5. **Fire all N category-create calls as a single concurrent batch.** Each call is independent (creates a different category), so issue them as siblings in one assistant message — do not serialize. For 3 categories this saves ~6–8 s of wall vs. sequential calls.
+
 When calling the endpoint, make sure the request body includes a top-level `treeReference` field. It must **not** be nested inside the `category` object.
 
 Use the following example format:
@@ -78,16 +79,20 @@ Use the following example format:
 1. **YOU MUST** add each existing product to at least one category that most makes sense.
 2. First acquire the product's ids to use for this action.
 3. Then adding a product to a category **MUST** be done using the Category API, specifically [Bulk Add Items To Category](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/bulk-add-items-to-category), where products are referred to as items. This endpoint enables adding multiple products at once to a category.
+4. **Fire all N add-items calls as a single concurrent batch.** Each call targets a different `categoryId` (the path parameter is single, so one call per category is unavoidable), but the calls are independent and run as siblings in one assistant message. For 3 categories this saves another ~6–8 s of wall.
 
 **⚠️ CRITICAL: Use correct endpoint `/categories/v1/bulk/categories/{categoryId}/add-items` with `catalogItemId`, `appId: "215238eb-22a5-4c36-9e7b-e7c08025e04e"`, and `treeReference` object.**
 **Make Sure** you pass the treeReference correctly at the same level as "items".
 
 
-### STEP 5: Ensure Each Product was Added to a Category
-1. **YOU MUST** ensure that each product is connected to at least one category.
-2. **You MUST** do this by using the [List Items In Category](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/list-items-in-category) for EVERY Category (for example: 3 required api calls for 3 categories). If the list of items is empty, it means that the product was not added to that category and **YOU MUST** repeat step 4.
-The path for this endpoint in REST is: `https://www.wixapis.com/categories/v1/categories/{categoryId}/list-items`
-3. When calling the endpoint, make sure the request body includes a top-level `treeReference` field. It must **not** be nested inside the `category` object.
+### STEP 5: (Optional) Verify Each Product was Added to a Category
+**Skip this step in trusting flows.** Step 4's bulk add-items endpoint returns an `itemMetadata` array per call — check each result there for failures (`itemMetadata[i].success === false`). The `list-items` round-trip is a defense-in-depth that adds ~10 s of wall and rarely surfaces a failure that the metadata didn't already report.
+
+If you keep the verification (e.g., for high-stakes catalogs):
+1. Use [List Items In Category](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/list-items-in-category) for each category. Path: `https://www.wixapis.com/categories/v1/categories/{categoryId}/list-items`.
+2. **Fire all N list-items calls as a single concurrent batch** — they're independent.
+3. Body must include a top-level `treeReference` field (not nested inside `category`).
+4. If a list is empty for a category that should have items, repeat STEP 4 for that category only.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Blog:** Expands the bulk draft-posts section with a correct ✅ / wrong ❌ body-shape comparison, a full curl example, and a URL-shape gotcha list. Fixes a real 400-error footgun where agents wrap each post in a `draftPost` envelope (correct for the single-post endpoint) but the bulk endpoint expects a flat array.
- **Stores:** Clarifies that there is no bulk-create endpoint for `/categories/v1/` (the `events/v1/bulk/categories/create` URL belongs to Events, not Stores), adds concurrent-batch guidance for category-create and add-items calls (~6–8 s saved per flow), and downgrades STEP 5 verification from mandatory to optional — the `itemMetadata` response already surfaces failures without the extra round-trip.

## Test plan

- [ ] Verify blog bulk-create curl example works against the live API with the flat body shape
- [ ] Confirm stores category-create path (`POST /categories/v1/categories`) returns 200 (not the Events bulk URL)
