### PR TITLE
chore: add CODEOWNERS for Editor React Component skill docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Editor React Component skill docs
+/skills/wix-app/references/EDITOR_REACT_COMPONENT.md        @wix-private/ot-components-ee
+/skills/wix-app/references/editor-react-component/          @wix-private/ot-components-ee


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` to assign `@wix-private/ot-components-ee` as code owner for the Editor React Component skill documentation.
- Covers the single reference file `EDITOR_REACT_COMPONENT.md` and everything inside the `editor-react-component/` folder recursively.

## Test plan
- [ ] Verify that a PR touching `skills/wix-app/references/EDITOR_REACT_COMPONENT.md` automatically requests a review from `@wix-private/ot-components-ee`.
- [ ] Verify that a PR touching any file under `skills/wix-app/references/editor-react-component/` automatically requests a review from `@wix-private/ot-components-ee`.

Made with [Cursor](https://cursor.com)