### PR TITLE
feat(eval-gate): link to EvalForge run in PR comment

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34266,19 +34266,22 @@ function formatServiceError(message, blocking) {
     const { icon } = failIcon(blocking);
     return render(icon, blocking ? 'Error' : 'Warning', [message]);
 }
-function formatEvalPassed(m, runId) {
-    return render('✅', 'Passed', [`Pass rate: ${m.passRate}%`, `Run ID: ${runId}`]);
+function runLink(runId, runUrl) {
+    return `Run: [${runId}](${runUrl})`;
 }
-function formatEvalFailed(m, runId, blocking) {
+function formatEvalPassed(m, runId, runUrl) {
+    return render('✅', 'Passed', [`Pass rate: ${m.passRate}%`, runLink(runId, runUrl)]);
+}
+function formatEvalFailed(m, runId, runUrl, blocking) {
     const { icon, label } = failIcon(blocking);
     return render(icon, label, [
         `Pass rate: ${m.passRate}%`,
         `${m.failed} failed, ${m.errors} errored, ${m.passed}/${m.totalAssertions} passed`,
-        `Run ID: ${runId}`,
+        runLink(runId, runUrl),
     ]);
 }
-function formatEvalTimeout(runId, blocking) {
-    return render(blocking ? '⏱' : '⚠️', 'Timed Out', [`Run ID: ${runId}`]);
+function formatEvalTimeout(runId, runUrl, blocking) {
+    return render(blocking ? '⏱' : '⚠️', 'Timed Out', [runLink(runId, runUrl)]);
 }
 function formatNoChanges() {
     return render('✅', 'No Gated Changes', ['Nothing under `evals/` or sibling `.md` changed.']);
@@ -34765,6 +34768,7 @@ function jsonifyMaybe(v) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.EvalForgeClient = exports.DRAFT_PREFIX = exports.TERMINAL_RUN_STATUSES = void 0;
+exports.evalRunUrl = evalRunUrl;
 exports.draftTagFor = draftTagFor;
 exports.parseDraftTag = parseDraftTag;
 exports.isHttpError = isHttpError;
@@ -34772,6 +34776,11 @@ const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
 exports.TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'];
 exports.DRAFT_PREFIX = 'draft:';
+// Human-facing EvalForge results page (distinct from the REST `baseUrl` the client calls).
+const UI_BASE = 'https://bo.wix.com/pages/evalforge';
+function evalRunUrl(projectId, runId) {
+    return `${UI_BASE}/${projectId}/results?runId=${runId}`;
+}
 function draftTagFor(repo, prNumber) {
     return `${exports.DRAFT_PREFIX}${repo}#${prNumber}`;
 }
@@ -35115,6 +35124,7 @@ async function runGate() {
     }), 'Could not create eval run', comment, config);
     if (!run)
         return;
+    const runUrl = (0, evalforge_1.evalRunUrl)(config.projectId, run.id);
     const triggered = await guardedCall(() => evalforge.triggerEvalRun(config.projectId, run.id), 'Could not trigger eval run', comment, config);
     if (!triggered)
         return;
@@ -35124,7 +35134,7 @@ async function runGate() {
     }
     catch (e) {
         if (e instanceof eval_run_1.EvalRunTimeoutError) {
-            await comment((0, comment_1.formatEvalTimeout)(run.id, config.blocking));
+            await comment((0, comment_1.formatEvalTimeout)(run.id, runUrl, config.blocking));
             (0, github_1.fail)(`Eval timed out (run ID: ${run.id})`, config.blocking);
             return;
         }
@@ -35135,11 +35145,11 @@ async function runGate() {
     }
     const m = finalStatus.aggregateMetrics;
     if (finalStatus.status === 'completed' && m.failed === 0 && m.errors === 0) {
-        await comment((0, comment_1.formatEvalPassed)(m, run.id));
+        await comment((0, comment_1.formatEvalPassed)(m, run.id, runUrl));
         core.info(`Eval passed — ${m.passed}/${m.totalAssertions} (run ID: ${run.id})`);
     }
     else {
-        await comment((0, comment_1.formatEvalFailed)(m, run.id, config.blocking));
+        await comment((0, comment_1.formatEvalFailed)(m, run.id, runUrl, config.blocking));
         (0, github_1.fail)(`Eval failed (${m.passRate}%)`, config.blocking);
     }
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
@@ -56,21 +56,25 @@ export function formatServiceError(message: string, blocking: boolean): string {
   return render(icon, blocking ? 'Error' : 'Warning', [message]);
 }
 
-export function formatEvalPassed(m: EvalRunStatus['aggregateMetrics'], runId: string): string {
-  return render('✅', 'Passed', [`Pass rate: ${m.passRate}%`, `Run ID: ${runId}`]);
+function runLink(runId: string, runUrl: string): string {
+  return `Run: [${runId}](${runUrl})`;
 }
 
-export function formatEvalFailed(m: EvalRunStatus['aggregateMetrics'], runId: string, blocking: boolean): string {
+export function formatEvalPassed(m: EvalRunStatus['aggregateMetrics'], runId: string, runUrl: string): string {
+  return render('✅', 'Passed', [`Pass rate: ${m.passRate}%`, runLink(runId, runUrl)]);
+}
+
+export function formatEvalFailed(m: EvalRunStatus['aggregateMetrics'], runId: string, runUrl: string, blocking: boolean): string {
   const { icon, label } = failIcon(blocking);
   return render(icon, label, [
     `Pass rate: ${m.passRate}%`,
     `${m.failed} failed, ${m.errors} errored, ${m.passed}/${m.totalAssertions} passed`,
-    `Run ID: ${runId}`,
+    runLink(runId, runUrl),
   ]);
 }
 
-export function formatEvalTimeout(runId: string, blocking: boolean): string {
-  return render(blocking ? '⏱' : '⚠️', 'Timed Out', [`Run ID: ${runId}`]);
+export function formatEvalTimeout(runId: string, runUrl: string, blocking: boolean): string {
+  return render(blocking ? '⏱' : '⚠️', 'Timed Out', [runLink(runId, runUrl)]);
 }
 
 export function formatNoChanges(): string {

--- a/.github/actions/evalforge-yaml-gate/src/utils/evalforge.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/evalforge.ts
@@ -42,6 +42,13 @@ export type EvalRunStatus = {
 
 export const DRAFT_PREFIX = 'draft:';
 
+// Human-facing EvalForge results page (distinct from the REST `baseUrl` the client calls).
+const UI_BASE = 'https://bo.wix.com/pages/evalforge';
+
+export function evalRunUrl(projectId: string, runId: string): string {
+  return `${UI_BASE}/${projectId}/results?runId=${runId}`;
+}
+
 export function draftTagFor(repo: string, prNumber: number): string {
   return `${DRAFT_PREFIX}${repo}#${prNumber}`;
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -7,7 +7,7 @@ import { loadEvals, type LoadedScenario } from './evals';
 import { canonicalDocUrl } from './doc-url';
 import { computeCoverage } from './coverage';
 import { diffSyncPlan } from './sync';
-import { EvalForgeClient, draftTagFor } from './evalforge';
+import { EvalForgeClient, draftTagFor, evalRunUrl } from './evalforge';
 import { workspaceRoot } from './workspace';
 import { BASE_WORKSPACE_SUBDIR } from './paths';
 import { pollUntilDone, EvalRunTimeoutError } from './eval-run';
@@ -156,6 +156,7 @@ export async function runGate(): Promise<void> {
     'Could not create eval run', comment, config,
   );
   if (!run) return;
+  const runUrl = evalRunUrl(config.projectId, run.id);
 
   const triggered = await guardedCall(
     () => evalforge.triggerEvalRun(config.projectId, run.id),
@@ -168,7 +169,7 @@ export async function runGate(): Promise<void> {
     finalStatus = await pollUntilDone(evalforge, config.projectId, run.id);
   } catch (e) {
     if (e instanceof EvalRunTimeoutError) {
-      await comment(formatEvalTimeout(run.id, config.blocking));
+      await comment(formatEvalTimeout(run.id, runUrl, config.blocking));
       fail(`Eval timed out (run ID: ${run.id})`, config.blocking);
       return;
     }
@@ -180,10 +181,10 @@ export async function runGate(): Promise<void> {
 
   const m = finalStatus.aggregateMetrics;
   if (finalStatus.status === 'completed' && m.failed === 0 && m.errors === 0) {
-    await comment(formatEvalPassed(m, run.id));
+    await comment(formatEvalPassed(m, run.id, runUrl));
     core.info(`Eval passed — ${m.passed}/${m.totalAssertions} (run ID: ${run.id})`);
   } else {
-    await comment(formatEvalFailed(m, run.id, config.blocking));
+    await comment(formatEvalFailed(m, run.id, runUrl, config.blocking));
     fail(`Eval failed (${m.passRate}%)`, config.blocking);
   }
 }

--- a/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
@@ -41,11 +41,12 @@ describe('comment formatters', () => {
     expect(c.formatServiceError('boom', false)).toContain('⚠️');
   });
 
-  it('formatEvalPassed includes pass rate + run id', () => {
+  it('formatEvalPassed includes pass rate + run link', () => {
     const metrics = { totalAssertions: 1, passed: 1, failed: 0, skipped: 0, errors: 0, passRate: 100, avgDuration: 0, totalDuration: 0 };
-    const out = c.formatEvalPassed(metrics, 'run-1');
+    const out = c.formatEvalPassed(metrics, 'run-1', 'https://bo.wix.com/pages/evalforge/proj-1/results?runId=run-1');
     expect(out).toContain('100%');
     expect(out).toContain('run-1');
+    expect(out).toContain('(https://bo.wix.com/pages/evalforge/proj-1/results?runId=run-1)');
   });
 
   it('formatNoChanges signals success', () => {


### PR DESCRIPTION
Render the eval run as a markdown link to the EvalForge results page (https://bo.wix.com/pages/evalforge/{projectId}/results?runId={runId}) instead of a bare run ID, in the passed/failed/timeout comments.