### PR TITLE
fix: align wix-headless with folder-name CLI flow

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -125,7 +125,7 @@ See `references/SETUP.md` § "MCP Prefix Discovery + Schema Bootstrap".
 See `references/DISCOVERY.md` for full mechanics.
 
 - Infer vertical(s) from the user's opening message; if too vague, one conversational clarifier.
-- **Q1** (`AskUserQuestion`): brand name. On answer, launch scaffold in background: `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"`. Folder-name derivation + timing capture rules in `references/DISCOVERY.md` § "Scaffold dispatch".
+- **Q1** (`AskUserQuestion`): brand name. On answer, launch scaffold in background: `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"`. The brand is the CLI `business-name` and now owns Wix project naming; folder-name derivation + timing capture rules live in `references/DISCOVERY.md` § "Scaffold dispatch".
 - **Q2** (`AskUserQuestion`): vibe.
 - Craft a 2–3 sentence aesthetic direction in scratch (do not print standalone).
 - Present the plan as markdown (Design Direction → Features → Pages → CMS Collections → Apps & SDK). **Pages, CMS Collections, and Apps & SDK MUST be markdown tables.**

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -59,7 +59,7 @@ Any user request to build a new site. Infer vertical(s) from the prompt:
 
 | Scenario | Use Instead |
 |---|---|
-| Scaffold-only with no further design/wiring | `bash <SKILL_ROOT>/scripts/scaffold.sh <slug> "<Brand>"` |
+| Scaffold-only with no further design/wiring | `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` |
 | Build + preview an existing project | `bash <SKILL_ROOT>/scripts/preview.sh` (from project dir) |
 | Release / ship / go-live an existing project | `bash <SKILL_ROOT>/scripts/release.sh` (from project dir) |
 | Install a Wix app onto an existing site | Follow `<SKILL_ROOT>/references/commands/install-app.md` |
@@ -125,7 +125,7 @@ See `references/SETUP.md` § "MCP Prefix Discovery + Schema Bootstrap".
 See `references/DISCOVERY.md` for full mechanics.
 
 - Infer vertical(s) from the user's opening message; if too vague, one conversational clarifier.
-- **Q1** (`AskUserQuestion`): brand name. On answer, launch scaffold in background: `bash <SKILL_ROOT>/scripts/scaffold.sh <slug> "<Brand>"`. Slug-derivation + timing capture rules in `references/DISCOVERY.md` § "Scaffold dispatch".
+- **Q1** (`AskUserQuestion`): brand name. On answer, launch scaffold in background: `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"`. Folder-name derivation + timing capture rules in `references/DISCOVERY.md` § "Scaffold dispatch".
 - **Q2** (`AskUserQuestion`): vibe.
 - Craft a 2–3 sentence aesthetic direction in scratch (do not print standalone).
 - Present the plan as markdown (Design Direction → Features → Pages → CMS Collections → Apps & SDK). **Pages, CMS Collections, and Apps & SDK MUST be markdown tables.**

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -39,37 +39,37 @@ If the user already named the brand in the opening message, skip this step.
 
 Immediately after the brand name is confirmed (before Q2), emit **one concurrent batch** containing both the scaffold dispatch AND prefetch reads of the shared contract docs. These reads cost nothing during Q2 + plan review wait time but save ~1 min of post-approval latency that prior runs spent reading these docs serially.
 
-1. **Scaffold dispatch.** Derive the project slug from the brand, validate it, then run `bash <SKILL_ROOT>/scripts/scaffold.sh <slug> "<Brand>"` as a background shell. The script handles the npm-create invocation + slug pre-flight (regex `^[a-z0-9]{3,20}$`); the orchestrator handles slug derivation from the human-readable brand.
+1. **Scaffold dispatch.** Derive the folder name from the brand, validate it, then run `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` as a background shell. The script handles the npm-create invocation + folder-name pre-flight (regex `^[a-z0-9]{3,20}$`); the orchestrator handles folder-name derivation from the human-readable brand.
 
-   **Slug derivation (apply to brand before invoking the script):**
+   **Folder-name derivation (apply to brand before invoking the script):**
    1. Lowercase
    2. Strip every char that isn't `[a-z0-9]` (drop hyphens, spaces, punctuation, accents — the Wix CLI rejects them)
    3. Truncate to 20 chars
