### PR TITLE
fix(bookings): use RUN_IN_BROWSER for service form navigation

### DIFF
--- a/skills/wix-manage/references/bookings/create-appointment-service.md
+++ b/skills/wix-manage/references/bookings/create-appointment-service.md
@@ -188,9 +188,13 @@ Save the `serviceId` from the response: `results[0].item.service.id`
 
 ## Step 4: Navigate to Service Form
 
+Use the **RUN_IN_BROWSER** tool to navigate the user to the service form for final review:
+
 ```javascript
 window.location.href = `/bookings/services/form/${serviceId}?fromAria=true`;
 ```
+
+This executes in the user's browser and redirects them to the service editing page.
 
 ---
 

--- a/skills/wix-manage/references/bookings/create-class-service.md
+++ b/skills/wix-manage/references/bookings/create-class-service.md
@@ -166,9 +166,13 @@ Save the `serviceId` from the response: `results[0].item.service.id`
 
 ## Step 4: Navigate to Service Form
 
+Use the **RUN_IN_BROWSER** tool to navigate the user to the service form for final review:
+
 ```javascript
 window.location.href = `/bookings/services/form/${serviceId}?fromAria=true`;
 ```
+
+This executes in the user's browser and redirects them to the service editing page.
 
 ---
 

--- a/skills/wix-manage/references/bookings/create-course-service.md
+++ b/skills/wix-manage/references/bookings/create-course-service.md
@@ -169,9 +169,13 @@ Save the `serviceId` from the response: `results[0].item.service.id`
 
 ## Step 4: Navigate to Service Form
 
+Use the **RUN_IN_BROWSER** tool to navigate the user to the service form for final review:
+
 ```javascript
 window.location.href = `/bookings/services/form/${serviceId}?fromAria=true`;
 ```
+
+This executes in the user's browser and redirects them to the service editing page.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes the navigation step in all 3 booking service creation recipes (appointment, class, course)
- The recipes had bare `window.location.href` JavaScript that the AI agent cannot execute — it runs server-side via API tools, not in the browser
- The agent silently skipped the navigation step, so users were never redirected to the service form after creation
- Now explicitly instructs the agent to use the **RUN_IN_BROWSER** platform tool, which executes JavaScript in the user's browser

## Root cause

Discovered by reviewing conversations [53c662f3](https://wix-bo.com/ai-assistant/conversations/53c662f3-ba85-43ed-8005-6ada2a2bd36e) and [f2795c46](https://wix-bo.com/ai-assistant/conversations/f2795c46-d506-44c6-8cc0-87980972010b) — the agent followed all recipe steps correctly (gather context, apply defaults, create service via bulkCreateServices) but the `ADD_WIDGET` log showed `widget: ""` because no tool was specified for the navigation step.

## Test plan

- [ ] Create a booking service via Aria and verify the user is redirected to `/bookings/services/form/{serviceId}?fromAria=true`
- [ ] Verify RUN_IN_BROWSER tool call appears in conversation logs
- [ ] Test all three service types: appointment, class, course

🤖 Generated with [Claude Code](https://claude.com/claude-code)