### PR TITLE
test: exercise siteSetup site provisioning sync

### DIFF
--- a/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
+++ b/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
@@ -3,7 +3,18 @@ description: Verifies the agent reads the domain-search-and-purchase docs when a
 triggerPrompt: How do I programmatically search for an available domain on Wix and then purchase it? Please reference the relevant API methods.
 tags: [domains]
 siteSetup:
-  templateId: default
+  templateId: ecommerce
+  bootstrap:
+    steps:
+      - label: seed a product
+        method: post
+        url: https://www.wixapis.com/stores/v1/products
+        body:
+          product:
+            name: Bootstrap Test Product
+            productType: physical
+            priceData:
+              price: 19.99
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
+++ b/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
@@ -2,19 +2,6 @@ name: domains/domain-search-and-purchase
 description: Verifies the agent reads the domain-search-and-purchase docs when asked about programmatic Wix domain search and purchase.
 triggerPrompt: How do I programmatically search for an available domain on Wix and then purchase it? Please reference the relevant API methods.
 tags: [domains]
-siteSetup:
-  templateId: ecommerce
-  bootstrap:
-    steps:
-      - label: seed a product
-        method: post
-        url: https://www.wixapis.com/stores/v1/products
-        body:
-          product:
-            name: Bootstrap Test Product
-            productType: physical
-            priceData:
-              price: 19.99
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
+++ b/yaml/wix-manage-evals/domains/domain-search-and-purchase.yml
@@ -2,6 +2,8 @@ name: domains/domain-search-and-purchase
 description: Verifies the agent reads the domain-search-and-purchase docs when asked about programmatic Wix domain search and purchase.
 triggerPrompt: How do I programmatically search for an available domain on Wix and then purchase it? Please reference the relevant API methods.
 tags: [domains]
+siteSetup:
+  templateId: default
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/ecommerce/bootstrap-seeded-product-visible.yml
+++ b/yaml/wix-manage-evals/ecommerce/bootstrap-seeded-product-visible.yml
@@ -1,0 +1,37 @@
+name: ecommerce/bootstrap-seeded-product-visible
+description: >
+  End-to-end site-provisioning check. Provisions a fresh Stores site, seeds a
+  uniquely-named product via a bootstrap step, then asks the agent to list the
+  store's products and verifies the seeded product is actually present.
+triggerPrompt: >
+  List every product in my Wix store and report each product's exact name. If the
+  store has no products, say so explicitly.
+tags: [ecommerce]
+siteSetup:
+  templateId: ecommerce
+  bootstrap:
+    steps:
+      - label: seed a uniquely-named product
+        method: post
+        url: https://www.wixapis.com/stores/v1/products
+        body:
+          product:
+            name: Zorblax Quantum Widget 7782
+            productType: physical
+            priceData:
+              price: 42.50
+assertions:
+  - type: llm_judge
+    minScore: 8
+    maxTokens: 2048
+    prompt: |
+      The store was seeded (before this prompt) with a product named exactly
+      "Zorblax Quantum Widget 7782".
+
+      Pass only if the response lists/mentions a product named
+      "Zorblax Quantum Widget 7782" (exact or near-exact spelling).
+
+      Fail if the response:
+      - does not mention that product, OR
+      - reports the store as empty, OR
+      - only mentions generic/template placeholder products.

--- a/yaml/wix-manage-evals/ecommerce/bootstrap-seeded-product-visible.yml
+++ b/yaml/wix-manage-evals/ecommerce/bootstrap-seeded-product-visible.yml
@@ -11,15 +11,21 @@ siteSetup:
   templateId: ecommerce
   bootstrap:
     steps:
-      - label: seed a uniquely-named product
+      - label: seed a uniquely-named product (Catalog V3)
         method: post
-        url: https://www.wixapis.com/stores/v1/products
+        url: https://www.wixapis.com/stores/v3/products
         body:
           product:
             name: Zorblax Quantum Widget 7782
-            productType: physical
-            priceData:
-              price: 42.50
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price:
+                    actualPrice:
+                      amount: "42.50"
+                  physicalProperties: {}
+                  visible: true
 assertions:
   - type: llm_judge
     minScore: 8


### PR DESCRIPTION
Temporary test PR. Adds `siteSetup: { templateId: default }` to a scenario to verify the new site-provisioning mapping syncs to EvalForge and provisions a site end-to-end. Do not merge — close after verifying.