### PR TITLE
wix-app: trim Editor React Component reference loads; document Link.href

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -66,14 +66,29 @@ Reference: when modifying an _existing_ component, follow
 
 Core rules and workflow: [`editor-react-component/REACT-GUIDELINES.md`](editor-react-component/REACT-GUIDELINES.md).
 
-Topic-focused references (rules + patterns + common mistakes in one place):
+### Read upfront (always)
 
-- [`editor-react-component/ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md) — ARIA/a11y rules and patterns
-- [`editor-react-component/DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md) — RTL/LTR rules and patterns
-- [`editor-react-component/PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) — What should be a React prop vs CSS
+These three references apply to every Editor React Component — load them before writing code:
+
+- [`editor-react-component/REACT-GUIDELINES.md`](editor-react-component/REACT-GUIDELINES.md) — Core rules and workflow
 - [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
-- [`editor-react-component/REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, remaining common mistakes
+- [`editor-react-component/CSS-GUIDELINES.md`](editor-react-component/CSS-GUIDELINES.md) — CSS authoring rules (root layout, naming, RTL, state styles)
+
+### Load on demand (only when a signal in the spec matches)
+
+Do **not** read these upfront. Pull each one only when the component spec has the trigger listed — they add ~5–15k tokens each to your context window and inflate every subsequent tool turn's cache-read cost:
+
+| Reference | Load when the spec mentions… |
+| --- | --- |
+| [`PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) | per-breakpoint visibility, `show*`/`hide*` toggles, orientation/alignment variations, or you're tempted to add a visual-toggle prop |
+| [`ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md) | icon-only buttons/links, ARIA attributes, screen-reader behavior, or interactive elements without visible text |
+| [`DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md) | non-trivial RTL behavior beyond `dir={direction}` on the root, JS that branches on direction (keyboard nav, animations), or RTL-aware transforms |
+| [`PARTS.md`](editor-react-component/PARTS.md) | non-obvious decisions about which elements deserve a named part (lists/grids of items, repeated structural elements, ambiguous wrappers) |
+| [`REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) | SSR-sensitive logic (`window`/`document`/`navigator`), pseudo-class state styling questions, or semantic-HTML choices for collection-style UI |
+| [`COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md) | always when editing `<ComponentName>.extension.ts` (sizing type, resize direction, `staticContainer`) — but not before |
+
+When in doubt, write the code first using the three upfront references and the inline rules above. Pull a topic file only when you hit a question it answers.
 
 ## CSS guidelines
 
-Reference: [`editor-react-component/CSS-GUIDELINES.md`](editor-react-component/CSS-GUIDELINES.md).
+Reference: [`editor-react-component/CSS-GUIDELINES.md`](editor-react-component/CSS-GUIDELINES.md) — included in the "Read upfront" set above.

--- a/skills/wix-app/references/editor-react-component/COMPONENT-API.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-API.md
@@ -163,6 +163,20 @@ When creating TypeScript interfaces for component props, use types from `@wix/ed
 import type { Link } from "@wix/editor-react-types"; // Reference at node_modules/@wix/react-component-schema/dist/editor-react-types.d.ts
 ```
 
+#### Field-name gotchas
+
+Don't guess field names — these are the ones agents most often get wrong:
+
+- **`Link`**: the URL field is **`href`**, not `url`. Shape: `{ href?: string; target?: '_self' | '_blank'; rel?: string }`.
+  ```tsx
+  // ✅ Correct
+  <a href={ctaLink?.href ?? '#'} target={ctaLink?.target ?? '_self'}>{ctaLabel}</a>
+
+  // ❌ Wrong — `Link.url` doesn't exist; tsc will error
+  <a href={ctaLink?.url ?? '#'} />
+  ```
+- **`Image`**: the source field is **`url`** (the absolute Wix-hosted URL); **`uri`** is the bare `fileName`. Both should be populated together when you author defaults. See the "Default values for `Image` props" section below.
+
 ### External resources are forbidden
 
 All resources rendered or fetched by the component (images, icons, fonts,


### PR DESCRIPTION
## Summary

Editor React Component init runs are paying a high cache-read tax because the parent reference instructs the agent to read all 9 topic files upfront. On a recent `INIT_CODEGEN` run for a simple list-of-cards widget, that pushed the per-turn cache-read floor to ~58k and the run cost to **\$0.81 / 3:21** (SLO: <\$0.50 / <3 min). Cache reads alone accounted for ~\$0.54 of the bill.

Two contained changes to the `wix-app` skill:

- **`EDITOR_REACT_COMPONENT.md`** — split the topic references into "read upfront" (`REACT-GUIDELINES`, `COMPONENT-API`, `CSS-GUIDELINES`) and "load on demand" (everything else), with a per-topic trigger table so the agent only pulls `ACCESSIBILITY` / `DIRECTIONALITY` / `PARTS` / `PROPS-VS-CSS` / `REACT-PATTERNS` / `COMPONENT-CONFIGURATION` when the spec actually warrants them.
- **`COMPONENT-API.md`** — add a "Field-name gotchas" callout in the Component Data Types section documenting that `Link`'s URL field is `href` (not `url`), and that `Image` uses `url` (absolute) and `uri` (fileName) together. The agent guessed `Link.url` in the breaching run, blew a `tsc` cycle, and went grepping `node_modules` to find the right name.

## Context

- Breaching job: `ff287973-d6f2-4fd7-9960-c242a732d456` (BracketBlaze, `INIT_CODEGEN`)
- 36 steps · 1.86M total tokens · 1.81M cache-read · \$0.8141 · 3:21 wall

The full investigation flagged two other fixes that live in different repos and aren't in this PR:

- Missing `*.module.css` + `*.tsx?url` ambient declarations in the project scaffold (lives in `ditto/packages/scaffolding`).
- `wix generate` output for `EDITOR_REACT_COMPONENT` doesn't match the named-export pattern this skill teaches in `EXTENSION_REGISTRATION.md` (either the scaffolder or that doc needs to move).

## Test plan

- [ ] Skim rendered `EDITOR_REACT_COMPONENT.md` to confirm the trigger table reads clearly and the "Read upfront" set is unambiguous.
- [ ] Re-run an `INIT_CODEGEN` for a simple Editor React Component (similar shape to BracketBlaze) and confirm the agent no longer reads `ACCESSIBILITY` / `DIRECTIONALITY` / `PARTS` upfront — expect cache-read floor to drop ~25–40%.
- [ ] Re-run an init that uses `Link` and confirm the agent no longer hallucinates `.url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)