-   4. If the result is shorter than 3 chars, ask the user explicitly for a slug (`AskUserQuestion`)
+   4. If the result is shorter than 3 chars, ask the user explicitly for a folder name (`AskUserQuestion`)
 
    Examples: `"Acme-Co" → "acmeco"`; `"Sole Society" → "solesociety"`; `"E&E Co." → "eeco"`; `"AB" → ask the user`.
 
    The Wix CLI requires `[a-z0-9]{3,20}` — hyphens, underscores, uppercase, and other punctuation are rejected.
 
-   **Pre-flight validation (orchestrator-side, before invoking the script).** Both must pass; if either fails, regenerate the slug or re-prompt the user — do NOT rely solely on the script's pre-flight (it'll exit non-zero, but that costs a round-trip):
-   - `slug` matches `^[a-z0-9]{3,20}$`
+   **Pre-flight validation (orchestrator-side, before invoking the script).** Both must pass; if either fails, regenerate the folder name or re-prompt the user — do NOT rely solely on the script's pre-flight (it'll exit non-zero, but that costs a round-trip):
+   - derived folder name matches `^[a-z0-9]{3,20}$`
    - `brand` is non-empty after trimming whitespace
 
    **The scaffold call (background shell, with timing capture):**
 
    ```bash
    STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-   bash "<SKILL_ROOT>/scripts/scaffold.sh" "<slug>" "<brand>"
+   bash "<SKILL_ROOT>/scripts/scaffold.sh" "<folder-name>" "<brand>"
    ENDED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
    ```
 
-   - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). Substitute `<slug>` with the validated slug.
+   - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). Substitute `<folder-name>` with the validated folder name.
    - The script pins `--site-template-id` to the pure-headless blank template (`212b41cb-0da6-4401-9c72-7c579e6477a2`). Vibe-compatible templates trigger an interactive prompt that blocks non-TTY runs — the template ID is intentionally hardcoded inside the script.
    - Append timing to `.wix/run.json.phases[]` as `{ phase: "scaffold", seconds: <duration>, started: $STARTED_AT, ended: $ENDED_AT }`.
 
-   **Strict-then-recover:**
-   1. Script exit 2 (slug or brand validation failed) → orchestrator-side bug; the orchestrator should have caught this in pre-flight. Fix the slug derivation and retry.
-   2. Auth error from npm/Wix CLI → run `npx @wix/cli login` yourself per SKILL.md § "Authentication" (background, surface the device code, resume) — do not stop and punt to the user.
+  **Strict-then-recover:**
+  1. Script exit 2 (folder name or brand validation failed) → orchestrator-side bug; the orchestrator should have caught this in pre-flight. Fix the folder-name derivation and retry.
+  2. Auth error from npm/Wix CLI → run `npx @wix/cli login` yourself per SKILL.md § "Authentication" (background, surface the device code, resume) — do not stop and punt to the user.
    3. `invalid template` error → the template ID inside `scaffold.sh` is stale. Look up the current ID via `<prefix>SearchWixCLIDocumentation` query `create headless template`, edit the script's `TEMPLATE_ID` constant, retry once, log to `.wix/run.json.commandDrift[]` so the script can be tightened.
    4. Other errors → surface stderr to the user.
 
