### PR TITLE
chore: update homepage URL to new AI tools docs path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Wix",
     "url": "https://dev.wix.com"
   },
-  "homepage": "https://dev.wix.com/docs/wix-cli/guides/development/about-wix-skills",
+  "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": ["wix", "wix-cli", "wix-mcp", "ecommerce", "cms", "wix-apps"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Wix",
     "url": "https://dev.wix.com"
   },
-  "homepage": "https://dev.wix.com/docs/wix-cli/guides/development/about-wix-skills",
+  "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Wix",
     "url": "https://dev.wix.com"
   },
-  "homepage": "https://dev.wix.com/docs/wix-cli/guides/development/about-wix-skills",
+  "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
   "repository": "https://github.com/wix/skills",
   "license": "MIT",
   "keywords": ["wix", "wix-cli", "mcp", "ecommerce", "cms", "backend-api"],

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > ⚠️ **EXPERIMENTAL**: This project is in early development. APIs, skill definitions, and behavior may change without notice. Use at your own risk.
 
-Agent skills for building Wix applications with AI coding assistants.
+Agent skills for building Wix app extensions, managing Wix business solutions, developing headless sites, and using the Wix Design System with AI agents.
 
-> **Note**: These skills are designed for the **new Wix CLI**. See [About the Wix CLI](https://dev.wix.com/docs/api-reference/articles/ai-tools/about-the-wix-cli) to learn more.
+> **Note**: These skills are designed for the **new Wix CLI**. See [About the Wix CLI](https://dev.wix.com/docs/wix-cli/guides/about-the-wix-cli) to learn more. For an overview of how skills work with AI tools, see [About Wix Skills](https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Agent skills for building Wix applications with AI coding assistants.
 
-> **Note**: These skills are designed for the **new Wix CLI**. See [About the Wix CLI](https://dev.wix.com/docs/wix-cli/guides/about-the-wix-cli) to learn more.
+> **Note**: These skills are designed for the **new Wix CLI**. See [About the Wix CLI](https://dev.wix.com/docs/api-reference/articles/ai-tools/about-the-wix-cli) to learn more.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Updates the `homepage` field in `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `.cursor-plugin/plugin.json`
- Changes the URL from `https://dev.wix.com/docs/wix-cli/guides/development/about-wix-skills` to `https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills`

## Test plan

- [ ] Verify the new homepage URL resolves correctly in a browser

Made with [Cursor](https://cursor.com)