### PR TITLE
fix(wix-headless): restore non-interactive auth flow lost in headless rewrite

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -33,6 +33,16 @@ Every subagent is a **general-purpose worker** that loads its behavior from a sp
 
 Subagents run with the project as CWD and cannot resolve `<SKILL_ROOT>` themselves — pass absolute paths.
 
+## Authentication
+
+`wix login` (and `npx @wix/cli login`) are **safe to run from a non-interactive AI-agent environment**. When the CLI detects an AI agent it skips the interactive UI and emits JSON events on stdout, one per line:
+
+- `{"event":"awaiting_user","verificationUri":"...","userCode":"...","expiresInSeconds":...}` — surface the URL and code to the user; wait for them to complete login in their browser.
+- `{"event":"success","email":"...","userId":"..."}` — login complete; resume the step that failed.
+- `{"event":"logged_in","email":"...","userId":"..."}` — there was already a valid session, nothing to do.
+
+**How to run it:** run `wix login` (or `npx @wix/cli login`) with `run_in_background: true` since it blocks until the human finishes the browser step. Tail the output file to read the `awaiting_user` event as soon as it appears; you'll be notified when the process exits with the terminal event. Do **not** stop and tell the user to "run login and retry" — drive the login yourself and resume the step that failed.
+
 ## When This Skill Triggers
 
 Any user request to build a new site. Infer vertical(s) from the prompt:
@@ -129,7 +139,7 @@ See `references/DISCOVERY.md` for full mechanics.
 See `references/SETUP.md`. After approval, run **one concurrent batch** with no narration between operations.
 
 1. **App install** for every entry in `apps[*]` of every loaded vertical. Follow `<SKILL_ROOT>/references/commands/install-app.md` — owns the `CallWixSiteAPI` body shape, `appName → appDefId` lookup, and recovery ladder. **An empty `apps: []` array means install nothing for that pack** — gift-cards, ecom, cms all ship `apps: []`. Do not invent an `appName` from the pack name or SDK packages. Capture `APP_INSTALL_START`/`END` via `date -u +%s` around the `CallWixSiteAPI` invocation; record `{ phase: "app-install-<appName>", seconds }`.
-2. **`npx @wix/cli env pull`** (foreground, fast). Produces `.env.local` with `WIX_CLIENT_ID`. On auth error: surface `"Run \`npx @wix/cli login\` and retry."` and stop. Record `{ phase: "env-pull", seconds }`.
+2. **`npx @wix/cli env pull`** (foreground, fast). Produces `.env.local` with `WIX_CLIENT_ID`. On auth error: run `npx @wix/cli login` yourself per the **Authentication** section (background, surface the device code, resume) — do not stop and punt to the user. Record `{ phase: "env-pull", seconds }`.
 3. **`rm -f package-lock.json && npm install …`** as a **background shell** with the union of all loaded verticals' `packages` arrays plus the always-packages (`@wix/sdk tailwindcss @tailwindcss/vite`). Flags: `--no-fund --no-audit --legacy-peer-deps`. Bake `NPM_INSTALL_START=$(date -u +%s)` and `NPM_INSTALL_END=$(date -u +%s)` into the SAME background bash command so the values land in its output. Record `{ phase: "npm-install", seconds }` when the install finishes. **Do not add packages beyond this set** — see `SETUP.md` § anti-hallucination rule.
 4. **`bash <SKILL_ROOT>/scripts/seed-utilities.sh`** — copies `<SKILL_ROOT>/shared-utilities/*.ts` (`wix-image.ts`, `analytics.ts`, `ricos.ts`) into `src/utils/` with `cp -n` and strips the Astro starter cruft. Record `{ phase: "seed-utilities", seconds }`.
 5. **Memory writes** — `project` memory with brand/apps/pages/phase.

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -69,7 +69,7 @@ Immediately after the brand name is confirmed (before Q2), emit **one concurrent
 
    **Strict-then-recover:**
    1. Script exit 2 (slug or brand validation failed) → orchestrator-side bug; the orchestrator should have caught this in pre-flight. Fix the slug derivation and retry.
-   2. Auth error from npm/Wix CLI → surface `"Run \`npx @wix/cli login\` and retry."` and stop.
+   2. Auth error from npm/Wix CLI → run `npx @wix/cli login` yourself per SKILL.md § "Authentication" (background, surface the device code, resume) — do not stop and punt to the user.
    3. `invalid template` error → the template ID inside `scaffold.sh` is stale. Look up the current ID via `<prefix>SearchWixCLIDocumentation` query `create headless template`, edit the script's `TEMPLATE_ID` constant, retry once, log to `.wix/run.json.commandDrift[]` so the script can be tightened.
    4. Other errors → surface stderr to the user.
 

--- a/skills/wix-headless/scripts/release.sh
+++ b/skills/wix-headless/scripts/release.sh
@@ -18,8 +18,10 @@
 #   0 — ok; release URL on stdout
 #   <other> — build or release failed; stderr surfaces the underlying error.
 #             Build failures are code bugs (TypeScript / Astro / missing
-#             module) — the orchestrator does NOT retry. Release auth failures
-#             surface as `Run npx @wix/cli login and retry.`
+#             module) — the orchestrator does NOT retry. On a release auth
+#             failure the orchestrator runs `npx @wix/cli login` itself per
+#             SKILL.md § "Authentication" (background, surface the device code,
+#             resume) — it does NOT stop and punt to the user.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

[#221](https://github.com/wix/skills/pull/221) added guidance for running `wix login` from a non-interactive AI-agent environment, but the later headless rewrite ([#228](https://github.com/wix/skills/pull/228)) replaced `SKILL.md` wholesale and that guidance never made it into the new reference-file structure. As a result the skill reverted to telling the user to "run login and retry" and stopping — exactly the behavior #221 fixed.

This restores the guidance and wires it into every call site that handled auth failures.

## What changed

- **`SKILL.md`** — new `## Authentication` section restoring #221's content: `wix login` is safe in a non-interactive agent, the JSON stdout events (`awaiting_user` / `success` / `logged_in`), and how to run it with `run_in_background: true`.
- Fixed the three remaining stop-and-punt call sites to drive the login themselves and resume:
  - `SKILL.md` — Wave 2 `env pull` auth error
  - `references/DISCOVERY.md` — scaffold auth error
  - `scripts/release.sh` — release auth failure (header comment)

## Notes for reviewers

- No behavior change to the happy path; this only affects the auth-failure recovery path.
- The `plugins/wix/` mirror is a symlink into the same tree, so it updates automatically — no separate edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)