@@ -322,7 +322,7 @@ If the user wants to adjust, handle it conversationally (swap brand, change vibe
 Save the project context to memory (type: `project`) so future sessions can resume:
 - Brand name, vertical(s) inferred
 - Apps, packages, pages from the loaded packs
-- Project name + absolute project directory
+- Folder name + absolute project directory
 - Current phase: `scaffolding`
 
 > **Do NOT narrate the internal sub-steps.** After approval, proceed silently through setup, launch phases, etc. The user tracks progress via TaskList — that's enough. No *"Now I'll install Wix Stores via MCP"*, no *"Launching Phase 1 agents"*, no MCP / sidecar / agent-name / `.wix/` leakage.

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -39,7 +39,7 @@ If the user already named the brand in the opening message, skip this step.
 
 Immediately after the brand name is confirmed (before Q2), emit **one concurrent batch** containing both the scaffold dispatch AND prefetch reads of the shared contract docs. These reads cost nothing during Q2 + plan review wait time but save ~1 min of post-approval latency that prior runs spent reading these docs serially.
 
-1. **Scaffold dispatch.** Derive the folder name from the brand, validate it, then run `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` as a background shell. The script handles the npm-create invocation + folder-name pre-flight; the orchestrator handles folder-name derivation from the human-readable brand.
+1. **Scaffold dispatch.** Derive the folder name from the brand, validate it, then run `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` as a background shell. The script handles the npm-create invocation + folder-name pre-flight; the orchestrator handles folder-name derivation from the human-readable brand. The folder name only controls the local project directory. The same brand is passed to the CLI as `business-name`, and that value now drives the Wix project display name and project URL slug.
 
    **Folder-name derivation (apply to brand before invoking the script):**
    1. Lowercase
@@ -67,7 +67,7 @@ Immediately after the brand name is confirmed (before Q2), emit **one concurrent
    ENDED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
    ```
 
-   - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). Substitute `<folder-name>` with the validated folder name.
+   - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). This is the value sent to the CLI as `--business-name`, so it owns the Wix project display name and URL-slug generation. Substitute `<folder-name>` with the validated folder name for the local directory only.
    - The script pins `--site-template-id` to the pure-headless blank template (`212b41cb-0da6-4401-9c72-7c579e6477a2`). Vibe-compatible templates trigger an interactive prompt that blocks non-TTY runs — the template ID is intentionally hardcoded inside the script.
    - Append timing to `.wix/run.json.phases[]` as `{ phase: "scaffold", seconds: <duration>, started: $STARTED_AT, ended: $ENDED_AT }`.
 
@@ -324,7 +324,7 @@ If the user wants to adjust, handle it conversationally (swap brand, change vibe
 ## After Approval
 
 Save the project context to memory (type: `project`) so future sessions can resume:
-- Brand name, vertical(s) inferred
+- Brand name (also the Wix project display-name / URL-slug source), vertical(s) inferred
 - Apps, packages, pages from the loaded packs
 - Folder name + absolute project directory
 - Current phase: `scaffolding`

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -39,21 +39,25 @@ If the user already named the brand in the opening message, skip this step.
 
 Immediately after the brand name is confirmed (before Q2), emit **one concurrent batch** containing both the scaffold dispatch AND prefetch reads of the shared contract docs. These reads cost nothing during Q2 + plan review wait time but save ~1 min of post-approval latency that prior runs spent reading these docs serially.
 
-1. **Scaffold dispatch.** Derive the folder name from the brand, validate it, then run `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` as a background shell. The script handles the npm-create invocation + folder-name pre-flight (regex `^[a-z0-9]{3,20}$`); the orchestrator handles folder-name derivation from the human-readable brand.
+1. **Scaffold dispatch.** Derive the folder name from the brand, validate it, then run `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` as a background shell. The script handles the npm-create invocation + folder-name pre-flight; the orchestrator handles folder-name derivation from the human-readable brand.
 
    **Folder-name derivation (apply to brand before invoking the script):**
    1. Lowercase
-   2. Strip every char that isn't `[a-z0-9]` (drop hyphens, spaces, punctuation, accents — the Wix CLI rejects them)
-   3. Truncate to 20 chars
-   4. If the result is shorter than 3 chars, ask the user explicitly for a folder name (`AskUserQuestion`)
+   2. Convert whitespace / punctuation runs to `-`
+   3. Remove every char that isn't `[a-z0-9-]`
+   4. Trim leading / trailing hyphens and collapse repeated hyphens
+   5. If the result is empty, ask the user explicitly for a folder name (`AskUserQuestion`)
 
-   Examples: `"Acme-Co" → "acmeco"`; `"Sole Society" → "solesociety"`; `"E&E Co." → "eeco"`; `"AB" → ask the user`.
+   Examples: `"Acme-Co" → "acme-co"`; `"Sole Society" → "sole-society"`; `"E&E Co." → "e-e-co"`; `"!!!" → ask the user`.
 
-   The Wix CLI requires `[a-z0-9]{3,20}` — hyphens, underscores, uppercase, and other punctuation are rejected.
+   The Wix CLI's `--folder-name` accepts lowercase letters, numbers, and hyphens. The value must also pass npm package-name validation, so keep it npm-safe.
+
+   **Business-name guardrail.** The CLI now derives the Wix project URL slug from `business-name`, not from `folder-name`. If the confirmed brand contains no English letters or numbers (for example, only emoji or punctuation), the CLI rejects it. In that case, ask the user for a brand name that includes at least one English letter or number before scaffolding.
 
    **Pre-flight validation (orchestrator-side, before invoking the script).** Both must pass; if either fails, regenerate the folder name or re-prompt the user — do NOT rely solely on the script's pre-flight (it'll exit non-zero, but that costs a round-trip):
-   - derived folder name matches `^[a-z0-9]{3,20}$`
-   - `brand` is non-empty after trimming whitespace
+   - derived folder name matches `^[a-z0-9][a-z0-9-]*$`
+   - derived folder name is npm-safe (same rule the CLI enforces)
+   - `brand` is non-empty after trimming whitespace and contains at least one English letter or number
 
    **The scaffold call (background shell, with timing capture):**
 

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -68,13 +68,13 @@ Immediately after the brand name is confirmed (before Q2), emit **one concurrent
    ```
 
    - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). This is the value sent to the CLI as `--business-name`, so it owns the Wix project display name and URL-slug generation. Substitute `<folder-name>` with the validated folder name for the local directory only.
