### PR TITLE
fix(wix-app): prevent codegen TS errors from wrong imports and deprec…

### DIFF
--- a/skills/wix-app/references/dashboard-page/DASHBOARD_API.md
+++ b/skills/wix-app/references/dashboard-page/DASHBOARD_API.md
@@ -2,6 +2,17 @@
 
 Complete reference for the `@wix/dashboard` host module.
 
+## Package
+
+The dashboard host module is provided by **`@wix/dashboard`** — ensure it is in your dependencies.
+
+Import pattern:
+```typescript
+import { dashboard } from '@wix/dashboard';
+```
+
+> ⚠️ **`@wix/dashboard-sdk` is deprecated and must NOT be used.** It has a different API (flat named exports, no `dashboard` namespace object) and is no longer maintained. Always import from `@wix/dashboard`.
+
 ## navigate()
 
 Host Module '@wix/dashboard' 'navigate()' method for navigating between dashboard pages.

--- a/skills/wix-app/references/data-collection/WIX_DATA.md
+++ b/skills/wix-app/references/data-collection/WIX_DATA.md
@@ -52,6 +52,8 @@ If you see any method with `DataItem` in the name, it is **wrong**.
 
 ### WixDataItem
 
+> **Not importable.** `WixDataItem` is not exported from `@wix/data` — `import type { WixDataItem } from "@wix/data"` will fail. Define your own interface based on the shape below.
+
 ```ts
 interface WixDataItem {
   _id: string;


### PR DESCRIPTION
…ated package

- WIX_DATA.md: add "Not importable" warning to WixDataItem section so agents don't attempt `import type { WixDataItem } from '@wix/data'` (fails TS2305)
- DASHBOARD_API.md: add Package section noting @wix/dashboard is the correct import and @wix/dashboard-sdk is deprecated with incompatible flat exports
- DASHBOARD_PAGE.md: remove Common Mistakes section (covered by DASHBOARD_API.md)
- Sync all changes to plugins/wix mirror