### PR TITLE
fix(wix-headless): correct broken SDK docs-search kbName

### DIFF
--- a/plugins/wix/skills/wix-headless/references/shared/DOCS_SEARCH.md
+++ b/plugins/wix/skills/wix-headless/references/shared/DOCS_SEARCH.md
@@ -11,7 +11,7 @@ Operational calls in this skill use `npx @wix/cli token --site "$SITE_ID"` + `cu
 | Read method schema | Same URL with `schema=true` |
 | Browse REST docs menu | `GET https://dev.wix.com/docs/api/v1/get-menu-content?url=<url>&format=markdown` |
 
-**kbName values** (common): `REST_METHODS_KB_ID`, `SDK_KB_ID`, `HEADLESS_KB_ID`.
+**kbName values** (common): `REST_METHODS_KB_ID`, `SDK_METHODS_KB_ID`, `HEADLESS_KB_ID`. For SDK guide articles (not method reference) use `SDK_DOCS_KB_ID`.
 
 Example — search REST docs for app install:
 

--- a/skills/wix-headless/references/shared/DOCS_SEARCH.md
+++ b/skills/wix-headless/references/shared/DOCS_SEARCH.md
@@ -11,7 +11,7 @@ Operational calls in this skill use `npx @wix/cli token --site "$SITE_ID"` + `cu
 | Read method schema | Same URL with `schema=true` |
 | Browse REST docs menu | `GET https://dev.wix.com/docs/api/v1/get-menu-content?url=<url>&format=markdown` |
 
-**kbName values** (common): `REST_METHODS_KB_ID`, `SDK_KB_ID`, `HEADLESS_KB_ID`.
+**kbName values** (common): `REST_METHODS_KB_ID`, `SDK_METHODS_KB_ID`, `HEADLESS_KB_ID`. For SDK guide articles (not method reference) use `SDK_DOCS_KB_ID`.
 
 Example — search REST docs for app install:
 


### PR DESCRIPTION
## Problem

`references/shared/DOCS_SEARCH.md` documented `SDK_KB_ID` as a valid `kbName` for the docs-search endpoint. It isn't — the endpoint returns:

```
HTTP 400 {"error":"KB name is not provided"}
```

SDK lookups are the bulk of Path B (existing-project SDK wiring) work, so the broken value errored out exactly where the docs-search endpoint matters most — and the recipe's "if it errors, fall back" framing then trained agents to bail to web search instead of using the docs API.

## Fix

Replace `SDK_KB_ID` with the working values:
- `SDK_METHODS_KB_ID` — SDK method reference
- `SDK_DOCS_KB_ID` — SDK guide articles

Applied to both the skill root and the `plugins/wix/` mirror.

## Verification

All documented KB names tested live against `https://www.wixapis.com/mcp-docs-search/v1/search`:

| kbName | HTTP |
|---|---|
| `REST_METHODS_KB_ID` | 200 |
| `SDK_METHODS_KB_ID` | 200 |
| `HEADLESS_KB_ID` | 200 |
| `SDK_DOCS_KB_ID` | 200 |

`grep -rn SDK_KB_ID skills/ plugins/` → no matches remaining.

## Follow-up (not in this PR)

This is the correctness half of a larger diagnosis on why agents skip the docs endpoints. A follow-up will raise the endpoint's prominence (precedence steer in `DOCS_SEARCH.md` + `SKILL.md`, and decision-time pointers in the per-vertical `INSTRUCTIONS.md` files) so docs-search is tried *before* web search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)