### PR TITLE
ci(codex): echo has_changes value in sync workflow log

### DIFF
--- a/.github/workflows/sync-plugin-mirror.yml
+++ b/.github/workflows/sync-plugin-mirror.yml
@@ -28,9 +28,9 @@ jobs:
         id: sync
         run: |
           if git diff --quiet -- plugins/wix; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "has_changes=false" | tee -a "$GITHUB_OUTPUT"
           else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "has_changes=true" | tee -a "$GITHUB_OUTPUT"
           fi
 
       - name: Create or update Pull Request


### PR DESCRIPTION
Small ergonomic tweak to the sync workflow added in #261.

The `Check for changes` step writes `has_changes=true|false` to `$GITHUB_OUTPUT` so the next step's `if:` can read it. Without an `echo` to stdout, the runtime value isn't visible in the step's log — you have to infer it from whether the `Create or update Pull Request` step ran or was skipped.

This switches `>> $GITHUB_OUTPUT` to `| tee -a $GITHUB_OUTPUT` so the value is also printed to the step log. No behavioral change.

Useful for debugging future drift / no-drift smoke tests directly from the workflow log.