### PR TITLE
fix(mcp): keep Gemini on npx bridge (native HTTP OAuth fails)

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,7 +4,8 @@
   "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
   "mcpServers": {
     "wix-mcp": {
-      "httpUrl": "https://mcp.wix.com/mcp"
+      "command": "npx",
+      "args": ["-y", "@wix/mcp-remote@latest", "https://mcp.wix.com/mcp"]
     }
   }
 }


### PR DESCRIPTION
Follow-up to #317.

## Problem

After #317 switched Gemini to a native remote HTTP server (`httpUrl`), Gemini CLI fails to authenticate:

```
✕ Failed to authenticate with MCP server 'wix-mcp':
  Protected resource https://mcp.wix.com does not match expected https://mcp.wix.com/mcp
```

This is a **known Gemini CLI OAuth bug** ([google-gemini/gemini-cli#20017](https://github.com/google-gemini/gemini-cli/issues/20017), [#24484](https://github.com/google-gemini/gemini-cli/issues/24484)): its RFC 9728 resource validation is too strict. The Wix MCP server is served at `/mcp` but advertises the **root** resource `https://mcp.wix.com` in its `.well-known/oauth-protected-resource` — which legitimately covers `/mcp` — yet Gemini demands an exact match and rejects auth.

## Fix

Revert **only** `gemini-extension.json` to the `npx @wix/mcp-remote` bridge, which runs the OAuth flow itself and sidesteps Gemini's discovery validation. Gemini runs locally (npm isn't blocked there), so the bridge works fine.

`.mcp.json` / `plugins/wix/.mcp.json` (Claude / Cursor / Codex) **stay on native HTTP** — only Cowork/Claude needed that change, and it's the whole point of #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)