### PR TITLE
fix(wix-manage): correct coupons API base path to /stores/v2/coupons

### DIFF
--- a/skills/wix-manage/references/ecommerce/setup-coupons.md
+++ b/skills/wix-manage/references/ecommerce/setup-coupons.md
@@ -11,10 +11,10 @@ layer: config
 
 ## Required APIs
 
-- [Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/create-a-coupon) — `POST /v2/coupons`
-- [Update Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/update-a-coupon) — `PATCH /v2/coupons/{id}`
-- [Query Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/query-coupons) — `POST /v2/coupons/query`
-- [Delete Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/delete-a-coupon) — `DELETE /v2/coupons/{id}`
+- [Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/create-a-coupon) — `POST /stores/v2/coupons`
+- [Update Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/update-a-coupon) — `PATCH /stores/v2/coupons/{id}`
+- [Query Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/query-coupons) — `POST /stores/v2/coupons/query`
+- [Delete Coupon](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/delete-a-coupon) — `DELETE /stores/v2/coupons/{id}`
 
 ---
 
@@ -22,7 +22,7 @@ layer: config
 
 Before creating a coupon, check for code conflicts and existing promotions on the same scope.
 
-**Endpoint**: `POST https://www.wixapis.com/v2/coupons/query`
+**Endpoint**: `POST https://www.wixapis.com/stores/v2/coupons/query`
 
 **Request**:
 ```json
@@ -70,7 +70,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
 
 ## Step 2: Create a percentage-off coupon
 
-**Endpoint**: `POST https://www.wixapis.com/v2/coupons`
+**Endpoint**: `POST https://www.wixapis.com/stores/v2/coupons`
 
 **Request** — 15% off all store products:
 ```json


### PR DESCRIPTION
## Problem
The `setup-coupons` ecommerce recipe (`skills/wix-manage/references/ecommerce/setup-coupons.md`) lists the Coupons V2 endpoints **without the `/stores/` prefix**, e.g.:

```
**Endpoint**: `POST https://www.wixapis.com/v2/coupons/query`
```

The correct executable public path is **`/stores/v2/coupons`** — verified against the live API spec (`SearchWixAPISpec` → `publicUrl`) and the coupons service proto (`wix-private/ecom/.../QueryCoupons.curl` → `https://www.wixapis.com/stores/v2/coupons/query`).

## Impact
Agents that activate this skill copy the endpoint verbatim and get a **404**, then have to recover via `SearchWixAPISpec`. Observed in production Aria conversations.

## Fix
Add the `/stores/` prefix to all 6 occurrences (the endpoint list lines + the two `**Endpoint**` lines). Docs links are unchanged.

## Note on root cause (separate follow-up)
The recipe copied the path from the canonical docs article's **method summary line** (`POST /v2/coupons/query`), which shows the relative `wix.coupons.api.v2` path, while the curl example in the same article shows the correct `/stores/v2/coupons/query`. The docs summary-line inconsistency is the upstream source and likely affects other `wix.*.api.vN` methods that are gateway-mapped under a prefix — worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)