### PR TITLE
docs(wix-headless): point components/pages subagents at docs-search

### DIFF
--- a/skills/wix-headless/references/shared/IMPLEMENTER.md
+++ b/skills/wix-headless/references/shared/IMPLEMENTER.md
@@ -9,7 +9,7 @@ Read **only** the files your scope needs. The reading set varies by scope:
 | Your scope | Mandatory | Conditional |
 |---|---|---|
 | `seed` | this file, `RETURN_CONTRACT.md`, `DOCS_SEARCH.md` | — |
-| `components`, `components-css`, `pages`, `pages-*` | this file, `RETURN_CONTRACT.md`, `STYLING.md` | — |
+| `components`, `components-css`, `pages`, `pages-*` | this file, `RETURN_CONTRACT.md`, `STYLING.md` | `DOCS_SEARCH.md` — when looking up a Wix API not covered by your recipe (use it before WebSearch) |
 | Image scopes | (read `references/images/INSTRUCTIONS.md` § Self-Loading) | — |
 
 Then read the specific reference(s) for your declared scope (see your vertical's `INSTRUCTIONS.md` scope table). Do NOT read references for scopes other than the one named in your prompt — wastes context and blurs ownership.


### PR DESCRIPTION
## Problem

The `IMPLEMENTER.md` self-load table is the authoritative map of what each subagent scope reads. It pointed `seed` and image scopes at `DOCS_SEARCH.md`, but the **`components` / `pages`** scopes — the subagents authoring SDK wiring and page queries, the ones *most* likely to need a Wix API lookup — had no pointer to it at all. So they default straight to `WebSearch`.

## Fix

One-line edit: add `DOCS_SEARCH.md` to the conditional reading set for `components`, `components-css`, `pages`, `pages-*`:

> `DOCS_SEARCH.md` — when looking up a Wix API not covered by your recipe (use it before WebSearch)

Conditional (not mandatory) keeps the "read only what your scope needs" discipline — no forced extra read every dispatch — while making the endpoint discoverable to the authors who need it.

## Related

- #299 — fixes the broken `SDK_KB_ID` value
- #300 — adds the explicit lookup-order line inside `DOCS_SEARCH.md`

Together: #299 makes the endpoint work, #300 states the precedence, this PR makes the right subagents actually see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)