### PR TITLE
feat(wix-headless): combinatorial layout composition (CODEAI-696)

### DIFF
--- a/skills/wix-headless/references/BUILD-astro.md
+++ b/skills/wix-headless/references/BUILD-astro.md
@@ -58,6 +58,8 @@ The whole Setup window is a single message of sibling `Bash` calls — **emit th
 
    The compose-input shape is documented in `scripts/compose.mjs`'s header.
 
+   **Layout is assembled + randomized by `compose.mjs` — no input required.** The homepage is composed from one random hero fragment + one random about fragment, with a random nav, drawn from `references/astro/templates/fragments/<slot>/`, so every build comes out structurally different (the theme/skin still tracks the vibe via `DESIGN.md`). The run is non-reproducible by design; the chosen combo is recorded in the manifest's `data.layout`. (For a reproducible layout in tests, pass an integer `layoutSeed` in the compose input.)
+
 **In the SAME message — the business Setup Step 4 batch** (frontend-blind; `SETUP.md` owns recipes/package set). These overlap the bridge's `compose.mjs` (~20 s) so it adds no serial wall:
 
 3. `Bash` × N — app installs, one curl per `pack.apps[*]` → `SETUP.md` § Step 4a. Packs with no `apps[*]` (`cms`, `ecom`, `gift-cards`) install nothing — skip them.

--- a/skills/wix-headless/references/DISCOVERY-create.md
+++ b/skills/wix-headless/references/DISCOVERY-create.md
@@ -124,7 +124,7 @@ The Designer owns the design — it **authors `DESIGN.md`** (the tokens) and ret
 
 The plan has two halves: a **decision card** (Sections A + B — what the user weighs in on) and a **technical scope** block (Section C + Imagery — "for free" from the loaded packs, skimmable).
 
