### PR TITLE
fix(wix-app): require WDS global CSS import in main component

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -25,6 +25,7 @@ Helps build extensions for Wix CLI applications. Covers all extension types: das
 - [ ] **Step 4a:** Scaffolded each CLI-supported extension via `wix generate --params`
 - [ ] **Step 4b:** Filled in business logic in the generated files
   - [ ] Invoked `wix-design-system` skill ONLY before editing the first `.tsx`/`.jsx` file that imports `@wix/design-system`. Skip for backend-only or data-only extensions.
+  - [ ] WDS: imported `@wix/design-system/styles.global.css` in the main component entry file (`page.tsx`, modal `.tsx`, etc.) — not child/tab/helper files.
 - [ ] **Step 5:** Ran validation (see [Validation](#validation))
   - [ ] Dependencies installed
   - [ ] TypeScript compiled
@@ -257,6 +258,7 @@ If the command fails because of unknown or invalid params, run `npx wix schema g
 Open every path returned in `newFiles` and replace stubbed handler bodies / UI / queries with the user's actual logic, guided by the extension reference file's API and configuration sections.
 
 - ⚠️ MANDATORY when using WDS: Invoke the `wix-design-system` skill **before editing your first `.tsx`/`.jsx` file that imports `@wix/design-system`**. Do NOT invoke it preemptively for backend-only or data-only jobs — it adds large content to context that you won't use.
+- ⚠️ MANDATORY when using WDS: Add `import "@wix/design-system/styles.global.css";` in the **main component** entry file (`page.tsx`, modal `.tsx`, etc.) — not in child/tab/helper files.
 - ⚠️ MANDATORY when using Data Collections: Use the EXACT collection ID from `idSuffix` (case-sensitive). If `idSuffix` is `"product-recommendations"`, use `<app-namespace>/product-recommendations` NOT `productRecommendations`.
 
 ### Step 5: Run Validation


### PR DESCRIPTION
## Summary
- Add mandatory WDS global CSS import guidance to `skills/wix-app/SKILL.md` only
- Agents must add `import "@wix/design-system/styles.global.css";` in the main component entry file (`page.tsx`, modal `.tsx`, etc.) — not child/tab/helper files

## Problem
Codegen runs were producing dashboard pages with `@wix/design-system` components but no `styles.global.css` import, resulting in unstyled UI.

## Test plan
- [ ] `wix-app` checklist includes WDS CSS import step
- [ ] Step 4b documents mandatory import in main component only
- [ ] Spot-check a dashboard codegen run includes the import in `page.tsx`


Made with [Cursor](https://cursor.com)