### PR TITLE
chore: disable PR eval job

### DIFF
--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   skill-eval:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: false
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- Disables the `skill-eval` job on PRs by setting `if: false`

## Test plan
- [ ] Open a PR touching `yaml/wix-manage/` — confirm the skill-eval job is skipped