### PR TITLE
feat(wix-app): integrate a11y review into Editor React Component flow

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -54,10 +54,11 @@ File where you can override the generated manifest from `<componentName>.generat
 `[[ -d "node_modules/@wix/react-component-schema" && -d "node_modules/@wix/react-component-utils" && -d "node_modules/@wix/editor-react-types" ]] || ([ -f yarn.lock ] && yarn add @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types || npm install @wix/react-component-schema @wix/react-component-utils @wix/editor-react-types)`
 3. Edit the generated react and CSS files in
    `src/site/components/ComponentName/`.
-4. Run `npx wix build && npx wix generate manifest` so the editor picks up
+4. Run the A11y Review on the edited component per [`editor-react-component/A11Y-REVIEW.md`](editor-react-component/A11Y-REVIEW.md). It runs two scanners over the component's `.tsx`/`.jsx` files, triages findings, and applies fixes before the manifest is regenerated.
+5. Run `npx wix build && npx wix generate manifest` so the editor picks up
    the new/updated prop schema. This command regenerates manifest
    parts for all components.
-5. Update `Component.extensions.ts` file according to [`editor-react-component/COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md)
+6. Update `Component.extensions.ts` file according to [`editor-react-component/COMPONENT-CONFIGURATION.md`](editor-react-component/COMPONENT-CONFIGURATION.md)
 
 Reference: when modifying an _existing_ component, follow
 [`editor-react-component/EDIT-FLOW.md`](editor-react-component/EDIT-FLOW.md).
