### PR TITLE
feat(wix-headless): expand allowed tools for skill execution

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: wix-headless
 description: "Build a complete Wix Managed Headless site from a single prompt, OR connect an existing project (HTML/JSX/Vite app, Claude Design output, etc.) to Wix Headless for hosting + Business Solutions. Entry point for both: (1) new-site requests — runs discovery, design, feature wiring, and preview; and (2) existing-project requests — runs `npm create @wix/new@latest init`, analyzes the project for needed Business Solutions, installs apps, **wires the Wix SDK into the existing source files so each installed app actually powers its corresponding feature**, and releases. Triggers: build me a site, create a website, make me a website, new website, online store, I want to sell X, start a business online, launch a site, ecommerce, portfolio, business website, sell online, online shop, connect this to Wix Headless, add Wix Headless to this project, host this on Wix, deploy this to Wix, implement the features of this project using Wix Headless. Use this skill instead of the WixSiteBuilder MCP tool for new-site requests."
+allowed-tools:
+  - Bash(cd *)
+  - Bash(npx @wix/cli@latest *)
+  - Bash(npx @wix/cli *)
+  - Bash(npm create @wix/new@latest *)
+  - Bash(npm install *)
+  - Bash(npm run *)
+  - Bash(node *)
+  - Bash(bash *)
+  - Bash(curl *)
+  - Read
+  - Write
+  - Edit
+  - Skill
 ---
 
 # Wix Headless

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -11,10 +11,19 @@ allowed-tools:
   - Bash(node *)
   - Bash(bash *)
   - Bash(curl *)
+  - Bash(ls *)
+  - Bash(grep *)
+  - Bash(find *)
+  - Bash(cat *)
+  - Bash(head *)
+  - Bash(wc *)
+  - Bash(mkdir *)
+  - Bash(cp *)
   - Read
   - Write
   - Edit
   - Skill
+  - Agent
 ---
 
 # Wix Headless


### PR DESCRIPTION
## Summary

Adds an `allowed-tools` allowlist to the `wix-headless` skill's `SKILL.md` frontmatter so the commands the skill relies on run without triggering permission prompts.

Allowlisted tools:
- `Bash(npx @wix/cli@latest *)`, `Bash(npx @wix/cli *)`
- `Bash(npm create @wix/new@latest *)`, `Bash(npm install *)`, `Bash(npm run *)`
- `Bash(node *)`, `Bash(bash *)`, `Bash(curl *)`, `Bash(cd *)` 
- `Read`, `Write`, `Edit`, `Skill`
