### PR TITLE
Ecl 17326 add support on design states for all components in studio 2

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -43,7 +43,7 @@ File where you can override the generated manifest from `<componentName>.generat
 4. Wire design states (Hover / Focus / Disabled / Invalid / Selected /
    custom keys) into the React + CSS per
    [`editor-react-component/DESIGN-STATES.md`](editor-react-component/DESIGN-STATES.md).
-   Paired pseudo-class + `:global(.elem<PascalKey>)` rules with matching TSX
+   Paired pseudo-class + `:global(.<component>--<state>)` rules with matching TSX
    markers are required for the manifest generator to emit the editor's
    `states` block.
 5. Run `npx wix build && npx wix generate manifest` so the editor picks up

--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -40,10 +40,16 @@ File where you can override the generated manifest from `<componentName>.generat
 `[[ -d "node_modules/@wix/react-component-schema" && -d "node_modules/@wix/react-component-utils" && -d "node_modules/@wix/editor-react-types" ]] || ([ -f yarn.lock ] && yarn add @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types || npm install @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types)`
 3. Edit the generated react and CSS files in
    `src/site/components/ComponentName/`.
-4. Run `npx wix build && npx wix generate manifest` so the editor picks up
+4. Wire design states (Hover / Focus / Disabled / Invalid / Selected /
+   custom keys) into the React + CSS per
+   [`editor-react-component/DESIGN-STATES.md`](editor-react-component/DESIGN-STATES.md).
+   Paired pseudo-class + `:global(.elem<PascalKey>)` rules with matching TSX
+   markers are required for the manifest generator to emit the editor's
+   `states` block.
+5. Run `npx wix build && npx wix generate manifest` so the editor picks up
    the new/updated prop schema. This command regenerates manifest
    parts for all components.
-5. Update `Component.extensions.ts` file according to [`editor-react-component/COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md)
+6. Update `Component.extensions.ts` file according to [`editor-react-component/COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md)
 
 Reference: when modifying an _existing_ component, follow
 [`editor-react-component/EDIT-FLOW.md`](editor-react-component/EDIT-FLOW.md).
