### PR TITLE
chore(wix-headless): pin npx @wix/cli to @latest

### DIFF
--- a/plugins/wix/skills/wix-headless/SKILL.md
+++ b/plugins/wix/skills/wix-headless/SKILL.md
@@ -5,7 +5,7 @@ description: "Build a complete Wix Managed Headless site from a single prompt, O
 
 # Wix Headless
 
-**Discovery, setup, and seed** run from `DISCOVERY.md`, `SETUP.md`, `SEED.md`. **Design system through release** run from `ORCHESTRATION.md` and per-vertical references. All site operations use `npx @wix/cli token` + `curl` — no MCP.
+**Discovery, setup, and seed** run from `DISCOVERY.md`, `SETUP.md`, `SEED.md`. **Design system through release** run from `ORCHESTRATION.md` and per-vertical references. All site operations use `npx @wix/cli@latest token` + `curl` — no MCP.
 
 > **Explicit invocation only.** Do not auto-route on generic "build me a site" prompts; production `wix-headless` should win those unless the user names this skill.
 
@@ -41,7 +41,7 @@ Subagent invocations: Designer (Discovery Step 2.6) as `designer_handle` (bg, ab
 Every Wix API call uses `@wix/cli` + `curl`:
 
 ```
-Authorization: Bearer $(npx @wix/cli token --site "$SITE_ID")
+Authorization: Bearer $(npx @wix/cli@latest token --site "$SITE_ID")
 wix-site-id: $SITE_ID
 ```
 

--- a/plugins/wix/skills/wix-headless/references/DISCOVERY.md
+++ b/plugins/wix/skills/wix-headless/references/DISCOVERY.md
@@ -11,21 +11,21 @@ Infer as much as possible from the user's opening message; ask only what's genui
 The first Wix touch in this phase is the background `scaffold.sh` dispatched after Q1 — `npm create @wix/new@latest headless` creates a business + project against the user's Wix account, so it requires an active CLI session. Without one, the scaffold fails in the background and the failure doesn't surface until SETUP.md Step 1 — **after** Q1, Q2, Q2.5, Q3, plan, and approval. That's a ~5-minute interview the user has to redo. Run the auth check foreground here so a logged-out user sees the login prompt before any `AskUserQuestion`.
 
 ```bash
-npx @wix/cli whoami >/dev/null 2>&1
+npx @wix/cli@latest whoami >/dev/null 2>&1
 ```
 
 - Exit 0 → continue to Step 0.
-- Exit non-zero → **run `npx @wix/cli login` yourself with `run_in_background: true`** (do NOT instruct the user to run it). The exact shape:
+- Exit non-zero → **run `npx @wix/cli@latest login` yourself with `run_in_background: true`** (do NOT instruct the user to run it). The exact shape:
 
   | Step | Action | Anti-pattern |
   |---|---|---|
-  | 1 | `Bash` tool, command = `npx @wix/cli login`, `run_in_background: true`. **No shell `&`, no `mktemp` redirect, no chaining.** | `TMPFILE=$(mktemp …) && npx @wix/cli login > "$TMPFILE" 2>&1 &` — stacks shell `&` on harness `run_in_background`, splits wix-login output from the harness task file. |
+  | 1 | `Bash` tool, command = `npx @wix/cli@latest login`, `run_in_background: true`. **No shell `&`, no `mktemp` redirect, no chaining.** | `TMPFILE=$(mktemp …) && npx @wix/cli@latest login > "$TMPFILE" 2>&1 &` — stacks shell `&` on harness `run_in_background`, splits wix-login output from the harness task file. |
   | 2 | The tool reply gives you the harness output-file path in `<bash-stdout>`. **`Read` that path** (or use `TaskOutput`). | Reading any other file. The harness path IS the right file. |
   | 3 | Parse line 1 of the file: `{"event":"awaiting_user","userCode":"…","verificationUri":"…"}`. (Node may emit a `TimeoutNaNWarning` on lines 3-5; ignore.) | Trying to re-invoke wix-login "to do it properly" after seeing the event. The event means it's working — surface and wait. |
   | 4 | Surface to user in one plain-prose message: *"Open `<verificationUri>` in your browser and enter the code `<userCode>` — I'll continue once you've completed the login."* | `AskUserQuestion`. The URL + code are text the user needs to copy, not a multiple-choice answer. |
   | 5 | Wait for the harness `task-notification` with `<status>completed</status>`. Run `whoami` once on completion to confirm. Then proceed to Step 0. | Polling `whoami` in a sleep loop while waiting. The notification is the only signal. |
 
-  Do **not** punt to the user with *"Run `npx @wix/cli login` and retry"* and stop — that breaks the flow (the harness backgrounds the user-issued command, you don't know which output file to read, and the user has to manually prompt you to read it; ~60 s + interrupt of recovery wall). Full reference: [`shared/AUTHENTICATION.md`](shared/AUTHENTICATION.md#wix-login-from-a-non-interactive-agent).
+  Do **not** punt to the user with *"Run `npx @wix/cli@latest login` and retry"* and stop — that breaks the flow (the harness backgrounds the user-issued command, you don't know which output file to read, and the user has to manually prompt you to read it; ~60 s + interrupt of recovery wall). Full reference: [`shared/AUTHENTICATION.md`](shared/AUTHENTICATION.md#wix-login-from-a-non-interactive-agent).
 
 ## Step 0 — Infer Vertical(s) and Business Context
 
@@ -147,10 +147,10 @@ Worked examples:
 
 ### 2.5.2 — Fetch the AI-credit balance
 
-`npx @wix/cli token` **without** `--site` mints an **account-scoped** token. With that token, the balance endpoint at `POST https://manage.wix.com/credit-transactions/v1/credit-transactions/get-account-balance` returns the current periodic credit balance + cap. Verified against the production endpoint on 2026-05-24.
+`npx @wix/cli@latest token` **without** `--site` mints an **account-scoped** token. With that token, the balance endpoint at `POST https://manage.wix.com/credit-transactions/v1/credit-transactions/get-account-balance` returns the current periodic credit balance + cap. Verified against the production endpoint on 2026-05-24.
 
 ```bash
-ACCOUNT_TOKEN=$(npx @wix/cli token)   # NO --site — mints account-scoped
+ACCOUNT_TOKEN=$(npx @wix/cli@latest token)   # NO --site — mints account-scoped
 curl -sS -X POST \
   -H "Authorization: Bearer $ACCOUNT_TOKEN" \
   -H "Content-Type: application/json" \
@@ -178,7 +178,7 @@ Hold `balance = response.periodicCredits.balance` and `cap = response.periodicCr
 3. **POST returns 4xx other than 401/403** — log the response in scratch (do not crash) and set `balance = null`. This includes the 400 you'd see if you accidentally GET the endpoint instead of POST: every prior revision of this section hit that and concluded the endpoint was broken. It isn't — it's POST-only.
 4. **Network error / timeout** — set `balance = null`. The credit estimate (§ 2.5.1) is unaffected; only the Q3 description's *"Current balance: …"* tail goes silent.
 
-> **Don't share the token across calls.** The account-scoped token is for account-level reads only (balance, account metadata). Every other site-operating call in this skill uses `npx @wix/cli token --site "$SITE_ID"` — site-scoped — per `references/shared/AUTHENTICATION.md`. Mix-ups have caused `403 SITE_TOKEN_REQUIRED` on Wix-site calls and `403 ACCOUNT_TOKEN_REQUIRED` on the balance call.
+> **Don't share the token across calls.** The account-scoped token is for account-level reads only (balance, account metadata). Every other site-operating call in this skill uses `npx @wix/cli@latest token --site "$SITE_ID"` — site-scoped — per `references/shared/AUTHENTICATION.md`. Mix-ups have caused `403 SITE_TOKEN_REQUIRED` on Wix-site calls and `403 ACCOUNT_TOKEN_REQUIRED` on the balance call.
 
 > **Historical note.** Earlier revisions of this section claimed the CLI did not expose an account-scoped token primitive, and the balance lookup was disabled unconditionally. Both claims were wrong — `wix token` without `--site` is exactly that primitive. The omission was paying ~1 informational line at Q3 plus losing visibility into whether the user had credits before opting into AI imagery.
 

--- a/plugins/wix/skills/wix-headless/references/ORCHESTRATION.md
+++ b/plugins/wix/skills/wix-headless/references/ORCHESTRATION.md
@@ -61,7 +61,7 @@ Scope: <scope string>
 Project directory (absolute path): <project path>
 site-root: <absolute path to eval run dir — parent of scaffold; .wix/site.json lives here>
 siteId: <from wix.config.json>
-Auth: <SKILL_ROOT>/references/shared/AUTHENTICATION.md — mint TOKEN once via npx @wix/cli token --site "$SITE_ID"; every curl uses Bearer + wix-site-id headers
+Auth: <SKILL_ROOT>/references/shared/AUTHENTICATION.md — mint TOKEN once via npx @wix/cli@latest token --site "$SITE_ID"; every curl uses Bearer + wix-site-id headers
 Brand context: name, vibe, aesthetic direction, colors, fonts, mood, page color strategy
 Design tokens: .wix/design-tokens.css (generated from site.json.designTokens)
 ```
@@ -193,7 +193,7 @@ Scope subagents MUST NOT:
 
 ## Wait: Phase 4 → Build
 
-> **HARD GATE: Do NOT run `npx @wix/cli build` until `image-phase-2-entity` has completed or timed out (120s) — ONLY when it was dispatched.** This gate applies only to runs where `intent.imagery === "ai-generated"` and Step 4.5 actually dispatched Image Phase 2. On the default `themed-blocks` run, Image Phase 2 was skipped at Step 4.5 and recorded as `{phase: "image-phase-2-entity", status: "skipped"}` in `run.json` — there is no handle to wait on; proceed to the build immediately when Phase 4 Pages return. **Skipping it on an ai-generated run has shipped previews with no product images and `run.json` recording `image-phase-2-entity` as `"in_progress"`, so do not collapse this gate.**
+> **HARD GATE: Do NOT run `npx @wix/cli@latest build` until `image-phase-2-entity` has completed or timed out (120s) — ONLY when it was dispatched.** This gate applies only to runs where `intent.imagery === "ai-generated"` and Step 4.5 actually dispatched Image Phase 2. On the default `themed-blocks` run, Image Phase 2 was skipped at Step 4.5 and recorded as `{phase: "image-phase-2-entity", status: "skipped"}` in `run.json` — there is no handle to wait on; proceed to the build immediately when Phase 4 Pages return. **Skipping it on an ai-generated run has shipped previews with no product images and `run.json` recording `image-phase-2-entity` as `"in_progress"`, so do not collapse this gate.**
 
 All Step 7 Phase 4 Pages subagents return. When Image Phase 2 was dispatched (ai-generated runs), it has been running through Phase 3 + Phase 4 in parallel — typically ~5–8 minutes by the time Phase 4 Pages finish, which is enough for it to be done or in its tail. When skipped (themed-blocks runs), no wait. All return JSON is in session context.
 
@@ -227,8 +227,8 @@ Record the rate-limit event in `run.json` `notes[]` regardless of recovery outco
 
 ## Build & Release
 
-1. `npx @wix/cli build` — if it fails, inspect `.wix/debug.log` for the specific error, fix, retry. Common failure modes are listed in `references/shared/RETURN_CONTRACT.md` § "Common failure modes".
-2. `npx @wix/cli release` — extract the published URL from the `Site published on <url>` line in stdout. This command also populates the **Frontend link** in headless settings natively, so transactional emails link to the deployed frontend without any extra API calls.
+1. `npx @wix/cli@latest build` — if it fails, inspect `.wix/debug.log` for the specific error, fix, retry. Common failure modes are listed in `references/shared/RETURN_CONTRACT.md` § "Common failure modes".
+2. `npx @wix/cli@latest release` — extract the published URL from the `Site published on <url>` line in stdout. This command also populates the **Frontend link** in headless settings natively, so transactional emails link to the deployed frontend without any extra API calls.
 
 ---
 

--- a/plugins/wix/skills/wix-headless/references/SEED.md
+++ b/plugins/wix/skills/wix-headless/references/SEED.md
@@ -127,13 +127,13 @@ Inputs (do not re-derive these):
 Steps:
 
 1. **Open with one concurrent batch** (single assistant message, multiple tool calls):
-   - One `Bash` to mint and capture the site-scoped REST token: `TOKEN=$(npx @wix/cli token --site "<siteId>")`. Cache the token in subagent scratch — every subsequent `curl` reuses it. (The token is stable for the duration of the run; do not re-mint per call.) Use `npx @wix/cli token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness.
+   - One `Bash` to mint and capture the site-scoped REST token: `TOKEN=$(npx @wix/cli@latest token --site "<siteId>")`. Cache the token in subagent scratch — every subsequent `curl` reuses it. (The token is stable for the duration of the run; do not re-mint per call.) Use `npx @wix/cli@latest token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness.
    - One `Read` per absolute recipe path you were given. If you have N recipe paths, issue N Reads as siblings — do not serialize them.
    No narration, no "Reading recipe and minting token:" preamble. Issue the batch.
 
 2. Fire the recipe's REST calls via `curl` against `wixapis.com`. Every call carries the headers documented in `<skill-root>/references/shared/AUTHENTICATION.md` — `Authorization: Bearer $TOKEN` (the token from Step 1), `wix-site-id: <siteId>`, and `Content-Type: application/json` — plus the recipe's documented body. Construct request bodies from intent.<pack> + brand. **When the recipe documents N independent calls** (e.g., creating N categories, adding products to N categories), issue them as one parallel batch — not sequentially.
 
-   **On 401/403**, re-mint the token with `npx @wix/cli token --site "<siteId>"` and retry once; if it still fails, return `status: "error"` with the response body. Do **not** spend turns debugging the auth call shape — if the retry fails, the issue is upstream (expired CLI session, missing app install, or a resource that requires a provisioning step the recipe didn't run), and recipe-level header A/B-testing will not recover it.
+   **On 401/403**, re-mint the token with `npx @wix/cli@latest token --site "<siteId>"` and retry once; if it still fails, return `status: "error"` with the response body. Do **not** spend turns debugging the auth call shape — if the retry fails, the issue is upstream (expired CLI session, missing app install, or a resource that requires a provisioning step the recipe didn't run), and recipe-level header A/B-testing will not recover it.
 
 3. Text-only seeding only — do not call media-manager import or generate AI imagery. Use the placeholder image patterns the recipes document.
 

--- a/plugins/wix/skills/wix-headless/references/SETUP.md
+++ b/plugins/wix/skills/wix-headless/references/SETUP.md
@@ -33,7 +33,7 @@ By the time the wait returns, `wix-manage` is in context — so the only foregro
 **Do not** speculatively `Read <project-slug>/wix.config.json` and fall back to a wait — the speculative read returns `File does not exist` on every fast-Q&A run (the file isn't there yet), emits a `[MED]` anomaly in the trace, and costs 3–5 s of round-trip + recovery thinking. Wait first; read second.
 
 Once the wait returns exit-0, read `<project-slug>/wix.config.json` and extract:
-- `siteId` — the site id passed as `--site` to `npx @wix/cli token` and embedded in every install body + as the `wix-site-id` header on every site-scoped REST call.
+- `siteId` — the site id passed as `--site` to `npx @wix/cli@latest token` and embedded in every install body + as the `wix-site-id` header on every site-scoped REST call.
 - `appId` — the project's appId, written into `.wix/site.json` for downstream phases.
 
 `cd` into `<project-slug>/` so all subsequent file ops + shell calls are relative to the project root.
@@ -42,7 +42,7 @@ Once the wait returns exit-0, read `<project-slug>/wix.config.json` and extract:
 
 **Before `cd`, capture the current working directory as `<site-root>` and hold it in session scratch.** This is where Discovery's `init-site-json.mjs` wrote `.wix/site.json` (`<site-root>/.wix/site.json`). Phase 3 Seed reads from and writes back to this same root — both for the patched `site.json` and for the per-pack `seed-returns/`. Mixing the eval-run dir with the scaffold subdir is a known cause of `merge-seed-results.mjs: site.json does not exist` failures.
 
-`cd` into `<project-slug>/` so subsequent shell calls (`npm`, `npx @wix/cli env pull`) are relative to the project root. **Use the captured `<site-root>` (an absolute path) for every subsequent `Read`/`Write`/`Bash` that touches `.wix/site.json` or `.wix/seed-returns/`** — do not rely on relative paths after the `cd`.
+`cd` into `<project-slug>/` so subsequent shell calls (`npm`, `npx @wix/cli@latest env pull`) are relative to the project root. **Use the captured `<site-root>` (an absolute path) for every subsequent `Read`/`Write`/`Bash` that touches `.wix/site.json` or `.wix/seed-returns/`** — do not rely on relative paths after the `cd`.
 
 ---
 
@@ -103,7 +103,7 @@ Mint the site-scoped REST token once and cache it for the rest of the run, then 
 
 ```bash
 SITE_ID="<siteId>"
-TOKEN=$(npx @wix/cli token --site "$SITE_ID")  # once; cache in scratch for the run
+TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")  # once; cache in scratch for the run
 
 # per-pack iteration; one curl per pack.apps[*]:
 curl -sS -X POST "https://www.wixapis.com/apps-installer-service/v1/app-instance/install" \
@@ -116,7 +116,7 @@ curl -sS -X POST "https://www.wixapis.com/apps-installer-service/v1/app-instance
   }'
 ```
 
-Use `npx @wix/cli token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness, and `npx` resolves to the project-local copy that scaffold just produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
+Use `npx @wix/cli@latest token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness, and `npx` resolves to the project-local copy that scaffold just produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
 
 A 200 response confirms the install. On 401/403, re-mint and retry once per the recovery ladder in `references/shared/AUTHENTICATION.md`; if it still fails, surface the response body — recovery beyond a single re-mint usually means the CLI session expired and `wix login` is required.
 
@@ -124,7 +124,7 @@ A 200 response confirms the install. On 401/403, re-mint and retry once per the 
 
 **Packs with `disabled: true` (today: `gift-cards`):** the pack still loads and contributes to the resolved set, but its `apps:` array is empty by design (the user opts in via the dashboard later). No curl. Same `skipped` phase entry as above.
 
-### 4b. `npx @wix/cli env pull`
+### 4b. `npx @wix/cli@latest env pull`
 
 Foreground shell, ~5 s. Writes `WIX_CLIENT_ID` to `.env.local`. Idempotent. Skipping this historically caused `Missing environment variable WIX_CLIENT_ID` build failures in downstream phases.
 
@@ -211,7 +211,7 @@ Before transitioning to SEED.md in Step 5:
 
 - `wix.config.json` was read and `siteId` + `appId` were extracted (not empty, not undefined).
 - `.wix/site.json` now contains both `siteId` and `appId` at the top level.
-- `npx @wix/cli token --site "$SITE_ID"` returned a non-empty token (cached in session scratch).
+- `npx @wix/cli@latest token --site "$SITE_ID"` returned a non-empty token (cached in session scratch).
 - Every loaded pack with non-empty `apps:` got a 200 OK from the install endpoint.
 - Every loaded pack with empty `apps:` got a `skipped` phase entry.
 - `.env.local` exists and contains `WIX_CLIENT_ID`.
@@ -234,7 +234,7 @@ Use this path when the user already has a working frontend on disk (Claude Desig
 | Seeders / Designer / Pages / ORCHESTRATION | Run | **Skipped** — there is no Astro structure to populate |
 | App installs | From inferred vertical packs | From a quick **project analysis** (see E2) — only apps the existing project actually needs |
 | SDK wiring into source | N/A (subagents write Astro + SDK calls from scratch) | **Required (E4)** — edit the project's existing source files in place |
-| Build / release | `npx @wix/cli build` + `release` via `release.sh` | `npx @wix/cli release` directly — **no build step**; existing `index.html` is published as-is |
+| Build / release | `npx @wix/cli@latest build` + `release` via `release.sh` | `npx @wix/cli@latest release` directly — **no build step**; existing `index.html` is published as-is |
 | Entry file | `src/pages/index.astro` (Astro convention) | **Must be `index.html`** at the configured `outputDirectory` |
 
 Run **only**: DISCOVERY.md pre-flight (CLI-auth check) → E1 → E2 → E3 → E4 → E5 → E6. Skip Steps 1–5 above entirely.
@@ -270,7 +270,7 @@ This creates a Wix Site + Headless Project (App) connected to that Site, and wri
 4. Capture `{ phase: "init", seconds, started, ended }` in `run.json.phases[]`.
 
 Recovery ladder:
-- Auth error → surface `"Run \`npx @wix/cli login\` and retry."` and stop (same as Path A; full ladder in `references/shared/AUTHENTICATION.md`).
+- Auth error → surface `"Run \`npx @wix/cli@latest login\` and retry."` and stop (same as Path A; full ladder in `references/shared/AUTHENTICATION.md`).
 - `wix.config.json` already exists → skip E1, continue to E2.
 - Network / unknown → surface stderr to the user.
 
@@ -319,12 +319,12 @@ Capture `{ phase: "sdk-wiring-<pack>", seconds }` per pack.
 
 ### Step E5 — Release (no build)
 
-**Do NOT run `release.sh`** in this flow — `release.sh` runs `npx @wix/cli build` first, and there is nothing to build. The existing project's `index.html` and its sibling assets already sit at the configured `site.outputDirectory`; Wix just needs to publish that directory as-is. Calling `build` here either no-ops (wastes ~5–15 s) or fails if the project has no Astro/Vite config the Wix CLI knows how to invoke.
+**Do NOT run `release.sh`** in this flow — `release.sh` runs `npx @wix/cli@latest build` first, and there is nothing to build. The existing project's `index.html` and its sibling assets already sit at the configured `site.outputDirectory`; Wix just needs to publish that directory as-is. Calling `build` here either no-ops (wastes ~5–15 s) or fails if the project has no Astro/Vite config the Wix CLI knows how to invoke.
 
 Run release directly:
 
 ```bash
-npx @wix/cli release
+npx @wix/cli@latest release
 ```
 
 Capture stdout. The CLI prints `Site published on <url>` on success — extract that URL (same parser logic as `release.sh` uses):
@@ -335,9 +335,9 @@ sed -nE 's/.*Site published on ([^[:space:]]+).*/\1/p'
 
 Capture `{ phase: "release", seconds }` around the call. No `{ phase: "build" }` entry in `run.json` for this flow.
 
-Auth-failure recovery: same as `release.sh` — if stderr mentions login, surface `"Run \`npx @wix/cli login\` and retry."` and stop. Transient errors (`ECONNRESET`, `temporarily unavailable`, etc.) — retry up to 3 times with `attempt * 5` second backoff, mirroring `release.sh`.
+Auth-failure recovery: same as `release.sh` — if stderr mentions login, surface `"Run \`npx @wix/cli@latest login\` and retry."` and stop. Transient errors (`ECONNRESET`, `temporarily unavailable`, etc.) — retry up to 3 times with `attempt * 5` second backoff, mirroring `release.sh`.
 
-> **If the project needs a client build** (Vite, React, Webpack, etc.), run the project's own build command manually (e.g. `npm run build`) before `npx @wix/cli release`, and make sure `site.outputDirectory` points at the build output. Do not use `wix build`.
+> **If the project needs a client build** (Vite, React, Webpack, etc.), run the project's own build command manually (e.g. `npm run build`) before `npx @wix/cli@latest release`, and make sure `site.outputDirectory` points at the build output. Do not use `wix build`.
 
 ### Step E6 — Final message
 

--- a/plugins/wix/skills/wix-headless/references/cms/CMS_FOUNDATIONS.md
+++ b/plugins/wix/skills/wix-headless/references/cms/CMS_FOUNDATIONS.md
@@ -367,6 +367,6 @@ Emit a structured JSON block at the end of your completion message per `../share
 1. Create a data collection in the Wix dashboard → CMS
 2. Add fields matching the use case schema (see the specific use case reference)
 3. Add at least 2–3 items with all fields populated, including `slug` and `published` (if applicable)
-4. Run `npx @wix/cli dev`
+4. Run `npx @wix/cli@latest dev`
 5. Navigate to the listing page — should show items
 6. Click an item — should navigate to the detail page

--- a/plugins/wix/skills/wix-headless/references/cms/FAQ_KNOWLEDGE_BASE.md
+++ b/plugins/wix/skills/wix-headless/references/cms/FAQ_KNOWLEDGE_BASE.md
@@ -224,7 +224,7 @@ Key details:
 
 1. Create a "FAQ" collection in the Wix dashboard → CMS with the schema above
 2. Add 6+ FAQ items across 2+ categories, all with `published: true`
-3. Run `npx @wix/cli dev`
+3. Run `npx @wix/cli@latest dev`
 4. `/faq` — shows all questions grouped by category
 5. Click a question — accordion opens with the answer
 6. Type in search — filters questions in real-time

--- a/plugins/wix/skills/wix-headless/references/cms/PORTFOLIO.md
+++ b/plugins/wix/skills/wix-headless/references/cms/PORTFOLIO.md
@@ -448,7 +448,7 @@ body: {
 1. Create a "Projects" collection in the Wix dashboard → CMS with the schema above
 2. Add 3+ projects with cover images, categories, and at least one with gallery images
 3. Mark 1–2 as `featured: true`
-4. Run `npx @wix/cli dev`
+4. Run `npx @wix/cli@latest dev`
 5. `/work` — grid with category filter tabs
 6. Click a category — filters projects
 7. Click a project — detail page with gallery lightbox

--- a/plugins/wix/skills/wix-headless/references/cms/RESOURCE_LIBRARY.md
+++ b/plugins/wix/skills/wix-headless/references/cms/RESOURCE_LIBRARY.md
@@ -350,7 +350,7 @@ body: {
 1. Create a "Resources" collection in the Wix dashboard → CMS with the schema above
 2. Add 4+ resources across 2+ categories with different file types (PDF, DOC, ZIP)
 3. Include `fileUrl` links (can be any downloadable URL for testing)
-4. Run `npx @wix/cli dev`
+4. Run `npx @wix/cli@latest dev`
 5. `/resources` — shows all resources with category filters and file type badges
 6. Click a category — filters resources
 7. Click a resource — detail page with download button and related resources

--- a/plugins/wix/skills/wix-headless/references/cms/TEAM_DIRECTORY.md
+++ b/plugins/wix/skills/wix-headless/references/cms/TEAM_DIRECTORY.md
@@ -294,6 +294,6 @@ body: {
 
 1. Create a "Team" collection in the Wix dashboard → CMS with the schema above
 2. Add 4+ members across 2+ departments, with photos and social links
-3. Run `npx @wix/cli dev`
+3. Run `npx @wix/cli@latest dev`
 4. `/team` — shows members grouped by department
 5. Click a member — profile page with photo, bio, and social links

--- a/plugins/wix/skills/wix-headless/references/forms/CONTACT_FORM.md
+++ b/plugins/wix/skills/wix-headless/references/forms/CONTACT_FORM.md
@@ -471,7 +471,7 @@ After form verification, write a sidecar file at `.wix/logs/forms-data.md` (form
 
 ## Testing
 
-1. Run `npx @wix/cli dev`
+1. Run `npx @wix/cli@latest dev`
 2. Navigate to `/contact`
 3. Fill in the form and submit
 4. Check the Wix dashboard → Forms → Submissions to verify the data arrived

--- a/plugins/wix/skills/wix-headless/references/shared/AUTHENTICATION.md
+++ b/plugins/wix/skills/wix-headless/references/shared/AUTHENTICATION.md
@@ -4,16 +4,16 @@ Every Wix API call this skill makes goes through `@wix/cli` + `curl` — no MCP,
 
 ## Prerequisites
 
-- `@wix/cli` resolvable via `npx`. The scaffold installs it project-local, so `npx @wix/cli …` works without a global install.
-- An authenticated CLI session. Test with `npx @wix/cli whoami` — exits **0** when logged in (prints the authenticated email + user id), **non-zero** when logged out.
+- `@wix/cli` resolvable via `npx`. The scaffold installs it project-local, so `npx @wix/cli@latest …` works without a global install.
+- An authenticated CLI session. Test with `npx @wix/cli@latest whoami` — exits **0** when logged in (prints the authenticated email + user id), **non-zero** when logged out.
 
-The primary place this check runs is DISCOVERY.md § "Pre-flight" — foreground, before any `AskUserQuestion`. `scaffold.sh` repeats the check defensively for its standalone-invocation path. **If the check fails, run `npx @wix/cli login` yourself with `run_in_background: true`** per the next section — do not tell the user "run wix login and retry" and stop. Punting to the user breaks the flow: the harness backgrounds the user-issued command, the agent doesn't know which output file to read, and you end up paying ~60 s + a manual user interrupt to recover.
+The primary place this check runs is DISCOVERY.md § "Pre-flight" — foreground, before any `AskUserQuestion`. `scaffold.sh` repeats the check defensively for its standalone-invocation path. **If the check fails, run `npx @wix/cli@latest login` yourself with `run_in_background: true`** per the next section — do not tell the user "run wix login and retry" and stop. Punting to the user breaks the flow: the harness backgrounds the user-issued command, the agent doesn't know which output file to read, and you end up paying ~60 s + a manual user interrupt to recover.
 
 The "stop and tell the user" path is a **last-resort fallback** for when the background-run mechanism itself is broken (e.g. the harness rejects `run_in_background: true`, or the task output file never gets created). Try the agent-driven flow first.
 
 ## `wix login` from a non-interactive agent
 
-`wix login` (or `npx @wix/cli login`) emits one JSON event per line on **stdout** and blocks until the human finishes the browser step. The first event you care about is `awaiting_user`:
+`wix login` (or `npx @wix/cli@latest login`) emits one JSON event per line on **stdout** and blocks until the human finishes the browser step. The first event you care about is `awaiting_user`:
 
 ```json
 {"event":"awaiting_user","expiresInSeconds":600,"userCode":"TPV5HUG5","verificationUri":"https://users.wix.com/login/device-login?color=developer&studio=true"}
@@ -26,7 +26,7 @@ The "stop and tell the user" path is a **last-resort fallback** for when the bac
 The Bash command is just the CLI invocation, **nothing else**:
 
 ```bash
-npx @wix/cli login
+npx @wix/cli@latest login
 ```
 
 Pass `run_in_background: true` on the Bash tool call. **Do not** add shell `&`, **do not** redirect to your own `mktemp` file, **do not** chain with `echo`/`sleep`. The harness wraps the process for you and writes stdout+stderr to its own task output file at `/tmp/claude-<uid>/<project>/tasks/<task-id>.output`. The tool's `<bash-stdout>` reply gives you that path verbatim — that's the file you read. Stacking shell `&` on top of `run_in_background` creates two layers of backgrounding: the harness captures only the parent shell's `pid:` / `file:` echoes while wix-login's actual JSON events write somewhere else.
@@ -52,11 +52,11 @@ On `<status>completed</status>` with exit 0, run `whoami` once to confirm and pr
 
 ```bash
 SITE_ID="<siteId>"  # from wix.config.json after scaffold
-TOKEN=$(npx @wix/cli token --site "$SITE_ID")
+TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")
 ```
 
 - Mints a **site-scoped REST token**. Stable for the duration of a run — cache it in session scratch and reuse on every `curl`. Do not re-mint per call (each mint costs ~3–5 s of CLI startup).
-- Use `npx @wix/cli token …` rather than bare `wix token …`. `@wix/cli` may not be globally installed in every harness; `npx` resolves the project-local copy the scaffold produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
+- Use `npx @wix/cli@latest token …` rather than bare `wix token …`. `@wix/cli` may not be globally installed in every harness; `npx` resolves the project-local copy the scaffold produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
 - The first `--site "$SITE_ID"` invocation in a run is the source of truth for `SITE_ID`. Bind it in session scratch; do not re-derive from `wix.config.json` mid-run.
 
 ## REST call shape
@@ -81,7 +81,7 @@ The body is the recipe's documented JSON payload, with `siteId` inlined where th
 
 | Symptom | First response | If it still fails |
 |---|---|---|
-| `401 Unauthorized` | Re-mint with `npx @wix/cli token --site "$SITE_ID"` and retry the call once. | The CLI session expired — run `wix login` per the stderr-scrape flow above. |
+| `401 Unauthorized` | Re-mint with `npx @wix/cli@latest token --site "$SITE_ID"` and retry the call once. | The CLI session expired — run `wix login` per the stderr-scrape flow above. |
 | `403 Forbidden` | Re-mint and retry once. | The token shape is fine but the caller lacks the permission. The two real causes: (a) the relevant app is not installed yet (re-check `apps-installer-service` returned 200 for that app in Setup Step 4a), (b) the resource requires a provisioning step the recipe doesn't run. Surface the response body; do not loop on retries. |
 | `404 Not Found` on a documented URL | Re-read the recipe — URL path segments are easy to typo (e.g. `/blog/v3/bulk/draft-posts/create`, **not** `/blog/v3/draft-posts/bulk/create`). | Recipe bug; surface and stop. |
 
@@ -89,16 +89,16 @@ The body is the recipe's documented JSON payload, with `siteId` inlined where th
 
 ## Account-scoped calls
 
-`npx @wix/cli token` (no flags) mints an **account-scoped** token. `npx @wix/cli token --site "$SITE_ID"` mints a **site-scoped** token. The CLI's `--site` flag is what toggles between the two scopes; there is no separate `--account` flag because omitting `--site` is itself the account-scoped form.
+`npx @wix/cli@latest token` (no flags) mints an **account-scoped** token. `npx @wix/cli@latest token --site "$SITE_ID"` mints a **site-scoped** token. The CLI's `--site` flag is what toggles between the two scopes; there is no separate `--account` flag because omitting `--site` is itself the account-scoped form.
 
 Verified against the production endpoint on 2026-05-24 — the account-scoped token authenticates against `manage.wix.com` endpoints (e.g. `POST /credit-transactions/v1/credit-transactions/get-account-balance`).
 
 ```bash
 # Account-scoped — for /credit-transactions, /accounts, /subscriptions, etc.
-ACCOUNT_TOKEN=$(npx @wix/cli token)
+ACCOUNT_TOKEN=$(npx @wix/cli@latest token)
 
 # Site-scoped — for everything site-operating (apps install, products, blog, cms, …)
-SITE_TOKEN=$(npx @wix/cli token --site "$SITE_ID")
+SITE_TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")
 ```
 
 **Do not share tokens across scopes.** Site-operating calls (`wixapis.com/stores/v3/...`, `/blog/v3/...`, `/wix-data/v2/...`) need the **site** token + `wix-site-id` header; using the account token returns `403 SITE_TOKEN_REQUIRED`. Account-level calls (`manage.wix.com/credit-transactions/...`, `/subscriptions/...`) need the **account** token alone — no `wix-site-id` header; using the site token returns `403 ACCOUNT_TOKEN_REQUIRED`.

--- a/plugins/wix/skills/wix-headless/references/shared/BUILD_NOISE.md
+++ b/plugins/wix/skills/wix-headless/references/shared/BUILD_NOISE.md
@@ -1,6 +1,6 @@
 # Build-output noise — known false positives
 
-Read this only if `npx @wix/cli build` surfaces warnings or errors and you're trying to decide whether they're real. A clean build emits a few warnings that are NOT real failures:
+Read this only if `npx @wix/cli@latest build` surfaces warnings or errors and you're trying to decide whether they're real. A clean build emits a few warnings that are NOT real failures:
 
 - **`Astro.request.headers used on prerendered page`** — emitted by the `@wix/astro` integration's middleware on every prerendered route. Internal to the integration, not from skill-emitted code. Ignore.
 - **`Failed to resolve dependency: @wix/stores, present in client 'optimizeDeps.include'`** — Vite warning. The integration speculatively lists `@wix/stores` in `optimizeDeps` regardless of whether the project depends on it. Harmless.

--- a/plugins/wix/skills/wix-headless/references/shared/DOCS_SEARCH.md
+++ b/plugins/wix/skills/wix-headless/references/shared/DOCS_SEARCH.md
@@ -1,6 +1,6 @@
 # Wix documentation lookups
 
-Operational calls in this skill use `npx @wix/cli token --site "$SITE_ID"` + `curl` against `wixapis.com` (see `AUTHENTICATION.md`). When a bundled recipe falls short and you need to look up an endpoint, method schema, or article body, use the public unauthenticated REST endpoints below. **No MCP, no SDK** — these are plain `curl` calls.
+Operational calls in this skill use `npx @wix/cli@latest token --site "$SITE_ID"` + `curl` against `wixapis.com` (see `AUTHENTICATION.md`). When a bundled recipe falls short and you need to look up an endpoint, method schema, or article body, use the public unauthenticated REST endpoints below. **No MCP, no SDK** — these are plain `curl` calls.
 
 ## Doc search
 

--- a/plugins/wix/skills/wix-headless/references/shared/IMPLEMENTER.md
+++ b/plugins/wix/skills/wix-headless/references/shared/IMPLEMENTER.md
@@ -26,7 +26,7 @@ Standard scope names (see architecture-proposal §3):
 
 ## REST auth
 
-Scopes that call Wix APIs (`seed`, image phases) receive `siteId` in the prompt. Mint once: `TOKEN=$(npx @wix/cli token --site "$SITE_ID")`. Every `curl` uses the headers in `references/shared/AUTHENTICATION.md`. Doc lookups use the public REST endpoints listed in `references/shared/DOCS_SEARCH.md`.
+Scopes that call Wix APIs (`seed`, image phases) receive `siteId` in the prompt. Mint once: `TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")`. Every `curl` uses the headers in `references/shared/AUTHENTICATION.md`. Doc lookups use the public REST endpoints listed in `references/shared/DOCS_SEARCH.md`.
 
 If your scope is `components` or `pages`, you should NOT make REST calls — those scopes are frontend-only. If you find yourself needing a site API call, it's a scope violation — return `status: "partial"` with an error note, do not proceed.
 

--- a/plugins/wix/skills/wix-headless/references/shared/RETURN_CONTRACT.md
+++ b/plugins/wix/skills/wix-headless/references/shared/RETURN_CONTRACT.md
@@ -407,8 +407,8 @@ Agents should check their output for these before returning `complete`:
 
 | Failure | How to detect | Fix |
 |---------|---------------|-----|
-| `Legacy HTML single-line comments` | `npx @wix/cli build` stderr | See Astro/React row 1 above — Phase 2 agent emitted HTML comments |
-| `Missing environment variable WIX_CLIENT_ID` | Build stderr | Run `npx @wix/cli env pull` then retry |
+| `Legacy HTML single-line comments` | `npx @wix/cli@latest build` stderr | See Astro/React row 1 above — Phase 2 agent emitted HTML comments |
+| `Missing environment variable WIX_CLIENT_ID` | Build stderr | Run `npx @wix/cli@latest env pull` then retry |
 | `Cannot find module '@wix/…'` | Build stderr | npm install didn't include that package; check pack's `packages` list |
 
 ## Notes for agent authors

--- a/plugins/wix/skills/wix-headless/references/stores/PRODUCT_CATALOG_DATA.md
+++ b/plugins/wix/skills/wix-headless/references/stores/PRODUCT_CATALOG_DATA.md
@@ -17,7 +17,7 @@ Replace the default sample products Wix Stores installs with on-brand products v
 
 > **Conditional:** This section only applies when ALL of these are true:
 > - The Stores app was just installed (default sample products exist)
-> - CLI auth works (`npx @wix/cli token --site "$SITE_ID"` returns a token)
+> - CLI auth works (`npx @wix/cli@latest token --site "$SITE_ID"` returns a token)
 > - Discovery context is available in your prompt (business type, brand name, style)
 >
 > **If CLI auth is not available, skip this entire section.** The 12 default products remain and can be customized later in the Wix dashboard.

--- a/plugins/wix/skills/wix-headless/scripts/preview.sh
+++ b/plugins/wix/skills/wix-headless/scripts/preview.sh
@@ -6,7 +6,7 @@
 #
 # Run from the project directory (CWD = <project>/). Requires wix.config.json.
 #
-# Output: stdout is the preview URL that `npx @wix/cli preview` printed; the
+# Output: stdout is the preview URL that `npx @wix/cli@latest preview` printed; the
 # orchestrator captures it and records as outcome.previewUrl in run.json. All
 # other CLI output goes to stderr.
 #
@@ -23,14 +23,14 @@
 set -euo pipefail
 
 # Build first; surface compile errors verbatim if it fails.
-npx @wix/cli build 1>&2
+npx @wix/cli@latest build 1>&2
 
 # Preview captures the deployed URL on stdout. We tee its output to stderr for
 # the user-visible log AND parse the URL out for the orchestrator's stdout.
 PREVIEW_OUTPUT="$(mktemp)"
 trap 'rm -f "$PREVIEW_OUTPUT"' EXIT
 
-npx @wix/cli preview 2>&1 | tee "$PREVIEW_OUTPUT" 1>&2
+npx @wix/cli@latest preview 2>&1 | tee "$PREVIEW_OUTPUT" 1>&2
 
 # Wix CLI prints `Site preview URL: <url>` (or similar) — extract the first
 # https URL from the output. If multiple are printed, the first is the canonical

--- a/plugins/wix/skills/wix-headless/scripts/release.sh
+++ b/plugins/wix/skills/wix-headless/scripts/release.sh
@@ -9,7 +9,7 @@
 #
 # Run from the project directory (CWD = <project>/). Requires wix.config.json.
 #
-# Output: stdout is the released URL that `npx @wix/cli release` printed
+# Output: stdout is the released URL that `npx @wix/cli@latest release` printed
 # (extracted from the line `Site published on <url>`); the orchestrator
 # captures it as outcome.releaseUrl in run.json. All other CLI output goes
 # to stderr.
@@ -19,12 +19,12 @@
 #   <other> — build or release failed; stderr surfaces the underlying error.
 #             Build failures are code bugs (TypeScript / Astro / missing
 #             module) — the orchestrator does NOT retry. Release auth failures
-#             surface as `Run npx @wix/cli login and retry.`
+#             surface as `Run npx @wix/cli@latest login and retry.`
 #             Known transient release failures are retried by this script.
 
 set -euo pipefail
 
-npx @wix/cli build 1>&2
+npx @wix/cli@latest build 1>&2
 
 RELEASE_OUTPUT="$(mktemp)"
 trap 'rm -f "$RELEASE_OUTPUT"' EXIT
@@ -39,7 +39,7 @@ RELEASE_STATUS=1
 for ((attempt = 1; attempt <= MAX_RELEASE_ATTEMPTS; attempt++)); do
   : >"$RELEASE_OUTPUT"
   set +e
-  npx @wix/cli release 2>&1 | tee "$RELEASE_OUTPUT" 1>&2
+  npx @wix/cli@latest release 2>&1 | tee "$RELEASE_OUTPUT" 1>&2
   RELEASE_STATUS=${PIPESTATUS[0]}
   set -e
 

--- a/plugins/wix/skills/wix-headless/scripts/scaffold.sh
+++ b/plugins/wix/skills/wix-headless/scripts/scaffold.sh
@@ -48,9 +48,9 @@ fi
 # an active CLI session and otherwise fails mid-run with an opaque error.
 # `wix whoami` exits non-zero on a logged-out session and prints the
 # authenticated email + user id when logged in.
-if ! npx @wix/cli whoami >/dev/null 2>&1; then
+if ! npx @wix/cli@latest whoami >/dev/null 2>&1; then
   echo "scaffold.sh: not logged in to Wix CLI." >&2
-  echo "Run 'npx @wix/cli login' and retry." >&2
+  echo "Run 'npx @wix/cli@latest login' and retry." >&2
   exit 3
 fi
 

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -5,7 +5,7 @@ description: "Build a complete Wix Managed Headless site from a single prompt, O
 
 # Wix Headless
 
-**Discovery, setup, and seed** run from `DISCOVERY.md`, `SETUP.md`, `SEED.md`. **Design system through release** run from `ORCHESTRATION.md` and per-vertical references. All site operations use `npx @wix/cli token` + `curl` — no MCP.
+**Discovery, setup, and seed** run from `DISCOVERY.md`, `SETUP.md`, `SEED.md`. **Design system through release** run from `ORCHESTRATION.md` and per-vertical references. All site operations use `npx @wix/cli@latest token` + `curl` — no MCP.
 
 > **Explicit invocation only.** Do not auto-route on generic "build me a site" prompts; production `wix-headless` should win those unless the user names this skill.
 
@@ -41,7 +41,7 @@ Subagent invocations: Designer (Discovery Step 2.6) as `designer_handle` (bg, ab
 Every Wix API call uses `@wix/cli` + `curl`:
 
 ```
-Authorization: Bearer $(npx @wix/cli token --site "$SITE_ID")
+Authorization: Bearer $(npx @wix/cli@latest token --site "$SITE_ID")
 wix-site-id: $SITE_ID
 ```
 

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -11,21 +11,21 @@ Infer as much as possible from the user's opening message; ask only what's genui
 The first Wix touch in this phase is the background `scaffold.sh` dispatched after Q1 — `npm create @wix/new@latest headless` creates a business + project against the user's Wix account, so it requires an active CLI session. Without one, the scaffold fails in the background and the failure doesn't surface until SETUP.md Step 1 — **after** Q1, Q2, Q2.5, Q3, plan, and approval. That's a ~5-minute interview the user has to redo. Run the auth check foreground here so a logged-out user sees the login prompt before any `AskUserQuestion`.
 
 ```bash
-npx @wix/cli whoami >/dev/null 2>&1
+npx @wix/cli@latest whoami >/dev/null 2>&1
 ```
 
 - Exit 0 → continue to Step 0.
-- Exit non-zero → **run `npx @wix/cli login` yourself with `run_in_background: true`** (do NOT instruct the user to run it). The exact shape:
+- Exit non-zero → **run `npx @wix/cli@latest login` yourself with `run_in_background: true`** (do NOT instruct the user to run it). The exact shape:
 
   | Step | Action | Anti-pattern |
   |---|---|---|
-  | 1 | `Bash` tool, command = `npx @wix/cli login`, `run_in_background: true`. **No shell `&`, no `mktemp` redirect, no chaining.** | `TMPFILE=$(mktemp …) && npx @wix/cli login > "$TMPFILE" 2>&1 &` — stacks shell `&` on harness `run_in_background`, splits wix-login output from the harness task file. |
+  | 1 | `Bash` tool, command = `npx @wix/cli@latest login`, `run_in_background: true`. **No shell `&`, no `mktemp` redirect, no chaining.** | `TMPFILE=$(mktemp …) && npx @wix/cli@latest login > "$TMPFILE" 2>&1 &` — stacks shell `&` on harness `run_in_background`, splits wix-login output from the harness task file. |
   | 2 | The tool reply gives you the harness output-file path in `<bash-stdout>`. **`Read` that path** (or use `TaskOutput`). | Reading any other file. The harness path IS the right file. |
   | 3 | Parse line 1 of the file: `{"event":"awaiting_user","userCode":"…","verificationUri":"…"}`. (Node may emit a `TimeoutNaNWarning` on lines 3-5; ignore.) | Trying to re-invoke wix-login "to do it properly" after seeing the event. The event means it's working — surface and wait. |
   | 4 | Surface to user in one plain-prose message: *"Open `<verificationUri>` in your browser and enter the code `<userCode>` — I'll continue once you've completed the login."* | `AskUserQuestion`. The URL + code are text the user needs to copy, not a multiple-choice answer. |
   | 5 | Wait for the harness `task-notification` with `<status>completed</status>`. Run `whoami` once on completion to confirm. Then proceed to Step 0. | Polling `whoami` in a sleep loop while waiting. The notification is the only signal. |
 
-  Do **not** punt to the user with *"Run `npx @wix/cli login` and retry"* and stop — that breaks the flow (the harness backgrounds the user-issued command, you don't know which output file to read, and the user has to manually prompt you to read it; ~60 s + interrupt of recovery wall). Full reference: [`shared/AUTHENTICATION.md`](shared/AUTHENTICATION.md#wix-login-from-a-non-interactive-agent).
+  Do **not** punt to the user with *"Run `npx @wix/cli@latest login` and retry"* and stop — that breaks the flow (the harness backgrounds the user-issued command, you don't know which output file to read, and the user has to manually prompt you to read it; ~60 s + interrupt of recovery wall). Full reference: [`shared/AUTHENTICATION.md`](shared/AUTHENTICATION.md#wix-login-from-a-non-interactive-agent).
 
 ## Step 0 — Infer Vertical(s) and Business Context
 
@@ -147,10 +147,10 @@ Worked examples:
 
 ### 2.5.2 — Fetch the AI-credit balance
 
-`npx @wix/cli token` **without** `--site` mints an **account-scoped** token. With that token, the balance endpoint at `POST https://manage.wix.com/credit-transactions/v1/credit-transactions/get-account-balance` returns the current periodic credit balance + cap. Verified against the production endpoint on 2026-05-24.
+`npx @wix/cli@latest token` **without** `--site` mints an **account-scoped** token. With that token, the balance endpoint at `POST https://manage.wix.com/credit-transactions/v1/credit-transactions/get-account-balance` returns the current periodic credit balance + cap. Verified against the production endpoint on 2026-05-24.
 
 ```bash
-ACCOUNT_TOKEN=$(npx @wix/cli token)   # NO --site — mints account-scoped
+ACCOUNT_TOKEN=$(npx @wix/cli@latest token)   # NO --site — mints account-scoped
 curl -sS -X POST \
   -H "Authorization: Bearer $ACCOUNT_TOKEN" \
   -H "Content-Type: application/json" \
@@ -178,7 +178,7 @@ Hold `balance = response.periodicCredits.balance` and `cap = response.periodicCr
 3. **POST returns 4xx other than 401/403** — log the response in scratch (do not crash) and set `balance = null`. This includes the 400 you'd see if you accidentally GET the endpoint instead of POST: every prior revision of this section hit that and concluded the endpoint was broken. It isn't — it's POST-only.
 4. **Network error / timeout** — set `balance = null`. The credit estimate (§ 2.5.1) is unaffected; only the Q3 description's *"Current balance: …"* tail goes silent.
 
-> **Don't share the token across calls.** The account-scoped token is for account-level reads only (balance, account metadata). Every other site-operating call in this skill uses `npx @wix/cli token --site "$SITE_ID"` — site-scoped — per `references/shared/AUTHENTICATION.md`. Mix-ups have caused `403 SITE_TOKEN_REQUIRED` on Wix-site calls and `403 ACCOUNT_TOKEN_REQUIRED` on the balance call.
+> **Don't share the token across calls.** The account-scoped token is for account-level reads only (balance, account metadata). Every other site-operating call in this skill uses `npx @wix/cli@latest token --site "$SITE_ID"` — site-scoped — per `references/shared/AUTHENTICATION.md`. Mix-ups have caused `403 SITE_TOKEN_REQUIRED` on Wix-site calls and `403 ACCOUNT_TOKEN_REQUIRED` on the balance call.
 
 > **Historical note.** Earlier revisions of this section claimed the CLI did not expose an account-scoped token primitive, and the balance lookup was disabled unconditionally. Both claims were wrong — `wix token` without `--site` is exactly that primitive. The omission was paying ~1 informational line at Q3 plus losing visibility into whether the user had credits before opting into AI imagery.
 

--- a/skills/wix-headless/references/ORCHESTRATION.md
+++ b/skills/wix-headless/references/ORCHESTRATION.md
@@ -61,7 +61,7 @@ Scope: <scope string>
 Project directory (absolute path): <project path>
 site-root: <absolute path to eval run dir — parent of scaffold; .wix/site.json lives here>
 siteId: <from wix.config.json>
-Auth: <SKILL_ROOT>/references/shared/AUTHENTICATION.md — mint TOKEN once via npx @wix/cli token --site "$SITE_ID"; every curl uses Bearer + wix-site-id headers
+Auth: <SKILL_ROOT>/references/shared/AUTHENTICATION.md — mint TOKEN once via npx @wix/cli@latest token --site "$SITE_ID"; every curl uses Bearer + wix-site-id headers
 Brand context: name, vibe, aesthetic direction, colors, fonts, mood, page color strategy
 Design tokens: .wix/design-tokens.css (generated from site.json.designTokens)
 ```
@@ -193,7 +193,7 @@ Scope subagents MUST NOT:
 
 ## Wait: Phase 4 → Build
 
-> **HARD GATE: Do NOT run `npx @wix/cli build` until `image-phase-2-entity` has completed or timed out (120s) — ONLY when it was dispatched.** This gate applies only to runs where `intent.imagery === "ai-generated"` and Step 4.5 actually dispatched Image Phase 2. On the default `themed-blocks` run, Image Phase 2 was skipped at Step 4.5 and recorded as `{phase: "image-phase-2-entity", status: "skipped"}` in `run.json` — there is no handle to wait on; proceed to the build immediately when Phase 4 Pages return. **Skipping it on an ai-generated run has shipped previews with no product images and `run.json` recording `image-phase-2-entity` as `"in_progress"`, so do not collapse this gate.**
+> **HARD GATE: Do NOT run `npx @wix/cli@latest build` until `image-phase-2-entity` has completed or timed out (120s) — ONLY when it was dispatched.** This gate applies only to runs where `intent.imagery === "ai-generated"` and Step 4.5 actually dispatched Image Phase 2. On the default `themed-blocks` run, Image Phase 2 was skipped at Step 4.5 and recorded as `{phase: "image-phase-2-entity", status: "skipped"}` in `run.json` — there is no handle to wait on; proceed to the build immediately when Phase 4 Pages return. **Skipping it on an ai-generated run has shipped previews with no product images and `run.json` recording `image-phase-2-entity` as `"in_progress"`, so do not collapse this gate.**
 
 All Step 7 Phase 4 Pages subagents return. When Image Phase 2 was dispatched (ai-generated runs), it has been running through Phase 3 + Phase 4 in parallel — typically ~5–8 minutes by the time Phase 4 Pages finish, which is enough for it to be done or in its tail. When skipped (themed-blocks runs), no wait. All return JSON is in session context.
 
@@ -227,8 +227,8 @@ Record the rate-limit event in `run.json` `notes[]` regardless of recovery outco
 
 ## Build & Release
 
-1. `npx @wix/cli build` — if it fails, inspect `.wix/debug.log` for the specific error, fix, retry. Common failure modes are listed in `references/shared/RETURN_CONTRACT.md` § "Common failure modes".
-2. `npx @wix/cli release` — extract the published URL from the `Site published on <url>` line in stdout. This command also populates the **Frontend link** in headless settings natively, so transactional emails link to the deployed frontend without any extra API calls.
+1. `npx @wix/cli@latest build` — if it fails, inspect `.wix/debug.log` for the specific error, fix, retry. Common failure modes are listed in `references/shared/RETURN_CONTRACT.md` § "Common failure modes".
+2. `npx @wix/cli@latest release` — extract the published URL from the `Site published on <url>` line in stdout. This command also populates the **Frontend link** in headless settings natively, so transactional emails link to the deployed frontend without any extra API calls.
 
 ---
 

--- a/skills/wix-headless/references/SEED.md
+++ b/skills/wix-headless/references/SEED.md
@@ -127,13 +127,13 @@ Inputs (do not re-derive these):
 Steps:
 
 1. **Open with one concurrent batch** (single assistant message, multiple tool calls):
-   - One `Bash` to mint and capture the site-scoped REST token: `TOKEN=$(npx @wix/cli token --site "<siteId>")`. Cache the token in subagent scratch — every subsequent `curl` reuses it. (The token is stable for the duration of the run; do not re-mint per call.) Use `npx @wix/cli token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness.
+   - One `Bash` to mint and capture the site-scoped REST token: `TOKEN=$(npx @wix/cli@latest token --site "<siteId>")`. Cache the token in subagent scratch — every subsequent `curl` reuses it. (The token is stable for the duration of the run; do not re-mint per call.) Use `npx @wix/cli@latest token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness.
    - One `Read` per absolute recipe path you were given. If you have N recipe paths, issue N Reads as siblings — do not serialize them.
    No narration, no "Reading recipe and minting token:" preamble. Issue the batch.
 
 2. Fire the recipe's REST calls via `curl` against `wixapis.com`. Every call carries the headers documented in `<skill-root>/references/shared/AUTHENTICATION.md` — `Authorization: Bearer $TOKEN` (the token from Step 1), `wix-site-id: <siteId>`, and `Content-Type: application/json` — plus the recipe's documented body. Construct request bodies from intent.<pack> + brand. **When the recipe documents N independent calls** (e.g., creating N categories, adding products to N categories), issue them as one parallel batch — not sequentially.
 
-   **On 401/403**, re-mint the token with `npx @wix/cli token --site "<siteId>"` and retry once; if it still fails, return `status: "error"` with the response body. Do **not** spend turns debugging the auth call shape — if the retry fails, the issue is upstream (expired CLI session, missing app install, or a resource that requires a provisioning step the recipe didn't run), and recipe-level header A/B-testing will not recover it.
+   **On 401/403**, re-mint the token with `npx @wix/cli@latest token --site "<siteId>"` and retry once; if it still fails, return `status: "error"` with the response body. Do **not** spend turns debugging the auth call shape — if the retry fails, the issue is upstream (expired CLI session, missing app install, or a resource that requires a provisioning step the recipe didn't run), and recipe-level header A/B-testing will not recover it.
 
 3. Text-only seeding only — do not call media-manager import or generate AI imagery. Use the placeholder image patterns the recipes document.
 

--- a/skills/wix-headless/references/SETUP.md
+++ b/skills/wix-headless/references/SETUP.md
@@ -33,7 +33,7 @@ By the time the wait returns, `wix-manage` is in context — so the only foregro
 **Do not** speculatively `Read <project-slug>/wix.config.json` and fall back to a wait — the speculative read returns `File does not exist` on every fast-Q&A run (the file isn't there yet), emits a `[MED]` anomaly in the trace, and costs 3–5 s of round-trip + recovery thinking. Wait first; read second.
 
 Once the wait returns exit-0, read `<project-slug>/wix.config.json` and extract:
-- `siteId` — the site id passed as `--site` to `npx @wix/cli token` and embedded in every install body + as the `wix-site-id` header on every site-scoped REST call.
+- `siteId` — the site id passed as `--site` to `npx @wix/cli@latest token` and embedded in every install body + as the `wix-site-id` header on every site-scoped REST call.
 - `appId` — the project's appId, written into `.wix/site.json` for downstream phases.
 
 `cd` into `<project-slug>/` so all subsequent file ops + shell calls are relative to the project root.
@@ -42,7 +42,7 @@ Once the wait returns exit-0, read `<project-slug>/wix.config.json` and extract:
 
 **Before `cd`, capture the current working directory as `<site-root>` and hold it in session scratch.** This is where Discovery's `init-site-json.mjs` wrote `.wix/site.json` (`<site-root>/.wix/site.json`). Phase 3 Seed reads from and writes back to this same root — both for the patched `site.json` and for the per-pack `seed-returns/`. Mixing the eval-run dir with the scaffold subdir is a known cause of `merge-seed-results.mjs: site.json does not exist` failures.
 
-`cd` into `<project-slug>/` so subsequent shell calls (`npm`, `npx @wix/cli env pull`) are relative to the project root. **Use the captured `<site-root>` (an absolute path) for every subsequent `Read`/`Write`/`Bash` that touches `.wix/site.json` or `.wix/seed-returns/`** — do not rely on relative paths after the `cd`.
+`cd` into `<project-slug>/` so subsequent shell calls (`npm`, `npx @wix/cli@latest env pull`) are relative to the project root. **Use the captured `<site-root>` (an absolute path) for every subsequent `Read`/`Write`/`Bash` that touches `.wix/site.json` or `.wix/seed-returns/`** — do not rely on relative paths after the `cd`.
 
 ---
 
@@ -103,7 +103,7 @@ Mint the site-scoped REST token once and cache it for the rest of the run, then 
 
 ```bash
 SITE_ID="<siteId>"
-TOKEN=$(npx @wix/cli token --site "$SITE_ID")  # once; cache in scratch for the run
+TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")  # once; cache in scratch for the run
 
 # per-pack iteration; one curl per pack.apps[*]:
 curl -sS -X POST "https://www.wixapis.com/apps-installer-service/v1/app-instance/install" \
@@ -116,7 +116,7 @@ curl -sS -X POST "https://www.wixapis.com/apps-installer-service/v1/app-instance
   }'
 ```
 
-Use `npx @wix/cli token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness, and `npx` resolves to the project-local copy that scaffold just produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
+Use `npx @wix/cli@latest token …` (not bare `wix token …`): `@wix/cli` may not be globally installed in every harness, and `npx` resolves to the project-local copy that scaffold just produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
 
 A 200 response confirms the install. On 401/403, re-mint and retry once per the recovery ladder in `references/shared/AUTHENTICATION.md`; if it still fails, surface the response body — recovery beyond a single re-mint usually means the CLI session expired and `wix login` is required.
 
@@ -124,7 +124,7 @@ A 200 response confirms the install. On 401/403, re-mint and retry once per the 
 
 **Packs with `disabled: true` (today: `gift-cards`):** the pack still loads and contributes to the resolved set, but its `apps:` array is empty by design (the user opts in via the dashboard later). No curl. Same `skipped` phase entry as above.
 
-### 4b. `npx @wix/cli env pull`
+### 4b. `npx @wix/cli@latest env pull`
 
 Foreground shell, ~5 s. Writes `WIX_CLIENT_ID` to `.env.local`. Idempotent. Skipping this historically caused `Missing environment variable WIX_CLIENT_ID` build failures in downstream phases.
 
@@ -211,7 +211,7 @@ Before transitioning to SEED.md in Step 5:
 
 - `wix.config.json` was read and `siteId` + `appId` were extracted (not empty, not undefined).
 - `.wix/site.json` now contains both `siteId` and `appId` at the top level.
-- `npx @wix/cli token --site "$SITE_ID"` returned a non-empty token (cached in session scratch).
+- `npx @wix/cli@latest token --site "$SITE_ID"` returned a non-empty token (cached in session scratch).
 - Every loaded pack with non-empty `apps:` got a 200 OK from the install endpoint.
 - Every loaded pack with empty `apps:` got a `skipped` phase entry.
 - `.env.local` exists and contains `WIX_CLIENT_ID`.
@@ -234,7 +234,7 @@ Use this path when the user already has a working frontend on disk (Claude Desig
 | Seeders / Designer / Pages / ORCHESTRATION | Run | **Skipped** — there is no Astro structure to populate |
 | App installs | From inferred vertical packs | From a quick **project analysis** (see E2) — only apps the existing project actually needs |
 | SDK wiring into source | N/A (subagents write Astro + SDK calls from scratch) | **Required (E4)** — edit the project's existing source files in place |
-| Build / release | `npx @wix/cli build` + `release` via `release.sh` | `npx @wix/cli release` directly — **no build step**; existing `index.html` is published as-is |
+| Build / release | `npx @wix/cli@latest build` + `release` via `release.sh` | `npx @wix/cli@latest release` directly — **no build step**; existing `index.html` is published as-is |
 | Entry file | `src/pages/index.astro` (Astro convention) | **Must be `index.html`** at the configured `outputDirectory` |
 
 Run **only**: DISCOVERY.md pre-flight (CLI-auth check) → E1 → E2 → E3 → E4 → E5 → E6. Skip Steps 1–5 above entirely.
@@ -270,7 +270,7 @@ This creates a Wix Site + Headless Project (App) connected to that Site, and wri
 4. Capture `{ phase: "init", seconds, started, ended }` in `run.json.phases[]`.
 
 Recovery ladder:
-- Auth error → surface `"Run \`npx @wix/cli login\` and retry."` and stop (same as Path A; full ladder in `references/shared/AUTHENTICATION.md`).
+- Auth error → surface `"Run \`npx @wix/cli@latest login\` and retry."` and stop (same as Path A; full ladder in `references/shared/AUTHENTICATION.md`).
 - `wix.config.json` already exists → skip E1, continue to E2.
 - Network / unknown → surface stderr to the user.
 
@@ -319,12 +319,12 @@ Capture `{ phase: "sdk-wiring-<pack>", seconds }` per pack.
 
 ### Step E5 — Release (no build)
 
-**Do NOT run `release.sh`** in this flow — `release.sh` runs `npx @wix/cli build` first, and there is nothing to build. The existing project's `index.html` and its sibling assets already sit at the configured `site.outputDirectory`; Wix just needs to publish that directory as-is. Calling `build` here either no-ops (wastes ~5–15 s) or fails if the project has no Astro/Vite config the Wix CLI knows how to invoke.
+**Do NOT run `release.sh`** in this flow — `release.sh` runs `npx @wix/cli@latest build` first, and there is nothing to build. The existing project's `index.html` and its sibling assets already sit at the configured `site.outputDirectory`; Wix just needs to publish that directory as-is. Calling `build` here either no-ops (wastes ~5–15 s) or fails if the project has no Astro/Vite config the Wix CLI knows how to invoke.
 
 Run release directly:
 
 ```bash
-npx @wix/cli release
+npx @wix/cli@latest release
 ```
 
 Capture stdout. The CLI prints `Site published on <url>` on success — extract that URL (same parser logic as `release.sh` uses):
@@ -335,9 +335,9 @@ sed -nE 's/.*Site published on ([^[:space:]]+).*/\1/p'
 
 Capture `{ phase: "release", seconds }` around the call. No `{ phase: "build" }` entry in `run.json` for this flow.
 
-Auth-failure recovery: same as `release.sh` — if stderr mentions login, surface `"Run \`npx @wix/cli login\` and retry."` and stop. Transient errors (`ECONNRESET`, `temporarily unavailable`, etc.) — retry up to 3 times with `attempt * 5` second backoff, mirroring `release.sh`.
+Auth-failure recovery: same as `release.sh` — if stderr mentions login, surface `"Run \`npx @wix/cli@latest login\` and retry."` and stop. Transient errors (`ECONNRESET`, `temporarily unavailable`, etc.) — retry up to 3 times with `attempt * 5` second backoff, mirroring `release.sh`.
 
-> **If the project needs a client build** (Vite, React, Webpack, etc.), run the project's own build command manually (e.g. `npm run build`) before `npx @wix/cli release`, and make sure `site.outputDirectory` points at the build output. Do not use `wix build`.
+> **If the project needs a client build** (Vite, React, Webpack, etc.), run the project's own build command manually (e.g. `npm run build`) before `npx @wix/cli@latest release`, and make sure `site.outputDirectory` points at the build output. Do not use `wix build`.
 
 ### Step E6 — Final message
 

--- a/skills/wix-headless/references/cms/CMS_FOUNDATIONS.md
+++ b/skills/wix-headless/references/cms/CMS_FOUNDATIONS.md
@@ -367,6 +367,6 @@ Emit a structured JSON block at the end of your completion message per `../share
 1. Create a data collection in the Wix dashboard → CMS
 2. Add fields matching the use case schema (see the specific use case reference)
 3. Add at least 2–3 items with all fields populated, including `slug` and `published` (if applicable)
-4. Run `npx @wix/cli dev`
+4. Run `npx @wix/cli@latest dev`
 5. Navigate to the listing page — should show items
 6. Click an item — should navigate to the detail page

--- a/skills/wix-headless/references/cms/FAQ_KNOWLEDGE_BASE.md
+++ b/skills/wix-headless/references/cms/FAQ_KNOWLEDGE_BASE.md
@@ -224,7 +224,7 @@ Key details:
 
 1. Create a "FAQ" collection in the Wix dashboard → CMS with the schema above
 2. Add 6+ FAQ items across 2+ categories, all with `published: true`
-3. Run `npx @wix/cli dev`
+3. Run `npx @wix/cli@latest dev`
 4. `/faq` — shows all questions grouped by category
 5. Click a question — accordion opens with the answer
 6. Type in search — filters questions in real-time

--- a/skills/wix-headless/references/cms/PORTFOLIO.md
+++ b/skills/wix-headless/references/cms/PORTFOLIO.md
@@ -448,7 +448,7 @@ body: {
 1. Create a "Projects" collection in the Wix dashboard → CMS with the schema above
 2. Add 3+ projects with cover images, categories, and at least one with gallery images
 3. Mark 1–2 as `featured: true`
-4. Run `npx @wix/cli dev`
+4. Run `npx @wix/cli@latest dev`
 5. `/work` — grid with category filter tabs
 6. Click a category — filters projects
 7. Click a project — detail page with gallery lightbox

--- a/skills/wix-headless/references/cms/RESOURCE_LIBRARY.md
+++ b/skills/wix-headless/references/cms/RESOURCE_LIBRARY.md
@@ -350,7 +350,7 @@ body: {
 1. Create a "Resources" collection in the Wix dashboard → CMS with the schema above
 2. Add 4+ resources across 2+ categories with different file types (PDF, DOC, ZIP)
 3. Include `fileUrl` links (can be any downloadable URL for testing)
-4. Run `npx @wix/cli dev`
+4. Run `npx @wix/cli@latest dev`
 5. `/resources` — shows all resources with category filters and file type badges
 6. Click a category — filters resources
 7. Click a resource — detail page with download button and related resources

--- a/skills/wix-headless/references/cms/TEAM_DIRECTORY.md
+++ b/skills/wix-headless/references/cms/TEAM_DIRECTORY.md
@@ -294,6 +294,6 @@ body: {
 
 1. Create a "Team" collection in the Wix dashboard → CMS with the schema above
 2. Add 4+ members across 2+ departments, with photos and social links
-3. Run `npx @wix/cli dev`
+3. Run `npx @wix/cli@latest dev`
 4. `/team` — shows members grouped by department
 5. Click a member — profile page with photo, bio, and social links

--- a/skills/wix-headless/references/forms/CONTACT_FORM.md
+++ b/skills/wix-headless/references/forms/CONTACT_FORM.md
@@ -471,7 +471,7 @@ After form verification, write a sidecar file at `.wix/logs/forms-data.md` (form
 
 ## Testing
 
-1. Run `npx @wix/cli dev`
+1. Run `npx @wix/cli@latest dev`
 2. Navigate to `/contact`
 3. Fill in the form and submit
 4. Check the Wix dashboard → Forms → Submissions to verify the data arrived

--- a/skills/wix-headless/references/shared/AUTHENTICATION.md
+++ b/skills/wix-headless/references/shared/AUTHENTICATION.md
@@ -4,16 +4,16 @@ Every Wix API call this skill makes goes through `@wix/cli` + `curl` — no MCP,
 
 ## Prerequisites
 
-- `@wix/cli` resolvable via `npx`. The scaffold installs it project-local, so `npx @wix/cli …` works without a global install.
-- An authenticated CLI session. Test with `npx @wix/cli whoami` — exits **0** when logged in (prints the authenticated email + user id), **non-zero** when logged out.
+- `@wix/cli` resolvable via `npx`. The scaffold installs it project-local, so `npx @wix/cli@latest …` works without a global install.
+- An authenticated CLI session. Test with `npx @wix/cli@latest whoami` — exits **0** when logged in (prints the authenticated email + user id), **non-zero** when logged out.
 
-The primary place this check runs is DISCOVERY.md § "Pre-flight" — foreground, before any `AskUserQuestion`. `scaffold.sh` repeats the check defensively for its standalone-invocation path. **If the check fails, run `npx @wix/cli login` yourself with `run_in_background: true`** per the next section — do not tell the user "run wix login and retry" and stop. Punting to the user breaks the flow: the harness backgrounds the user-issued command, the agent doesn't know which output file to read, and you end up paying ~60 s + a manual user interrupt to recover.
+The primary place this check runs is DISCOVERY.md § "Pre-flight" — foreground, before any `AskUserQuestion`. `scaffold.sh` repeats the check defensively for its standalone-invocation path. **If the check fails, run `npx @wix/cli@latest login` yourself with `run_in_background: true`** per the next section — do not tell the user "run wix login and retry" and stop. Punting to the user breaks the flow: the harness backgrounds the user-issued command, the agent doesn't know which output file to read, and you end up paying ~60 s + a manual user interrupt to recover.
 
 The "stop and tell the user" path is a **last-resort fallback** for when the background-run mechanism itself is broken (e.g. the harness rejects `run_in_background: true`, or the task output file never gets created). Try the agent-driven flow first.
 
 ## `wix login` from a non-interactive agent
 
-`wix login` (or `npx @wix/cli login`) emits one JSON event per line on **stdout** and blocks until the human finishes the browser step. The first event you care about is `awaiting_user`:
+`wix login` (or `npx @wix/cli@latest login`) emits one JSON event per line on **stdout** and blocks until the human finishes the browser step. The first event you care about is `awaiting_user`:
 
 ```json
 {"event":"awaiting_user","expiresInSeconds":600,"userCode":"TPV5HUG5","verificationUri":"https://users.wix.com/login/device-login?color=developer&studio=true"}
@@ -26,7 +26,7 @@ The "stop and tell the user" path is a **last-resort fallback** for when the bac
 The Bash command is just the CLI invocation, **nothing else**:
 
 ```bash
-npx @wix/cli login
+npx @wix/cli@latest login
 ```
 
 Pass `run_in_background: true` on the Bash tool call. **Do not** add shell `&`, **do not** redirect to your own `mktemp` file, **do not** chain with `echo`/`sleep`. The harness wraps the process for you and writes stdout+stderr to its own task output file at `/tmp/claude-<uid>/<project>/tasks/<task-id>.output`. The tool's `<bash-stdout>` reply gives you that path verbatim — that's the file you read. Stacking shell `&` on top of `run_in_background` creates two layers of backgrounding: the harness captures only the parent shell's `pid:` / `file:` echoes while wix-login's actual JSON events write somewhere else.
@@ -52,11 +52,11 @@ On `<status>completed</status>` with exit 0, run `whoami` once to confirm and pr
 
 ```bash
 SITE_ID="<siteId>"  # from wix.config.json after scaffold
-TOKEN=$(npx @wix/cli token --site "$SITE_ID")
+TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")
 ```
 
 - Mints a **site-scoped REST token**. Stable for the duration of a run — cache it in session scratch and reuse on every `curl`. Do not re-mint per call (each mint costs ~3–5 s of CLI startup).
-- Use `npx @wix/cli token …` rather than bare `wix token …`. `@wix/cli` may not be globally installed in every harness; `npx` resolves the project-local copy the scaffold produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
+- Use `npx @wix/cli@latest token …` rather than bare `wix token …`. `@wix/cli` may not be globally installed in every harness; `npx` resolves the project-local copy the scaffold produced. The first invocation auto-fetches the CLI (~3–5 s) if missing; subsequent calls are instant.
 - The first `--site "$SITE_ID"` invocation in a run is the source of truth for `SITE_ID`. Bind it in session scratch; do not re-derive from `wix.config.json` mid-run.
 
 ## REST call shape
@@ -81,7 +81,7 @@ The body is the recipe's documented JSON payload, with `siteId` inlined where th
 
 | Symptom | First response | If it still fails |
 |---|---|---|
-| `401 Unauthorized` | Re-mint with `npx @wix/cli token --site "$SITE_ID"` and retry the call once. | The CLI session expired — run `wix login` per the stderr-scrape flow above. |
+| `401 Unauthorized` | Re-mint with `npx @wix/cli@latest token --site "$SITE_ID"` and retry the call once. | The CLI session expired — run `wix login` per the stderr-scrape flow above. |
 | `403 Forbidden` | Re-mint and retry once. | The token shape is fine but the caller lacks the permission. The two real causes: (a) the relevant app is not installed yet (re-check `apps-installer-service` returned 200 for that app in Setup Step 4a), (b) the resource requires a provisioning step the recipe doesn't run. Surface the response body; do not loop on retries. |
 | `404 Not Found` on a documented URL | Re-read the recipe — URL path segments are easy to typo (e.g. `/blog/v3/bulk/draft-posts/create`, **not** `/blog/v3/draft-posts/bulk/create`). | Recipe bug; surface and stop. |
 
@@ -89,16 +89,16 @@ The body is the recipe's documented JSON payload, with `siteId` inlined where th
 
 ## Account-scoped calls
 
-`npx @wix/cli token` (no flags) mints an **account-scoped** token. `npx @wix/cli token --site "$SITE_ID"` mints a **site-scoped** token. The CLI's `--site` flag is what toggles between the two scopes; there is no separate `--account` flag because omitting `--site` is itself the account-scoped form.
+`npx @wix/cli@latest token` (no flags) mints an **account-scoped** token. `npx @wix/cli@latest token --site "$SITE_ID"` mints a **site-scoped** token. The CLI's `--site` flag is what toggles between the two scopes; there is no separate `--account` flag because omitting `--site` is itself the account-scoped form.
 
 Verified against the production endpoint on 2026-05-24 — the account-scoped token authenticates against `manage.wix.com` endpoints (e.g. `POST /credit-transactions/v1/credit-transactions/get-account-balance`).
 
 ```bash
 # Account-scoped — for /credit-transactions, /accounts, /subscriptions, etc.
-ACCOUNT_TOKEN=$(npx @wix/cli token)
+ACCOUNT_TOKEN=$(npx @wix/cli@latest token)
 
 # Site-scoped — for everything site-operating (apps install, products, blog, cms, …)
-SITE_TOKEN=$(npx @wix/cli token --site "$SITE_ID")
+SITE_TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")
 ```
 
 **Do not share tokens across scopes.** Site-operating calls (`wixapis.com/stores/v3/...`, `/blog/v3/...`, `/wix-data/v2/...`) need the **site** token + `wix-site-id` header; using the account token returns `403 SITE_TOKEN_REQUIRED`. Account-level calls (`manage.wix.com/credit-transactions/...`, `/subscriptions/...`) need the **account** token alone — no `wix-site-id` header; using the site token returns `403 ACCOUNT_TOKEN_REQUIRED`.

--- a/skills/wix-headless/references/shared/BUILD_NOISE.md
+++ b/skills/wix-headless/references/shared/BUILD_NOISE.md
@@ -1,6 +1,6 @@
 # Build-output noise — known false positives
 
-Read this only if `npx @wix/cli build` surfaces warnings or errors and you're trying to decide whether they're real. A clean build emits a few warnings that are NOT real failures:
+Read this only if `npx @wix/cli@latest build` surfaces warnings or errors and you're trying to decide whether they're real. A clean build emits a few warnings that are NOT real failures:
 
 - **`Astro.request.headers used on prerendered page`** — emitted by the `@wix/astro` integration's middleware on every prerendered route. Internal to the integration, not from skill-emitted code. Ignore.
 - **`Failed to resolve dependency: @wix/stores, present in client 'optimizeDeps.include'`** — Vite warning. The integration speculatively lists `@wix/stores` in `optimizeDeps` regardless of whether the project depends on it. Harmless.

--- a/skills/wix-headless/references/shared/DOCS_SEARCH.md
+++ b/skills/wix-headless/references/shared/DOCS_SEARCH.md
@@ -1,6 +1,6 @@
 # Wix documentation lookups
 
-Operational calls in this skill use `npx @wix/cli token --site "$SITE_ID"` + `curl` against `wixapis.com` (see `AUTHENTICATION.md`). When a bundled recipe falls short and you need to look up an endpoint, method schema, or article body, use the public unauthenticated REST endpoints below. **No MCP, no SDK** — these are plain `curl` calls.
+Operational calls in this skill use `npx @wix/cli@latest token --site "$SITE_ID"` + `curl` against `wixapis.com` (see `AUTHENTICATION.md`). When a bundled recipe falls short and you need to look up an endpoint, method schema, or article body, use the public unauthenticated REST endpoints below. **No MCP, no SDK** — these are plain `curl` calls.
 
 ## Doc search
 

--- a/skills/wix-headless/references/shared/IMPLEMENTER.md
+++ b/skills/wix-headless/references/shared/IMPLEMENTER.md
@@ -26,7 +26,7 @@ Standard scope names (see architecture-proposal §3):
 
 ## REST auth
 
-Scopes that call Wix APIs (`seed`, image phases) receive `siteId` in the prompt. Mint once: `TOKEN=$(npx @wix/cli token --site "$SITE_ID")`. Every `curl` uses the headers in `references/shared/AUTHENTICATION.md`. Doc lookups use the public REST endpoints listed in `references/shared/DOCS_SEARCH.md`.
+Scopes that call Wix APIs (`seed`, image phases) receive `siteId` in the prompt. Mint once: `TOKEN=$(npx @wix/cli@latest token --site "$SITE_ID")`. Every `curl` uses the headers in `references/shared/AUTHENTICATION.md`. Doc lookups use the public REST endpoints listed in `references/shared/DOCS_SEARCH.md`.
 
 If your scope is `components` or `pages`, you should NOT make REST calls — those scopes are frontend-only. If you find yourself needing a site API call, it's a scope violation — return `status: "partial"` with an error note, do not proceed.
 

--- a/skills/wix-headless/references/shared/RETURN_CONTRACT.md
+++ b/skills/wix-headless/references/shared/RETURN_CONTRACT.md
@@ -407,8 +407,8 @@ Agents should check their output for these before returning `complete`:
 
 | Failure | How to detect | Fix |
 |---------|---------------|-----|
-| `Legacy HTML single-line comments` | `npx @wix/cli build` stderr | See Astro/React row 1 above — Phase 2 agent emitted HTML comments |
-| `Missing environment variable WIX_CLIENT_ID` | Build stderr | Run `npx @wix/cli env pull` then retry |
+| `Legacy HTML single-line comments` | `npx @wix/cli@latest build` stderr | See Astro/React row 1 above — Phase 2 agent emitted HTML comments |
+| `Missing environment variable WIX_CLIENT_ID` | Build stderr | Run `npx @wix/cli@latest env pull` then retry |
 | `Cannot find module '@wix/…'` | Build stderr | npm install didn't include that package; check pack's `packages` list |
 
 ## Notes for agent authors

--- a/skills/wix-headless/references/stores/PRODUCT_CATALOG_DATA.md
+++ b/skills/wix-headless/references/stores/PRODUCT_CATALOG_DATA.md
@@ -17,7 +17,7 @@ Replace the default sample products Wix Stores installs with on-brand products v
 
 > **Conditional:** This section only applies when ALL of these are true:
 > - The Stores app was just installed (default sample products exist)
-> - CLI auth works (`npx @wix/cli token --site "$SITE_ID"` returns a token)
+> - CLI auth works (`npx @wix/cli@latest token --site "$SITE_ID"` returns a token)
 > - Discovery context is available in your prompt (business type, brand name, style)
 >
 > **If CLI auth is not available, skip this entire section.** The 12 default products remain and can be customized later in the Wix dashboard.

--- a/skills/wix-headless/scripts/preview.sh
+++ b/skills/wix-headless/scripts/preview.sh
@@ -6,7 +6,7 @@
 #
 # Run from the project directory (CWD = <project>/). Requires wix.config.json.
 #
-# Output: stdout is the preview URL that `npx @wix/cli preview` printed; the
+# Output: stdout is the preview URL that `npx @wix/cli@latest preview` printed; the
 # orchestrator captures it and records as outcome.previewUrl in run.json. All
 # other CLI output goes to stderr.
 #
@@ -23,14 +23,14 @@
 set -euo pipefail
 
 # Build first; surface compile errors verbatim if it fails.
-npx @wix/cli build 1>&2
+npx @wix/cli@latest build 1>&2
 
 # Preview captures the deployed URL on stdout. We tee its output to stderr for
 # the user-visible log AND parse the URL out for the orchestrator's stdout.
 PREVIEW_OUTPUT="$(mktemp)"
 trap 'rm -f "$PREVIEW_OUTPUT"' EXIT
 
-npx @wix/cli preview 2>&1 | tee "$PREVIEW_OUTPUT" 1>&2
+npx @wix/cli@latest preview 2>&1 | tee "$PREVIEW_OUTPUT" 1>&2
 
 # Wix CLI prints `Site preview URL: <url>` (or similar) — extract the first
 # https URL from the output. If multiple are printed, the first is the canonical

--- a/skills/wix-headless/scripts/release.sh
+++ b/skills/wix-headless/scripts/release.sh
@@ -9,7 +9,7 @@
 #
 # Run from the project directory (CWD = <project>/). Requires wix.config.json.
 #
-# Output: stdout is the released URL that `npx @wix/cli release` printed
+# Output: stdout is the released URL that `npx @wix/cli@latest release` printed
 # (extracted from the line `Site published on <url>`); the orchestrator
 # captures it as outcome.releaseUrl in run.json. All other CLI output goes
 # to stderr.
@@ -19,12 +19,12 @@
 #   <other> — build or release failed; stderr surfaces the underlying error.
 #             Build failures are code bugs (TypeScript / Astro / missing
 #             module) — the orchestrator does NOT retry. Release auth failures
-#             surface as `Run npx @wix/cli login and retry.`
+#             surface as `Run npx @wix/cli@latest login and retry.`
 #             Known transient release failures are retried by this script.
 
 set -euo pipefail
 
-npx @wix/cli build 1>&2
+npx @wix/cli@latest build 1>&2
 
 RELEASE_OUTPUT="$(mktemp)"
 trap 'rm -f "$RELEASE_OUTPUT"' EXIT
@@ -39,7 +39,7 @@ RELEASE_STATUS=1
 for ((attempt = 1; attempt <= MAX_RELEASE_ATTEMPTS; attempt++)); do
   : >"$RELEASE_OUTPUT"
   set +e
-  npx @wix/cli release 2>&1 | tee "$RELEASE_OUTPUT" 1>&2
+  npx @wix/cli@latest release 2>&1 | tee "$RELEASE_OUTPUT" 1>&2
   RELEASE_STATUS=${PIPESTATUS[0]}
   set -e
 

--- a/skills/wix-headless/scripts/scaffold.sh
+++ b/skills/wix-headless/scripts/scaffold.sh
@@ -48,9 +48,9 @@ fi
 # an active CLI session and otherwise fails mid-run with an opaque error.
 # `wix whoami` exits non-zero on a logged-out session and prints the
 # authenticated email + user id when logged in.
-if ! npx @wix/cli whoami >/dev/null 2>&1; then
+if ! npx @wix/cli@latest whoami >/dev/null 2>&1; then
   echo "scaffold.sh: not logged in to Wix CLI." >&2
-  echo "Run 'npx @wix/cli login' and retry." >&2
+  echo "Run 'npx @wix/cli@latest login' and retry." >&2
   exit 3
 fi
 


### PR DESCRIPTION
## What

Every Wix CLI invocation in the **wix-headless** skill called `npx @wix/cli <subcommand>` with **no version specifier** — so npx resolved to whatever `@wix/cli` happened to be cached/installed locally, which can drift to a stale version.

This pins all ~59 invocations to `npx @wix/cli@latest`, so commands always run the latest CLI. This matches the existing scaffold pattern (`npm create @wix/new@latest …`).

## Changes

- Replaced `npx @wix/cli` → `npx @wix/cli@latest` across all 20 files in `skills/wix-headless/` (3 shell scripts + 17 reference docs), covering executable commands, code blocks, tables, and prose mentions for consistency.
- Regenerated the auto-synced `plugins/wix/` mirror via `.github/scripts/sync-plugin-mirror.mjs` (not hand-edited).
- Left the unrelated `npm create @wix/new@latest …` scaffold/init commands untouched.

## Verification

- ✅ No bare `npx @wix/cli` invocations remain (root or mirror)
- ✅ `diff -r` shows root and mirror are byte-identical
- ✅ `bash -n` passes on all three shell scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)