### PR TITLE
test: verify EvalForge run-link in gate comment

### DIFF
--- a/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
+++ b/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
@@ -1,5 +1,5 @@
 name: domains/domain-search-and-purchase
-description: Verifies the agent reads the domain-search-and-purchase docs when asked about programmatic Wix domain search and purchase.
+description: Verifies the agent reads the domain-search-and-purchase docs when asked about programmatic Wix domain search and purchase. (run-link gate test)
 triggerPrompt: How do I programmatically search for an available domain on Wix and then purchase it? Please reference the relevant API methods.
 tags: [domains]
 assertions:


### PR DESCRIPTION
Temporary test PR to exercise the new **EvalForge run link** in the gate comment (from `feat/eval-gate-run-link`, now cherry-picked onto `task/eval-gate-baseline`).

Touches `yaml/wix-manage-evals/domains/domain-search-and-purchase.yml` (description tweak) so the gate runs end-to-end against `task/eval-gate-baseline`'s action code, creates a real EvalForge run, and posts the comment.

**What to verify:** the gate comment shows `Run: [<runId>](https://bo.wix.com/pages/evalforge/<projectId>/results?runId=<runId>)` as a clickable link.

Do not merge — close after verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)