### PR TITLE
feat(editor-react-component): add dedicated SSR guidance

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -72,7 +72,8 @@ Topic-focused references (rules + patterns + common mistakes in one place):
 - [`editor-react-component/DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md) — RTL/LTR rules and patterns
 - [`editor-react-component/PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
-- [`editor-react-component/REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, remaining common mistakes
+- [`editor-react-component/SSR.md`](editor-react-component/SSR.md) — Server-side rendering rules (mandatory)
+- [`editor-react-component/REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) — CSS rules, remaining common mistakes
 
 ## CSS guidelines
 

--- a/skills/wix-app/references/editor-react-component/ACCESSIBILITY.md
+++ b/skills/wix-app/references/editor-react-component/ACCESSIBILITY.md
@@ -13,6 +13,20 @@ Rules and patterns for ARIA accessibility support in Editor React components.
 - The `A11y` type includes: `ariaLabel`, `ariaDescribedBy`, `ariaLabelledBy`, `role`, `ariaHidden`, `ariaLive`, and all other ARIA attributes.
 - Users provide ARIA values through the `a11y` prop: `<Component a11y={{ ariaLabel: "..." }} />`
 
+### Stable IDs for Element Relationships
+
+ARIA relationships (`aria-controls`, `aria-labelledby`, `aria-describedby`) and `htmlFor` need element ids. Generate them with `useStableId` from `@wix/react-component-utils` — passing the `id` prop as the override — never `Math.random()`, a manual counter, or a bare `React.useId()` (those break SSR/hydration). See [`SSR.md`](SSR.md) for the full rule.
+
+```tsx
+import { useStableId } from '@wix/react-component-utils';
+
+const rootId = useStableId(id);
+const panelId = `${rootId}-panel`;
+
+<button aria-controls={panelId}>{label}</button>
+<div id={panelId} role="tabpanel">{content}</div>
+```
+
 ### ARIA Label Rules
 
 ARIA labels are user-facing content and must NEVER be hardcoded as string literals in JSX.

--- a/skills/wix-app/references/editor-react-component/REACT-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/REACT-GUIDELINES.md
@@ -8,7 +8,8 @@ This guide defines rules and guidance on **how to implement** production-quality
 - [`DIRECTIONALITY.md`](DIRECTIONALITY.md) — RTL/LTR rules and patterns
 - [`PROPS-VS-CSS.md`](PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`COMPONENT-API.md`](COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
-- [`REACT-PATTERNS.md`](REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, common mistakes
+- [`SSR.md`](SSR.md) — Server-side rendering rules (mandatory)
+- [`REACT-PATTERNS.md`](REACT-PATTERNS.md) — CSS rules, common mistakes
 
 ## React 18 features are not supported
 
@@ -42,6 +43,10 @@ Direction support is mandatory — see [`DIRECTIONALITY.md`](DIRECTIONALITY.md).
 
 See [`ACCESSIBILITY.md`](ACCESSIBILITY.md) for full rules and patterns.
 
+### SSR Safety
+
+Components are server-rendered, then hydrated — they MUST render correctly, completely, and identically on the server. See [`SSR.md`](SSR.md) for full rules and patterns.
+
 ### TypeScript
 
 - All components must be fully typed
@@ -67,11 +72,11 @@ All components MUST follow these patterns:
 
 **1. SSR-Safe Implementation**
 
-- NO browser APIs at module scope (window, document, navigator, etc.)
-- Guard browser APIs with typeof checks or useEffect
-- All browser-dependent logic must run client-side only
+- NO browser APIs at module scope or during render (window, document, navigator, etc.) — guard inside `useEffect`
+- First render must be complete and deterministic; effects are client-only enhancement
+- Internal ids via `useStableId`; NO `useLayoutEffect`
 
-See [`REACT-PATTERNS.md`](REACT-PATTERNS.md) §1.1 for code examples.
+See [`SSR.md`](SSR.md) for full rules and code examples.
 
 **2. Clean Code**
 
@@ -162,6 +167,6 @@ See [`PROPS-VS-CSS.md`](PROPS-VS-CSS.md) and [`COMPONENT-API.md`](COMPONENT-API.
 
 **Phase 1: Analysis** — Parse information, map component structure (see Part 0)
 
-**Phase 2: Component File** — Apply all §1.1 mandatory features and §1.2 implementation standards
+**Phase 2: Component File** — Apply all §1.1 mandatory features and §1.2 implementation standards; verify SSR safety against [`SSR.md`](SSR.md)
 
 **Phase 3: Styles** — Apply Part 2 SCSS rules

--- a/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
+++ b/skills/wix-app/references/editor-react-component/REACT-PATTERNS.md
@@ -6,23 +6,7 @@ Code patterns and common mistakes for Editor React components.
 
 ## 1.1 SSR-Safe Implementation
 
-Avoid browser-only APIs at module scope or during render; use them inside `useEffect` with `typeof window !== 'undefined'`.
-
-**❌ Wrong:**
-
-```typescript
-const userAgent = window.navigator.userAgent;
-```
-
-**✅ Correct:**
-
-```typescript
-useEffect(() => {
-  if (typeof window !== "undefined") {
-    const userAgent = window.navigator.userAgent;
-  }
-}, []);
-```
+Components are server-rendered then hydrated. See [`SSR.md`](SSR.md) for the full rules and code examples (browser globals, complete first render, deterministic output, `useStableId`, no `useLayoutEffect`).
 
 ## 1.2 Element Visibility (Platform-Managed)
 
@@ -101,6 +85,8 @@ different — they go through a JS-toggled modifier class; see
 ```
 
 ## 3.2 Browser APIs at module scope
+
+See [`SSR.md`](SSR.md) for the full SSR rules.
 
 **❌ Wrong:**
 

--- a/skills/wix-app/references/editor-react-component/SSR.md
+++ b/skills/wix-app/references/editor-react-component/SSR.md
@@ -1,0 +1,119 @@
+# Server-Side Rendering (SSR)
+
+Rules and patterns for SSR-safe Editor React components.
+
+Editor React components are server-rendered and then hydrated on the client — every component MUST render correctly, completely, and identically on the server. SSR safety is mandatory for every component.
+
+---
+
+## Rules
+
+### No browser globals at module scope or during render
+
+`window`, `document`, `navigator`, `localStorage`, `sessionStorage`, `matchMedia`, `IntersectionObserver`, `ResizeObserver`, and other DOM/BOM APIs do not exist on the server. Never touch them at module scope or in the render body. Access them only inside `useEffect`, optionally guarded with `typeof window !== 'undefined'`.
+
+**❌ Wrong:**
+
+```typescript
+const userAgent = window.navigator.userAgent;
+```
+
+**✅ Correct:**
+
+```typescript
+useEffect(() => {
+  if (typeof window !== "undefined") {
+    const userAgent = window.navigator.userAgent;
+  }
+}, []);
+```
+
+### First render must be complete
+
+Render all parts unconditionally — never gate structural elements behind effect-set state. Initialize `useState` to a valid, server-renderable default so the first (server) render already shows the final structure. Element visibility is platform-managed; see [`PROPS-VS-CSS.md`](PROPS-VS-CSS.md) and [`REACT-PATTERNS.md`](REACT-PATTERNS.md) §1.2.
+
+**❌ Wrong — content only appears after an effect runs (missing on the server):**
+
+```tsx
+const [items, setItems] = useState<Array<Item>>([]);
+useEffect(() => {
+  setItems(buildItems(props));
+}, [props]);
+return <ul>{items.map(/* ... */)}</ul>; // empty on the server
+```
+
+**✅ Correct — derive during render so it exists on the first pass:**
+
+```tsx
+const items = buildItems(props);
+return <ul>{items.map(/* ... */)}</ul>;
+```
+
+### Deterministic render
+
+The same props MUST produce the same markup on the server and the client. No `Math.random()`, `Date.now()`, `new Date()`, or locale/timezone-dependent output during render — these differ across environments and break hydration.
+
+**❌ Wrong:**
+
+```tsx
+<span>{new Date().toLocaleString()}</span>
+```
+
+**✅ Correct — derive from props, or compute in an effect:**
+
+```tsx
+<span>{formatDate(props.timestamp)}</span>
+```
+
+### Stable IDs via `useStableId`
+
+When a component needs an internal id (ARIA wiring such as `aria-controls` / `aria-labelledby`, or `htmlFor`), generate it with `useStableId` from `@wix/react-component-utils`. Never use `Math.random()`, a manual counter, or a bare `React.useId()` — those break hydration or are not available across runtimes. Pass the component's `id` prop as the override so a caller-supplied id wins, then derive child ids from the result.
+
+**✅ Correct:**
+
+```tsx
+import { useStableId } from '@wix/react-component-utils';
+
+const rootId = useStableId(id);
+const panelId = `${rootId}-panel`;
+
+<button aria-controls={panelId}>{label}</button>
+<div id={panelId} role="tabpanel">{content}</div>
+```
+
+**❌ Wrong:**
+
+```tsx
+const panelId = `tab-${Math.random()}`; // ❌ differs every render
+const panelId = React.useId();          // ❌ use the useStableId util instead
+```
+
+### No `useLayoutEffect`
+
+`useLayoutEffect` does nothing on the server and triggers a React warning. Use `useEffect` for client-only work.
+
+**❌ Wrong:**
+
+```tsx
+useLayoutEffect(() => { measure(); }, []);
+```
+
+**✅ Correct:**
+
+```tsx
+useEffect(() => { measure(); }, []);
+```
+
+### Effects are client-only enhancement
+
+`useEffect` runs only after hydration, never on the server. Use effects to enhance — not to produce the initial UI. The server-rendered default state must already look correct before any effect runs.
+
+---
+
+## SSR Checklist
+
+- [ ] No browser globals at module scope or in the render body — guarded inside `useEffect` only
+- [ ] All parts render unconditionally on the first pass; state initialized to a server-safe default
+- [ ] Render output is deterministic — no `Math.random()` / `Date.now()` / `new Date()` / locale-dependent output during render
+- [ ] Internal ids come from `useStableId(id)`, never random values, counters, or bare `React.useId()`
+- [ ] No `useLayoutEffect`


### PR DESCRIPTION
Elevate SSR safety to a first-class, mandatory concern for generated Editor React components, which are server-rendered then hydrated.

- Add SSR.md topic file (sibling to ACCESSIBILITY.md/DIRECTIONALITY.md) with rules for browser globals, complete first render, deterministic output, useStableId for ids, no useLayoutEffect, and a checklist
- Promote "SSR Safety" to a mandatory feature in REACT-GUIDELINES.md and repoint the SSR-safe implementation guidance to SSR.md
- Collapse REACT-PATTERNS.md SSR section to a pointer; cross-link from the browser-APIs common mistake
- Add stable-id wiring rule to ACCESSIBILITY.md (aria-controls, aria-labelledby, htmlFor) via useStableId from @wix/react-component-utils
- List SSR.md in the EDITOR_REACT_COMPONENT.md reference index

Recommends the useStableId util rather than React.useId directly, keeping consistency with the existing "React 18 features are not supported" note.