### PR TITLE
Update description in SKILL.md inside wix-design-system skill

### DIFF
--- a/skills/wix-design-system/SKILL.md
+++ b/skills/wix-design-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-design-system
-description: Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking props and examples, or writing tests with component testkits. Triggers on "what component", "how do I make", "WDS", "show me props", "testkit", "driver", or component names like Button, Card, Modal, Box, Text.
+description: Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking props and examples, or writing tests with component testkits. Triggers on "what component", "how do I make", "WDS", "show me props", "testkit", "driver", or component names like Button, Card, Box, Text.
 ---
 
 # WDS Documentation Navigator


### PR DESCRIPTION
Removed 'Modal' from the component reference description - sometimes (in dashboard pages), a modal should be used via Wix CLI modal extension.
Also as part of a skill sync test for @vltansky.