### PR TITLE
fix(wix-app): trim trailing whitespace in skill references

### DIFF
--- a/skills/wix-app/references/data-collection/WIX_DATA.md
+++ b/skills/wix-app/references/data-collection/WIX_DATA.md
@@ -17,7 +17,7 @@ npm install @wix/data
 ❌ **WRONG**: Do not create mock implementations or workarounds
 ✅ **CORRECT**: Install the package using `npm install @wix/data`
 
-The `@wix/data` package is a real npm package that provides access to Wix Data collections. 
+The `@wix/data` package is a real npm package that provides access to Wix Data collections.
 It must be installed before TypeScript compilation will succeed.
 
 ## SDK Methods & Interfaces

--- a/skills/wix-app/references/editor-react-component/COMPONENT-API.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-API.md
@@ -119,7 +119,7 @@ Array elements MUST be objects with named keys. This enables stable item identit
 
 - Primitives: `Array<string>`, `Array<number>`, `Array<boolean>`
 - Leaf data types from `@wix/editor-react-types`: `Array<Image>`, `Array<Link>`, `Array<Video>`, `Array<Audio>`, `Array<VectorArt>`, `Array<RichText>`. Wrap them in an object instead.
-- Nested arrays:  `Array<Array<{cover: image, caption: string}>>` `Array<{items: Array<image>, caption: string}>` 
+- Nested arrays:  `Array<Array<{cover: image, caption: string}>>` `Array<{items: Array<image>, caption: string}>`
 
 **❌ Wrong:**
 

--- a/skills/wix-app/references/site-plugin/SLOTS.md
+++ b/skills/wix-app/references/site-plugin/SLOTS.md
@@ -58,8 +58,8 @@ This reference provides detailed information about all available slots for site 
 - `product-page-details-2`
 - Additional slots vary by layout (Classic, Simple, Sleek, Spotlight, Stunning)
 
-**Note:** Check which Wix Stores version is installed before building 
-plugins, as slots differ between versions. Your app should include 
+**Note:** Check which Wix Stores version is installed before building
+plugins, as slots differ between versions. Your app should include
 placements for both versions for maximum compatibility.
 
 **Plugin API Properties:** Same as New Version above.


### PR DESCRIPTION
Three skill reference files had trailing whitespace at end of line. One of them (`site-plugin/SLOTS.md`) had **two trailing spaces** on a prose line — CommonMark treats that as a hard `<br>`, so the sentence:

> Check which Wix Stores version is installed before building<br>
> plugins, as slots differ between versions.

was being rendered with a forced line break in the middle of the paragraph. The other two are one-space trailings that don't render incorrectly but are gratuitous.

Three files touched, four lines changed.

### Bonus: also a drift smoke-test for #261

This PR doesn't touch `plugins/wix/skills/wix-app/references/*`, so after merge those mirror files will be out of sync with their canonical counterparts at the repo root. The next run of the **Sync Plugin Mirror** workflow (cron at 08:00 UTC, or via Actions → "Run workflow") should detect the drift and auto-open `chore: sync plugins/wix/ mirror with repo root`. That validates the second half of #261's test plan.