@@ -59,6 +65,7 @@ Topic-focused references (rules + patterns + common mistakes in one place):
 - [`editor-react-component/PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
 - [`editor-react-component/REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, remaining common mistakes
+- [`editor-react-component/DESIGN-STATES.md`](editor-react-component/DESIGN-STATES.md) — Paired CSS + TSX signals for Hover / Focus / Disabled / Invalid / Selected and custom states
 
 ## CSS guidelines
 

--- a/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
@@ -417,41 +417,36 @@ refined default costs nothing.
 | Hierarchy | Interactive elements visually distinct from static via weight, fill, or elevation |
 | Touch targets | Interactive elements ≥ 44×44 px |
 
-### Don't author state styles (`:hover`, `:focus`, `:disabled`, `[data-state]`)
+### State styles go through the design-states contract
 
-State pseudo-classes and state attribute selectors are not allowed
-in component CSS. That includes `:hover`, `:focus`, `:focus-visible`,
-`:active`, `:disabled`, and attribute selectors like
-`[data-state='open']` or `[aria-selected='true']`.
+State pseudo-classes (`:hover`, `:focus`, `:focus-visible`, `:disabled`, `:invalid`) and state attribute selectors (`[aria-disabled='true']`, `[aria-invalid='true']`, `[data-state='<key>']`) are only authored as part of the **design-states contract**: a paired rule that combines the pseudo-class (or state attribute) with a `:global(.elem<PascalKey>)` class, backed by a matching TSX marker on the same element. The manifest generator reads both signals together and emits the editor's `states` block from them; the editor then applies the site owner's state styling by injecting `elem<PascalKey>` onto the DOM at runtime.
 
-**Why:** the editor owns state styling. Hover, focus, disabled, and
-similar interaction states are exposed to the site owner as
-editable visual states — the platform writes those rules itself
-based on what the user configures. State styles authored in the
-component compete with the platform's rules and produce two
-sources of truth for the same state.
+Full procedure — state catalog (`hover` / `focus` / `disabled` / `invalid` / `selected` / custom keys), default-styling table, base-class resolution, TSX markers, key collision rule, manifest output — lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
+
+**Why:** an unpaired pseudo-class rule is invisible to the editor — the platform can never apply the user's state styling to that surface. The paired form (`<base>:<pseudo>, <base>:global(.elem<PascalKey>)`) is the protocol the platform reads to know the component supports a given state. Authoring state CSS outside this contract still produces two competing sources of truth for the same state.
 
 ```css
-/* ❌ Don't: hover/focus/disabled state — platform owns these */
+/* ❌ Don't: unpaired pseudo-class — invisible to the editor */
 .button:hover {
   background-color: #f0f0f0;
 }
-.button:focus {
-  outline: 2px solid blue;
-}
-.button:disabled {
-  opacity: 0.5;
-}
 
-/* ❌ Don't: state attribute selectors — same problem */
+/* ❌ Don't: unpaired state attribute — same problem */
 .panel[data-state='open'] {
   background-color: #fafafa;
 }
 
-/* ✅ Do: Style the resting state only — platform layers state styling on top */
-.button {
-  background-color: #ffffff;
-  color: #111;
+/* ✅ Do: paired CSS + matching TSX marker (see DESIGN-STATES.md) */
+.button:hover,
+.button:global(.elemHover) {
+  filter: brightness(1.05);
+}
+
+.button[aria-disabled='true'],
+.button:global(.elemDisabled) {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
 }
 ```
 

--- a/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
@@ -419,36 +419,9 @@ refined default costs nothing.
 
 ### State styles go through the design-states contract
 
-State pseudo-classes (`:hover`, `:focus`, `:focus-visible`, `:disabled`, `:invalid`) and state attribute selectors (`[aria-disabled='true']`, `[aria-invalid='true']`, `[data-state='<key>']`) are only authored as part of the **design-states contract**: a paired rule that combines the pseudo-class (or state attribute) with a BEM modifier class (`:global(.<component>--<state>)`), backed by a matching TSX marker on the same element. The manifest generator reads both signals together and emits the editor's `states` block from them; the editor then applies the site owner's state styling by injecting the `<component>--<state>` class onto the DOM at runtime.
+State pseudo-classes (`:hover`, `:focus`, `:focus-visible`, `:disabled`, `:invalid`) and state attribute selectors (`[aria-disabled='true']`, `[aria-invalid='true']`, `[data-state='<key>']`) are only authored as part of the **design-states contract** — a paired rule combining the pseudo-class with `:global(.<component>--<state>)`, backed by a matching TSX marker. Full procedure (state catalog, default styling, base-class resolution, TSX markers, collision rule, manifest output) in [`DESIGN-STATES.md`](DESIGN-STATES.md).
 
-Full procedure — state catalog (`hover` / `focus` / `disabled` / `invalid` / `selected` / custom keys), default-styling table, base-class resolution, TSX markers, key collision rule, manifest output — lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
-
-**Why:** an unpaired pseudo-class rule is invisible to the editor — the platform can never apply the user's state styling to that surface. The paired form (`<base>:<pseudo>, <base>:global(.<component>--<state>)`) is the protocol the platform reads to know the component supports a given state. Authoring state CSS outside this contract still produces two competing sources of truth for the same state.
-
-```css
-/* ❌ Don't: unpaired pseudo-class — invisible to the editor */
-.button:hover {
-  background-color: #f0f0f0;
-}
-
-/* ❌ Don't: unpaired state attribute — same problem */
-.panel[data-state='open'] {
-  background-color: #fafafa;
-}
-
-/* ✅ Do: paired CSS + matching TSX marker (see DESIGN-STATES.md) */
-.button:hover,
-.button:global(.button--hover) {
-  filter: brightness(1.05);
-}
-
-.button[aria-disabled='true'],
-.button:global(.button--disabled) {
-  opacity: 0.5;
-  pointer-events: none;
-  cursor: not-allowed;
-}
-```
+**Why:** an unpaired pseudo-class rule is invisible to the editor — the platform can never apply the user's state styling. The paired form is the protocol the platform reads to know the component supports a given state.
 
 ### Express selection / mode variants with JS-toggled modifier classes
 

--- a/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/CSS-GUIDELINES.md
@@ -419,11 +419,11 @@ refined default costs nothing.
 
 ### State styles go through the design-states contract
 
-State pseudo-classes (`:hover`, `:focus`, `:focus-visible`, `:disabled`, `:invalid`) and state attribute selectors (`[aria-disabled='true']`, `[aria-invalid='true']`, `[data-state='<key>']`) are only authored as part of the **design-states contract**: a paired rule that combines the pseudo-class (or state attribute) with a `:global(.elem<PascalKey>)` class, backed by a matching TSX marker on the same element. The manifest generator reads both signals together and emits the editor's `states` block from them; the editor then applies the site owner's state styling by injecting `elem<PascalKey>` onto the DOM at runtime.
+State pseudo-classes (`:hover`, `:focus`, `:focus-visible`, `:disabled`, `:invalid`) and state attribute selectors (`[aria-disabled='true']`, `[aria-invalid='true']`, `[data-state='<key>']`) are only authored as part of the **design-states contract**: a paired rule that combines the pseudo-class (or state attribute) with a BEM modifier class (`:global(.<component>--<state>)`), backed by a matching TSX marker on the same element. The manifest generator reads both signals together and emits the editor's `states` block from them; the editor then applies the site owner's state styling by injecting the `<component>--<state>` class onto the DOM at runtime.
 
 Full procedure — state catalog (`hover` / `focus` / `disabled` / `invalid` / `selected` / custom keys), default-styling table, base-class resolution, TSX markers, key collision rule, manifest output — lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
 
-**Why:** an unpaired pseudo-class rule is invisible to the editor — the platform can never apply the user's state styling to that surface. The paired form (`<base>:<pseudo>, <base>:global(.elem<PascalKey>)`) is the protocol the platform reads to know the component supports a given state. Authoring state CSS outside this contract still produces two competing sources of truth for the same state.
+**Why:** an unpaired pseudo-class rule is invisible to the editor — the platform can never apply the user's state styling to that surface. The paired form (`<base>:<pseudo>, <base>:global(.<component>--<state>)`) is the protocol the platform reads to know the component supports a given state. Authoring state CSS outside this contract still produces two competing sources of truth for the same state.
 
 ```css
 /* ❌ Don't: unpaired pseudo-class — invisible to the editor */
@@ -438,12 +438,12 @@ Full procedure — state catalog (`hover` / `focus` / `disabled` / `invalid` / `
 
 /* ✅ Do: paired CSS + matching TSX marker (see DESIGN-STATES.md) */
 .button:hover,
-.button:global(.elemHover) {
+.button:global(.button--hover) {
   filter: brightness(1.05);
 }
 
 .button[aria-disabled='true'],
-.button:global(.elemDisabled) {
+.button:global(.button--disabled) {
   opacity: 0.5;
   pointer-events: none;
   cursor: not-allowed;

--- a/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
+++ b/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
@@ -1,0 +1,290 @@
+# Design States
+
+Wire **design states** into an Editor React component's source files so the Wix editor surfaces a state-switcher in the design panel (Hover, Focus, Disabled, Invalid, Selected, custom keys) and applies the user's state styling on top of the component's defaults.
+
+A design state is declared via **two source signals** the editor / manifest extractor reads together:
+
+1. **CSS pairs** in the component's CSS module — a pseudo-class (or state attribute) selector **and** a matching `.elem<PascalKey>` class on the same base element.
+2. **TSX markers** on the rendered element — `aria-checked`, `aria-selected`, `aria-disabled`, `aria-invalid`, or `data-state="<key>"`.
+
+Both signals are required for non-pseudo keys (`disabled`, `invalid`, `selected`, custom). `hover` and `focus` only need the CSS pair — pseudo-classes fire natively from native pointer / focus events.
+
+`npx wix generate manifest` reads the paired CSS rules + the rendered TSX attributes and emits the manifest `states` block. **Never hand-write the `states` block into the manifest — the generator is the only writer.**
+
+> ⚠️ This is the **exception** to the "platform owns state styling" rule called out in [`CSS-GUIDELINES.md`](CSS-GUIDELINES.md) and [`REACT-PATTERNS.md`](REACT-PATTERNS.md). For components that opt into design states using the contract below, the component declares the state surface (paired rules + ARIA / data-state markers) and the platform layers the user's state styling on top via the `elem<PascalKey>` class. For everything else, the no-state-CSS rule still applies.
+
+---
+
+## CSS signal (in `<ComponentName>.module.css`)
+
+For each state on a given target, write a paired selector rule with sensible default styling. Because the project uses CSS Modules, the `.elem<PascalKey>` class must be wrapped in `:global(...)` so it stays unhashed — the editor injects the literal class name (`elemHover`, `elemDisabled`, …) onto the DOM at runtime, and the generated manifest references that literal string.
+
+```css
+.root:hover,
+.root:global(.elemHover) {
+  /* populated default styling — see Default styling */
+}
+```
+
+- **Native keys** (`hover` / `focus` / `disabled` / `invalid`) emit both the pseudo-class (or state attribute) **and** the `:global(.elem<PascalKey>)` class. These map 1:1 to `NATIVE_STATE_TYPE` from `@wix/react-component-schema`.
+- **Custom keys** (`selected`, `featured`, anything else) emit only the `:global(.elem<PascalKey>)` class (no pseudo-class):
+  ```css
+  .root:global(.elemSelected) {
+    /* populated default styling */
+  }
+  ```
+- `<PascalKey>` capitalizes the key with PascalCase on word boundaries — `hover` → `elemHover`, `in-progress` → `elemInProgress`.
+- The base class (`.root`, `.thumb`, …) is the CSS-Module class applied to the same element that carries the TSX markers. See [Picking the base class](#picking-the-base-class).
+
+### Picking the pseudo-class for `disabled` and `focus`
+
+The pseudo-class chosen depends on the rendered root element. Picking the wrong one means the rule never matches in the live site.
+
+| Rendered root | `disabled` pseudo | `focus` pseudo |
+|---|---|---|
+| Native form element (`<input>`, `<button>`, `<select>`, `<textarea>`) | `:disabled` | `:focus-visible` |
+| `<label>` wrapping an input (Switch / Checkbox library primitive) | `[aria-disabled='true']` | `:focus-within` |
+| Generic element with `role` + `tabindex` | `[aria-disabled='true']` | `:focus-visible` |
+| Anything else | `[aria-disabled='true']` | `:focus-visible` |
+
+`:disabled` and `:focus-visible` only match on native form elements (or a `<label>`'s child input). Choose the right selector for the actual rendered tag.
+
+---
+
+## TSX signal (in `<ComponentName>.tsx`)
+
+For each state on a given target, add the matching attribute on the JSX element that carries the base class. Some libraries emit equivalent attributes automatically when you set their props (`isSelected`, `isDisabled`), but write the markers explicitly anyway so the manifest generator can read them as deterministic signals.
+
+| State | TSX marker | Notes |
+|---|---|---|
+| `disabled` | `aria-disabled={isDisabled \|\| undefined}` | Ensure the component's props interface has an `isDisabled` (or detected equivalent) `boolean` prop; add it if missing. |
+| `invalid` | `aria-invalid={isInvalid \|\| undefined}` | Add an `isInvalid` prop if missing. |
+| `selected` (switch / checkbox role) | `aria-checked={isSelected \|\| undefined}` | Use when the rendered element has `role="switch"` / `role="checkbox"` (native `<input type="checkbox">` or library primitive that sets it). |
+| `selected` (tab / option / treeitem / gridcell / row / columnheader / rowheader role) | `aria-selected={isSelected \|\| undefined}` | Use when the role permits `aria-selected`. |
+| `selected` (anything else) | `data-state={isSelected ? 'selected' : undefined}` | Fallback when neither `aria-checked` nor `aria-selected` fits the role. |
+| custom key (`featured`, `in-progress`, …) | `data-state={state}` where `state` reflects the current key | One `data-state` attribute per target; comma-joined when more than one custom state is active (`data-state="selected,featured"`). |
+| `hover` / `focus` | no TSX change — pseudo-classes fire natively. | |
+
+These markers are what the manifest generator keys off — see [How the manifest gets generated](#how-the-manifest-gets-generated).
+
+---
+
+## Default styling
+
+Write **real default styling** for each state — never empty bodies. The site owner can override every value in the editor; defaults exist so the state is visibly distinct on stage out of the box.
+
+| State | Default styling |
+|---|---|
+| `hover` | `filter: brightness(1.05);` |
+| `focus` | `outline: 2px solid currentColor; outline-offset: 2px;` |
+| `disabled` | `opacity: 0.5; pointer-events: none; cursor: not-allowed;` |
+| `invalid` | `outline: 2px solid #d32f2f; outline-offset: 2px;` |
+| `selected` | `filter: brightness(0.95); font-weight: 600;` |
+| Other custom keys | `filter: brightness(0.95);` |
+
+Chosen so they:
+- Don't depend on theme colors (work against any background).
+- Are minimal — not the component's *intended* design, just enough that the state is visibly distinct on stage.
+- Don't break layout (no padding / margin / size changes).
+
+For inner elements with their own role (e.g., interactive list items), the same defaults apply against the inner element's base class.
+
+---
+
+## Picking the base class
+
+The state-switcher in the design panel adds `elem<Key>` classes to the rendered element. For the CSS rule to fire, its prefix must be a class that lives on that same element.
+
+### Case A — self-rendering component (default)
+
+The component applies `styles.root` to the outer rendered element. Base class = `.root`.
+
+```tsx
+<div className={classNames(className, 'profile-card', styles.root)}>
+```
+
+```css
+.root:hover,
+.root:global(.elemHover) { /* … */ }
+```
+
+### Case B — component wraps a library primitive
+
+The component composes a library primitive (e.g., React Aria `<Switch>`) and applies `styles.X` (where `X` is something other than `root`) to that primitive. Base class = the local class that IS applied alongside the primitive.
+
+```tsx
+<Switch className={classNames(styles.button, 'button')}>
+```
+
+```css
+.button:hover,
+.button:global(.elemHover) { /* … */ }
+```
+
+### Case C — inner elements
+
+Inner named parts (`heading`, `label`, `item`, …) follow the same pattern, each with their own base class. State markers (`data-state`, `aria-checked`, `aria-selected`) live on the inner element that carries the base class. `aria-disabled` / `aria-invalid` inverted-prop wiring belongs on the component **root**, not on inner elements.
+
+```tsx
+<span className={classNames('thumb', styles.thumb)} data-state={isSelected ? 'selected' : undefined} />
+```
+
+```css
+.thumb:global(.elemSelected) { /* … */ }
+```
+
+---
+
+## What states each component should support
+
+Read the component's React + props to infer which states each target should carry.
+
+### Role → suggested states
+
+| Role | Suggested states |
+|---|---|
+| Form control with `disabled` semantics | `hover`, `focus`, `disabled` |
+| Form input with validation | `hover`, `focus`, `disabled`, `invalid` |
+| Clickable interactive control (button, link, card with click) | `hover`, `focus` |
+| Self-contained interactive surface (handles its own UX internally) | no states on root |
+| Decorative / pure-display (line, divider, static image) | no states |
+| Container of interactive children (states live on the children, not the container) | no states on root |
+
+If a component has a discriminating prop (`isSelected`, `variant`, `featured`) that controls a meaningful visual variant, add a matching custom state (typically `selected`).
+
+### Per-state relevance
+
+Native states map 1:1 to CSS pseudo-classes. Available native keys come from `NATIVE_STATE_TYPE` (`@wix/react-component-schema`): `hover`, `focus`, `disabled`, `invalid`.
+
+| State | Suggest when… | Don't suggest when… |
+|---|---|---|
+| `hover` | the component reacts visually to mouse-over (button feedback, hoverable card, menu item highlight). | the component is decorative, a host surface, or interactivity is delegated to children. |
+| `focus` | the component is keyboard-targetable (natively focusable or `tabindex`-ed). | the component isn't focusable — `:focus-visible` will never match on the live site. |
+| `disabled` | the component has a UX concept of "off / not interactable" (`isDisabled` prop or similar). | the component has no off-state. |
+| `invalid` | the component accepts user input that can be validated. | the component is not a form control. |
+
+### What is NOT a state signal
+
+These look related but don't indicate design-state need:
+
+- Event-handler props (`onClick`, `onMouseEnter`, `onFocus`) — those signal "developers can listen for events", not "the component has a visual state when hovered/focused."
+- Generic motion / animation props (`isAnimated`, `transitionDuration`) — orthogonal to the state surface.
+
+### Inner-element rules
+
+Many components carry per-child states more than root states:
+
+- An inner element rendering a list of interactive sub-items (links, cards, list items) → infer **`hover`, `selected`** on the item.
+- An inner element rendering an action button (close, navigation, expand) → infer **`hover`** (and `disabled` if the React renders a disabled state for it).
+- An inner element that's structural (positions / groups its children) → infer **no states**.
+
+---
+
+## Key collision rule
+
+If a state's CSS rule already exists in the module (any selector that targets `<base>:<pseudoClass>` or `<base>:global(.elem<PascalKey>)`), **leave it alone**. Existing wins — no merge, no overwrite.
+
+Same rule applies to the TSX side: if the target element already has the matching `aria-*` or `data-state` attribute, leave it alone.
+
+---
+
+## Procedure
+
+Apply when generating new Editor React components, immediately after `<ComponentName>.tsx` + `<ComponentName>.module.css` exist. The manifest does **not** need to exist yet — `npx wix generate manifest` reads the source signals and produces the `states` block later.
+
+1. **Infer the state list per target.**
+   - **Root**: read `<ComponentName>.tsx`. Match against the [role → states](#role--suggested-states) and [per-state relevance](#per-state-relevance) tables.
+   - **Inner elements**: for each named part inside the component, apply the [inner-element rules](#inner-element-rules) against its rendered React.
+
+2. **Resolve the base class and rendered tag per target.** Read the component's `className` composition (Cases A–C above). Identify the rendered tag (`<input>` / `<button>` / `<label>` / generic) — this drives `:disabled` vs `[aria-disabled='true']` and `:focus-visible` vs `:focus-within` per [Picking the pseudo-class](#picking-the-pseudo-class-for-disabled-and-focus).
+
+3. **Patch the CSS (root).** For each root state in the inferred list:
+   - Build the paired selector with the right pseudo (per Step 2) **plus** `:global(.elem<PascalKey>)`.
+   - Populate the body with default styling from [Default styling](#default-styling).
+   - Collision check (skip if matching `<base>:<pseudo>` or `<base>:global(.elem<PascalKey>)` already exists).
+   - Append the new rule. Don't emit comments.
+
+4. **Patch the TSX (root).** For each root state that has a TSX marker:
+   - `disabled` → ensure an `isDisabled` (or detected inverted prop) typed `boolean` exists on the props interface; add it if missing. Add `aria-disabled={isDisabled || undefined}` on the root element.
+   - `invalid` → same pattern with `isInvalid`.
+   - `selected` → pick the marker based on the rendered role (`aria-checked` for switch/checkbox role; `aria-selected` for tab/option/treeitem/gridcell/row/columnheader/rowheader; `data-state` otherwise). Add the matching prop if missing.
+   - Other custom keys → add `data-state` on the root element if not present.
+   - Skip if the attribute is already wired. Don't emit comments.
+
+5. **Patch the CSS + TSX (inner elements).**
+   - For each inner-element target with a non-empty inferred state list:
+     - Resolve its base class and rendered tag (Step 2).
+     - Append paired-selector rules with default styling to the same CSS module.
+     - For TSX markers on inner elements: only `data-state`, `aria-selected`, and `aria-checked` apply — `disabled` / `invalid` inverted-prop wiring lives on the component root.
+
+6. **Regenerate the manifest.**
+   ```
+   npx wix build && npx wix generate manifest
+   ```
+   The generated `<ComponentName>.generated.ts` now contains a `states` block. **Do not hand-edit it.**
+
+---
+
+## How the manifest gets generated
+
+`npx wix generate manifest` reads the source signals you wrote and emits the manifest `states` block in this shape:
+
+```ts
+import { NATIVE_STATE_TYPE } from '@wix/react-component-schema';
+
+states: {
+  hover: {
+    displayName: 'Hover',
+    className: 'elemHover',
+    pseudoClass: NATIVE_STATE_TYPE.hover,
+  },
+  disabled: {
+    displayName: 'Disabled',
+    className: 'elemDisabled',
+    pseudoClass: NATIVE_STATE_TYPE.disabled,
+    props: { isDisabled: true },
+  },
+  selected: {
+    displayName: 'Selected',
+    className: 'elemSelected',
+  },
+}
+```
+
+The deterministic mapping the generator applies:
+
+| Source signal | Manifest output |
+|---|---|
+| `<base>:hover` paired with `<base>:global(.elemHover)` | `hover: { className: 'elemHover', pseudoClass: NATIVE_STATE_TYPE.hover }` |
+| `<base>:focus-visible` / `:focus-within` paired with `:global(.elemFocus)` | `focus: { className: 'elemFocus', pseudoClass: NATIVE_STATE_TYPE.focus }` |
+| `<base>:disabled` or `<base>[aria-disabled='true']` paired with `:global(.elemDisabled)` **+** TSX `aria-disabled` | `disabled: { className: 'elemDisabled', pseudoClass: NATIVE_STATE_TYPE.disabled, props: { isDisabled: true } }` *(props only on root)* |
+| `<base>:invalid` or `[aria-invalid='true']` paired with `:global(.elemInvalid)` **+** TSX `aria-invalid` | `invalid: { className: 'elemInvalid', pseudoClass: NATIVE_STATE_TYPE.invalid }` |
+| `<base>:global(.elemSelected)` **+** TSX `aria-checked` *(switch/checkbox role)* | `selected: { className: 'elemSelected' }` |
+| `<base>:global(.elemSelected)` **+** TSX `aria-selected` *(tab/option/treeitem/etc.)* | `selected: { className: 'elemSelected' }` |
+| `<base>:global(.elemSelected)` **+** TSX `data-state="selected"` | `selected: { className: 'elemSelected' }` |
+| `<base>:global(.elem<PascalKey>)` **+** TSX `data-state="<key>"` | `<key>: { className: 'elem<PascalKey>' }` |
+
+**Gating:** for non-pseudo keys, a CSS pair without a confirming TSX marker is skipped silently (treated as stale CSS). A TSX marker without a CSS pair is skipped too. This is how the generator catches drift between the two source files.
+
+**Custom-key manifest key** uses the verbatim `data-state` token (e.g. `data-state="in-progress"` → manifest key `'in-progress'`, paired with `className: 'elemInProgress'`). The TSX side is the source of truth for naming.
+
+The same shape applies to inner-element `states` blocks — inner-element `disabled` omits the `props` field (inverted-prop wiring is root-only).
+
+---
+
+## Self-checks before considering the wiring done
+
+| Check | How |
+|---|---|
+| Every inferred key produced a paired CSS rule at the correct scope with populated default styling | Read the CSS module |
+| `aria-*` / `data-state` markers present on the right JSX element when required | Read `<ComponentName>.tsx` |
+| New props (if any) typed on the component's props interface | `npx wix build` passes type-check |
+| Generated manifest contains the expected `states` entries | `npx wix build && npx wix generate manifest`, then read `<ComponentName>.generated.ts` |
+
+---
+
+## Out of scope
+
+- Writing or updating the `states` block in the manifest manually — the generator owns it.
+- Removing states — this procedure only adds.
+- Modifying existing CSS rules or TSX attributes (collision rule).

--- a/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
+++ b/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
@@ -94,45 +94,15 @@ For inner elements with their own role (e.g., interactive list items), the same 
 
 ## Picking the base class
 
-The state-switcher in the design panel adds `<component>--<state>` (or `<component>__<element>--<state>` for inner elements) modifier classes to the rendered element. For the CSS rule to fire, its prefix must be a class that lives on that same element.
+The state-switcher in the design panel injects `<component>--<state>` (or `<component>__<element>--<state>` for inner elements) onto the rendered element. The paired CSS rule's prefix must be a class that lives on that same element. Read the JSX `className` composition; pick by case:
 
-### Case A — self-rendering component (default)
+| Case | When | Base class |
+|---|---|---|
+| A | Self-rendering component — `styles.root` on the outer element | `.root` |
+| B | Wraps a library primitive (e.g. React Aria `<Switch>`) — different `styles.X` lands alongside the unscoped global string (e.g. `styles.button` + `'button'`) | `.<the local class>` (e.g. `.button`) |
+| C | Inner named part (`heading`, `label`, `thumb`, …) | `.<part>` — the local class on the inner element |
 
-The component applies `styles.root` to the outer rendered element. Base class = `.root`.
-
-```tsx
-<div className={classNames(className, 'profile-card', styles.root)}>
-```
-
-```css
-.root:hover,
-.root:global(.profile-card--hover) { /* … */ }
-```
-
-### Case B — component wraps a library primitive
-
-The component composes a library primitive (e.g., React Aria `<Switch>`) and applies `styles.X` (where `X` is something other than `root`) to that primitive. Base class = the local class that IS applied alongside the primitive.
-
-```tsx
-<Switch className={classNames(styles.button, 'button')}>
-```
-
-```css
-.button:hover,
-.button:global(.button--hover) { /* … */ }
-```
-
-### Case C — inner elements
-
-Inner named parts (`heading`, `label`, `item`, …) follow the same pattern, each with their own base class. State markers (`data-state`, `aria-checked`, `aria-selected`) live on the inner element that carries the base class. `aria-disabled` / `aria-invalid` inverted-prop wiring belongs on the component **root**, not on inner elements.
-
-```tsx
-<span className={classNames('thumb', styles.thumb)} data-state={isSelected ? 'selected' : undefined} />
-```
-
-```css
-.thumb:global(.<component>__thumb--selected) { /* e.g. .toggle__thumb--selected */ }
-```
+Inner-element TSX markers are limited to `data-state` / `aria-selected` / `aria-checked`; `aria-disabled` / `aria-invalid` inverted-prop wiring belongs on the component **root**.
 
 ---
 
@@ -191,34 +161,17 @@ Same rule applies to the TSX side: if the target element already has the matchin
 
 ## Procedure
 
-Apply when generating new Editor React components, immediately after `<ComponentName>.tsx` + `<ComponentName>.module.css` exist. The manifest does **not** need to exist yet — `npx wix generate manifest` reads the source signals and produces the `states` block later.
+Apply immediately after `<ComponentName>.tsx` + `<ComponentName>.module.css` exist. The manifest does **not** need to exist yet — `npx wix generate manifest` reads the source signals and produces the `states` block later.
 
-1. **Infer the state list per target.**
-   - **Root**: read `<ComponentName>.tsx`. Match against the [role → states](#role--suggested-states) and [per-state relevance](#per-state-relevance) tables.
-   - **Inner elements**: for each named part inside the component, apply the [inner-element rules](#inner-element-rules) against its rendered React.
+1. **Infer the state list per target** (§ [What states each component should support](#what-states-each-component-should-support)). Root from JSX + props; inner elements from each named part inside the component.
 
-2. **Resolve the base class and rendered tag per target.** Read the component's `className` composition (Cases A–C above). Identify the rendered tag (`<input>` / `<button>` / `<label>` / generic) — this drives `:disabled` vs `[aria-disabled='true']` and `:focus-visible` vs `:focus-within` per [Picking the pseudo-class](#picking-the-pseudo-class-for-disabled-and-focus).
+2. **Resolve the base class and rendered tag per target.** Cases A–C for the base class. Rendered tag (`<input>` / `<button>` / `<label>` / generic) drives `:disabled` vs `[aria-disabled='true']` and `:focus-visible` vs `:focus-within` per § [Picking the pseudo-class](#picking-the-pseudo-class-for-disabled-and-focus).
 
-3. **Patch the CSS (root).** For each root state in the inferred list:
-   - Build the paired selector with the right pseudo (per Step 2) **plus** `:global(.<component>--<state>)`.
-   - Populate the body with default styling from [Default styling](#default-styling).
-   - Collision check (skip if matching `<base>:<pseudo>` or `<base>:global(.<component>--<state>)` already exists).
-   - Append the new rule. Don't emit comments.
+3. **Patch the CSS.** For each inferred state on each target: build the paired selector (`<base>:<pseudo>` + `:global(.<component>--<state>)`, or `:global(.<component>__<element>--<state>)` for inner elements), populate with default styling (§ [Default styling](#default-styling)), append. Collision check on `<base>` + key — skip silently. No comments.
 
-4. **Patch the TSX (root).** For each root state that has a TSX marker:
-   - `disabled` → ensure an `isDisabled` (or detected inverted prop) typed `boolean` exists on the props interface; add it if missing. Add `aria-disabled={isDisabled || undefined}` on the root element.
-   - `invalid` → same pattern with `isInvalid`.
-   - `selected` → pick the marker based on the rendered role (`aria-checked` for switch/checkbox role; `aria-selected` for tab/option/treeitem/gridcell/row/columnheader/rowheader; `data-state` otherwise). Add the matching prop if missing.
-   - Other custom keys → add `data-state` on the root element if not present.
-   - Skip if the attribute is already wired. Don't emit comments.
+4. **Patch the TSX.** Per § [TSX signal](#tsx-signal-in-componentnametsx) — for native gated keys (`disabled` / `invalid`), add the matching inverted prop (`isDisabled` / `isInvalid`) to the props interface if missing. For inner elements, only `data-state` / `aria-selected` / `aria-checked` apply. Collision check on the attribute. No comments.
 
-5. **Patch the CSS + TSX (inner elements).**
-   - For each inner-element target with a non-empty inferred state list:
-     - Resolve its base class and rendered tag (Step 2).
-     - Append paired-selector rules with default styling to the same CSS module.
-     - For TSX markers on inner elements: only `data-state`, `aria-selected`, and `aria-checked` apply — `disabled` / `invalid` inverted-prop wiring lives on the component root.
-
-6. **Regenerate the manifest.**
+5. **Regenerate the manifest.**
    ```
    npx wix build && npx wix generate manifest
    ```
@@ -253,42 +206,13 @@ states: {
 }
 ```
 
-The deterministic mapping the generator applies:
+The deterministic mapping: each key in the emitted `states` block comes from a CSS pair on `<base>` (per § [CSS signal](#css-signal-in-componentnamemodulecss)) **confirmed by** its TSX marker on the same element (per § [TSX signal](#tsx-signal-in-componentnametsx)). The native keys (`hover` / `focus` / `disabled` / `invalid`) emit `pseudoClass: NATIVE_STATE_TYPE.<key>`; custom keys (incl. `selected`) emit just `className`. Root `disabled` additionally emits `props: { isDisabled: true }` — inner-element `disabled` omits `props` (inverted-prop wiring is root-only). Custom-key names are the verbatim kebab-case `data-state` token (`data-state="in-progress"` → key `'in-progress'`).
 
-| Source signal | Manifest output |
-|---|---|
-| `<base>:hover` paired with `<base>:global(.<component>--hover)` | `hover: { className: '<component>--hover', pseudoClass: NATIVE_STATE_TYPE.hover }` |
-| `<base>:focus-visible` / `:focus-within` paired with `:global(.<component>--focus)` | `focus: { className: '<component>--focus', pseudoClass: NATIVE_STATE_TYPE.focus }` |
-| `<base>:disabled` or `<base>[aria-disabled='true']` paired with `:global(.<component>--disabled)` **+** TSX `aria-disabled` | `disabled: { className: '<component>--disabled', pseudoClass: NATIVE_STATE_TYPE.disabled, props: { isDisabled: true } }` *(props only on root)* |
-| `<base>:invalid` or `[aria-invalid='true']` paired with `:global(.<component>--invalid)` **+** TSX `aria-invalid` | `invalid: { className: '<component>--invalid', pseudoClass: NATIVE_STATE_TYPE.invalid }` |
-| `<base>:global(.<component>--selected)` **+** TSX `aria-checked` *(switch/checkbox role)* | `selected: { className: '<component>--selected' }` |
-| `<base>:global(.<component>--selected)` **+** TSX `aria-selected` *(tab/option/treeitem/etc.)* | `selected: { className: '<component>--selected' }` |
-| `<base>:global(.<component>--selected)` **+** TSX `data-state="selected"` | `selected: { className: '<component>--selected' }` |
-| `<base>:global(.<component>--<key>)` **+** TSX `data-state="<key>"` | `<key>: { className: '<component>--<key>' }` |
-
-For inner-element targets, the modifier class is `<component>__<element>--<state>` (e.g. `button__label--hover`, `toggle__thumb--selected`) — the same mapping applies, just with the inner-element BEM block prefix in place of `<component>--`.
-
-**Gating:** for non-pseudo keys, a CSS pair without a confirming TSX marker is skipped silently (treated as stale CSS). A TSX marker without a CSS pair is skipped too. This is how the generator catches drift between the two source files.
-
-**Custom-key manifest key** uses the verbatim `data-state` token (e.g. `data-state="in-progress"` → manifest key `'in-progress'`, paired with `className: '<component>--in-progress'`). The state name in both the manifest key and the BEM class is kebab-case verbatim — no casing transform. The TSX side is the source of truth for naming.
-
-The same shape applies to inner-element `states` blocks — inner-element `disabled` omits the `props` field (inverted-prop wiring is root-only).
-
----
-
-## Self-checks before considering the wiring done
-
-| Check | How |
-|---|---|
-| Every inferred key produced a paired CSS rule at the correct scope with populated default styling | Read the CSS module |
-| `aria-*` / `data-state` markers present on the right JSX element when required | Read `<ComponentName>.tsx` |
-| New props (if any) typed on the component's props interface | `npx wix build` passes type-check |
-| Generated manifest contains the expected `states` entries | `npx wix build && npx wix generate manifest`, then read `<ComponentName>.generated.ts` |
+**Gating:** for non-pseudo keys, a CSS pair without a confirming TSX marker is skipped silently (treated as stale CSS). A TSX marker without a CSS pair is skipped too. This catches drift between the two source files.
 
 ---
 
 ## Out of scope
 
-- Writing or updating the `states` block in the manifest manually — the generator owns it.
-- Removing states — this procedure only adds.
-- Modifying existing CSS rules or TSX attributes (collision rule).
+- Hand-writing the `states` block in the manifest — the generator owns it.
+- Removing states or modifying existing CSS / TSX (collision rule — existing wins).

--- a/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
+++ b/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
@@ -4,36 +4,37 @@ Wire **design states** into an Editor React component's source files so the Wix 
 
 A design state is declared via **two source signals** the editor / manifest extractor reads together:
 
-1. **CSS pairs** in the component's CSS module — a pseudo-class (or state attribute) selector **and** a matching `.elem<PascalKey>` class on the same base element.
+1. **CSS pairs** in the component's CSS module — a pseudo-class (or state attribute) selector **and** a matching BEM modifier class (`.<component>--<state>` for the root, `.<component>__<element>--<state>` for inner elements) on the same base element.
 2. **TSX markers** on the rendered element — `aria-checked`, `aria-selected`, `aria-disabled`, `aria-invalid`, or `data-state="<key>"`.
 
 Both signals are required for non-pseudo keys (`disabled`, `invalid`, `selected`, custom). `hover` and `focus` only need the CSS pair — pseudo-classes fire natively from native pointer / focus events.
 
 `npx wix generate manifest` reads the paired CSS rules + the rendered TSX attributes and emits the manifest `states` block. **Never hand-write the `states` block into the manifest — the generator is the only writer.**
 
-> ⚠️ This is the **exception** to the "platform owns state styling" rule called out in [`CSS-GUIDELINES.md`](CSS-GUIDELINES.md) and [`REACT-PATTERNS.md`](REACT-PATTERNS.md). For components that opt into design states using the contract below, the component declares the state surface (paired rules + ARIA / data-state markers) and the platform layers the user's state styling on top via the `elem<PascalKey>` class. For everything else, the no-state-CSS rule still applies.
+> ⚠️ This is the **exception** to the "platform owns state styling" rule called out in [`CSS-GUIDELINES.md`](CSS-GUIDELINES.md) and [`REACT-PATTERNS.md`](REACT-PATTERNS.md). For components that opt into design states using the contract below, the component declares the state surface (paired rules + ARIA / data-state markers) and the platform layers the user's state styling on top via the `<component>--<state>` modifier class. For everything else, the no-state-CSS rule still applies.
 
 ---
 
 ## CSS signal (in `<ComponentName>.module.css`)
 
-For each state on a given target, write a paired selector rule with sensible default styling. Because the project uses CSS Modules, the `.elem<PascalKey>` class must be wrapped in `:global(...)` so it stays unhashed — the editor injects the literal class name (`elemHover`, `elemDisabled`, …) onto the DOM at runtime, and the generated manifest references that literal string.
+For each state on a given target, write a paired selector rule with sensible default styling. Because the project uses CSS Modules, the `.<component>--<state>` class must be wrapped in `:global(...)` so it stays unhashed — the editor injects the literal class name (e.g. `profile-card--hover`, `profile-card--disabled`) onto the DOM at runtime, and the generated manifest references that literal string.
 
 ```css
 .root:hover,
-.root:global(.elemHover) {
+.root:global(.<component>--hover) {
   /* populated default styling — see Default styling */
 }
 ```
 
-- **Native keys** (`hover` / `focus` / `disabled` / `invalid`) emit both the pseudo-class (or state attribute) **and** the `:global(.elem<PascalKey>)` class. These map 1:1 to `NATIVE_STATE_TYPE` from `@wix/react-component-schema`.
-- **Custom keys** (`selected`, `featured`, anything else) emit only the `:global(.elem<PascalKey>)` class (no pseudo-class):
+- **Native keys** (`hover` / `focus` / `disabled` / `invalid`) emit both the pseudo-class (or state attribute) **and** the `:global(.<component>--<state>)` modifier class. These map 1:1 to `NATIVE_STATE_TYPE` from `@wix/react-component-schema`.
+- **Custom keys** (`selected`, `featured`, anything else) emit only the `:global(.<component>--<state>)` modifier class (no pseudo-class):
   ```css
-  .root:global(.elemSelected) {
+  .root:global(.<component>--selected) {
     /* populated default styling */
   }
   ```
-- `<PascalKey>` capitalizes the key with PascalCase on word boundaries — `hover` → `elemHover`, `in-progress` → `elemInProgress`.
+- The state suffix follows `--` verbatim in kebab-case — `hover` → `--hover`, `in-progress` → `--in-progress`. No casing transform.
+- `<component>` is the component's public block class (kebab-case, e.g. `profile-card`, `button`, `accordion-component`). For inner-element targets the modifier class is `<component>__<element>--<state>` (e.g. `.toggle__thumb--selected`).
 - The base class (`.root`, `.thumb`, …) is the CSS-Module class applied to the same element that carries the TSX markers. See [Picking the base class](#picking-the-base-class).
 
 ### Picking the pseudo-class for `disabled` and `focus`
@@ -93,7 +94,7 @@ For inner elements with their own role (e.g., interactive list items), the same 
 
 ## Picking the base class
 
-The state-switcher in the design panel adds `elem<Key>` classes to the rendered element. For the CSS rule to fire, its prefix must be a class that lives on that same element.
+The state-switcher in the design panel adds `<component>--<state>` (or `<component>__<element>--<state>` for inner elements) modifier classes to the rendered element. For the CSS rule to fire, its prefix must be a class that lives on that same element.
 
 ### Case A — self-rendering component (default)
 
@@ -105,7 +106,7 @@ The component applies `styles.root` to the outer rendered element. Base class = 
 
 ```css
 .root:hover,
-.root:global(.elemHover) { /* … */ }
+.root:global(.profile-card--hover) { /* … */ }
 ```
 
 ### Case B — component wraps a library primitive
@@ -118,7 +119,7 @@ The component composes a library primitive (e.g., React Aria `<Switch>`) and app
 
 ```css
 .button:hover,
-.button:global(.elemHover) { /* … */ }
+.button:global(.button--hover) { /* … */ }
 ```
 
 ### Case C — inner elements
@@ -130,7 +131,7 @@ Inner named parts (`heading`, `label`, `item`, …) follow the same pattern, eac
 ```
 
 ```css
-.thumb:global(.elemSelected) { /* … */ }
+.thumb:global(.<component>__thumb--selected) { /* e.g. .toggle__thumb--selected */ }
 ```
 
 ---
@@ -182,7 +183,7 @@ Many components carry per-child states more than root states:
 
 ## Key collision rule
 
-If a state's CSS rule already exists in the module (any selector that targets `<base>:<pseudoClass>` or `<base>:global(.elem<PascalKey>)`), **leave it alone**. Existing wins — no merge, no overwrite.
+If a state's CSS rule already exists in the module (any selector that targets `<base>:<pseudoClass>` or `<base>:global(.<component>--<state>)`), **leave it alone**. Existing wins — no merge, no overwrite.
 
 Same rule applies to the TSX side: if the target element already has the matching `aria-*` or `data-state` attribute, leave it alone.
 
@@ -199,9 +200,9 @@ Apply when generating new Editor React components, immediately after `<Component
 2. **Resolve the base class and rendered tag per target.** Read the component's `className` composition (Cases A–C above). Identify the rendered tag (`<input>` / `<button>` / `<label>` / generic) — this drives `:disabled` vs `[aria-disabled='true']` and `:focus-visible` vs `:focus-within` per [Picking the pseudo-class](#picking-the-pseudo-class-for-disabled-and-focus).
 
 3. **Patch the CSS (root).** For each root state in the inferred list:
-   - Build the paired selector with the right pseudo (per Step 2) **plus** `:global(.elem<PascalKey>)`.
+   - Build the paired selector with the right pseudo (per Step 2) **plus** `:global(.<component>--<state>)`.
    - Populate the body with default styling from [Default styling](#default-styling).
-   - Collision check (skip if matching `<base>:<pseudo>` or `<base>:global(.elem<PascalKey>)` already exists).
+   - Collision check (skip if matching `<base>:<pseudo>` or `<base>:global(.<component>--<state>)` already exists).
    - Append the new rule. Don't emit comments.
 
 4. **Patch the TSX (root).** For each root state that has a TSX marker:
@@ -232,21 +233,22 @@ Apply when generating new Editor React components, immediately after `<Component
 ```ts
 import { NATIVE_STATE_TYPE } from '@wix/react-component-schema';
 
+// Example for a Button component (block name 'button'):
 states: {
   hover: {
     displayName: 'Hover',
-    className: 'elemHover',
+    className: 'button--hover',
     pseudoClass: NATIVE_STATE_TYPE.hover,
   },
   disabled: {
     displayName: 'Disabled',
-    className: 'elemDisabled',
+    className: 'button--disabled',
     pseudoClass: NATIVE_STATE_TYPE.disabled,
     props: { isDisabled: true },
   },
   selected: {
     displayName: 'Selected',
-    className: 'elemSelected',
+    className: 'button--selected',
   },
 }
 ```
@@ -255,18 +257,20 @@ The deterministic mapping the generator applies:
 
 | Source signal | Manifest output |
 |---|---|
-| `<base>:hover` paired with `<base>:global(.elemHover)` | `hover: { className: 'elemHover', pseudoClass: NATIVE_STATE_TYPE.hover }` |
-| `<base>:focus-visible` / `:focus-within` paired with `:global(.elemFocus)` | `focus: { className: 'elemFocus', pseudoClass: NATIVE_STATE_TYPE.focus }` |
-| `<base>:disabled` or `<base>[aria-disabled='true']` paired with `:global(.elemDisabled)` **+** TSX `aria-disabled` | `disabled: { className: 'elemDisabled', pseudoClass: NATIVE_STATE_TYPE.disabled, props: { isDisabled: true } }` *(props only on root)* |
-| `<base>:invalid` or `[aria-invalid='true']` paired with `:global(.elemInvalid)` **+** TSX `aria-invalid` | `invalid: { className: 'elemInvalid', pseudoClass: NATIVE_STATE_TYPE.invalid }` |
-| `<base>:global(.elemSelected)` **+** TSX `aria-checked` *(switch/checkbox role)* | `selected: { className: 'elemSelected' }` |
-| `<base>:global(.elemSelected)` **+** TSX `aria-selected` *(tab/option/treeitem/etc.)* | `selected: { className: 'elemSelected' }` |
-| `<base>:global(.elemSelected)` **+** TSX `data-state="selected"` | `selected: { className: 'elemSelected' }` |
-| `<base>:global(.elem<PascalKey>)` **+** TSX `data-state="<key>"` | `<key>: { className: 'elem<PascalKey>' }` |
+| `<base>:hover` paired with `<base>:global(.<component>--hover)` | `hover: { className: '<component>--hover', pseudoClass: NATIVE_STATE_TYPE.hover }` |
+| `<base>:focus-visible` / `:focus-within` paired with `:global(.<component>--focus)` | `focus: { className: '<component>--focus', pseudoClass: NATIVE_STATE_TYPE.focus }` |
+| `<base>:disabled` or `<base>[aria-disabled='true']` paired with `:global(.<component>--disabled)` **+** TSX `aria-disabled` | `disabled: { className: '<component>--disabled', pseudoClass: NATIVE_STATE_TYPE.disabled, props: { isDisabled: true } }` *(props only on root)* |
+| `<base>:invalid` or `[aria-invalid='true']` paired with `:global(.<component>--invalid)` **+** TSX `aria-invalid` | `invalid: { className: '<component>--invalid', pseudoClass: NATIVE_STATE_TYPE.invalid }` |
+| `<base>:global(.<component>--selected)` **+** TSX `aria-checked` *(switch/checkbox role)* | `selected: { className: '<component>--selected' }` |
+| `<base>:global(.<component>--selected)` **+** TSX `aria-selected` *(tab/option/treeitem/etc.)* | `selected: { className: '<component>--selected' }` |
+| `<base>:global(.<component>--selected)` **+** TSX `data-state="selected"` | `selected: { className: '<component>--selected' }` |
+| `<base>:global(.<component>--<key>)` **+** TSX `data-state="<key>"` | `<key>: { className: '<component>--<key>' }` |
+
+For inner-element targets, the modifier class is `<component>__<element>--<state>` (e.g. `button__label--hover`, `toggle__thumb--selected`) — the same mapping applies, just with the inner-element BEM block prefix in place of `<component>--`.
 
 **Gating:** for non-pseudo keys, a CSS pair without a confirming TSX marker is skipped silently (treated as stale CSS). A TSX marker without a CSS pair is skipped too. This is how the generator catches drift between the two source files.
 
-**Custom-key manifest key** uses the verbatim `data-state` token (e.g. `data-state="in-progress"` → manifest key `'in-progress'`, paired with `className: 'elemInProgress'`). The TSX side is the source of truth for naming.
+**Custom-key manifest key** uses the verbatim `data-state` token (e.g. `data-state="in-progress"` → manifest key `'in-progress'`, paired with `className: '<component>--in-progress'`). The state name in both the manifest key and the BEM class is kebab-case verbatim — no casing transform. The TSX side is the source of truth for naming.
 
 The same shape applies to inner-element `states` blocks — inner-element `disabled` omits the `props` field (inverted-prop wiring is root-only).
 

--- a/skills/wix-app/references/editor-react-component/REACT-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/REACT-GUIDELINES.md
@@ -9,6 +9,7 @@ This guide defines rules and guidance on **how to implement** production-quality
 - [`PROPS-VS-CSS.md`](PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`COMPONENT-API.md`](COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
 - [`REACT-PATTERNS.md`](REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, common mistakes
+- [`DESIGN-STATES.md`](DESIGN-STATES.md) — Paired CSS + TSX signals for Hover / Focus / Disabled / Invalid / Selected and custom states
 
 ## React 18 features are not supported
 
@@ -41,6 +42,10 @@ Direction support is mandatory — see [`DIRECTIONALITY.md`](DIRECTIONALITY.md).
 ### Accessibility ARIA Support
 
 See [`ACCESSIBILITY.md`](ACCESSIBILITY.md) for full rules and patterns.
+
+### Design States
+
+Every interactive component must declare its design states (Hover, Focus, Disabled, Invalid, Selected, custom keys) via the paired CSS + TSX contract — see [`DESIGN-STATES.md`](DESIGN-STATES.md) for the procedure, the role → states inference table, and the default-styling catalog. The manifest generator emits the editor's state-switcher entries from these signals.
 
 ### TypeScript
 

--- a/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
+++ b/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
@@ -44,7 +44,7 @@ transition: all 0.3s;        // ❌
 animation: fadeIn 0.5s;      // ❌
 ```
 
-State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **only** written through the design-states contract — paired pseudo-class + `:global(.<component>--<state>)` rules driven by TSX markers. See [`DESIGN-STATES.md`](DESIGN-STATES.md) for the full procedure. Ad-hoc `:hover` / `:focus` / `:disabled` rules outside that contract still don't belong in component CSS — the platform owns the state surface and only reads paired rules.
+State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **only** written through the design-states contract — paired pseudo-class + `:global(.<component>--<state>)` rules driven by TSX markers. See [`DESIGN-STATES.md`](DESIGN-STATES.md). Ad-hoc rules outside that contract don't belong in component CSS — the platform owns the state surface and only reads paired rules.
 
 ---
 
@@ -52,42 +52,9 @@ State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **onl
 
 ## 3.1 Authoring state CSS
 
-State CSS (`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `:invalid`, `[data-state]`, `[aria-selected]`) only belongs in component CSS via the **design-states contract** — paired pseudo-class + `:global(.<component>--<state>)` rules with matching TSX markers. The manifest generator reads both signals and emits the editor's `states` block from them. Full procedure (state catalog, default styling, base-class resolution, TSX markers, key collision rule) lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
-
-A pseudo-class rule **without** a matching `:global(.<component>--<state>)` partner is invisible to the editor — the platform can never apply the user's state styling to that surface. That's why ad-hoc `:hover` rules are still rejected.
+State CSS (`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `:invalid`, `[data-state]`, `[aria-selected]`) only belongs in component CSS via the **design-states contract** — paired pseudo-class + `:global(.<component>--<state>)` rules with matching TSX markers. A pseudo-class rule without its `:global(.<component>--<state>)` partner is invisible to the editor. Full procedure (state catalog, default styling, base-class resolution, TSX markers, collision rule) lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
 
 Selection / mode variants that are part of the component's own data model (not surfaced as editable design states) still go through a JS-toggled modifier class — see `CSS-GUIDELINES.md` §"Express selection / mode variants".
-
-**❌ Wrong — pseudo-class rule with no paired `:global(.<component>--<state>)`:**
-
-```scss
-.button:hover {
-  background-color: #f0f0f0;
-}
-```
-
-**✅ Correct — paired CSS + TSX marker per [`DESIGN-STATES.md`](DESIGN-STATES.md):**
-
-```scss
-.button:hover,
-.button:global(.button--hover) {
-  filter: brightness(1.05);
-}
-
-.button[aria-disabled='true'],
-.button:global(.button--disabled) {
-  opacity: 0.5;
-  pointer-events: none;
-  cursor: not-allowed;
-}
-```
-
-```tsx
-<button
-  className={classNames('button', styles.button)}
-  aria-disabled={isDisabled || undefined}
->
-```
 
 ## 3.2 Browser APIs at module scope
 

--- a/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
+++ b/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
@@ -44,7 +44,7 @@ transition: all 0.3s;        // ❌
 animation: fadeIn 0.5s;      // ❌
 ```
 
-State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **only** written through the design-states contract — paired pseudo-class + `:global(.elem<PascalKey>)` rules driven by TSX markers. See [`DESIGN-STATES.md`](DESIGN-STATES.md) for the full procedure. Ad-hoc `:hover` / `:focus` / `:disabled` rules outside that contract still don't belong in component CSS — the platform owns the state surface and only reads paired rules.
+State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **only** written through the design-states contract — paired pseudo-class + `:global(.<component>--<state>)` rules driven by TSX markers. See [`DESIGN-STATES.md`](DESIGN-STATES.md) for the full procedure. Ad-hoc `:hover` / `:focus` / `:disabled` rules outside that contract still don't belong in component CSS — the platform owns the state surface and only reads paired rules.
 
 ---
 
@@ -52,13 +52,13 @@ State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **onl
 
 ## 3.1 Authoring state CSS
 
-State CSS (`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `:invalid`, `[data-state]`, `[aria-selected]`) only belongs in component CSS via the **design-states contract** — paired pseudo-class + `:global(.elem<PascalKey>)` rules with matching TSX markers. The manifest generator reads both signals and emits the editor's `states` block from them. Full procedure (state catalog, default styling, base-class resolution, TSX markers, key collision rule) lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
+State CSS (`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `:invalid`, `[data-state]`, `[aria-selected]`) only belongs in component CSS via the **design-states contract** — paired pseudo-class + `:global(.<component>--<state>)` rules with matching TSX markers. The manifest generator reads both signals and emits the editor's `states` block from them. Full procedure (state catalog, default styling, base-class resolution, TSX markers, key collision rule) lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
 
-A pseudo-class rule **without** a matching `:global(.elem<PascalKey>)` partner is invisible to the editor — the platform can never apply the user's state styling to that surface. That's why ad-hoc `:hover` rules are still rejected.
+A pseudo-class rule **without** a matching `:global(.<component>--<state>)` partner is invisible to the editor — the platform can never apply the user's state styling to that surface. That's why ad-hoc `:hover` rules are still rejected.
 
 Selection / mode variants that are part of the component's own data model (not surfaced as editable design states) still go through a JS-toggled modifier class — see `CSS-GUIDELINES.md` §"Express selection / mode variants".
 
-**❌ Wrong — pseudo-class rule with no paired `:global(.elem<PascalKey>)`:**
+**❌ Wrong — pseudo-class rule with no paired `:global(.<component>--<state>)`:**
 
 ```scss
 .button:hover {
@@ -70,12 +70,12 @@ Selection / mode variants that are part of the component's own data model (not s
 
 ```scss
 .button:hover,
-.button:global(.elemHover) {
+.button:global(.button--hover) {
   filter: brightness(1.05);
 }
 
 .button[aria-disabled='true'],
-.button:global(.elemDisabled) {
+.button:global(.button--disabled) {
   opacity: 0.5;
   pointer-events: none;
   cursor: not-allowed;

--- a/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
+++ b/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
@@ -39,65 +39,54 @@ Authoritative SCSS rules: `REACT-GUIDELINES.md` Part 2. For RTL/logical CSS patt
 ```scss
 // ❌ NEVER include:
 
-// State CSS
-&:hover { ... }              // ❌
-&:focus { ... }              // ❌
-&:disabled { ... }           // ❌
-&[data-state='open'] { ... } // ❌
-
 // Transitions/Animations
 transition: all 0.3s;        // ❌
 animation: fadeIn 0.5s;      // ❌
 ```
 
+State CSS (`:hover`, `:focus`, `:disabled`, `:invalid`, `[data-state]`) is **only** written through the design-states contract — paired pseudo-class + `:global(.elem<PascalKey>)` rules driven by TSX markers. See [`DESIGN-STATES.md`](DESIGN-STATES.md) for the full procedure. Ad-hoc `:hover` / `:focus` / `:disabled` rules outside that contract still don't belong in component CSS — the platform owns the state surface and only reads paired rules.
+
 ---
 
 # Part 3: Common Mistakes
 
-## 3.1 Adding interaction-state CSS to parts
+## 3.1 Authoring state CSS
 
-The resting visual (background, color, border-radius, padding, font)
-belongs in the component's CSS — see `CSS-GUIDELINES.md` §"Keep all
-styling in CSS". What does NOT belong is **interaction-state CSS**
-(`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`,
-`[data-state]`, `[aria-selected]`) — the platform owns those.
-Selection / mode variants (`selected`, `active`, `open`) are
-different — they go through a JS-toggled modifier class; see
-`CSS-GUIDELINES.md` §"Express selection / mode variants".
+State CSS (`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `:invalid`, `[data-state]`, `[aria-selected]`) only belongs in component CSS via the **design-states contract** — paired pseudo-class + `:global(.elem<PascalKey>)` rules with matching TSX markers. The manifest generator reads both signals and emits the editor's `states` block from them. Full procedure (state catalog, default styling, base-class resolution, TSX markers, key collision rule) lives in [`DESIGN-STATES.md`](DESIGN-STATES.md).
 
-**❌ Wrong — pseudo-class rules must be removed:**
+A pseudo-class rule **without** a matching `:global(.elem<PascalKey>)` partner is invisible to the editor — the platform can never apply the user's state styling to that surface. That's why ad-hoc `:hover` rules are still rejected.
+
+Selection / mode variants that are part of the component's own data model (not surfaced as editable design states) still go through a JS-toggled modifier class — see `CSS-GUIDELINES.md` §"Express selection / mode variants".
+
+**❌ Wrong — pseudo-class rule with no paired `:global(.elem<PascalKey>)`:**
 
 ```scss
-.button {
-  background-color: #ffffff;
-  color: #0f172a;
-  border-radius: 8px;
-  padding-block: 8px;
-  padding-inline: 16px;
-}
-
-.button:hover { /* ❌ Interaction state — platform owns this */
+.button:hover {
   background-color: #f0f0f0;
-}
-
-.button:disabled { /* ❌ Interaction state — platform owns this */
-  opacity: 0.5;
 }
 ```
 
-**✅ Correct — keep the resting visual; drop the pseudo-class rules:**
+**✅ Correct — paired CSS + TSX marker per [`DESIGN-STATES.md`](DESIGN-STATES.md):**
 
 ```scss
-.button {
-  display: flex;
-  align-items: center;
-  background-color: #ffffff;
-  color: #0f172a;
-  border-radius: 8px;
-  padding-block: 8px;
-  padding-inline: 16px;
-  box-sizing: border-box;
+.button:hover,
+.button:global(.elemHover) {
+  filter: brightness(1.05);
 }
+
+.button[aria-disabled='true'],
+.button:global(.elemDisabled) {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+```
+
+```tsx
+<button
+  className={classNames('button', styles.button)}
+  aria-disabled={isDisabled || undefined}
+>
 ```
 
 ## 3.2 Browser APIs at module scope


### PR DESCRIPTION
## Summary

This is the **wix/skills** piece of [ECL-17326](https://wix.atlassian.net/browse/ECL-17326) (*Add support for design states across all Studio 2 components*). It publishes the **design-states authoring contract** that the upcoming `/builder-add-design-states` subskill (Phase 2 of `/builder-create-component`) writes against, and that ZeroConfig consumes downstream to emit the manifest `states` block.

The contract lets an editor-react component declare its state surface (Hover / Focus / Disabled / Invalid / Selected / custom keys) via **two paired source signals** — a CSS pair (pseudo-class + BEM modifier class) and a matching TSX marker (`aria-*` / `data-state`) on the same element. The editor reads those signals to render the design-panel state-switcher and to inject the modifier class onto the DOM at runtime.

## Changes

- **NEW** `skills/wix-app/references/editor-react-component/DESIGN-STATES.md` — single source of truth. Covers the CSS signal, TSX markers, default-styling catalog, base-class resolution, key collision rule, and how `npx wix generate manifest` turns the two signals into the manifest `states` block.
- `EDITOR_REACT_COMPONENT.md` — threads a new "wire design states" step into the component workflow and links DESIGN-STATES.md from the topic-focused references list.
- `CSS-GUIDELINES.md` — rewrites the "don't author state styles" rule: state pseudo-classes / state attributes are now allowed **only** when authored as paired rules per the design-states contract. Unpaired `:hover` / `:focus` / `:disabled` / `[data-state]` rules are still rejected (they're invisible to the editor).
- `REACT-GUIDELINES.md` — adds a mandatory "Design States" subsection pointing at the contract.
- `REACT-PATTERNS.md` — rewrites the §3.1 "interaction-state CSS" common-mistake to reflect the contract (paired rule is correct; unpaired pseudo-class is still wrong).

## Naming convention

Class names follow **orthodox BEM**, finalized 2026-05-19 across all three repos (editor-elements, ZeroConfig, skills):

- Root: `<block>--<state>` (e.g. `button--hover`, `tabs--disabled`)
- Inner element: `<block>__<element>--<state>` (e.g. `button__label--hover`, `menu__dropdown-item--selected`)
- State suffix is kebab-case verbatim — no PascalCase, no `elem` prefix.

Commit `b4a4f4c` renames the convention from the earlier `elem<PascalKey>` proposal to BEM to match what shipped in `wix-private/editor-elements` (`ce3c3e9`) and `wix-private/ZeroConfig` (`774a521`).

## Related work

- `wix-private/editor-elements` — 10 manifests migrated by hand, BEM rename in `ce3c3e9` (gated behind `sp.erc.isSupportDesignStates`).
- `wix-private/ZeroConfig` — parser + fixtures emit the manifest `states` block from paired CSS + TSX signals (`04dc75a`, BEM rename in `774a521`).
- This repo — publishes the contract docs that the `/builder-add-design-states` subskill writes against. No skill code yet; that lands in a follow-up.

## Test plan

- [ ] Re-read DESIGN-STATES.md against `wix-private/editor-elements/docs/builder/design-states.md` and confirm the contract (catalog, base-class resolution table, default-styling table, manifest-generation section) stays in sync with what ZeroConfig actually parses.
- [ ] Spot-check the four cross-doc links (`CSS-GUIDELINES.md`, `REACT-PATTERNS.md`, `REACT-GUIDELINES.md`, `EDITOR_REACT_COMPONENT.md` → `DESIGN-STATES.md`) render in the GitHub preview.
- [ ] End-to-end QA (covered in the editor-elements branch, not here): toggle `sp.erc.isSupportDesignStates` against a Studio 2 test site, verify the state-switcher injects `<component>--<state>` and the paired CSS rule fires for each migrated component.