### PR TITLE
fix(wix-app): steer agents to ReadFullDocsMethodSchema for SDK method lookups

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -230,7 +230,8 @@ Use the Extension Types Reference Table and decision content above. State extens
 **MCP Tools for discovery (when needed):**
 
 - `SearchWixSDKDocumentation` - SDK methods and APIs (**Always use maxResults: 5**)
-- `ReadFullDocsArticle` - Full documentation when needed (only if search results need more detail)
+- `ReadFullDocsMethodSchema` - Full type schema for a specific SDK method (parameters, return type, permissions)
+- `ReadFullDocsArticle` - Prose guides and conceptual articles only (not for SDK method signatures)
 
 ### Step 4: Implement Extensions
 
@@ -336,7 +337,7 @@ Stop and report errors if any step fails. Check `.wix/debug.log` on failures.
 - **Check API references first** — read relevant API reference files before using MCP discovery
 - **Skip discovery** when all required APIs are in reference files
 - **maxResults: 5** for all MCP SDK searches
-- **ReadFullDocsArticle** only when search results need more context
+- **ReadFullDocsMethodSchema** for SDK method schemas; **ReadFullDocsArticle** for prose guides only
 - **Invoke wix-design-system** first when using WDS (prevents import errors)
 
 ## Documentation


### PR DESCRIPTION
## Problem

Agents were calling `ReadFullDocsArticle` for SDK method lookups — getting prose documentation instead of structured type schemas. The skill listed only `ReadFullDocsArticle` as the follow-up MCP tool after `SearchWixSDKDocumentation`, with no mention of `ReadFullDocsMethodSchema`.

Two codegen jobs traced to this:
- `aae0537f-30e6-493e-9d49-b73b503a716a` — 3× `ReadFullDocsArticle`, 0× `ReadFullDocsMethodSchema`
- `d800b97a-58c6-4938-84c8-8e7962c15a95` — 4× `ReadFullDocsArticle`, 0× `ReadFullDocsMethodSchema`

Both jobs also had a concurrent doc-MCP ranking failure (blog domain), so the article reads were on top of already-wrong search results. The combination drove cost to $1.94 and $1.13 (SLO: $0.50).

Note: the wix-mcp `SearchWixSDKDocumentation` response footer also says _"use ReadFullDocsArticle for methods"_ — that's a separate fix needed in the MCP server. This PR covers the skill side.

## Change

- Added `ReadFullDocsMethodSchema` to the MCP tools list with clear guidance: use it for SDK method type schemas.
- Restricted `ReadFullDocsArticle` to prose guides and conceptual articles only.
- Updated the Cost Optimization section to match.

## Test plan

- [ ] Verify codegen jobs that call `SearchWixSDKDocumentation` follow up with `ReadFullDocsMethodSchema` for method lookups (not `ReadFullDocsArticle`)
- [ ] Verify `ReadFullDocsArticle` still used for prose/guide URLs (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)