-   - The script pins `--site-template-id` to the pure-headless blank template (`212b41cb-0da6-4401-9c72-7c579e6477a2`). Vibe-compatible templates trigger an interactive prompt that blocks non-TTY runs — the template ID is intentionally hardcoded inside the script.
+   - The script pins `--site-template blank` to the pure-headless blank template. Vibe-compatible templates trigger an interactive prompt that blocks non-TTY runs — the template name is intentionally hardcoded inside the script.
    - Append timing to `.wix/run.json.phases[]` as `{ phase: "scaffold", seconds: <duration>, started: $STARTED_AT, ended: $ENDED_AT }`.
 
-  **Strict-then-recover:**
-  1. Script exit 2 (folder name or brand validation failed) → orchestrator-side bug; the orchestrator should have caught this in pre-flight. Fix the folder-name derivation and retry.
-  2. Auth error from npm/Wix CLI → run `npx @wix/cli login` yourself per SKILL.md § "Authentication" (background, surface the device code, resume) — do not stop and punt to the user.
-   3. `invalid template` error → the template ID inside `scaffold.sh` is stale. Look up the current ID via `<prefix>SearchWixCLIDocumentation` query `create headless template`, edit the script's `TEMPLATE_ID` constant, retry once, log to `.wix/run.json.commandDrift[]` so the script can be tightened.
+   **Strict-then-recover:**
+   1. Script exit 2 (folder name or brand validation failed) → orchestrator-side bug; the orchestrator should have caught this in pre-flight. Fix the folder-name derivation and retry.
+   2. Auth error from npm/Wix CLI → surface `"Run \`npx @wix/cli login\` and retry."` and stop.
+   3. `invalid template` error → the template name inside `scaffold.sh` is stale. Look up the current name via `<prefix>SearchWixCLIDocumentation` query `create headless template`, edit the script's `TEMPLATE_ID` constant (it holds the `--site-template` name, e.g. `blank`), retry once, log to `.wix/run.json.commandDrift[]` so the script can be tightened.
    4. Other errors → surface stderr to the user.
 
    Launch with background.

--- a/skills/wix-headless/scripts/scaffold.sh
+++ b/skills/wix-headless/scripts/scaffold.sh
@@ -4,8 +4,8 @@
 # Usage:
 #   bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand Name>"
 #
-# <folder-name>:  3-20 lowercase alphanumeric chars (no hyphens, no spaces) — the
-#                 Wix CLI rejects anything else. Becomes the project directory name.
+# <folder-name>:  lowercase letters, numbers, and hyphens only. Becomes the
+#                 local project directory name.
 # <Brand Name>:   human-readable business name; quote if it contains spaces.
 #
 # After scaffold succeeds, read <folder-name>/wix.config.json to extract appId
@@ -13,7 +13,7 @@
 # read; this script just runs the npm create.
 #
 # Behavior:
-#   - Pre-flight validates the folder name (regex ^[a-z0-9]{3,20}$).
+#   - Pre-flight validates the folder name syntax.
 #   - Pre-flight requires both args.
 #   - Runs `npm create @wix/new@latest headless` with --no-publish + --skip-install
 #     so the orchestrator can deferred-install with its own package set.
