### PR TITLE
T0: covered .md change triggers gate + eval (new yaml/ path)

### DIFF
--- a/skills/wix-manage/references/domains/domain-search-and-purchase.md
+++ b/skills/wix-manage/references/domains/domain-search-and-purchase.md
@@ -13,7 +13,7 @@ Use this recipe when a user wants to:
 
 ## How Purchase Works
 
-You help the user find an available domain, then collect registration details (cycle, privacy protection, contact info) directly in the chat. Once collected, you save the contact info, create a cart with the domain + addons, and provide a checkout link where the user only needs to complete payment.
+You help the user find an available domain, then collect registration details (registration cycle, privacy protection, contact info) directly in the chat. Once collected, you save the contact info, create a cart with the domain + addons, and provide a checkout link where the user only needs to complete payment.
 
 **UX guidelines**: Keep the conversation natural. Do NOT expose internal implementation details to the user (e.g. don't say "I'm canceling the old cart", "saving to intent API", "adding line items"). Just tell them what matters: "Setting up your order..." then show the summary and checkout link.
 


### PR DESCRIPTION
## T0: covered .md change

Trivial rephrase in `skills/wix-manage/references/domains/domain-search-and-purchase.md`.

## Expected gate behavior

- Coverage step finds scenario `domains/domain-search-and-purchase` at `yaml/wix-manage-evals/domains/domain-search-and-purchase.yml` (new path).
- No Missing Coverage failure.
- Eval runs against EvalForge.
- Results posted as PR comment (pass expected).

Test against `task/eval-gate-baseline`. Do not merge — close after verification.