### PR TITLE
fix: align wix-headless with folder-name CLI flow

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -147,7 +147,7 @@ The skill runs two semi-independent tracks (business = frontend-blind site/app/s
 
 | Scenario | Use instead |
 |---|---|
-| Scaffold-only with no further design/wiring | `bash <SKILL_ROOT>/scripts/scaffold.sh <slug> "<Brand>"` |
+| Scaffold-only with no further design/wiring | `bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand>"` |
 | Release an existing wix-headless project | from the project dir: `npx @wix/cli@latest build` then `release` (astro); `release` only (custom — no build) |
 | Install a Wix app onto an existing site | Follow `<SKILL_ROOT>/references/commands/install-app.md` |
 | Add a feature / restyle a prior wix-headless run | Resume on disk; ask whether to start fresh |

--- a/skills/wix-headless/references/BUILD-astro.md
+++ b/skills/wix-headless/references/BUILD-astro.md
@@ -28,7 +28,7 @@ The user just approved; `init-site-json.mjs` wrote the slim `.wix/site.json`. **
 ### 0. Dispatch scaffold + Designer (background, immediately on entry)
 
 Fire both as one concurrent batch (`PLAN.md` § "Batching discipline") — they are independent:
-- **Scaffold** — `scaffold.sh <slug> "<brand>" --frontend <value>` (background, capture `scaffold_handle` + its stderr tempfile). Slug derivation + the command shape are `DISCOVERY-create.md` § "After Q1". `npm install` is **not** chained here (Setup Step 4c dispatches it). The stderr tempfile is for **post-hoc error inspection only** (read it *if* the scaffold reports a failure) — it is **not** a progress file to poll.
+- **Scaffold** — `scaffold.sh <folder-name> "<brand>" --frontend <value>` (background, capture `scaffold_handle` + its stderr tempfile). Folder-name derivation + the command shape are `DISCOVERY-create.md` § "After Q1". `npm install` is **not** chained here (Setup Step 4c dispatches it). The stderr tempfile is for **post-hoc error inspection only** (read it *if* the scaffold reports a failure) — it is **not** a progress file to poll.
 - **Designer** — background, capture `designer_handle`. Dispatch with **Instruction file = `<SKILL_ROOT>/references/DESIGN_SYSTEM.md`** (the subagent opens it — **do not Read it in the orchestrator**, per `SKILL.md` § "Path resolution"). Inline Discovery's aesthetic craft held in scratch: brand, aesthetic direction, palette, type, mood, page color strategy. Judgment-only (~10–15 s; JSON `data.designTokens` + `data.shell`, no files). Do **not** pass application inputs (packs, nav links) — those go to the Composer.
 
 The Designer's ~13 s overlaps the scaffold's ~23 s. Setup waits on `scaffold_handle` at Step 1; the bridge (step 2) waits on `designer_handle`.

--- a/skills/wix-headless/references/BUILD.md
+++ b/skills/wix-headless/references/BUILD.md
@@ -30,7 +30,7 @@ Almost everything in Build is a 1-D framework switch (install/build/release, bel
 
 | | `create` | `connect` | `extend` *(later)* |
 |---|---|---|---|
-| **astro** (`wix`) | `scaffold.sh <slug> "<brand>" --frontend astro` → `npm create @wix/new@latest headless` — `BUILD-astro.md` run-step 0 | — | add `.astro` + nav/home markers *(extend plan)* |
+| **astro** (`wix`) | `scaffold.sh <folder-name> "<brand>" --frontend astro` → `npm create @wix/new@latest headless` — `BUILD-astro.md` run-step 0 | — | add `.astro` + nav/home markers *(extend plan)* |
 | **own-build** (`own`) | create vite/… → `init` — **reserved**, the framework-SPA plan | `init` over brought source — **reserved** | add to source *(extend plan)* |
 | **none / html** (`none`) | — | `npm create @wix/new@latest init` over the brought HTML + fix `wix.config.json.site.outputDirectory` — `BUILD-own-build.md` § "Bootstrap cell" | — |
 

--- a/skills/wix-headless/references/DISCOVERY-create.md
+++ b/skills/wix-headless/references/DISCOVERY-create.md
@@ -41,7 +41,7 @@ If the user already named the brand in the opening message, skip this step.
 
 ### After Q1 — read the loaded pack files; scaffold inputs
 
-Once the brand is confirmed, read the loaded pack contents (to compose the plan) and prepare the scaffold inputs (slug + frontend value) for later. **The scaffold is NOT dispatched during Discovery** — it is dispatched post-approval (`BUILD-astro.md` run-step 0), so the funnel can present the plan without waiting on anything. This section defines only the slug derivation + the `scaffold.sh` command shape.
+Once the brand is confirmed, read the loaded pack contents (to compose the plan) and prepare the scaffold inputs (folder name + frontend value) for later. **The scaffold is NOT dispatched during Discovery** — it is dispatched post-approval (`BUILD-astro.md` run-step 0), so the funnel can present the plan without waiting on anything. This section defines only the folder-name derivation + the `scaffold.sh` command shape.
 
 **(a) Read every pack in the resolved set.** The full resolved set lives in SKILL.md § "When this skill triggers" (third column). For example, a `stores` run reads four files: `stores.md`, `cms.md`, `ecom.md`, `gift-cards.md`. Read the whole resolved set at once — do **not** read the top-level pack alone, then discover its `requires:` and issue a second batch.
 
@@ -52,25 +52,25 @@ These reads pre-load the `routes:`, `apps:`, `requires:`, and `disabled` fields 
 **(b) The scaffold inputs.** The scaffolder is invoked as:
 
 ```bash
-bash <SKILL_ROOT>/scripts/scaffold.sh <slug> "<brand>" --frontend <frontend> 2> <tempfile>
+bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<brand>" --frontend <frontend> 2> <tempfile>
 ```
 
 `<frontend>` is `astro` — the only scaffolded frontend. The scaffold step is reached only on the create/astro path; a connect run never gets here, because Wave 0 routes it to connect discovery (`DISCOVERY-connect.md`), which bootstraps via `npm create @wix/new@latest init` instead of `scaffold.sh`. If an existing/brought-in site is detected, Wave 0 already set `operation = "connect"` (`frontend = "custom"`) — this step does not run.
 
-**Slug derivation:** lowercase the brand, then **STRIP every character not matching `[a-z0-9]` — do NOT replace them with hyphens or underscores**. Truncate to 20 chars. The `scaffold.sh` pre-flight enforces `^[a-z0-9]{3,20}$` and rejects anything else with exit 2; a rejected slug forces a re-run of the ~30 s scaffold (the indie-bookshop-class regression).
+**Folder-name derivation:** the folder name only controls the local project directory — the Wix project display name and URL slug are derived by the CLI from `business-name` (the brand). Derive the folder name from the brand: (1) lowercase, (2) convert whitespace / punctuation runs to `-`, (3) remove every char that isn't `[a-z0-9-]`, (4) trim leading / trailing hyphens and collapse repeated hyphens. If the result is empty, ask the user explicitly for a folder name (`AskUserQuestion`). The `scaffold.sh` pre-flight enforces `^[a-z0-9][a-z0-9-]*$` (and the value must also pass npm package-name validation), rejecting anything else with exit 2; a rejected folder name forces a re-run of the ~30 s scaffold (the indie-bookshop-class regression).
 
-   - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). Substitute `<slug>` with the validated slug.
+   - Substitute `<brand>` with the user's confirmed brand (preserve original case; quotes are passed by the shell). This is sent to the CLI as `--business-name`, so it owns the Wix project display name and URL-slug generation. Substitute `<folder-name>` with the validated folder name for the local directory only.
+   - **Business-name guardrail.** Because the CLI generates the project URL slug from `business-name`, the brand must contain at least one English letter or number. If the confirmed brand is only emoji or punctuation, the CLI rejects it — ask the user for a brand that includes at least one English letter or number before scaffolding.
    - The script passes bare `--site-template` so non-interactive scaffolding stays on the blank starter. Keep the new-site flow there unless the skill is explicitly redesigned around another scaffold. (Without it, `@wix/create-new` ≥0.0.72 prompts for a template and aborts in the agent's non-TTY shell.)
    - Append timing to `.wix/run.json.phases[]` as `{ phase: "scaffold", seconds: <duration>, started: $STARTED_AT, ended: $ENDED_AT }`.
 
-Correct (strip-and-concatenate):
-- `"Bloom & Root"` → `"bloomroot"` (not `"bloom-and-root"`, not `"bloom-root"`)
-- `"Page & Ember"` → `"pageember"` (not `"page-ember"`, not `"page-and-ember"`)
-- `"ACME, Co."` → `"acmeco"`
-- `"42 Below"` → `"42below"`
-- `"Single-Origin Roasters"` → `"singleoriginroasters"` (cap at 20 → `"singleoriginroaster"` if truncation needed)
-
-**Wrong** (kebab-case / snake-case): any slug containing `-`, `_`, or any other separator. The transformation is **strip**, not **replace** — there are no separators in a valid slug.
+Examples (kebab-case is valid — hyphens are allowed):
+- `"Bloom & Root"` → `"bloom-root"`
+- `"Page & Ember"` → `"page-ember"`
+- `"ACME, Co."` → `"acme-co"`
+- `"42 Below"` → `"42-below"`
+- `"Single-Origin Roasters"` → `"single-origin-roasters"`
+- `"!!!"` (no English letters or numbers) → ask the user for a folder name, and for a brand that includes at least one English letter or number
 
 Then continue to Q2.
 

--- a/skills/wix-headless/references/SETUP.md
+++ b/skills/wix-headless/references/SETUP.md
@@ -14,15 +14,15 @@ Routing (which path runs) is owned by `PLAN.md` § "Operation routing" (operatio
 
 ## Step 1 — Read the scaffolded project config (siteId + appId)
 
-**Do not** speculatively `Read <project-slug>/wix.config.json` before the scaffold exists — the speculative read returns `File does not exist` on every fast-Q&A run (the file isn't there yet), emits a `[MED]` anomaly in the trace, and costs 3–5 s of round-trip + recovery thinking.
+**Do not** speculatively `Read <folder-name>/wix.config.json` before the scaffold exists — the speculative read returns `File does not exist` on every fast-Q&A run (the file isn't there yet), emits a `[MED]` anomaly in the trace, and costs 3–5 s of round-trip + recovery thinking.
 
-Once the scaffolded project exists, read `<project-slug>/wix.config.json` and extract:
+Once the scaffolded project exists, read `<folder-name>/wix.config.json` and extract:
 - `siteId` — the site id passed as `--site` to `npx @wix/cli@latest token` and embedded in every install body + as the `wix-site-id` header on every site-scoped REST call. Hold it in orchestrator session scratch.
 - `appId` — the project's appId. Hold it in session scratch (it goes into the SDK's `createClient` inputs in later steps).
 
 **Before `cd`, capture the current working directory as `<site-root>` and hold it in session scratch.** This is where Discovery's `init-site-json.mjs` wrote the slim `.wix/site.json` snapshot. The orchestrator is the **sole** reader/writer of that file; no subagent or downstream script reads it during the run. Hold `<site-root>` as an absolute path so the `cd` into the scaffold subdir below does not lose it.
 
-`cd` into `<project-slug>/` so all subsequent file ops + shell calls (`npm`, `npx @wix/cli@latest env pull`) are relative to the project root.
+`cd` into `<folder-name>/` so all subsequent file ops + shell calls (`npm`, `npx @wix/cli@latest env pull`) are relative to the project root.
 
 ---
 

--- a/skills/wix-headless/scripts/scaffold.sh
+++ b/skills/wix-headless/scripts/scaffold.sh
@@ -2,11 +2,13 @@
 # Scaffold a new Wix Managed Headless project using the CLI's preset blank template.
 #
 # Usage:
-#   bash <SKILL_ROOT>/scripts/scaffold.sh <project-slug> "<Brand Name>" [--frontend astro|custom]
+#   bash <SKILL_ROOT>/scripts/scaffold.sh <folder-name> "<Brand Name>" [--frontend astro|custom]
 #
-# <project-slug>: 3-20 lowercase alphanumeric chars (no hyphens, no spaces) — the
-#                 Wix CLI rejects anything else. Becomes the project directory name.
-# <Brand Name>:   human-readable business name; quote if it contains spaces.
+# <folder-name>:  lowercase letters, numbers, and hyphens only; must start with a
+#                 letter or number. Becomes the local project directory name.
+# <Brand Name>:   human-readable business name; quote if it contains spaces. The
+#                 CLI derives the Wix project display-name and URL slug from it, so
+#                 it must include at least one English letter or number.
 # --frontend:     the frontend axis. Defaults to "astro" — the only supported (and
 #                 only scaffolded) frontend. "custom" (any non-astro frontend) is
 #                 NOT scaffolded yet: Discovery routes custom to the not-available
@@ -14,12 +16,12 @@
 #                 so this script should only ever be invoked with "astro". If it is
 #                 invoked with "custom" it exits 4 (recognized, not staged).
 #
-# After scaffold succeeds, read <project-slug>/wix.config.json to extract appId
+# After scaffold succeeds, read <folder-name>/wix.config.json to extract appId
 # (project's appId) and siteId (used as --site for `wix token` and in REST call
 # bodies). The orchestrator does that read; this script just runs the npm create.
 #
 # Behavior:
-#   - Pre-flight validates the slug (regex ^[a-z0-9]{3,20}$).
+#   - Pre-flight validates the folder name syntax (regex ^[a-z0-9][a-z0-9-]*$).
 #   - Pre-flight requires both positional args.
 #   - Runs `npm create @wix/new@latest headless` with --no-publish + --skip-install
 #     so the orchestrator can deferred-install with its own package set.
@@ -30,7 +32,7 @@
 #
 # Exit codes:
 #   0 — ok
-#   2 — argument validation failed (bad slug, missing args, unknown --frontend value)
+#   2 — argument validation failed (bad folder name, missing args, unknown --frontend value)
 #   3 — Wix CLI not logged in (defensive; the Discovery pre-flight is the primary check)
 #   4 — frontend value recognized but not scaffolded yet (custom today)
 #   <other> — npm create failed; stderr surfaced to caller for orchestrator-side
@@ -62,8 +64,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#POSITIONAL[@]} -lt 2 || -z "${POSITIONAL[0]:-}" || -z "${POSITIONAL[1]:-}" ]]; then
-  echo "scaffold.sh: both positional args required. Got project-slug='${POSITIONAL[0]:-}' brand-name='${POSITIONAL[1]:-}'." >&2
-  echo "Usage: bash scaffold.sh <slug> \"<Brand Name>\" [--frontend astro|custom] — slug first, brand quoted." >&2
+  echo "scaffold.sh: both positional args required. Got folder-name='${POSITIONAL[0]:-}' brand-name='${POSITIONAL[1]:-}'." >&2
+  echo "Usage: bash scaffold.sh <folder-name> \"<Brand Name>\" [--frontend astro|custom] — folder name first, brand quoted." >&2
   exit 2
 fi
 
@@ -81,10 +83,10 @@ case "$FRONTEND" in
     ;;
 esac
 
-if [[ ! "${POSITIONAL[0]}" =~ ^[a-z0-9]{3,20}$ ]]; then
-  echo "scaffold.sh: project-slug='${POSITIONAL[0]}' is not valid." >&2
-  echo "Slug must be 3-20 lowercase alphanumeric chars (no hyphens, no spaces)." >&2
-  echo "Derive from the brand: lowercase, strip non-[a-z0-9], truncate to 20." >&2
+if [[ ! "${POSITIONAL[0]}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "scaffold.sh: folder-name='${POSITIONAL[0]}' is not valid." >&2
+  echo "Folder name must contain only lowercase letters, numbers, and hyphens, and start with a letter or number." >&2
+  echo "Derive it from the brand as a lowercase, npm-safe directory name." >&2
   exit 2
 fi
 
@@ -102,7 +104,7 @@ fi
 
 npm create @wix/new@latest headless -- \
   --business-name "${POSITIONAL[1]}" \
-  --project-name "${POSITIONAL[0]}" \
+  --folder-name "${POSITIONAL[0]}" \
   --site-template \
   --no-publish \
   --skip-install


### PR DESCRIPTION
## Summary

- update the wix-headless scaffold flow to use `--folder-name` terminology instead of `--project-name`
- align folder-name derivation and validation guidance with the CLI behavior, including hyphen support and npm-safe naming
- document that the Wix project slug is derived from `business-name`, including the new guardrail for names that contain no English letters or numbers


## Testing
- not run

---
_Recreated from #287, which was opened against the now-deleted `master` branch and could not be retargeted to `main`._