@@ -69,6 +70,7 @@ Core rules and workflow: [`editor-react-component/REACT-GUIDELINES.md`](editor-r
 Topic-focused references (rules + patterns + common mistakes in one place):
 
 - [`editor-react-component/ACCESSIBILITY.md`](editor-react-component/ACCESSIBILITY.md) — ARIA/a11y rules and patterns
+- [`editor-react-component/A11Y-REVIEW.md`](editor-react-component/A11Y-REVIEW.md) — Automated a11y scan + triage workflow to run after editing
 - [`editor-react-component/DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md) — RTL/LTR rules and patterns
 - [`editor-react-component/PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props

--- a/skills/wix-app/references/editor-react-component/A11Y-REVIEW.md
+++ b/skills/wix-app/references/editor-react-component/A11Y-REVIEW.md
@@ -1,0 +1,183 @@
+# Editor React Component A11y Review
+
+Use this reference to audit and fix accessibility issues in an Editor React Component before reporting completion. This complements [`ACCESSIBILITY.md`](ACCESSIBILITY.md) (which covers ARIA prop conventions and patterns) by adding an automated scan + triage workflow over the component's runtime, manifest extension, and shared code.
+
+This is not a separate skill — it runs as part of the Editor React Component workflow described in [`../EDITOR_REACT_COMPONENT.md`](../EDITOR_REACT_COMPONENT.md). Run it after editing the React/CSS sources and before `npx wix build && npx wix generate manifest`.
+
+## Scanner Invocation
+
+Two scanners live at the wix-app skill root:
+
+```bash
+node skills/wix-app/scripts/scan-a11y-eslint.js <file1> [file2] ...
+node skills/wix-app/scripts/scan-a11y-code.js  <file1> [file2] ...
+```
+
+Run them from the consumer project root (the Wix CLI app's working directory) so dependencies resolve from the project's `package.json`. Pass paths relative to that cwd.
+
+The ESLint scanner uses `eslint-plugin-jsx-a11y` (usually transitively available); the custom scanner performs cross-file semantic resolution (follows imports up to 4 levels deep) with confidence scoring.
+
+## When To Run
+
+Run the review when:
+
+- You finished editing an Editor React Component's `.tsx` / `.module.css` files.
+- The user asks for an a11y audit, accessibility review, or a11y fix on an Editor React Component.
+- The user mentions missing alt text, invalid ARIA, broken semantics, direction issues, icon-only controls, or wrappers that hide accessibility issues.
+
+Do not run on generated files (`*.generated.ts`) — they're regenerated from JSX and CSS Modules.
+
+## Target Resolution
+
+Resolve scope before scanning:
+
+| User says | Required scope |
+|-----------|----------------|
+| Specific file | That file plus any imported wrappers / shared components it renders |
+| "this component" | `<componentName>.tsx`, `component.tsx`, `<componentName>.extension.ts`, plus shared imports |
+| A component name | All in-component files (excluding `*.generated.ts`) |
+| "full audit" | Every Editor React Component folder under `src/site/components/`, excluding `*.generated.ts` |
+
+## Workflow
+
+Execute phases in order; do not pause for approval between phases.
+
+### Phase 1: Resolve Topology
+
+1. Enumerate in-scope files under `src/site/components/<componentName>/`.
+2. Include any imported shared components or utilities that affect rendered semantics.
+3. Exclude `*.generated.ts`.
+4. Note the topology (wrapper → shared primitive → leaf element) before scanning.
+
+### Phase 2a: ESLint JSX A11y Scan (Tier 0)
+
+```bash
+node skills/wix-app/scripts/scan-a11y-eslint.js <file1> [file2] ...
+```
+
+Single-file lint-level detections covering 31 `jsx-a11y` rules (interaction, focus, labeling, structural). High-signal for native elements; treat as leads for custom components. Full rule list: [`a11y-review/RULES.md`](a11y-review/RULES.md).
+
+### Phase 2b: Custom Semantic Scan (Tier 1)
+
+```bash
+node skills/wix-app/scripts/scan-a11y-code.js <file1> [file2] ...
+```
+
+Cross-file semantic resolution with confidence scoring. Covers five rule families:
+
+- `alt-text`
+- `anchor-is-valid`
+- `aria-props`
+- `aria-role`
+- `aria-unsupported-elements`
+
+Neither scanner validates manifest contracts or all project-specific patterns — see Phase 3.
+
+### Deduplication and Triage
+
+After both scans, evaluate every Tier 0 finding before fixing.
+
+**Deduplicate.** When both scanners flag the same location for the same issue, keep the richer one — prefer the custom scanner when it has semantic evidence; prefer ESLint when it covers a rule the custom scanner does not.
+
+**Verdicts:**
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| `confirmed` | The violation is real | Proceed to fix |
+| `false-positive` | Lint rule fires but code is correct | Discard with one-sentence reason |
+| `not-relevant` | Rule does not apply in this architecture | Discard with one-sentence reason |
+
+**How to evaluate:**
+
+1. **Native vs custom.** Native element findings are usually real. Custom component findings need verification — does the component render the element the rule assumes?
+2. **Delegated semantics.** Editor React Components route ARIA through the typed `a11y` prop and `convertA11yKeysToHtmlFormat(a11y)` (see [`ACCESSIBILITY.md`](ACCESSIBILITY.md)). If a11y attributes reach the element via a runtime path the linter can't see, the finding is a false positive.
+3. **Conditional interactivity.** When `onClick` is spread conditionally with `role`, `tabIndex`, and `onKeyDown`, the finding is a false positive. If only `onClick` is conditional, the finding is confirmed.
+4. **Repo-specific exemptions** — see the originals in [`a11y-review/MANUAL-REVIEW-CHECKLIST.md`](a11y-review/MANUAL-REVIEW-CHECKLIST.md).
+5. **When uncertain, default to `confirmed`.**
+
+Only confirmed findings proceed to fix. Report discards in Phase 6 with reasons.
+
+### Phase 3: Editor React Component Semantic Review
+
+Perform a manual semantic review even when scanners return zero findings.
+
+Editor React Component–specific checks:
+
+- All ARIA attributes come through the typed `a11y?: A11y` prop — never individual `ariaLabel?: string`, `role?: string`, etc. (See [`ACCESSIBILITY.md`](ACCESSIBILITY.md).)
+- `a11y` is forwarded to the root via `{...(a11y && convertA11yKeysToHtmlFormat(a11y))}`, or to an inner element via `elementProps.<name>.a11y` when requirements specify.
+- Icon-only interactive elements (icon/emoji/image/svg with no text node) have an accessible name from `constants.ts` or from user-configurable `a11y` — never a hardcoded string literal.
+- If the component supports text direction, the root applies `dir` (see [`DIRECTIONALITY.md`](DIRECTIONALITY.md)).
+- `<componentName>.extension.ts` overrides do not strip a11y-relevant manifest fields generated from the JSX.
+- Decorative-only output is hidden with `aria-hidden` when appropriate.
+- Heading/tag selection (when configurable) reaches the rendered semantic element.
+- Interactive-looking non-interactive elements expose keyboard behavior and roles.
+
+Use the Tier 2 checklist in [`a11y-review/MANUAL-REVIEW-CHECKLIST.md`](a11y-review/MANUAL-REVIEW-CHECKLIST.md) alongside these checks.
+
+### Phase 4: Fix
+
+Apply fixes only to findings that survived triage. Confidence drives action:
+
+- `high`: fix immediately
+- `medium`: read surrounding code, confirm, then fix
+- `low`: attempt to resolve semantics; fix only if confirmed
+
+Confirmed safe/local fixes must be applied; only ambiguous or risky non-local changes may remain unresolved. See [`a11y-review/CONFIDENCE-MODEL.md`](a11y-review/CONFIDENCE-MODEL.md).
+
+**Fix principles:**
+
+- Preserve intended visual and runtime behavior.
+- Fix the real semantic owner: component root, inner element via `elementProps`, or shared base.
+- Prefer Editor React Component–native patterns: route ARIA through `a11y`, use `constants.ts` for required labels, never hardcode string literals.
+- Before adding `role`, `tabIndex`, or keyboard handlers to a non-interactive element, run the pre-fix checks in [`a11y-review/FIX-STRATEGIES.md`](a11y-review/FIX-STRATEGIES.md#pre-fix-checks-for-adding-button-semantics-to-a-non-interactive-element).
+
+### Phase 5: Verify
+
+If any `.tsx` / `.jsx` file was edited:
+
+1. Re-run both scanners on the modified files.
+2. Run `npx wix build && npx wix generate manifest` so the manifest reflects any JSX changes (this is also required by the Editor React Component workflow).
+3. Run the project's TypeScript check (`npx tsc --noEmit`) — already part of the wix-app validation flow.
+
+Verification is mandatory after edits. Do not consider the review complete until it has run or you've explicitly reported why it could not.
+
+### Phase 6: Report
+
+Summarize:
+
+1. **Topology and scope** — files reviewed, layers covered.
+2. **Tier 0 ESLint findings** — grouped by rule with dispositions.
+3. **Tier 1 custom scanner findings** — grouped by rule with dispositions.
+4. **Tier 2 semantic findings** — including manifest/shared-layer items neither scanner catches.
+5. **Verification** — scanner re-runs, `npx wix build && npx wix generate manifest`, `npx tsc --noEmit`.
+6. **Unresolved items** — with exact blockers.
+
+Every finding ends in one of:
+
+- `fixed`
+- `skipped-ambiguous`
+- `skipped-risky`
+- `false-positive` (one-sentence reason)
+- `not-relevant` (one-sentence reason)
+
+Any disposition other than `fixed` requires a one-sentence concrete blocker or reason.
+
+## Confidence Handling
+
+- `high`: fix immediately
+- `medium`: confirm by reading code, then fix
+- `low`: attempt to resolve semantics; fix only if confirmed; otherwise report as advisory
+
+Severity affects reporting priority, not whether a confirmed safe/local fix should be applied.
+
+See [`a11y-review/CONFIDENCE-MODEL.md`](a11y-review/CONFIDENCE-MODEL.md).
+
+## References
+
+- Rule criteria: [`a11y-review/RULES.md`](a11y-review/RULES.md)
+- Fix strategies: [`a11y-review/FIX-STRATEGIES.md`](a11y-review/FIX-STRATEGIES.md)
+- Tier 2 semantic checklist: [`a11y-review/MANUAL-REVIEW-CHECKLIST.md`](a11y-review/MANUAL-REVIEW-CHECKLIST.md)
+- Semantic inference model: [`a11y-review/SEMANTIC-RESOLUTION.md`](a11y-review/SEMANTIC-RESOLUTION.md)
+- Confidence handling: [`a11y-review/CONFIDENCE-MODEL.md`](a11y-review/CONFIDENCE-MODEL.md)
+- Pattern examples: [`a11y-review/EXAMPLES.md`](a11y-review/EXAMPLES.md)
+- ARIA conventions for Editor React Components: [`ACCESSIBILITY.md`](ACCESSIBILITY.md)

--- a/skills/wix-app/references/editor-react-component/a11y-review/CONFIDENCE-MODEL.md
+++ b/skills/wix-app/references/editor-react-component/a11y-review/CONFIDENCE-MODEL.md
@@ -1,0 +1,81 @@
+# Confidence Model
+
+## Tier 0 (ESLint) Findings
+
+ESLint findings do not carry a confidence level from the scanner. During the triage step, assign confidence based on the flagged element:
+
+- **Native element** (`div`, `img`, `a`, `button`, etc.): treat as `high` confidence. The rule sees the actual semantic element.
+- **Custom component that resolves to a known native element** (confirmed via Tier 1 scan or by reading the source): treat as `medium` confidence.
+- **Custom component that cannot be resolved** or whose semantics are delegated through runtime props/spread: evaluate for `false-positive` or `not-relevant`. If neither applies, treat as `low` confidence.
+
+After assigning confidence, apply the same fix eligibility rules as Tier 1 findings below.
+
+---
+
+## Tier 1 (Custom Scanner) and Tier 2 (Manual) Findings
+
+## High
+
+Use high confidence when:
+
+- the element is a native tag
+- a local or package component clearly resolves to a native semantic element
+- a polymorphic prop explicitly sets a native semantic element
+
+High-confidence findings can be presented as definite issues.
+
+**Fix eligibility**: Fix immediately. No confirmation needed.
+
+## Medium
+
+Use medium confidence when:
+
+- props strongly imply semantics
+- a wrapper only partially resolves but still preserves likely semantics
+- the component name and surrounding evidence strongly agree
+
+Medium-confidence findings can be presented as likely issues, but the code should still be read before applying a fix.
+
+**Fix eligibility**: Fix after reading the surrounding code to confirm the semantic inference is correct. If confirmed, fix without asking. If the code contradicts the inference, skip the fix and report the finding as unresolved.
+
+## Low
+
+Use low confidence when:
+
+- only weak heuristics support the semantic guess
+- the implementation cannot be resolved
+- the component might be semantic but the evidence is thin
+
+Low-confidence matches are not definite violations. Treat them as leads for manual review.
+
+**Fix eligibility**: Read the code and attempt to resolve the semantics. If the code confirms the issue, upgrade to medium or high and fix. If the semantics remain unclear, skip the fix and report the finding as advisory only.
+
+## Confidence vs. Actionability
+
+Confidence answers "is this issue real?" It does not answer "is this issue important enough to fix?"
+
+Use this decision rule after reading the code:
+
+- Confirmed + safe/local fix => fix now.
+- Confirmed + risky behavior change or non-local refactor => report as unresolved with the exact blocker.
+- Unconfirmed or ambiguous => advisory only.
+
+If you can see the violation in the code and describe a localized, behavior-preserving fix, treat it as confirmed and fix it.
+
+## Valid Reasons to Skip a Fix
+
+Only skip a fix when one of these is true:
+
+- the semantics remain ambiguous after reading the code
+- product intent cannot be derived from the code
+- the fix would require a risky behavior change or a non-local refactor
+
+## Invalid Reasons to Skip a Fix
+
+Never skip a confirmed finding for any of these reasons:
+
+- it seems low severity
+- it is a secondary or convenience interaction
+- it lives in a shared layer, wrapper, or component-library file
+- it is outside the main component file or package the user first mentioned
+- it is probably intentional without code evidence proving that intent

--- a/skills/wix-app/references/editor-react-component/a11y-review/EXAMPLES.md
+++ b/skills/wix-app/references/editor-react-component/a11y-review/EXAMPLES.md
@@ -1,0 +1,224 @@
+# Examples
+
+## Native image -- missing alt
+
+```tsx
+// Before
+<img src={photoUrl} />
+```
+
+Scanner result: `alt-text`, `high`, semantic type `img`
+
+```tsx
+// After
+<img src={photoUrl} alt="Product photo" />
+```
+
+## Wrapper around image -- forwards props, missing alt at call site
+
+```tsx
+export const ProductPhoto = (props) => <img {...props} />;
+```
+
+```tsx
+// Before (call site)
+<ProductPhoto src={photoUrl} />
+```
+
+Scanner result: `alt-text`, `high` or `medium` depending on wrapper resolution
+
+```tsx
+// After (call site -- wrapper already forwards alt via spread)
+<ProductPhoto src={photoUrl} alt="Blue running shoes" />
+```
+
+## Wrapper around image -- does NOT forward alt
+
+```tsx
+// Before (wrapper definition)
+const Avatar = ({ src }: { src: string }) => <img src={src} />;
+```
+
+Scanner result: `alt-text`, `high` or `medium`
+
+```tsx
+// After (wrapper definition -- add alt prop and forward it)
+const Avatar = ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />;
+
+// Then at call site
+<Avatar src="/me.jpg" alt="Profile photo" />
+```
+
+## Link-like component with invalid target
+
+```tsx
+// Before
+<LinkButton href="#" />
+```
+
+Scanner result: `anchor-is-valid` if the component resolves or strongly infers to anchor semantics
+
+```tsx
+// After (if it navigates)
+<LinkButton href="/destination" />
+
+// After (if it triggers an action -- change to button)
+<ActionButton onClick={handleAction} />
+```
+
+## Invalid ARIA prop
+
+```tsx
+// Before
+<SomeComponent aria-labeledby="title" />
+```
+
+Scanner result: `aria-props`, usually `high`
+
+```tsx
+// After
+<SomeComponent aria-labelledby="title" />
+```
+
+## Invalid role
+
+```tsx
+// Before
+<Box role="container" />
+```
+
+Scanner result: `aria-role`, confidence depends on whether the component forwards DOM props
+
+```tsx
+// After (if grouping)
+<Box role="group" />
+
+// After (if no role needed)
+<Box />
+```
+
+## ARIA on unsupported element
+
+```tsx
+// Before
+<meta aria-label="description" />
+```
+
+Scanner result: `aria-unsupported-elements`, `high`
+
+```tsx
+// After
+<meta />
+```
+
+## Anchor used as button
+
+```tsx
+// Before
+<a onClick={handleSave}>Save</a>
+```
+
+Scanner result: `anchor-is-valid`, `high`
+
+```tsx
+// After
+<button onClick={handleSave}>Save</button>
+```
+
+## Conditional onClick on non-interactive element -- missing keyboard semantics
+
+The conditional spread pattern `{...(cond && { onClick })}` is common in this codebase and must be checked alongside direct `onClick` props. When the condition is true the element becomes interactive, so it needs full keyboard semantics even though it is non-interactive in other states.
+
+**Before applying any fix, run the pre-fix checks in [FIX-STRATEGIES.md](FIX-STRATEGIES.md#pre-fix-checks-for-adding-button-semantics-to-a-non-interactive-element).**
+
+### Simple case -- no interactive children, no existing tabIndex management
+
+```tsx
+// Before
+<div
+  {...(isClickable && { onClick: toggleReducedMotion })}
+  className={styles.root}
+>
+  {children}
+</div>
+```
+
+Tier 2 finding: `high` confidence — native `<div>` conditionally receives `onClick` but has no `role`, `tabIndex`, or keyboard handler.
+
+```tsx
+// After
+const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = e => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    toggleReducedMotion();
+  }
+};
+
+<div
+  {...(isClickable && {
+    onClick: toggleReducedMotion,
+    onKeyDown: handleKeyDown,
+    role: 'button' as const,
+    tabIndex: 0,
+  })}
+  className={styles.root}
+>
+  {children}
+</div>
+```
+
+### Compound case -- element may contain a link
+
+When the same wrapper conditionally renders a `<Link>` or `<a>` as a child, adding `role="button"` to the wrapper creates nested interactive elements — a WCAG violation that confuses keyboard navigation and screen readers.
+
+```tsx
+// Before (BROKEN -- wrapper is a button containing a link)
+const isClickable = animated && !forceReducedMotion;
+
+<div
+  {...(isClickable && {
+    onClick: toggleReducedMotion,
+    role: 'button',
+    tabIndex: 0,
+  })}
+>
+  {link ? <Link {...link}><Tag>{children}</Tag></Link> : <Tag>{children}</Tag>}
+</div>
+```
+
+```tsx
+// After -- exclude the link case from button semantics
+const isClickable = animated && forceReducedMotion === undefined && !link;
+
+<div
+  {...(isClickable && {
+    onClick: toggleReducedMotion,
+    onKeyDown: handleKeyDown,
+    role: 'button' as const,
+    tabIndex: 0,
+  })}
+>
+  {link ? <Link {...link}><Tag>{children}</Tag></Link> : <Tag>{children}</Tag>}
+</div>
+```
+
+Key differences from the simple case:
+- `isClickable` explicitly excludes `link` to avoid nested interactives.
+- `forceReducedMotion === undefined` replaces `!forceReducedMotion` for type safety when the variable is `true | undefined`.
+
+### Existing tabIndex management on the same element
+
+When another utility already sets `tabIndex` on the same element (e.g., `getTabIndexAttribute(a11y)`), ensure the button-semantics `tabIndex: 0` does not silently override or conflict. Place the clickable spread **before** the a11y-driven spread so the a11y value wins when present. When the a11y source returns nothing, the clickable `tabIndex: 0` serves as fallback.
+
+```tsx
+// tabIndex: 0 from clickable spread is overridden by getTabIndexAttribute(a11y) when a11y.tabIndex is set
+<div
+  {...(isClickable && {
+    onClick: toggleReducedMotion,
+    onKeyDown: handleKeyDown,
+    role: 'button' as const,
+    tabIndex: 0,
+  })}
+  {...getTabIndexAttribute(a11y)}
+>
+```

--- a/skills/wix-app/references/editor-react-component/a11y-review/FIX-STRATEGIES.md
+++ b/skills/wix-app/references/editor-react-component/a11y-review/FIX-STRATEGIES.md
@@ -1,0 +1,206 @@
+# Fix Strategies
+
+This document describes how to fix each Tier 1 rule family. Apply these strategies only to findings with `high` or `medium` confidence. `low` confidence findings require reading the code first -- fix only when the semantic guess is confirmed.
+
+## General Principles
+
+- Read the surrounding code before editing. The scanner finding provides location and evidence, but the fix depends on context.
+- Preserve existing behavior. A fix must not change what sighted users see or how the component functions.
+- Prefer the simplest correct fix. Do not refactor unrelated code while fixing an a11y issue.
+- **Call site vs definition**: When a wrapper hides the underlying element, decide where to fix:
+  - If the wrapper already accepts and forwards the missing prop (e.g., via spread), add the prop at the call site.
+  - If the wrapper does NOT accept or forward the missing prop, fix the wrapper definition to accept and forward it, then add the prop at the call site.
+  - If you are writing the component definition itself, the fix is to add the prop to the interface and forward it. Do not hardcode accessibility values (like alt text) inside reusable components -- they should come from the consumer.
+
+## `alt-text`
+
+### Native `<img>`
+
+Add an `alt` prop with descriptive text. If the image is decorative, use `alt=""`.
+
+```tsx
+// Before
+<img src={photoUrl} />
+
+// After (meaningful)
+<img src={photoUrl} alt="Product photo" />
+
+// After (decorative)
+<img src={photoUrl} alt="" />
+```
+
+### How to decide meaningful vs decorative
+
+- If the image conveys information not available from surrounding text, it is meaningful.
+- If the image is purely visual (decorative border, background pattern, icon next to visible label text), it is decorative.
+- When uncertain, default to meaningful with a descriptive alt. A redundant alt is better than a missing one.
+
+### Wrapper components
+
+When the finding is on a wrapper component (not a native `<img>`), the fix depends on whether the wrapper already accepts and forwards `alt`.
+
+**Step 1: Check the wrapper definition.** Read the component source to see if it accepts `alt` in its props and passes it to the underlying `<img>`.
+
+**If the wrapper already forwards `alt`**, add the prop at the call site:
+
+```tsx
+// Wrapper already forwards alt via spread or explicit prop
+export const ProductPhoto = (props) => <img {...props} />;
+
+// Before (call site)
+<ProductPhoto src={photoUrl} />
+
+// After (call site)
+<ProductPhoto src={photoUrl} alt="Blue running shoes" />
+```
+
+**If the wrapper does NOT forward `alt`**, fix the wrapper definition to accept and forward it, then add the prop at the call site:
+
+```tsx
+// Before (wrapper)
+export const ProductPhoto = ({ src }) => <img src={src} />;
+
+// After (wrapper -- add alt to destructured props and forward it)
+export const ProductPhoto = ({ src, alt }) => <img src={src} alt={alt} />;
+
+// Then at the call site
+<ProductPhoto src={photoUrl} alt="Blue running shoes" />
+```
+
+**If you are writing the component itself** (the finding is inside the component definition, not at a call site), the fix is to ensure the component accepts `alt` in its props interface and passes it through to the underlying `<img>`:
+
+```tsx
+// Before
+const Avatar = ({ src }: { src: string }) => <img src={src} />;
+
+// After
+const Avatar = ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />;
+```
+
+Do not hardcode alt text inside a reusable component. The alt value should come from the consumer.
+
+## `anchor-is-valid`
+
+### Missing `href`
+
+If the element is meant to navigate, add a real `href`. If it is meant to trigger an action, change it to a `<button>`.
+
+```tsx
+// Before (should navigate)
+<a onClick={goToPage}>About</a>
+
+// After
+<a href="/about">About</a>
+
+// Before (should trigger action)
+<a onClick={handleClick}>Save</a>
+
+// After
+<button onClick={handleClick}>Save</button>
+```
+
+### `href="#"` or `href="javascript:void(0)"`
+
+Replace with a real href or convert to a button. Never leave `href="#"` as a fix.
+
+```tsx
+// Before
+<a href="#">Learn more</a>
+
+// After (if it navigates)
+<a href="/learn-more">Learn more</a>
+
+// After (if it triggers an action)
+<button onClick={handleLearnMore}>Learn more</button>
+```
+
+### Wrapper components
+
+Check the wrapper definition first:
+
+- **If the wrapper forwards `href`**: fix the `href` value at the call site.
+- **If the wrapper does not accept or forward `href`**: fix the wrapper to accept it, then provide a valid value at the call site.
+- **If you are writing the wrapper itself**: ensure it accepts `href` in its props and passes it to the underlying `<a>`.
+
+## `aria-props`
+
+### Invalid attribute name
+
+Replace the misspelled ARIA attribute with the correct spelling. Common typos:
+
+| Wrong | Correct |
+|-------|---------|
+| `aria-labeledby` | `aria-labelledby` |
+| `aria-role` | `role` |
+| `aria-roledescribedby` | `aria-roledescription` |
+
+```tsx
+// Before
+<div aria-labeledby="title">Content</div>
+
+// After
+<div aria-labelledby="title">Content</div>
+```
+
+## `aria-role`
+
+### Invalid role value
+
+Replace the invalid role with a valid ARIA role or remove it if no role is needed.
+
+```tsx
+// Before
+<div role="container">Content</div>
+
+// After (if it's a generic grouping)
+<div role="group">Content</div>
+
+// After (if no role is needed)
+<div>Content</div>
+```
+
+When choosing a replacement role, read the component's purpose. Do not guess -- pick the role that matches the actual behavior.
+
+## `aria-unsupported-elements`
+
+### ARIA on unsupported elements
+
+Remove the ARIA attributes from the unsupported element. If the intent was to label or describe something, move the ARIA attributes to a supported element that wraps or replaces the unsupported one.
+
+```tsx
+// Before
+<meta aria-label="description" />
+
+// After
+<meta />
+```
+
+If the ARIA attribute was meaningful (e.g., on a `<link>` that should have been an `<a>`), change the element to the correct semantic one.
+
+## Tier 2 Fixes
+
+Tier 2 findings are discovered during the semantic review, not by the scanner. Apply fixes based on the specific checklist item:
+
+- **Missing accessible name on icon-only controls**: Add `aria-label` or visually hidden text.
+- **ARIA on wrong element**: Move the attribute to the semantically correct inner element.
+- **`display: none` hiding accessible content**: Switch to a visually-hidden CSS class or `aria-hidden` as appropriate.
+- **Interactive element missing keyboard support**: Add `role`, `tabIndex`, and keyboard event handlers as needed. **Before applying this fix, run the pre-fix checks below.**
+
+For Tier 2, always read the code and confirm the issue before fixing. These are not scanner-automated and require judgment.
+
+### Pre-fix checks for adding button semantics to a non-interactive element
+
+When the fix involves adding `role="button"`, `tabIndex`, and keyboard handlers to a `<div>` or similar element, verify each of these before writing code. Skipping any check can introduce a new violation while fixing the original one.
+
+1. **Check for interactive children.** If the element conditionally or unconditionally contains `<a>`, `<button>`, `<input>`, or components that resolve to them (such as a `<Link>` component), adding `role="button"` to the parent creates nested interactive content. This is a WCAG violation and confuses keyboard navigation and screen readers. In this case:
+   - Exclude the interactive-child branch from button semantics (e.g., `const isClickable = animated && !link`).
+   - Or use a separate `<button>` element for the toggle action instead of overloading the wrapper.
+
+2. **Check for existing `tabIndex` management.** If the same element already receives `tabIndex` from another source — such as a utility function (`getTabIndexAttribute`), a framework-level a11y spread, or an interactions hook — adding `tabIndex: 0` in the fix creates a conflict. Determine the spread/prop merge order and ensure only one source wins. Prefer letting the existing a11y-driven tabIndex remain authoritative; only set `tabIndex: 0` as a fallback when no other source provides it.
+
+3. **Audit the gating condition.** Read the boolean expression that controls whether the element is interactive (e.g., `const isClickable = animated && !forceReducedMotion`). Verify:
+   - Does the condition use explicit comparison (`=== undefined`, `=== true`) rather than truthiness when the variable's type includes semantically distinct values like `true | undefined` or `true | false | undefined`?
+   - Does the condition correctly exclude states where the element should not be interactive (editor preview, link-present case, externally controlled state)?
+   - If the condition is wrong, fix it as part of the a11y fix — a correct `role="button"` on a wrongly-activated element is still a bug.
+
+4. **Scope `aria-label` correctly.** If the element has an accessible label (e.g., from `a11y.label`), decide whether the label names the interactive behavior specifically or the component as a whole. If it names the component, apply it outside the clickable conditional so it persists in non-interactive states. If it names the button action specifically, apply it inside the conditional.

--- a/skills/wix-app/references/editor-react-component/a11y-review/MANUAL-REVIEW-CHECKLIST.md
+++ b/skills/wix-app/references/editor-react-component/a11y-review/MANUAL-REVIEW-CHECKLIST.md
@@ -1,0 +1,53 @@
+# Tier 2 Manual Review Checklist
+
+Use this checklist after Tier 1 scanner results are reviewed. Tier 2 is required even when Tier 1 returns zero findings.
+
+## Semantic Targeting
+
+- Do ARIA attributes land on the semantically correct element rather than a non-semantic wrapper?
+- Do labels, descriptions, and roles reach the actual interactive or landmark element?
+- Do wrapper components preserve the semantics they appear to expose?
+
+## Icon-Only and Visual-Only States
+
+- Do icon-only buttons, links, or controls still have an accessible name?
+- If visible text is hidden, is it visually hidden in an accessibility-safe way rather than removed from the tree?
+- Do meaningful icons or images expose accessible text when needed?
+
+## CSS and Hidden Content
+
+- Does `display: none` remove content that should remain available to assistive technology?
+- Are hidden or collapsed states consistent between visuals, focusability, and the accessibility tree?
+- Do CSS variables or conditional classes create states where labels or instructions disappear from assistive technology?
+
+## Decorative vs Meaningful Content
+
+- Are decorative separators, ornaments, and repeated icons hidden from assistive technology?
+- Are meaningful visuals, status icons, or graphics named appropriately?
+
+## Focus and Interaction Consistency
+
+- Can hidden or collapsed items still receive focus?
+- Do interactive-looking elements expose the right semantic role and keyboard behavior?
+- Do disabled, inert, or collapsed states behave consistently for both keyboard users and assistive technology?
+- Search all in-scope files for `onClick` on non-interactive native elements (`div`, `span`, `section`, `header`, `footer`, `li`, `td`, etc.). Include conditional patterns such as `{...(condition && { onClick: handler })}`. For each match, verify that the element also has `role`, `tabIndex`, and a keyboard event handler (`onKeyDown` or `onKeyUp`). A missing combination is a high-confidence finding.
+- Before proposing a fix for a missing-keyboard-semantics finding, perform these additional checks:
+  1. **Nested interactives**: Does the element already contain interactive children (`<a>`, `<button>`, `<input>`, `<Link>`, or components that resolve to them)? If yes, adding `role="button"` to the wrapper creates a nested interactive violation. The fix must either exclude the interactive-child case from button semantics or use a separate control element.
+  2. **Existing focus management**: Does the same element already receive `tabIndex` from another source (e.g., a utility like `getTabIndexAttribute`, a separate a11y prop spread, or an interactions framework)? If yes, the fix must not add a competing `tabIndex` without understanding the merge order and override behavior.
+  3. **Gating condition audit**: Read the boolean expression that controls interactivity (e.g., `isClickable`). Verify it uses explicit comparisons (`=== undefined`, `=== true`) rather than truthiness/falsiness when the variable's type includes `undefined`, `false`, and `true` as semantically distinct states. A fragile condition can silently enable interactivity in unintended states.
+
+## Structural Semantics
+
+- Are landmarks, headings, and list semantics preserved through wrappers and layout components?
+- When a component appears to implement breadcrumbs, tabs, menus, dialogs, or similar patterns, do the expected semantics reach the rendered structure?
+
+## Fix and Reporting Guidance
+
+- Fix Tier 2 issues inline as they are discovered. Use the same confidence-based approach as Tier 1.
+- If you can see the violation in the code and describe a localized, behavior-preserving fix, it is confirmed. Apply the fix immediately.
+- Do not label confirmed Tier 2 findings as advisory.
+- Severity affects reporting priority, not whether a confirmed safe/local fix should be applied.
+- Do not skip a confirmed fix because it is minor, secondary, in a shared layer, or outside the first file the user mentioned.
+- Report Tier 2 findings and fixes separately from Tier 1 scanner findings.
+- When Tier 2 reveals issues that the scanner missed, say so explicitly and state what was fixed.
+- Only describe the component as clean if both tiers are complete, all fixes are verified, and no unresolved issues remain.

--- a/skills/wix-app/references/editor-react-component/a11y-review/RULES.md
+++ b/skills/wix-app/references/editor-react-component/a11y-review/RULES.md
@@ -1,0 +1,127 @@
+# Automated Scanner Rules
+
+This file describes the automated scanner scope for both Tier 0 (ESLint) and Tier 1 (custom). It is not the full accessibility-review scope of the skill — Tier 2 semantic review covers additional checks.
+
+---
+
+## Tier 0: ESLint jsx-a11y Rules
+
+Tier 0 runs `eslint-plugin-jsx-a11y` via the ESLint Node API. It operates on individual files without cross-file resolution. Findings on native elements are high-signal; findings on custom components may need manual verification.
+
+### Interaction and keyboard rules (not covered by Tier 1)
+
+| Rule | What it catches |
+|------|----------------|
+| `jsx-a11y/click-events-have-key-events` | Click handlers without keyboard listeners |
+| `jsx-a11y/mouse-events-have-key-events` | Mouse hover/out without focus/blur equivalents |
+| `jsx-a11y/no-static-element-interactions` | Static elements (`div`, `span`) with event handlers but no role |
+| `jsx-a11y/no-noninteractive-element-interactions` | Non-interactive elements (`li`, `section`) with event handlers |
+| `jsx-a11y/interactive-supports-focus` | Interactive-role elements missing focusability |
+| `jsx-a11y/no-noninteractive-tabindex` | `tabIndex` on non-interactive elements without interactive role |
+| `jsx-a11y/tabindex-no-positive` | Positive `tabIndex` values that break natural tab order |
+| `jsx-a11y/no-access-key` | `accessKey` prop usage (inconsistent across browsers) |
+| `jsx-a11y/no-autofocus` | `autoFocus` prop usage |
+
+### Label and content rules (not covered by Tier 1)
+
+| Rule | What it catches |
+|------|----------------|
+| `jsx-a11y/anchor-has-content` | Anchors without accessible text content |
+| `jsx-a11y/heading-has-content` | Heading elements without accessible text content |
+| `jsx-a11y/iframe-has-title` | Iframes missing `title` attribute |
+| `jsx-a11y/img-redundant-alt` | Image alt text containing "image", "photo", "picture" |
+| `jsx-a11y/label-has-associated-control` | Labels not programmatically associated with a form control |
+| `jsx-a11y/media-has-caption` | Audio/video elements missing captions |
+| `jsx-a11y/control-has-associated-label` | Interactive controls without accessible labels |
+
+### Role and ARIA rules (overlap with Tier 1, but with additional checks)
+
+| Rule | What it catches |
+|------|----------------|
+| `jsx-a11y/aria-activedescendant-has-tabindex` | `aria-activedescendant` without `tabIndex` |
+| `jsx-a11y/aria-proptypes` | ARIA attribute values with wrong types |
+| `jsx-a11y/role-has-required-aria-props` | Roles missing required ARIA attributes |
+| `jsx-a11y/role-supports-aria-props` | ARIA attributes not supported by the element's role |
+| `jsx-a11y/no-aria-hidden-on-focusable` | `aria-hidden` on focusable elements |
+| `jsx-a11y/prefer-tag-over-role` | Using `role` when a native semantic element exists |
+| `jsx-a11y/scope` | `scope` attribute on non-`th` elements |
+
+### Structural rules (not covered by Tier 1)
+
+| Rule | What it catches |
+|------|----------------|
+| `jsx-a11y/no-interactive-element-to-noninteractive-role` | Interactive elements assigned non-interactive roles |
+| `jsx-a11y/no-noninteractive-element-to-interactive-role` | Non-interactive elements assigned interactive roles |
+| `jsx-a11y/no-redundant-roles` | Redundant roles matching the element's implicit role |
+| `jsx-a11y/no-distracting-elements` | `<marquee>` and `<blink>` usage |
+
+### Rules that overlap with Tier 1
+
+These rules are also checked by the custom scanner. When both flag the same location, prefer the finding with richer context (typically Tier 1 for cross-file resolution, Tier 0 for additional detail).
+
+| Tier 0 rule | Tier 1 equivalent |
+|-------------|-------------------|
+| `jsx-a11y/alt-text` | `alt-text` |
+| `jsx-a11y/anchor-is-valid` | `anchor-is-valid` |
+| `jsx-a11y/aria-props` | `aria-props` |
+| `jsx-a11y/aria-role` | `aria-role` |
+| `jsx-a11y/aria-unsupported-elements` | `aria-unsupported-elements` |
+
+---
+
+## Tier 1: Custom Scanner Rules
+
+The custom scanner checks five code-level rule families with cross-file semantic resolution.
+
+## `alt-text`
+
+Flag image-like elements that are missing `alt`.
+
+- Native tags: `img`
+- Inferred component cases: components resolved or inferred as image-like
+- Valid cases:
+  - `alt="Meaningful text"`
+  - `alt=""` for decorative images
+
+## `anchor-is-valid`
+
+Flag link-like elements that are missing valid navigation targets.
+
+- Native tags: `a`
+- Inferred component cases: wrappers or library components resolved as anchor-like
+- Invalid cases:
+  - missing `href`
+  - `href="#"`, empty string, or `javascript:void(0)`
+
+## `aria-props`
+
+Flag invalid `aria-*` attribute names on JSX elements.
+
+- Focus on invalid attribute names, not value validation
+- Example: `aria-labeledby` is invalid; `aria-labelledby` is valid
+
+## `aria-role`
+
+Flag invalid `role` attribute values.
+
+- Only static string role values can be validated with confidence
+- Dynamic expressions are not definite violations by themselves
+
+## `aria-unsupported-elements`
+
+Flag ARIA attributes on unsupported native elements such as:
+
+- `meta`
+- `script`
+- `style`
+- `head`
+- `html`
+- `base`
+- `link`
+- `param`
+- `source`
+- `track`
+- `col`
+- `colgroup`
+
+This rule is high-confidence when the element is native. Custom components are only in scope if their implementation clearly resolves to one of these unsupported elements.

--- a/skills/wix-app/references/editor-react-component/a11y-review/SEMANTIC-RESOLUTION.md
+++ b/skills/wix-app/references/editor-react-component/a11y-review/SEMANTIC-RESOLUTION.md
@@ -1,0 +1,32 @@
+# Semantic Resolution
+
+The scanner is library-agnostic. It does not assume Wix Design System, Material UI, Chakra, or any other specific package.
+
+## Resolution Order
+
+1. Native tag name
+2. Explicit polymorphic props such as `as="a"` or `component="button"`
+3. Local wrapper implementation
+4. Installed package source or declarations in `node_modules`
+5. Prop evidence such as `href`, `to`, `src`, `alt`, `role`
+6. Component-name heuristics
+
+## Semantic Types
+
+The scanner tries to classify a JSX element as one of:
+
+- `img`
+- `a`
+- `button`
+- `input`
+- `textarea`
+- unsupported native element
+- `unknown`
+
+## Wrapper Inspection
+
+For local imports, the scanner reads the imported file and tries to find the exported component's root JSX element. If that root resolves to another local or package component, it follows the chain until confidence drops or the recursion limit is reached.
+
+## Package Inspection
+
+For package imports, the scanner attempts to resolve the import source from `node_modules` and inspect the exported entry file. If the package structure hides semantics, the scanner falls back to prop and name evidence instead of pretending certainty.

--- a/skills/wix-app/scripts/scan-a11y-code.js
+++ b/skills/wix-app/scripts/scan-a11y-code.js
@@ -1,0 +1,594 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { createRequire } = require('module');
+
+const ROOT = process.cwd();
+const LOCAL_REQUIRE = createRequire(__filename);
+const ROOT_REQUIRE = createRequire(path.join(ROOT, 'package.json'));
+const parser = loadModule('@babel/parser');
+const traverse = loadModule('@babel/traverse').default;
+const t = loadModule('@babel/types');
+
+const MAX_RESOLUTION_DEPTH = 4;
+const VALID_ARIA_PROPS = new Set([
+  'aria-activedescendant', 'aria-atomic', 'aria-autocomplete', 'aria-braillelabel',
+  'aria-brailleroledescription', 'aria-busy', 'aria-checked', 'aria-colcount',
+  'aria-colindex', 'aria-colindextext', 'aria-colspan', 'aria-controls',
+  'aria-current', 'aria-describedby', 'aria-description', 'aria-details',
+  'aria-disabled', 'aria-dropeffect', 'aria-errormessage', 'aria-expanded',
+  'aria-flowto', 'aria-grabbed', 'aria-haspopup', 'aria-hidden', 'aria-invalid',
+  'aria-keyshortcuts', 'aria-label', 'aria-labelledby', 'aria-level',
+  'aria-live', 'aria-modal', 'aria-multiline', 'aria-multiselectable',
+  'aria-orientation', 'aria-owns', 'aria-placeholder', 'aria-posinset',
+  'aria-pressed', 'aria-readonly', 'aria-relevant', 'aria-required',
+  'aria-roledescription', 'aria-rowcount', 'aria-rowindex', 'aria-rowindextext',
+  'aria-rowspan', 'aria-selected', 'aria-setsize', 'aria-sort', 'aria-valuemax',
+  'aria-valuemin', 'aria-valuenow', 'aria-valuetext',
+]);
+const VALID_ROLES = new Set([
+  'alert', 'alertdialog', 'application', 'article', 'banner', 'button', 'cell',
+  'checkbox', 'columnheader', 'combobox', 'complementary', 'contentinfo',
+  'definition', 'dialog', 'directory', 'document', 'feed', 'figure', 'form',
+  'grid', 'gridcell', 'group', 'heading', 'img', 'link', 'list', 'listbox',
+  'listitem', 'log', 'main', 'marquee', 'math', 'menu', 'menubar', 'menuitem',
+  'menuitemcheckbox', 'menuitemradio', 'navigation', 'none', 'note', 'option',
+  'presentation', 'progressbar', 'radio', 'radiogroup', 'region', 'row',
+  'rowgroup', 'rowheader', 'scrollbar', 'search', 'searchbox', 'separator',
+  'slider', 'spinbutton', 'status', 'switch', 'tab', 'table', 'tablist',
+  'tabpanel', 'term', 'textbox', 'timer', 'toolbar', 'tooltip', 'tree',
+  'treegrid', 'treeitem',
+]);
+const UNSUPPORTED_ARIA_ELEMENTS = new Set([
+  'meta', 'script', 'style', 'head', 'html', 'base', 'link', 'param', 'source',
+  'track', 'col', 'colgroup',
+]);
+
+const FILE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs'];
+const parseCache = new Map();
+const resolutionWarnings = [];
+
+function loadModule(name) {
+  try {
+    return LOCAL_REQUIRE(name);
+  } catch (localError) {
+    try {
+      return ROOT_REQUIRE(name);
+    } catch (rootError) {
+      throw new Error(
+        `Missing dependency "${name}". Local resolution failed: ${localError.message}. Root resolution failed: ${rootError.message}`,
+      );
+    }
+  }
+}
+
+function parseFile(filePath) {
+  if (parseCache.has(filePath)) return parseCache.get(filePath);
+
+  try {
+    const code = fs.readFileSync(filePath, 'utf8');
+    const ast = parser.parse(code, {
+      sourceType: 'unambiguous',
+      plugins: [
+        'jsx',
+        'typescript',
+        'classProperties',
+        'objectRestSpread',
+        'optionalChaining',
+        'nullishCoalescingOperator',
+      ],
+      errorRecovery: true,
+    });
+    const recoverableErrors = Array.isArray(ast.errors)
+      ? ast.errors.map((error) => error.message)
+      : [];
+    const parsed = { ok: true, ast, code, recoverableErrors };
+    parseCache.set(filePath, parsed);
+    return parsed;
+  } catch (error) {
+    const parsed = { ok: false, error };
+    parseCache.set(filePath, parsed);
+    return parsed;
+  }
+}
+
+function getJsxName(node) {
+  if (t.isJSXIdentifier(node)) return node.name;
+  if (t.isJSXMemberExpression(node)) return `${getJsxName(node.object)}.${getJsxName(node.property)}`;
+  if (t.isJSXNamespacedName(node)) return `${node.namespace.name}:${node.name.name}`;
+  return null;
+}
+
+function getAttribute(node, name) {
+  return node.attributes.find((attr) => t.isJSXAttribute(attr) && getJsxName(attr.name) === name) || null;
+}
+
+function getLiteralAttributeValue(attr) {
+  if (!attr) return undefined;
+  if (!attr.value) return true;
+  if (t.isStringLiteral(attr.value)) return attr.value.value;
+  if (t.isJSXExpressionContainer(attr.value)) {
+    const expr = attr.value.expression;
+    if (t.isStringLiteral(expr)) return expr.value;
+    if (t.isBooleanLiteral(expr)) return expr.value;
+    if (t.isNumericLiteral(expr)) return expr.value;
+    if (t.isTemplateLiteral(expr) && expr.expressions.length === 0) {
+      return expr.quasis.map((q) => q.value.cooked || '').join('');
+    }
+  }
+  return undefined;
+}
+
+function hasTruthyAttribute(node, name) {
+  const attr = getAttribute(node, name);
+  return Boolean(attr);
+}
+
+function isNativeTag(name) {
+  return Boolean(name && /^[a-z]/.test(name));
+}
+
+function getImportMap(ast) {
+  const imports = new Map();
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.node.source.value;
+      for (const specifier of path.node.specifiers) {
+        if (t.isImportDefaultSpecifier(specifier)) {
+          imports.set(specifier.local.name, { source, imported: 'default' });
+        } else if (t.isImportSpecifier(specifier)) {
+          imports.set(specifier.local.name, { source, imported: specifier.imported.name });
+        } else if (t.isImportNamespaceSpecifier(specifier)) {
+          imports.set(specifier.local.name, { source, imported: '*' });
+        }
+      }
+    },
+  });
+
+  return imports;
+}
+
+function findRootJsx(pathLike) {
+  if (!pathLike) return null;
+  if (pathLike.isFunctionDeclaration() || pathLike.isFunctionExpression() || pathLike.isArrowFunctionExpression()) {
+    if (t.isJSXElement(pathLike.node.body) || t.isJSXFragment(pathLike.node.body)) return pathLike.node.body;
+    if (!t.isBlockStatement(pathLike.node.body)) return null;
+
+    for (const statement of pathLike.node.body.body) {
+      if (!t.isReturnStatement(statement)) continue;
+      const arg = statement.argument;
+      if (t.isJSXElement(arg) || t.isJSXFragment(arg)) return arg;
+    }
+  }
+  return null;
+}
+
+function resolveSourceFile(fromFile, source) {
+  const basedir = path.dirname(fromFile);
+  const tryFile = (candidate) => {
+    if (candidate && fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+    return null;
+  };
+
+  if (source.startsWith('.')) {
+    const base = path.resolve(basedir, source);
+    for (const ext of FILE_EXTENSIONS) {
+      const direct = tryFile(base + ext);
+      if (direct) return direct;
+    }
+    for (const ext of FILE_EXTENSIONS) {
+      const indexFile = tryFile(path.join(base, `index${ext}`));
+      if (indexFile) return indexFile;
+    }
+    return tryFile(base);
+  }
+
+  try {
+    return require.resolve(source, { paths: [basedir, ROOT] });
+  } catch (error) {
+    resolutionWarnings.push({
+      source,
+      fromFile,
+      method: 'require.resolve',
+      message: error.message,
+    });
+  }
+
+  try {
+    return ROOT_REQUIRE.resolve(source);
+  } catch (error) {
+    resolutionWarnings.push({
+      source,
+      fromFile,
+      method: 'rootRequire.resolve',
+      message: error.message,
+    });
+  }
+
+  return null;
+}
+
+function findExportedComponent(ast, exportName) {
+  let found = null;
+
+  traverse(ast, {
+    FunctionDeclaration(path) {
+      if (found) return;
+      if (path.node.id && path.node.id.name === exportName) found = findRootJsx(path);
+    },
+    VariableDeclarator(path) {
+      if (found) return;
+      if (!t.isIdentifier(path.node.id, { name: exportName })) return;
+      const initPath = path.get('init');
+      found = findRootJsx(initPath);
+    },
+    ExportDefaultDeclaration(path) {
+      if (found || exportName !== 'default') return;
+      const declPath = path.get('declaration');
+      if (declPath.isIdentifier()) {
+        found = findNamedBindingJsx(ast, declPath.node.name);
+      } else {
+        found = findRootJsx(declPath);
+      }
+    },
+  });
+
+  return found;
+}
+
+function findNamedBindingJsx(ast, name) {
+  let found = null;
+  traverse(ast, {
+    FunctionDeclaration(path) {
+      if (found) return;
+      if (path.node.id && path.node.id.name === name) found = findRootJsx(path);
+    },
+    VariableDeclarator(path) {
+      if (found) return;
+      if (!t.isIdentifier(path.node.id, { name })) return;
+      found = findRootJsx(path.get('init'));
+    },
+  });
+  return found;
+}
+
+function inferByName(name) {
+  const lower = String(name || '').toLowerCase();
+  if (!lower) return null;
+  if (/(^|\.)(img|image|avatar|thumbnail|photo|picture)$/.test(lower) || /(image|avatar|thumbnail|photo|picture)/.test(lower)) {
+    return { semanticType: 'img', confidence: 'low', sourceKind: 'heuristic', evidence: `Component name "${name}" looks image-like.` };
+  }
+  if (/(^|\.)(link|anchor|navlink)$/.test(lower) || /(link|anchor)/.test(lower)) {
+    return { semanticType: 'a', confidence: 'low', sourceKind: 'heuristic', evidence: `Component name "${name}" looks link-like.` };
+  }
+  if (/(button|btn|iconbutton|textbutton|closebutton)/.test(lower)) {
+    return { semanticType: 'button', confidence: 'low', sourceKind: 'heuristic', evidence: `Component name "${name}" looks button-like.` };
+  }
+  if (/(textarea|editor)/.test(lower)) {
+    return { semanticType: 'textarea', confidence: 'low', sourceKind: 'heuristic', evidence: `Component name "${name}" looks textarea-like.` };
+  }
+  if (/(input|textfield|search|select|checkbox|radio|switch|toggle)/.test(lower)) {
+    return { semanticType: 'input', confidence: 'low', sourceKind: 'heuristic', evidence: `Component name "${name}" looks input-like.` };
+  }
+  return null;
+}
+
+function inferFromProps(openingElement) {
+  const asValue = getLiteralAttributeValue(getAttribute(openingElement, 'as'));
+  if (typeof asValue === 'string' && isNativeTag(asValue)) {
+    return {
+      semanticType: asValue,
+      confidence: 'high',
+      sourceKind: 'polymorphic-prop',
+      evidence: `The component explicitly sets as="${asValue}".`,
+    };
+  }
+
+  const componentValue = getLiteralAttributeValue(getAttribute(openingElement, 'component'));
+  if (typeof componentValue === 'string' && isNativeTag(componentValue)) {
+    return {
+      semanticType: componentValue,
+      confidence: 'high',
+      sourceKind: 'polymorphic-prop',
+      evidence: `The component explicitly sets component="${componentValue}".`,
+    };
+  }
+
+  if (hasTruthyAttribute(openingElement, 'src')) {
+    return {
+      semanticType: 'img',
+      confidence: hasTruthyAttribute(openingElement, 'alt') ? 'low' : 'medium',
+      sourceKind: 'prop-evidence',
+      evidence: 'The component receives src-related props that suggest image semantics.',
+    };
+  }
+
+  if (hasTruthyAttribute(openingElement, 'href') || hasTruthyAttribute(openingElement, 'to')) {
+    return {
+      semanticType: 'a',
+      confidence: 'medium',
+      sourceKind: 'prop-evidence',
+      evidence: 'The component receives href/to props that suggest link semantics.',
+    };
+  }
+
+  if (hasTruthyAttribute(openingElement, 'onClick')) {
+    return {
+      semanticType: 'button',
+      confidence: 'low',
+      sourceKind: 'prop-evidence',
+      evidence: 'The component receives onClick, which may indicate button-like behavior.',
+    };
+  }
+
+  return null;
+}
+
+function chooseResolution(current, next) {
+  if (!next) return current;
+  if (!current) return next;
+  const rank = { high: 3, medium: 2, low: 1, unknown: 0 };
+  return rank[next.confidence] > rank[current.confidence] ? next : current;
+}
+
+function resolveComponentSemantic(filePath, openingElement, context, depth = 0) {
+  const name = getJsxName(openingElement.name);
+  if (!name) return { semanticType: 'unknown', confidence: 'unknown', sourceKind: 'unknown', evidence: 'Unable to resolve JSX element name.' };
+
+  if (isNativeTag(name)) {
+    return {
+      semanticType: name,
+      confidence: 'high',
+      sourceKind: 'native',
+      evidence: `The JSX element is the native tag <${name}>.`,
+    };
+  }
+
+  let resolved = chooseResolution(null, inferFromProps(openingElement));
+  resolved = chooseResolution(resolved, inferByName(name));
+
+  if (depth >= MAX_RESOLUTION_DEPTH) {
+    return resolved || {
+      semanticType: 'unknown',
+      confidence: 'unknown',
+      sourceKind: 'unknown',
+      evidence: `Resolution depth exceeded for ${name}.`,
+    };
+  }
+
+  const importInfo = context.imports.get(name);
+  if (importInfo) {
+    const resolvedSource = resolveSourceFile(filePath, importInfo.source);
+    if (resolvedSource) {
+      const parsed = parseFile(resolvedSource);
+      if (parsed.ok) {
+        const rootJsx = findExportedComponent(parsed.ast, importInfo.imported);
+        if (rootJsx && t.isJSXElement(rootJsx)) {
+          const innerImports = getImportMap(parsed.ast);
+          const nested = resolveComponentSemantic(resolvedSource, rootJsx.openingElement, { imports: innerImports }, depth + 1);
+          if (nested.semanticType !== 'unknown') {
+            const sourceKind = importInfo.source.startsWith('.') ? 'local-wrapper' : 'package-component';
+            resolved = chooseResolution(resolved, {
+              semanticType: nested.semanticType,
+              confidence: nested.confidence === 'low' ? 'medium' : nested.confidence,
+              sourceKind,
+              evidence: `${name} resolves through ${path.relative(ROOT, resolvedSource)} to ${nested.semanticType} semantics.`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const finalResolution = resolved || {
+    semanticType: 'unknown',
+    confidence: 'unknown',
+    sourceKind: 'unknown',
+    evidence: `Could not infer reliable semantics for ${name}.`,
+  };
+  return finalResolution;
+}
+
+function toRelative(filePath) {
+  return path.relative(ROOT, filePath) || filePath;
+}
+
+function findingFromNode(filePath, node, data) {
+  return {
+    file: toRelative(filePath),
+    line: node.loc ? node.loc.start.line : null,
+    column: node.loc ? node.loc.start.column + 1 : null,
+    rule: data.rule,
+    confidence: data.confidence,
+    message: data.message,
+    componentName: data.componentName,
+    semanticType: data.semanticType,
+    evidence: data.evidence,
+    sourceKind: data.sourceKind,
+  };
+}
+
+function scanFile(filePath) {
+  const parsed = parseFile(filePath);
+  if (!parsed.ok) {
+    return {
+      parseError: {
+        file: toRelative(filePath),
+        message: parsed.error.message,
+      },
+      findings: [],
+    };
+  }
+
+  const imports = getImportMap(parsed.ast);
+  const findings = [];
+  const parseWarnings = parsed.recoverableErrors || [];
+
+  traverse(parsed.ast, {
+    JSXOpeningElement(path) {
+      const node = path.node;
+      const name = getJsxName(node.name);
+      if (!name) return;
+
+      const semantic = resolveComponentSemantic(filePath, node, { imports });
+      const ariaAttrs = node.attributes.filter((attr) => t.isJSXAttribute(attr) && getJsxName(attr.name)?.startsWith('aria-'));
+      const roleAttr = getAttribute(node, 'role');
+
+      if (semantic.semanticType === 'img' && semantic.confidence !== 'low') {
+        const altAttr = getAttribute(node, 'alt');
+        if (!altAttr) {
+          findings.push(findingFromNode(filePath, node, {
+            rule: 'alt-text',
+            confidence: semantic.confidence,
+            message: `${name} is treated as image-like but is missing an alt prop.`,
+            componentName: name,
+            semanticType: semantic.semanticType,
+            evidence: semantic.evidence,
+            sourceKind: semantic.sourceKind,
+          }));
+        }
+      } else if (semantic.semanticType === 'img' && semantic.confidence === 'low') {
+        const altAttr = getAttribute(node, 'alt');
+        if (!altAttr) {
+          findings.push(findingFromNode(filePath, node, {
+            rule: 'alt-text',
+            confidence: semantic.confidence,
+            message: `${name} may be image-like and appears to be missing an alt prop.`,
+            componentName: name,
+            semanticType: semantic.semanticType,
+            evidence: semantic.evidence,
+            sourceKind: semantic.sourceKind,
+          }));
+        }
+      }
+
+      if (semantic.semanticType === 'a') {
+        const hrefAttr = getAttribute(node, 'href');
+        const toAttr = getAttribute(node, 'to');
+        const hrefValue = getLiteralAttributeValue(hrefAttr);
+        const toValue = getLiteralAttributeValue(toAttr);
+        const invalidLinkTarget = (!hrefAttr && !toAttr)
+          || hrefValue === ''
+          || hrefValue === '#'
+          || hrefValue === 'javascript:void(0)'
+          || toValue === ''
+          || toValue === '#'
+          || toValue === 'javascript:void(0)';
+        if (invalidLinkTarget) {
+          findings.push(findingFromNode(filePath, node, {
+            rule: 'anchor-is-valid',
+            confidence: semantic.confidence,
+            message: semantic.confidence === 'low'
+              ? `${name} may be link-like but does not appear to provide a valid navigation target.`
+              : `${name} is treated as link-like but does not provide a valid navigation target.`,
+            componentName: name,
+            semanticType: semantic.semanticType,
+            evidence: semantic.evidence,
+            sourceKind: semantic.sourceKind,
+          }));
+        }
+      }
+
+      for (const attr of ariaAttrs) {
+        const attrName = getJsxName(attr.name);
+        if (!VALID_ARIA_PROPS.has(attrName)) {
+          findings.push(findingFromNode(filePath, attr, {
+            rule: 'aria-props',
+            confidence: 'high',
+            message: `${attrName} is not a valid ARIA attribute name.`,
+            componentName: name,
+            semanticType: semantic.semanticType,
+            evidence: `The attribute name "${attrName}" is not in the allowed ARIA prop set.`,
+            sourceKind: semantic.sourceKind,
+          }));
+        }
+      }
+
+      const roleValue = getLiteralAttributeValue(roleAttr);
+      if (typeof roleValue === 'string' && !VALID_ROLES.has(roleValue)) {
+        findings.push(findingFromNode(filePath, roleAttr, {
+          rule: 'aria-role',
+          confidence: 'high',
+          message: `"${roleValue}" is not a valid ARIA role value.`,
+          componentName: name,
+          semanticType: semantic.semanticType,
+          evidence: `The role value "${roleValue}" is not in the supported ARIA roles set.`,
+          sourceKind: semantic.sourceKind,
+        }));
+      }
+
+      if ((ariaAttrs.length > 0 || roleAttr) && semantic.confidence !== 'low') {
+        const semanticTag = semantic.semanticType;
+        if (UNSUPPORTED_ARIA_ELEMENTS.has(semanticTag)) {
+          findings.push(findingFromNode(filePath, node, {
+            rule: 'aria-unsupported-elements',
+            confidence: semantic.confidence,
+            message: `${name} resolves to unsupported element <${semanticTag}> but carries ARIA attributes or role.`,
+            componentName: name,
+            semanticType: semantic.semanticType,
+            evidence: semantic.evidence,
+            sourceKind: semantic.sourceKind,
+          }));
+        }
+      }
+    },
+  });
+
+  return { parseError: null, findings, parseWarnings };
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.log(JSON.stringify({
+      error: 'No files specified.',
+      usage: 'node <skill-root>/scripts/scan-a11y-code.js <file1> [file2] ...',
+    }, null, 2));
+    process.exit(1);
+  }
+
+  const meta = {
+    filesScanned: files.length,
+    parser: '@babel/parser',
+    supportedRules: [
+      'alt-text',
+      'anchor-is-valid',
+      'aria-props',
+      'aria-role',
+      'aria-unsupported-elements',
+    ],
+    confidenceModel: ['high', 'medium', 'low', 'unknown'],
+    parseErrors: [],
+    resolutionWarnings,
+  };
+
+  const findings = [];
+
+  for (const file of files.map((file) => path.resolve(file))) {
+    const result = scanFile(file);
+    if (result.parseError) meta.parseErrors.push(result.parseError);
+    for (const warning of result.parseWarnings || []) {
+      meta.parseErrors.push({
+        file: toRelative(file),
+        message: warning,
+      });
+    }
+    findings.push(...result.findings);
+  }
+
+  const summary = {
+    findings: findings.length,
+    highConfidence: findings.filter((item) => item.confidence === 'high').length,
+    mediumConfidence: findings.filter((item) => item.confidence === 'medium').length,
+    lowConfidence: findings.filter((item) => item.confidence === 'low').length,
+    filesWithFindings: new Set(findings.map((item) => item.file)).size,
+    cleanFiles: files.length - new Set(findings.map((item) => item.file)).size,
+  };
+
+  console.log(JSON.stringify({ meta, findings, summary }, null, 2));
+}
+
+main();

--- a/skills/wix-app/scripts/scan-a11y-eslint.js
+++ b/skills/wix-app/scripts/scan-a11y-eslint.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { ESLint } = require('eslint');
+
+const ROOT = process.cwd();
+
+const RULE_CONFIG = {
+  'jsx-a11y/alt-text': 'error',
+  'jsx-a11y/anchor-has-content': 'error',
+  'jsx-a11y/anchor-is-valid': 'error',
+  'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
+  'jsx-a11y/aria-props': 'error',
+  'jsx-a11y/aria-proptypes': 'error',
+  'jsx-a11y/aria-role': 'error',
+  'jsx-a11y/aria-unsupported-elements': 'error',
+  'jsx-a11y/click-events-have-key-events': 'error',
+  'jsx-a11y/heading-has-content': 'error',
+  'jsx-a11y/iframe-has-title': 'error',
+  'jsx-a11y/img-redundant-alt': 'error',
+  'jsx-a11y/interactive-supports-focus': 'error',
+  'jsx-a11y/label-has-associated-control': 'error',
+  'jsx-a11y/media-has-caption': 'error',
+  'jsx-a11y/mouse-events-have-key-events': 'error',
+  'jsx-a11y/no-access-key': 'error',
+  'jsx-a11y/no-aria-hidden-on-focusable': 'error',
+  'jsx-a11y/no-autofocus': 'error',
+  'jsx-a11y/no-distracting-elements': 'error',
+  'jsx-a11y/no-interactive-element-to-noninteractive-role': 'error',
+  'jsx-a11y/no-noninteractive-element-interactions': 'error',
+  'jsx-a11y/no-noninteractive-element-to-interactive-role': 'error',
+  'jsx-a11y/no-noninteractive-tabindex': 'error',
+  'jsx-a11y/no-redundant-roles': 'error',
+  'jsx-a11y/no-static-element-interactions': 'error',
+  'jsx-a11y/prefer-tag-over-role': 'error',
+  'jsx-a11y/role-has-required-aria-props': 'error',
+  'jsx-a11y/role-supports-aria-props': 'error',
+  'jsx-a11y/scope': 'error',
+  'jsx-a11y/tabindex-no-positive': 'error',
+};
+
+function toRelative(filePath) {
+  return path.relative(ROOT, filePath) || filePath;
+}
+
+function severityLabel(severity) {
+  if (severity === 2) return 'error';
+  if (severity === 1) return 'warning';
+  return 'off';
+}
+
+async function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.log(
+      JSON.stringify(
+        {
+          error: 'No files specified.',
+          usage:
+            'node <skill-root>/scripts/scan-a11y-eslint.js <file1> [file2] ...',
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const absoluteFiles = files.map((f) => path.resolve(f));
+
+  const eslint = new ESLint({
+    useEslintrc: false,
+    overrideConfig: {
+      parser: '@typescript-eslint/parser',
+      plugins: ['jsx-a11y'],
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: RULE_CONFIG,
+    },
+    extensions: ['.tsx', '.jsx', '.ts', '.js'],
+  });
+
+  const results = await eslint.lintFiles(absoluteFiles);
+
+  const findings = [];
+  const parseErrors = [];
+
+  for (const result of results) {
+    const relFile = toRelative(result.filePath);
+
+    for (const msg of result.messages) {
+      if (msg.fatal) {
+        parseErrors.push({
+          file: relFile,
+          line: msg.line,
+          column: msg.column,
+          message: msg.message,
+        });
+        continue;
+      }
+
+      if (!msg.ruleId || !msg.ruleId.startsWith('jsx-a11y/')) continue;
+
+      findings.push({
+        file: relFile,
+        line: msg.line,
+        column: msg.column,
+        endLine: msg.endLine ?? null,
+        endColumn: msg.endColumn ?? null,
+        rule: msg.ruleId,
+        severity: severityLabel(msg.severity),
+        message: msg.message,
+      });
+    }
+  }
+
+  const ruleBreakdown = {};
+  for (const f of findings) {
+    ruleBreakdown[f.rule] = (ruleBreakdown[f.rule] || 0) + 1;
+  }
+
+  const output = {
+    meta: {
+      filesScanned: files.length,
+      engine: 'eslint + eslint-plugin-jsx-a11y',
+      rulesEnabled: Object.keys(RULE_CONFIG).length,
+      parseErrors,
+    },
+    findings,
+    summary: {
+      totalFindings: findings.length,
+      filesWithFindings: new Set(findings.map((f) => f.file)).size,
+      cleanFiles:
+        files.length - new Set(findings.map((f) => f.file)).size,
+      ruleBreakdown,
+    },
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ error: err.message }, null, 2));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add an automated a11y scan + triage workflow to the wix-app skill's Editor React Component creation flow.
- New reference `editor-react-component/A11Y-REVIEW.md` defines the workflow as a step inside the existing Editor React Component process, using Wix CLI verification commands (`npx wix build && npx wix generate manifest`, `npx tsc --noEmit`) and cross-linking the existing `ACCESSIBILITY.md` for ARIA conventions.
- New `editor-react-component/a11y-review/` subfolder ships the supporting docs (`RULES.md`, `FIX-STRATEGIES.md`, `MANUAL-REVIEW-CHECKLIST.md`, `CONFIDENCE-MODEL.md`, `EXAMPLES.md`, `SEMANTIC-RESOLUTION.md`) and two scanner scripts under `skills/wix-app/scripts/` (`scan-a11y-eslint.js`, `scan-a11y-code.js`).
- `EDITOR_REACT_COMPONENT.md` workflow now invokes the A11y Review after editing `.tsx`/`.module.css` and before regenerating the manifest; topic references list updated to surface the new doc next to `ACCESSIBILITY.md`.

## Test plan
- [ ] Scaffold an Editor React Component in a Wix CLI app and follow the updated workflow end-to-end.
- [ ] Run both scanners on the component's `.tsx` files from the project root and confirm JSON output parses cleanly.
- [ ] Introduce a deliberate a11y violation (e.g. icon-only `<button>` with no label) and confirm it is flagged, triaged, and fixable per the guide.
- [ ] Confirm `npx wix build && npx wix generate manifest` and `npx tsc --noEmit` still pass after fixes.
- [ ] Spot-check internal links in `A11Y-REVIEW.md` and the updated `EDITOR_REACT_COMPONENT.md`.