### PR TITLE
fix(wix-manage): remove incorrect wix-site-id header guidance

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Requires Wix REST API access (API key or OAuth).
 
 # Management Recipes Index
 
-> **Standard call shape for every curl example across these recipes.** The `<AUTH>` placeholder in example curls is shorthand for the `Authorization` header only; every actual call ALSO needs `wix-site-id: <SITE_ID>` and `Content-Type: application/json`. **POST/PATCH against `wix-data/*`, `form-schema-service/*`, `stores/v3/*`, `blog/v3/*`, and other site-scoped REST families return 403 without `wix-site-id`** — observed seeder regression cost ~100 s rediscovering this on a 2026-05-24 run.
+> **Standard call shape for every curl example across these recipes.** The `<AUTH>` placeholder in example curls is shorthand for the `Authorization` header only; body-bearing calls also need `Content-Type: application/json`.
 
 ## What Are Management Recipes?
 

--- a/skills/wix-manage/references/blog/how-to-create-blog-posts.md
+++ b/skills/wix-manage/references/blog/how-to-create-blog-posts.md
@@ -5,7 +5,7 @@ description: Creates and publishes blog posts using Blog Posts API. Covers Ricos
 
 **Article: Create and Publish Blog Posts with Rich Content and Images**
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST against `blog/v3/*` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 ---
 

--- a/skills/wix-manage/references/cms/cms-data-items-crud.md
+++ b/skills/wix-manage/references/cms/cms-data-items-crud.md
@@ -4,7 +4,7 @@ description: "Add, query, update, and delete items in CMS collections. Use this 
 ---
 # CMS Data Items CRUD
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST/PATCH against `wix-data/*` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 This recipe covers basic Create, Read, Update, Delete (CRUD) operations for Wix CMS data items.
 

--- a/skills/wix-manage/references/cms/cms-references-and-relationships.md
+++ b/skills/wix-manage/references/cms/cms-references-and-relationships.md
@@ -4,7 +4,7 @@ description: "Add, replace, or remove items from MULTI_REFERENCE fields. Use ins
 ---
 # CMS References & Relationships
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST/PATCH against `wix-data/*` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 This recipe covers linking CMS collections together using reference fields.
 

--- a/skills/wix-manage/references/cms/cms-schema-management.md
+++ b/skills/wix-manage/references/cms/cms-schema-management.md
@@ -4,7 +4,7 @@ description: Create and modify CMS collection structures. Covers listing collect
 ---
 # CMS Schema Management
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST/PATCH against `wix-data/*` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 This recipe covers managing the structure (schema) of Wix CMS collections using the REST API.
 

--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -4,7 +4,7 @@ description: Creates a form with fields (name, email, etc.) using the Form Schem
 ---
 # RECIPE: Create a Wix Form
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST against `form-schema-service/v4/forms` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 Create a form on a Wix site that appears in the Forms & Submissions dashboard. The form collects visitor information (e.g., name, email) and can automatically upsert contacts on submission.
 

--- a/skills/wix-manage/references/stores/bulk-create-products-with-options.md
+++ b/skills/wix-manage/references/stores/bulk-create-products-with-options.md
@@ -4,7 +4,7 @@ description: Uses bulk products endpoint to create multiple products with invent
 ---
 # RECIPE: Business Recipe - Bulk Creating Wix Store Products with inventory and options
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST against `stores/v3/bulk/*` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 Learn how to create multiple Wix store products with customizable options like colors, sizes, or other variants in a single bulk operation, allowing efficient creation of product catalogs.
 

--- a/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
+++ b/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
@@ -4,7 +4,7 @@ description: Initializes a Stores catalog with Catalog V3 Products API, bulk pro
 ---
 **RECIPE**: Business Recipe – Initial Setup for a Wix Online Store (Catalog V3)
 
-> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Every actual call ALSO needs `wix-site-id: <SITE_ID>` and (for body-bearing requests) `Content-Type: application/json`. **POST/PATCH against `stores/v3/*` and `categories/v1/*` returns 403 without `wix-site-id`** — recipe examples below show `<AUTH>` only for brevity, but the header is required on every call you make.
+> **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 A concise checklist for preparing any new Wix site that uses the Online Stores app with Catalog V3.
 **Notice** that this recipe is **NOT** meant for coding purposes and is **ONLY** meant for initial catalog setup.


### PR DESCRIPTION
## Problem

The "standard call shape" note in all 7 `wix-manage` recipes (and the global note in `SKILL.md`) instructed that every call needs a `wix-site-id: <SITE_ID>` header and that POST/PATCH **"returns 403 without `wix-site-id`."**

An experiment against a live headless site showed the header is **inert** for these REST families when using a CLI-minted token — what gates the call is the token's scope, not the header:

| token \ header | no header | with header |
|---|---|---|
| site-scoped | `200` | `200` |
| account-scoped | `403` | `403` |

Tested across `stores/v3`, `categories/v1`, `wix-data/v2`, `form-schema-service/v4`, `blog/v3`, `members/v1`, `site-media/v1`.

## Fix

Removes the `wix-site-id` mentions (and the mis-attributed "~100 s 2026-05-24 seeder regression" note) from the standard-call-shape blocks, keeping only the `<AUTH>` / `Content-Type` guidance. Token scope is already covered by the shared auth docs, so the recipes don't restate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)