### PR TITLE
chore(codeowners): bookings-calendar-platform owns the wix-headless bookings vertical

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,10 @@
 # Editor React Component skill docs
 /skills/wix-app/references/EDITOR_REACT_COMPONENT.md        @wix-private/ot-components-ee
 /skills/wix-app/references/editor-react-component/          @wix-private/ot-components-ee
+
+# Wix Headless — Bookings vertical
+/skills/wix-headless/references/bookings/                   @wix-private/bookings-calendar-platform
+/skills/wix-headless/references/astro/bookings/             @wix-private/bookings-calendar-platform
+/skills/wix-headless/references/astro/templates/bookings/   @wix-private/bookings-calendar-platform
+/skills/wix-headless/references/custom/bookings/            @wix-private/bookings-calendar-platform
+/skills/wix-headless/references/verticals/bookings.md       @wix-private/bookings-calendar-platform


### PR DESCRIPTION
Adds **@wix-private/bookings-calendar-platform** as a code owner of the **Bookings vertical** of the `wix-headless` skill, so the team can review/approve changes to it (per the request to manage bookings-skill ownership).

Paths owned:
- `skills/wix-headless/references/bookings/` — FLOW.md, INSTRUCTIONS.md, SERVICES_DATA.md
- `skills/wix-headless/references/astro/bookings/` + `…/astro/templates/bookings/`
- `skills/wix-headless/references/custom/bookings/`
- `skills/wix-headless/references/verticals/bookings.md`

Scoped to the bookings paths only (not the whole `wix-headless` skill, which also hosts stores/forms/etc.). Follows the existing `@wix-private/<team>` convention in the file.