### PR TITLE
fix: add V3 product media URL field to STORES_VERSIONING reference

### DIFF
--- a/skills/wix-app/references/STORES_VERSIONING.md
+++ b/skills/wix-app/references/STORES_VERSIONING.md
@@ -310,8 +310,7 @@ For the full table see the [Catalog V1 to V3 Migration Guide](https://dev.wix.co
 | `manageVariants: false` (customizations) | `modifiers[i]` |
 | `collectionIds[i]` | `directCategories[i].id` |
 | `ribbon`, `brand` (string) | `ribbon.name`, `brand.name` (managed via `ribbonsV3` / `brandsV3`) |
-| `media.mainMedia.image.url` (main image URL) | `media.main.url` — note: V3 `Media.main` is a `MediaItem`, the image URL is directly at `.url`, not `.image.url` |
-| `media.items[i].image.url` (gallery images) | `media.items[i].image.url` (same path, unchanged) |
+| `media.mainMedia.image.url` (main image URL) | `media.main.image ?? media.main.url` — in V3, `ProductMedia.image` is a `string` (Wix-hosted URL), `url` is a `string` (external URL); check both |
 
 **Pricing model** — V1 had a `discount` object; V3 removed it. Discounts are now expressed by the relationship between two fields on the variant: `actualPrice` (required, what the customer pays) vs `compareAtPrice` (optional, original price shown struck through). With discount: V1 `price`/`discountedPrice` → V3 `compareAtPrice`/`actualPrice`. Without discount: V1 `price` → V3 `actualPrice`, leave `compareAtPrice` empty.
 

--- a/skills/wix-app/references/STORES_VERSIONING.md
+++ b/skills/wix-app/references/STORES_VERSIONING.md
@@ -310,6 +310,8 @@ For the full table see the [Catalog V1 to V3 Migration Guide](https://dev.wix.co
 | `manageVariants: false` (customizations) | `modifiers[i]` |
 | `collectionIds[i]` | `directCategories[i].id` |
 | `ribbon`, `brand` (string) | `ribbon.name`, `brand.name` (managed via `ribbonsV3` / `brandsV3`) |
+| `media.mainMedia.image.url` (main image URL) | `media.main.url` — note: V3 `Media.main` is a `MediaItem`, the image URL is directly at `.url`, not `.image.url` |
+| `media.items[i].image.url` (gallery images) | `media.items[i].image.url` (same path, unchanged) |
 
 **Pricing model** — V1 had a `discount` object; V3 removed it. Discounts are now expressed by the relationship between two fields on the variant: `actualPrice` (required, what the customer pays) vs `compareAtPrice` (optional, original price shown struck through). With discount: V1 `price`/`discountedPrice` → V3 `compareAtPrice`/`actualPrice`. Without discount: V1 `price` → V3 `actualPrice`, leave `compareAtPrice` empty.
 


### PR DESCRIPTION
## Problem

When codegen agents generate Stores-integrated dashboard pages, they need to display product images. The `STORES_VERSIONING.md` reference file documents the V1→V3 field mapping table in detail but omits the image URL field entirely.

Without this, agents copy the V1 pattern (`media.mainMedia.image.url`) for V3 products, which fails TypeScript compilation because V3's `Media` type has no `mainMedia` field.

## Fix

Add the correct V3 image URL mapping to the field mapping table.

**V1:** `media.mainMedia.image.url` — where `image` is a nested object with a `url` property

**V3:** `media.main.image ?? media.main.url` — both are plain strings, not nested objects. `image` is populated for Wix-hosted media, `url` for external links. Only one is set per product, so check both:

```typescript
p.media?.main?.image ?? p.media?.main?.url ?? ''
```

## Eval

> What is the correct TypeScript expression to get the main image URL from a Wix Stores V3 product object `p` returned by `productsV3.queryProducts()`?

Expected: `p.media?.main?.image ?? p.media?.main?.url`
Wrong (pre-fix): `p.media?.mainMedia?.image?.url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)