@@ -34,10 +34,10 @@ if [[ $# -lt 2 || -z "${1:-}" || -z "${2:-}" ]]; then
   exit 2
 fi
 
-if [[ ! "$1" =~ ^[a-z0-9]{3,20}$ ]]; then
+if [[ ! "$1" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
   echo "scaffold.sh: folder-name='$1' is not valid." >&2
-  echo "Folder name must be 3-20 lowercase alphanumeric chars (no hyphens, no spaces)." >&2
-  echo "Derive it from the brand: lowercase, strip non-[a-z0-9], truncate to 20." >&2
+  echo "Folder name must contain only lowercase letters, numbers, and hyphens." >&2
+  echo "Derive it from the brand as a lowercase, npm-safe directory name." >&2
   exit 2
 fi
 

--- a/skills/wix-headless/scripts/scaffold.sh
+++ b/skills/wix-headless/scripts/scaffold.sh
@@ -7,6 +7,7 @@
 # <folder-name>:  lowercase letters, numbers, and hyphens only. Becomes the
 #                 local project directory name.
 # <Brand Name>:   human-readable business name; quote if it contains spaces.
+#                 The CLI uses this as the Wix project display-name / URL-slug source.
 #
 # After scaffold succeeds, read <folder-name>/wix.config.json to extract appId
 # (project's appId) and siteId (used for MCP calls). The orchestrator does that

--- a/skills/wix-headless/scripts/scaffold.sh
+++ b/skills/wix-headless/scripts/scaffold.sh
@@ -2,18 +2,18 @@
 # Scaffold a new Wix Managed Headless project with the pure-headless blank template.
 #
 # Usage:
-#   bash <SKILL_ROOT>/scripts/scaffold.sh <project-slug> "<Brand Name>"
+#   bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand Name>"
 #
-# <project-slug>: 3-20 lowercase alphanumeric chars (no hyphens, no spaces) — the
+# <folder-name>:  3-20 lowercase alphanumeric chars (no hyphens, no spaces) — the
 #                 Wix CLI rejects anything else. Becomes the project directory name.
 # <Brand Name>:   human-readable business name; quote if it contains spaces.
 #
-# After scaffold succeeds, read <project-slug>/wix.config.json to extract appId
+# After scaffold succeeds, read <folder-name>/wix.config.json to extract appId
 # (project's appId) and siteId (used for MCP calls). The orchestrator does that
 # read; this script just runs the npm create.
 #
 # Behavior:
-#   - Pre-flight validates the slug (regex ^[a-z0-9]{3,20}$).
+#   - Pre-flight validates the folder name (regex ^[a-z0-9]{3,20}$).
 #   - Pre-flight requires both args.
 #   - Runs `npm create @wix/new@latest headless` with --no-publish + --skip-install
 #     so the orchestrator can deferred-install with its own package set.
@@ -29,15 +29,15 @@
 set -euo pipefail
 
 if [[ $# -lt 2 || -z "${1:-}" || -z "${2:-}" ]]; then
-  echo "scaffold.sh: both args required. Got project-slug='${1:-}' brand-name='${2:-}'." >&2
-  echo "Usage: bash scaffold.sh <slug> \"<Brand Name>\" — slug first, brand quoted." >&2
+  echo "scaffold.sh: both args required. Got folder-name='${1:-}' brand-name='${2:-}'." >&2
+  echo "Usage: bash scaffold.sh <folder-name> \"<Brand Name>\" — folder name first, brand quoted." >&2
   exit 2
 fi
 
 if [[ ! "$1" =~ ^[a-z0-9]{3,20}$ ]]; then
-  echo "scaffold.sh: project-slug='$1' is not valid." >&2
-  echo "Slug must be 3-20 lowercase alphanumeric chars (no hyphens, no spaces)." >&2
-  echo "Derive from the brand: lowercase, strip non-[a-z0-9], truncate to 20." >&2
+  echo "scaffold.sh: folder-name='$1' is not valid." >&2
+  echo "Folder name must be 3-20 lowercase alphanumeric chars (no hyphens, no spaces)." >&2
+  echo "Derive it from the brand: lowercase, strip non-[a-z0-9], truncate to 20." >&2
   exit 2
 fi
 
@@ -47,7 +47,7 @@ TEMPLATE_ID="blank"
 
 npm create @wix/new@latest headless -- \
   --business-name "$2" \
-  --project-name "$1" \
+  --folder-name "$1" \
   --site-template "$TEMPLATE_ID" \
   --no-publish \
   --skip-install


### PR DESCRIPTION
## Summary

- update the wix-headless scaffold flow to use `--folder-name` terminology instead of `--project-name`
- align folder-name derivation and validation guidance with the CLI behavior, including hyphen support and npm-safe naming
- document that the Wix project slug is derived from `business-name`, including the new guardrail for names that contain no English letters or numbers


## Testing
- not run