-**Section A — Design Direction** (lead): the aesthetic paragraph, then a compact block — aesthetic tone · palette (2–3 colors + hex) · type pairing (display + body) · mood/key visuals · page color strategy (Uniform Light / Uniform Dark / Defined Hybrid).
+**Section A — Design Direction** (lead): the aesthetic paragraph, then a compact block — aesthetic tone · palette (2–3 colors + hex) · type pairing (display + body) · mood/key visuals · page color strategy (Uniform Light / Uniform Dark / Defined Hybrid). (Don't promise a specific page layout — the structural composition is assembled + randomized at build time by `compose.mjs`, after approval.)
 
 **Section B — Features**: 1–2 line bullets of user-facing functionality per pack; tag CMS-powered ones **(CMS-based)**. **Skip features from `disabled: true` packs** (today: `gift-cards`) — the code still ships (page + nav/home contributions) but the plan stays silent until the user enables the app. Non-disabled packs (incl. transitive ones like ecom) contribute normally.
 

--- a/skills/wix-headless/references/astro/templates/fragments/about/image-left.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/about/image-left.astro
@@ -1,0 +1,20 @@
+  <!-- about fragment: image-left — image left, brand story right -->
+  <section class="max-w-6xl mx-auto px-lg py-4xl grid grid-cols-1 md:grid-cols-2 gap-3xl items-center">
+    <div
+      class="about-image rounded-md order-last md:order-first"
+      data-decorative-slot="about"
+      style="aspect-ratio: 4/3; background-color: var(--color-paper-warm);"
+    >
+      <!-- orchestrator injects <img src={decorativeImages.about} …> here -->
+    </div>
+    <div class="flex flex-col gap-md max-w-prose">
+      <hr class="editorial-rule w-16 ml-0" />
+      <h2 class="font-display text-3xl leading-tight">The story behind {{brand.name}}</h2>
+      <p class="text-ink leading-relaxed">
+        A short, brand-contextual paragraph about what makes {{brand.name}} distinct.
+      </p>
+      <p class="text-mute leading-relaxed">
+        A second paragraph adding warmth and detail to the brand story.
+      </p>
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/about/image-right.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/about/image-right.astro
@@ -1,0 +1,20 @@
+  <!-- about fragment: image-right — brand story left, image right -->
+  <section class="max-w-6xl mx-auto px-lg py-4xl grid grid-cols-1 md:grid-cols-2 gap-3xl items-center">
+    <div class="flex flex-col gap-md max-w-prose">
+      <hr class="editorial-rule w-16 ml-0" />
+      <h2 class="font-display text-3xl leading-tight">The story behind {{brand.name}}</h2>
+      <p class="text-ink leading-relaxed">
+        A short, brand-contextual paragraph about what makes {{brand.name}} distinct.
+      </p>
+      <p class="text-mute leading-relaxed">
+        A second paragraph adding warmth and detail to the brand story.
+      </p>
+    </div>
+    <div
+      class="about-image rounded-md"
+      data-decorative-slot="about"
+      style="aspect-ratio: 4/3; background-color: var(--color-paper-warm);"
+    >
+      <!-- orchestrator injects <img src={decorativeImages.about} …> here -->
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/about/stacked.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/about/stacked.astro
@@ -1,0 +1,20 @@
+  <!-- about fragment: stacked — centered brand story above a wide image -->
+  <section class="max-w-6xl mx-auto px-lg py-4xl flex flex-col items-center gap-xl text-center">
+    <div class="flex flex-col gap-md items-center max-w-prose">
+      <hr class="editorial-rule w-16" />
+      <h2 class="font-display text-3xl leading-tight">The story behind {{brand.name}}</h2>
+      <p class="text-ink leading-relaxed">
+        A short, brand-contextual paragraph about what makes {{brand.name}} distinct.
+      </p>
+      <p class="text-mute leading-relaxed">
+        A second paragraph adding warmth and detail to the brand story.
+      </p>
+    </div>
+    <div
+      class="about-image rounded-md w-full"
+      data-decorative-slot="about"
+      style="aspect-ratio: 16/6; background-color: var(--color-paper-warm);"
+    >
+      <!-- orchestrator injects <img src={decorativeImages.about} …> here -->
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/hero/centered-banner.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/hero/centered-banner.astro
@@ -1,0 +1,16 @@
+  <!-- hero fragment: centered-banner — centered copy above a wide banner image -->
+  <section class="relative">
+    <div class="max-w-6xl mx-auto px-lg py-4xl flex flex-col items-center gap-xl text-center">
+      <div class="flex flex-col gap-lg items-center max-w-prose">
+        <h1 class="font-display text-4xl md:text-5xl leading-tight">{{shell.heroHeadline}}</h1>
+        <p class="text-lg text-mute">{{shell.heroSub}}</p>
+      </div>
+      <div
+        class="hero-image rounded-md w-full"
+        data-decorative-slot="hero"
+        style="aspect-ratio: 16/7; background-color: var(--color-paper-warm);"
+      >
+        <!-- orchestrator injects <img src={decorativeImages.hero} …> here -->
+      </div>
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/hero/split-left.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/hero/split-left.astro
@@ -1,0 +1,16 @@
+  <!-- hero fragment: split-left — image left, copy right -->
+  <section class="relative">
+    <div class="max-w-6xl mx-auto px-lg py-4xl grid grid-cols-1 md:grid-cols-2 gap-3xl items-center">
+      <div
+        class="hero-image rounded-md order-last md:order-first"
+        data-decorative-slot="hero"
+        style="aspect-ratio: 4/5; background-color: var(--color-paper-warm);"
+      >
+        <!-- orchestrator injects <img src={decorativeImages.hero} …> here -->
+      </div>
+      <div class="flex flex-col gap-lg">
+        <h1 class="font-display text-4xl md:text-5xl leading-tight">{{shell.heroHeadline}}</h1>
+        <p class="text-lg text-mute max-w-prose">{{shell.heroSub}}</p>
+      </div>
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/hero/split-right.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/hero/split-right.astro
@@ -1,0 +1,16 @@
+  <!-- hero fragment: split-right — copy left, image right -->
+  <section class="relative">
+    <div class="max-w-6xl mx-auto px-lg py-4xl grid grid-cols-1 md:grid-cols-2 gap-3xl items-center">
+      <div class="flex flex-col gap-lg">
+        <h1 class="font-display text-4xl md:text-5xl leading-tight">{{shell.heroHeadline}}</h1>
+        <p class="text-lg text-mute max-w-prose">{{shell.heroSub}}</p>
+      </div>
+      <div
+        class="hero-image rounded-md"
+        data-decorative-slot="hero"
+        style="aspect-ratio: 4/5; background-color: var(--color-paper-warm);"
+      >
+        <!-- orchestrator injects <img src={decorativeImages.hero} …> here -->
+      </div>
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/hero/stacked-top.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/hero/stacked-top.astro
@@ -1,0 +1,16 @@
+  <!-- hero fragment: stacked-top — wide image on top, copy below (left-aligned) -->
+  <section class="relative">
+    <div class="max-w-6xl mx-auto px-lg pt-4xl pb-2xl flex flex-col gap-xl">
+      <div
+        class="hero-image rounded-md w-full"
+        data-decorative-slot="hero"
+        style="aspect-ratio: 21/9; background-color: var(--color-paper-warm);"
+      >
+        <!-- orchestrator injects <img src={decorativeImages.hero} …> here -->
+      </div>
+      <div class="flex flex-col gap-md max-w-prose">
+        <h1 class="font-display text-4xl md:text-5xl leading-tight">{{shell.heroHeadline}}</h1>
+        <p class="text-lg text-mute">{{shell.heroSub}}</p>
+      </div>
+    </div>
+  </section>

--- a/skills/wix-headless/references/astro/templates/fragments/nav/brand-left.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/nav/brand-left.astro
@@ -1,0 +1,35 @@
+---
+// ── nav fragment: brand-left — wordmark left, links right (the classic) ───────
+//   {{shell.navBrandMark}} — brand mark / wordmark text from data.shell.
+//   {{nav.links}} — one <li class="site-nav-item"><a …></a></li> per entry.
+// Fixed bulk (keep literal): transition:persist, the <!-- nav:links --> marker,
+// the empty <div class="nav-actions"> mount, the mobile hamburger toggle.
+---
+<header class="site-nav" transition:persist="site-nav">
+  <nav class="max-w-6xl mx-auto px-lg flex items-center justify-between gap-lg py-md">
+    <a href="/" class="font-display text-lg tracking-tight">{{shell.navBrandMark}}</a>
+
+    <input type="checkbox" id="nav-toggle" class="peer hidden" aria-hidden="true" />
+    <label
+      for="nav-toggle"
+      class="md:hidden inline-flex flex-col gap-[5px] cursor-pointer"
+      aria-label="Toggle navigation"
+    >
+      <span class="block h-[2px] w-6 bg-ink"></span>
+      <span class="block h-[2px] w-6 bg-ink"></span>
+      <span class="block h-[2px] w-6 bg-ink"></span>
+    </label>
+
+    <div
+      class="hidden peer-checked:flex md:flex absolute md:static top-full left-0 right-0 md:right-auto
+             flex-col md:flex-row gap-md md:gap-lg items-start md:items-center
+             bg-paper md:bg-transparent border-b md:border-0 border-rule px-lg md:px-0 py-md md:py-0"
+    >
+      <ul class="flex flex-col md:flex-row gap-md md:gap-lg items-start md:items-center">
+        {{nav.links}}
+        <!-- nav:links -->
+      </ul>
+      <div class="nav-actions"></div>
+    </div>
+  </nav>
+</header>

--- a/skills/wix-headless/references/astro/templates/fragments/nav/centered.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/nav/centered.astro
@@ -1,0 +1,37 @@
+---
+// ── nav fragment: centered — centered wordmark, links centered on a 2nd row ───
+//   {{shell.navBrandMark}} — brand mark / wordmark text from data.shell.
+//   {{nav.links}} — one <li class="site-nav-item"><a …></a></li> per entry.
+// Fixed bulk (keep literal): transition:persist, the <!-- nav:links --> marker,
+// the empty <div class="nav-actions"> mount, the mobile hamburger toggle.
+---
+<header class="site-nav" transition:persist="site-nav">
+  <nav class="max-w-6xl mx-auto px-lg flex flex-col items-center gap-sm py-md">
+    <div class="w-full flex items-center justify-between md:justify-center gap-lg">
+      <a href="/" class="font-display text-lg tracking-tight">{{shell.navBrandMark}}</a>
+
+      <input type="checkbox" id="nav-toggle" class="peer hidden" aria-hidden="true" />
+      <label
+        for="nav-toggle"
+        class="md:hidden inline-flex flex-col gap-[5px] cursor-pointer"
+        aria-label="Toggle navigation"
+      >
+        <span class="block h-[2px] w-6 bg-ink"></span>
+        <span class="block h-[2px] w-6 bg-ink"></span>
+        <span class="block h-[2px] w-6 bg-ink"></span>
+      </label>
+    </div>
+
+    <div
+      class="hidden peer-checked:flex md:flex absolute md:static top-full left-0 right-0 md:right-auto
+             flex-col md:flex-row gap-md md:gap-lg items-start md:items-center md:justify-center
+             bg-paper md:bg-transparent border-b md:border-0 border-rule px-lg md:px-0 py-md md:py-0"
+    >
+      <ul class="flex flex-col md:flex-row gap-md md:gap-lg items-start md:items-center">
+        {{nav.links}}
+        <!-- nav:links -->
+      </ul>
+      <div class="nav-actions"></div>
+    </div>
+  </nav>
+</header>

--- a/skills/wix-headless/references/astro/templates/fragments/nav/left-clustered.astro
+++ b/skills/wix-headless/references/astro/templates/fragments/nav/left-clustered.astro
@@ -1,0 +1,35 @@
+---
+// ── nav fragment: left-clustered — wordmark + links grouped together on the left ─
+//   {{shell.navBrandMark}} — brand mark / wordmark text from data.shell.
+//   {{nav.links}} — one <li class="site-nav-item"><a …></a></li> per entry.
+// Fixed bulk (keep literal): transition:persist, the <!-- nav:links --> marker,
+// the empty <div class="nav-actions"> mount, the mobile hamburger toggle.
+---
+<header class="site-nav" transition:persist="site-nav">
+  <nav class="max-w-6xl mx-auto px-lg flex items-center justify-between md:justify-start gap-lg md:gap-2xl py-md">
+    <a href="/" class="font-display text-lg tracking-tight">{{shell.navBrandMark}}</a>
+
+    <input type="checkbox" id="nav-toggle" class="peer hidden" aria-hidden="true" />
+    <label
+      for="nav-toggle"
+      class="md:hidden inline-flex flex-col gap-[5px] cursor-pointer"
+      aria-label="Toggle navigation"
+    >
+      <span class="block h-[2px] w-6 bg-ink"></span>
+      <span class="block h-[2px] w-6 bg-ink"></span>
+      <span class="block h-[2px] w-6 bg-ink"></span>
+    </label>
+
+    <div
+      class="hidden peer-checked:flex md:flex absolute md:static top-full left-0 right-0 md:right-auto
+             flex-col md:flex-row gap-md md:gap-lg items-start md:items-center
+             bg-paper md:bg-transparent border-b md:border-0 border-rule px-lg md:px-0 py-md md:py-0"
+    >
+      <ul class="flex flex-col md:flex-row gap-md md:gap-lg items-start md:items-center">
+        {{nav.links}}
+        <!-- nav:links -->
+      </ul>
+      <div class="nav-actions"></div>
+    </div>
+  </nav>
+</header>

--- a/skills/wix-headless/references/astro/templates/index.astro
+++ b/skills/wix-headless/references/astro/templates/index.astro
@@ -1,56 +1,25 @@
 ---
 // ── Composer skeleton: src/pages/index.astro ──────────────────────────────────
-// Home shell. Substitutions (see compose.mjs):
-//   {{shell.heroHeadline}}, {{shell.heroSub}} — brand-voice hero copy.
-//   {{shell.footerTagline}} is NOT used here.
-//   {{brand.name}} — used in the brand-story copy.
+// Thin home shell. compose.mjs ASSEMBLES the page by substituting one randomly
+// chosen hero fragment (fragments/hero/) into {{hero}} and one about fragment
+// (fragments/about/) into {{about}}, then fills the inner slots. The home-pack
+// markers sit between them.
+//   {{hero}}        — one fragments/hero/*.astro (carries the hero copy + slot).
+//   {{about}}       — one fragments/about/*.astro (carries the brand story + slot).
 //   {{home-markers}} — one `<!-- home:<pack> -->` marker per LOADED pack that
 //        contributes a home section (e.g. stores, gift-cards). Emit a marker
 //        ONLY for such packs; never emit a marker no pack will fill (e.g. no
 //        <!-- home:cms --> — CMS owns brand-story directly). Disabled packs
 //        (gift-cards) still get their marker; do NOT add hero CTAs / teasers
 //        pointing at disabled-pack routes.
-// Fixed bulk (keep literal): the Layout wrapper, hero/brand-story structure,
-// the data-decorative-slot="hero" and "about" placeholders (the orchestrator
-// injects <img> into these after Image Phase 1 — keep them empty).
+// Fixed bulk (keep literal): the Layout wrapper and the {{hero}}/{{home-markers}}/
+// {{about}} assembly points.
 import Layout from '../layouts/Layout.astro';
 ---
 <Layout>
-  <section class="relative">
-    <div class="max-w-6xl mx-auto px-lg py-4xl grid grid-cols-1 md:grid-cols-2 gap-3xl items-center">
-      <div class="flex flex-col gap-lg">
-        <h1 class="font-display text-4xl md:text-5xl leading-tight">{{shell.heroHeadline}}</h1>
-        <p class="text-lg text-mute max-w-prose">{{shell.heroSub}}</p>
-      </div>
-      <div
-        class="hero-image rounded-md"
-        data-decorative-slot="hero"
-        style="aspect-ratio: 4/5; background-color: var(--color-paper-warm);"
-      >
-        <!-- orchestrator injects <img src={decorativeImages.hero} …> here -->
-      </div>
-    </div>
-  </section>
+{{hero}}
 
   {{home-markers}}
 
-  <section class="max-w-6xl mx-auto px-lg py-4xl grid grid-cols-1 md:grid-cols-2 gap-3xl items-center">
-    <div
-      class="about-image rounded-md order-last md:order-first"
-      data-decorative-slot="about"
-      style="aspect-ratio: 4/3; background-color: var(--color-paper-warm);"
-    >
-      <!-- orchestrator injects <img src={decorativeImages.about} …> here -->
-    </div>
-    <div class="flex flex-col gap-md max-w-prose">
-      <hr class="editorial-rule w-16 ml-0" />
-      <h2 class="font-display text-3xl leading-tight">The story behind {{brand.name}}</h2>
-      <p class="text-ink leading-relaxed">
-        A short, brand-contextual paragraph about what makes {{brand.name}} distinct.
-      </p>
-      <p class="text-mute leading-relaxed">
-        A second paragraph adding warmth and detail to the brand story.
-      </p>
-    </div>
-  </section>
+{{about}}
 </Layout>

--- a/skills/wix-headless/scripts/compose.mjs
+++ b/skills/wix-headless/scripts/compose.mjs
@@ -40,6 +40,13 @@
 //                       in order (COMPOSE § Layout.astro).
 //   - disabledPacks  — string[]; dormant packs still get their home/nav markers,
 //                       never a visible entry point.
+//   - layoutSeed     — optional integer. The homepage is ASSEMBLED from one
+//                       randomly chosen fragment per slot (hero, about) plus a
+//                       random nav, drawn from references/astro/templates/
+//                       fragments/<slot>/. Selection is random per run by default
+//                       (Math.random) so every build differs; pass an integer
+//                       layoutSeed to make the pick reproducible (tests). The
+//                       chosen combo is reported in the manifest (data.layout).
 //
 // What it writes (the 6 design-system files), by substituting {{…}} slots into
 // the pinned skeletons — the fixed bulk is copied byte-for-byte:
@@ -63,7 +70,7 @@
 // astro only. Custom (non-astro) frontends never reach the Composer — the
 // orchestrator only invokes this when frontend === "astro".
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname, resolve, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
@@ -337,6 +344,30 @@ function readTemplate(name) {
   if (!existsSync(p)) die("TEMPLATE_MISSING", `skeleton not found at ${p}`);
   return readFileSync(p, "utf8");
 }
+
+// ── layout fragment assembly ──────────────────────────────────────────────────
+const FRAGMENTS = join(TEMPLATES, "fragments");
+function makeRng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const layoutSeed = Number.isInteger(input.layoutSeed) ? (input.layoutSeed >>> 0) : Math.floor(Math.random() * 0x7fffffff);
+const rng = makeRng(layoutSeed);
+const chosenLayout = {};
+function pickFragment(slot) {
+  const dir = join(FRAGMENTS, slot);
+  if (!existsSync(dir)) return null;
+  const files = readdirSync(dir).filter((f) => f.endsWith(".astro")).sort();
+  if (!files.length) return null;
+  const file = files[Math.floor(rng() * files.length)];
+  chosenLayout[slot] = file.replace(/\.astro$/, "");
+  return readFileSync(join(dir, file), "utf8");
+}
 function writeProject(rel, content) {
   const dest = join(projectDir, rel);
   mkdirSync(dirname(dest), { recursive: true });
@@ -468,9 +499,10 @@ const navItems = navLinks
   .filter((l) => l && l.href != null && l.label != null)
   .map((l) => ({ href: String(l.href), label: String(l.label) }));
 
-// ── 4. Navigation.astro ──────────────────────────────────────────────────────────
+// ── 4. Navigation.astro (one random nav fragment; legacy fallback) ────────────
 {
-  let out = stripAstroHeader(readTemplate("Navigation.astro"));
+  const navFrag = pickFragment("nav");
+  let out = stripAstroHeader(navFrag ?? readTemplate("Navigation.astro"));
   out = out.replaceAll("{{shell.navBrandMark}}", shell.navBrandMark ?? brandName);
   const links = navItems
     .map((l) => `        <li class="site-nav-item"><a href="${escAttr(l.href)}">${l.label}</a></li>`)
@@ -499,7 +531,13 @@ const HOME_CONTRIBUTING = ["stores", "bookings", "gift-cards"]; // canonical ord
 const homePool = new Set([...loadedPacks, ...disabledPacks]);
 const homeMarkerPacks = HOME_CONTRIBUTING.filter((p) => homePool.has(p));
 {
+  const heroFrag = pickFragment("hero");
+  const aboutFrag = pickFragment("about");
+  if (!heroFrag) die("NO_HERO_FRAGMENT", `no hero fragments in ${join(FRAGMENTS, "hero")}`);
+  if (!aboutFrag) die("NO_ABOUT_FRAGMENT", `no about fragments in ${join(FRAGMENTS, "about")}`);
   let out = stripAstroHeader(readTemplate("index.astro"));
+  out = out.replace("{{hero}}", () => heroFrag);
+  out = out.replace("{{about}}", () => aboutFrag);
   out = out.replaceAll("{{shell.heroHeadline}}", shell.heroHeadline ?? brandName);
   out = out.replaceAll("{{shell.heroSub}}", shell.heroSub ?? "");
   out = out.replaceAll("{{brand.name}}", brandName);
@@ -522,6 +560,7 @@ const manifest = {
   phase: "compose",
   data: {
     filesWritten,
+    layout: { seed: layoutSeed, ...chosenLayout },
     componentCssImports: packsWithComponents,
     homeMarkers: homeMarkerPacks.map((p) => `home:${p}`),
     tokensApplied: {


### PR DESCRIPTION
## CODEAI-696 — generated sites share one layout

Every site `wix-headless` generated used the **same fixed layout** (same hero, same nav), so two sites from different prompts looked like the same template re-skinned — only colors/fonts varied. This makes the homepage **structure vary per build** while keeping the deterministic, no-LLM-layout pipeline (≤600s, reliable).

### Approach — combinatorial section composition
`compose.mjs` now **assembles** the homepage from one randomly chosen fragment per slot instead of filling a single fixed skeleton:

- `index.astro` is a thin shell — `{{hero}} {{home-markers}} {{about}}`.
- `fragments/hero/` (4) × `fragments/about/` (3) × `fragments/nav/` (3) = **36 homepage combinations**. New fragments are auto-discovered (drop a file in, no code change).
- **Random per run** (`Math.random`); pass an integer `layoutSeed` for a reproducible pick (tests). The chosen combo + seed are recorded in the manifest (`data.layout`) since the run is otherwise non-reproducible.
- Every fragment preserves the exact slots/markers the pipeline depends on (`heroHeadline`/`heroSub`, `data-decorative-slot="hero"|"about"`, `<!-- home:* -->` / `<!-- nav:links -->`, `nav-actions`, `site-nav`, `transition:persist`) → downstream build agents stay variant-agnostic. `global.css` / `Layout.astro` / `Footer.astro` are shared (View-Transitions wiring untouched).

`BUILD-astro.md` documents that layout is auto-randomized by compose (no input required). `DISCOVERY-create.md` no longer promises a specific layout in the plan (structure is chosen post-approval at compose time).

> Supersedes the earlier "3 whole-page variants" approach — those whole-page templates were decomposed into the per-slot fragment library (this branch was squashed to a single clean commit).

### Verification
- **compose unit runs:** across 16 seeds, every combo renders all slots/markers with no leftover `{{…}}`; same `layoutSeed` reproducible; random runs produce distinct combos; `global.css`/`Layout`/`Footer` stable across layouts.
- **End-to-end:** 3 minimal yoga sites built + published, each with a visibly different hero/nav layout (centered-banner / stacked-top / split-left), confirmed via Playwright screenshots.

### Scope & follow-ups
- **v1 scope:** homepage hero + navigation.
- **Follow-ups:** per-vertical page fragments (products/services/blog); section-order shuffle + vibe-weighted selection for more variety; persist chosen combo to `.wix/layout.json`/`AGENTS.md` for after-the-fact reproducibility; fragment-authoring contract doc + build-all-combos smoke test.
- Independent of PR #405 (CODEAI-667 theme vibe-binding), which stays in draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)