### PR TITLE
[DO NOT MERGE] SMB eval pilot — 3 frozen bookings skills + 9 EvalForge scenarios

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -64,6 +64,15 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Create Course Service](references/bookings/create-course-service.md)
 **Technical:** Use when the user wants to create a multi-session course — e.g. "create a 6-week workshop", "set up a training program for $300". Handles group capacity, full-course pricing, and fixed series via bulkCreateServices API.
 
+### [SMB Create Appointment Service](references/bookings/smb-create-appointment-service.md)
+**Technical:** SMB eval-pilot recipe (frozen fitness/US cohort). Creates a *bookable* APPOINTMENT service but refuses to finish until an instructor with real working hours is assigned, and confirms with the owner before creating. Not for merge.
+
+### [SMB Draft Cancellation Notification](references/bookings/smb-draft-cancellation-notification.md)
+**Technical:** SMB eval-pilot recipe (frozen fitness/US cohort). When a business-side cancellation occurs, drafts an owner-approved apology that names the instructor and proposes concrete rebook slots from that instructor's real availability. Not for merge.
+
+### [SMB Turn Intake Form Into First Booking](references/bookings/smb-turn-intake-form-into-first-booking.md)
+**Technical:** SMB eval-pilot recipe (frozen fitness/US cohort). On a new intake-form submission, finds/creates the contact, matches interest+availability to the real schedule, proposes specific slots, and waits for owner approval before sending. Not for merge.
+
 ### [End-to-End Booking Flow](references/bookings/end-to-end-booking-flow.md)
 **Technical:** Complete booking flow from service discovery to payment. Query services, check availability with Time Slots V2, create bookings, and process payment via eCommerce checkout.
 

--- a/skills/wix-manage/references/bookings/smb-create-appointment-service.md
+++ b/skills/wix-manage/references/bookings/smb-create-appointment-service.md
@@ -1,0 +1,117 @@
+---
+name: "SMB Create Appointment Service"
+description: Create a Wix Bookings APPOINTMENT-type service for 1-on-1 sessions — refusing to finish until at least one staff member with working hours is assigned.
+---
+
+## Required capabilities (platform-neutral)
+
+This skill declares the neutral capabilities it needs; the connected platform's tools (the Wix MCP) supply the concrete API calls at runtime.
+
+  - service.create
+  - service.get
+  - service.set-locations
+  - staff.schedule.get                         # confirm staff has working hours
+  - site.get-properties
+
+# Create an APPOINTMENT service
+
+## Goal
+
+Create a 1-on-1 bookable service that customers can actually schedule against staff availability. **Refuse to finish until at least one staff member is assigned AND that staff member has working hours on their schedule** — an APPOINTMENT service without an available staffer is non-bookable.
+
+## Flow at a glance
+
+```
+Caller passes: service_name + duration + price + staff_member_ids + staff_availability
+   ↓
+Agent: validate staff have working-hours schedules (staff.schedule.get)
+   ↓
+Agent → Owner: "Creating '{service_name}', {duration} min, ${price}, with instructors X and Y.
+                X works Mon-Fri 9-5; Y works Tue/Thu 18-21. Proceed?"  ← ⛔ STOP, await approval
+   ↓
+Owner: yes
+   ↓
+Agent: service.create
+   ↓
+Agent: HARD STOP if no service.id
+   ↓
+Agent: VERIFY — service.get + staff.schedule.get for each staff_id
+   ↓
+Agent → Owner: "Done. {service_name} is bookable. Public page: {url}"
+```
+
+## When to use
+
+- **Proactive data signal:** owner finished onboarding for a personal-training, nutrition-coaching, or bodywork subvertical (per Industry.md clusters).
+- **Human trigger:** owner says "add a private session" / "set up a consultation" / "create 1-on-1 service".
+
+## Inputs
+
+| name | required | example | notes |
+|---|---|---|---|
+| service_name | yes | "Personal Training" | Use Industry.md APPOINTMENT cluster names |
+| duration_min | no | `60` | Defaults to 60; common values 30/45/60/75/90 |
+| price | no | `77` | Industry median (USD 77). `USD` from Vocabulary |
+| staff_member_ids | **yes — blocker** | `["staff_abc123"]` | At least one required. Resolve from owner's staff list |
+| staff_availability | **yes — blocker** | `{ "staff_abc123": { "MO": [{start: "09:00", end: "17:00"}], ... } }` | Required: defines when this service can be booked |
+| location_type | no | `OWNER_BUSINESS` | For online-only services use `CUSTOM` + `is_video_session = true` |
+
+## Steps
+
+### 1. Resolve defaults
+- `USD` ← **the live site**, via `site.get-properties` — Wix Bookings has one site-wide currency, and `locale.country` drives the displayed symbol (US-locale site → `$`, IL → `₪`). Do **not** price from the `USD` geo default. If the owner's uploaded pricing implies a different currency than the site's, **reconcile before creating** — confirm with the owner and either set the site currency/locale or keep the site's; never silently price in the wrong currency. (Owner-facing verify rule — report the *real* currency, never show `$` for a `₪` price — lives in `guidance/host-prompt-guardrails.md`.)
+- `price` ← Industry.md APPOINTMENT median (`77`) if not provided
+- `instructor` ← Vocabulary (`instructor` / `trainer` / `coach` depending on subvertical)
+- `policy` defaults: `late_cancellation_limit_minutes = 1440`, `early_booking_limit_minutes = 60` (no last-minute walk-ins by default)
+
+### 2. Validate staff readiness — HARD STOP if not ready
+- For each `staff_id` in `staff_member_ids`:
+  - read the staff member's working-hours schedule (`staff.schedule.get`)
+  - Confirm the staff has at least one block of working hours
+- If any staff has no working hours, **block** and ask the owner to set hours for that staff first. Don't proceed — appointment availability comes from the intersection of service definition + staff working hours; without the latter, the service is non-bookable even with the former.
+
+### 3. Confirm the plan with the owner
+> Creating **{service_name}** — {duration_min} min, ${price}, with instructors {staff_names}. {staff_X} works {days/hours}; {staff_Y} works {days/hours}. Anyone booking will pick a slot from those hours. Proceed?
+
+### 4. Create the service shell
+- Create the service via `service.create` — an APPOINTMENT-type service carrying: name; session
+  duration(s) and buffer between sessions; price + currency (payable online and/or in person); location;
+  the assigned staff; the booking policy; and video conferencing when `is_video_session`.
+- HARD STOP: if the create doesn't return a persisted service with an id, surface the error to the owner
+  and ask retry/edit/cancel.
+
+### 5. Set locations explicitly
+- If the service uses a non-default location, set it via `service.set-locations` as a separate
+  step — location changes are not handled by the general service update.
+
+### 6. VERIFY — appointment is actually bookable
+- `service.get` and confirm the assigned staff match the input and the requested session duration
+  is present.
+- For each assigned staff, `staff.schedule.get` and confirm working hours are still present.
+- Optionally run an availability query for the next 7 days to confirm at least one bookable slot returns.
+
+### 7. Report back
+- Surface to the owner: service ID, public booking page URL, sample available slot from step 6's availability query.
+- Suggest next: if owner uploaded multiple staff but assigned only one, suggest `onboard-second-staff-member-into-the-business` to wire up the rest.
+
+## Decision points
+
+- **Staff has no working hours** → block. Hand off to the owner to set hours via the dashboard, then resume.
+- **Multiple staff with overlapping availability** → fine; Wix Bookings handles round-robin assignment by default.
+- **Owner wants the appointment to be free** → make it a no-fee service that is still bookable in person (a no-fee service that isn't marked in-person-payable fails validation).
+- **Owner wants only video sessions** → use a custom location and set `is_video_session`; enabling conferencing auto-generates the meeting links on booking confirmation.
+- **This service uses a shared room/equipment** → attach `resource_type_ids` at the **service level**; Wix then availability-checks the type's resources + staff and allocates a free one at booking. Attachment is **selective** — only pass `resource_type_ids` for services that actually need a resource; most appointment services need none. The pool itself is created **once** by `setup-rooms-and-equipment`, never here. Enforcing the assignment requires a **Business+ plan**; below it the link may be accepted but not enforced — recommend Business+ if the owner wants resource management.
+
+## Outputs
+
+- Service ID
+- Public booking page URL
+- A sample available slot in the next 7 days (proof of bookability)
+- Suggested next skill
+
+## Anti-patterns
+
+- ❌ Creating an APPOINTMENT service with no assigned staff. The Wix Bookings API accepts it, but the customer-facing page will show no slots.
+- ❌ Assuming staff with working hours implies bookable. Some staff have working hours blocked by vacation/time-off — the verify step's availability query catches this.
+- ❌ Folding a location change into the general service update. Use the dedicated `service.set-locations` capability.
+- ❌ Not handing this skill the `staff_availability` input upfront. The onboarding skill must collect staff availability from the uploaded staff list before invoking — empty availability is a guaranteed blocker.

--- a/skills/wix-manage/references/bookings/smb-draft-cancellation-notification.md
+++ b/skills/wix-manage/references/bookings/smb-draft-cancellation-notification.md
@@ -1,0 +1,118 @@
+---
+name: "SMB Draft Cancellation Notification"
+description: When a confirmed class is canceled, draft an apologetic notification to the member that names the instructor and proposes 2-3 concrete rebook slots from the same instructor's upcoming availability.
+---
+
+## Required capabilities (platform-neutral)
+
+This skill declares the neutral capabilities it needs; the connected platform's tools (the Wix MCP) supply the concrete API calls at runtime.
+
+  - booking.get
+  - service.get
+  - availability.query
+  - contact.get
+  - campaign.send
+
+# Draft cancellation notification + rebook offer
+
+## Goal
+
+A confirmed class was just canceled (owner / staff / system, not the member themselves). Send a short, human, apologetic note that **names the instructor** who would have led the session and offers **2-3 specific slots** with the same instructor in the next `7` days — owner approves once per send, the member gets a concrete next step instead of a dead end.
+
+## Flow at a glance
+
+```
+Trigger: booking.canceled (initiator ≠ customer)
+   ↓
+Agent: booking.get + service.get → service + staff + slot time
+   ↓
+Agent: contact.get → first name + email consent
+   ↓
+Agent: availability.query → next 3 slots same instructor, same service
+   ↓
+Agent → Owner: draft message + slot list. ⛔ STOP per send
+   ↓
+Owner: yes
+   ↓
+Agent: send via email; tag contact `cancel-notified-{date}`
+```
+
+## When to use
+
+- **Proactive data signal (primary):** `booking.canceled` event fires AND `cancellation_initiator` is `owner`, `staff`, or `system` (not the member).
+- **Human trigger:** owner says "cancel {first_name}'s class" or "apologize to {first_name} for the cancellation".
+
+## Inputs
+
+| name | required | example | notes |
+|---|---|---|---|
+| booking_id | yes | "bk_abc123" | The canceled booking |
+| rebook_window_days | no | `14` | How far ahead to search rebook slots |
+| rebook_slot_count | no | `3` | How many slots to surface (2 if same instructor has thin availability) |
+| cancellation_reason | no | "instructor sick" | If known, threads through the apology copy |
+
+## Steps
+
+### 1. Pull cancellation context
+- `booking.get` for `{booking_id}` → service_id, staff_resource_id, original slot time, member contact_id.
+- `service.get` for service_id → service name in the owner's catalog (use the real name, never "service").
+- HARD STOP if `cancellation_initiator` is the member themselves — they don't need an apology, just an acknowledgment (different skill, not this one).
+
+### 2. Resolve contact + consent
+- `contact.get` → first name, marketing consent on `email`.
+- HARD STOP if no consent — surface the cancellation to the owner with a "no consent, please call them" prompt rather than sending.
+
+### 3. Find rebook slots
+- `availability.query` filtered to:
+  - `service_id` = the canceled service
+  - `staff_resource_id` = the same instructor (continuity matters in fitness)
+  - `from = now`, `to = now + 7`
+- Pick `3` slots spaced across days/times to give real choice.
+- **Fallback:** if same instructor has < `3` slots in the window, broaden to any instructor on the same service and call that out in the copy ("with instructor {staff_name_2}").
+
+### 4. Draft the message
+
+> Hi {first_name},
+>
+> Really sorry — we had to cancel your {service_name} with instructor {staff_name} on {original_day_time}. {one-line cancellation_reason if provided}
+>
+> Here are 3 times you could grab instead, same instructor:
+> - {slot_1_day_time}
+> - {slot_2_day_time}
+> - {slot_3_day_time}
+>
+> One click and you're back in — or reply and I'll find a different mix.
+>
+> — {owner_first_name}
+
+Personalisation checklist: first name, the **real service name** (never "your session"), the instructor's name, the originally-booked day/time, and the cancellation reason when the owner provided one.
+
+### 5. ⛔ STOP for owner approval
+- Show: member's name, canceled slot, proposed slots, draft message, channel.
+- Owner: approve / edit / "let me call them instead" / skip.
+
+### 6. Send + tag
+- `campaign.send` (transactional, single-recipient) via `email`.
+- VERIFY: confirm `messageId` returned (don't trust 200-OK alone).
+- Tag contact: `cancel-notified-{booking_id}-{date}`.
+
+## Decision points
+
+- **No same-instructor slots within the window** → broaden to any instructor on the service; call it out in copy.
+- **No availability at all** within `7` → message becomes apology-only, with "I'll reach out as soon as {staff_name}'s schedule opens up" — flag to the owner that the instructor may be under-scheduled.
+- **member on a paused plan or canceled subscription** → tag them as `lapsed-with-cancel` and surface to owner for personal outreach rather than auto-send.
+- **Owner wants to call instead** → don't send; hand the owner the booking context and step back.
+
+## Outputs
+
+- Apology + rebook-offer message sent (or routed to owner-call)
+- Contact tagged `cancel-notified-{booking_id}-{date}`
+- instructor's availability surface, if thin, flagged to owner
+
+## Anti-patterns
+
+- ❌ Generic "your booking has been canceled" with no apology and no rebook. That's the PREINSTALLED default — owners do better.
+- ❌ Proposing rebook slots with a *different* instructor silently. members in fitness pick their instructor; the swap needs to be named.
+- ❌ Auto-sending without owner approval. Cancellation tone is high-stakes; the wrong wording loses the customer faster than silence.
+- ❌ Firing on customer-initiated cancellations. They canceled themselves — they don't need to be apologized to.
+- ❌ Sending without consent check. Even transactional notifications should respect a do-not-contact tag.

--- a/skills/wix-manage/references/bookings/smb-turn-intake-form-into-first-booking.md
+++ b/skills/wix-manage/references/bookings/smb-turn-intake-form-into-first-booking.md
@@ -1,0 +1,87 @@
+---
+name: "SMB Turn Intake Form Into First Booking"
+description: When a Wix Forms intake is submitted, surface a personal follow-up that proposes specific classs based on the form responses, owner-approved.
+---
+
+## Required capabilities (platform-neutral)
+
+This skill declares the neutral capabilities it needs; the connected platform's tools (the Wix MCP) supply the concrete API calls at runtime.
+
+  - form-submission.get
+  - service.query
+  - availability.query
+  - contact.query
+  - contact.create
+  - campaign.send
+
+# Turn intake form into first booking
+
+## Goal
+
+A new lead just submitted an intake form. Within an hour, the agent surfaces a personal follow-up that proposes 2-3 specific session times matched to the form responses, owner approves, sends. The faster + more specific the follow-up, the higher the conversion.
+
+## Flow at a glance
+
+```
+Trigger: form_submitted event
+   ↓
+Agent: form-submission.get → pull all form fields (name, email, interest, availability)
+   ↓
+Agent: find-or-create contact + tag `intake-{form_name}-{date}`
+   ↓
+Agent: match form's "service interest" + "availability" against actual schedule
+   ↓
+Agent: availability.query for 3 candidate slots in the lead's window
+   ↓
+Agent → Owner: draft + 3 proposed slots. ⛔ STOP, await approval
+   ↓
+Owner: yes
+   ↓
+Agent: send via email with booking-page deep link per slot
+```
+
+## Steps
+
+### 1. Pull the submission
+- `form-submission.get(submission_id)` → all fields (typically: name, email, phone, service interest, preferred days/times, goals).
+
+### 2. Find-or-create the contact
+- `contact.query` by email → if exists, use; if not, `contact.create` with form fields.
+- Tag: `intake-{form_slug}-{date}`.
+
+### 3. Match interest to available services
+- Map the form's "service interest" field (e.g. "personal training") to actual `services` of matching type/name.
+- If multi-select, pick the top match.
+
+### 4. Find 3 candidate slots
+- `availability.query` for the matched service + the lead's preferred window (or next 7 days if no preference).
+- Pick 3 spaced across different days/times.
+
+### 5. Draft the follow-up
+> Hi {first_name}, thanks for reaching out about {service_name}!
+>
+> Based on your note that {one-sentence echo of the form's "what are you looking for" field}, here are 3 times that could work:
+> 1. **{slot_1_human}** — book here: {link_1}
+> 2. **{slot_2_human}** — book here: {link_2}
+> 3. **{slot_3_human}** — book here: {link_3}
+>
+> Or just reply with what works better. — {owner_first_name}
+
+### 6. Surface to owner — ⛔ STOP
+- Show: form responses, draft, 3 slots.
+- Owner approves / edits.
+
+### 7. Send + tag
+- VERIFY messageId. Tag contact `intake-followup-sent-{date}`.
+
+## Decision points
+
+- **Form fields are incomplete** (no service interest) → ask the owner in a single nudge: "Sarah's form didn't say which service she wants — want me to ask?" Don't guess.
+- **Multiple services match** → propose the top 2; let the customer pick by replying.
+- **No available slots in the lead's window** → propose the closest 3 outside their window; surface as "the slots you asked about are full — closest available are…"
+
+## Anti-patterns
+
+- ❌ Sending without owner approval. Intake responses are warm leads, not list members.
+- ❌ Generic "thanks for your interest" with no concrete slots. The whole point is specificity.
+- ❌ Waiting > 4 hours to surface. Lead temperature halves after the first hour.

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-currency.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-currency.yml
@@ -1,0 +1,33 @@
+name: bookings/smb-create-appointment-service-currency
+description: >-
+  Verifies the agent reads the smb-create-appointment-service skill and prices the service in the live
+  site currency (read from site properties) rather than blindly assuming USD.
+triggerPrompt: >-
+  Add a 45-minute "Nutrition Consult" service at 65, assigned to an instructor who works Tuesday and
+  Thursday evenings. The number is the price — use my store's currency.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-create-appointment-service
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The owner asked to add a 45-min "Nutrition Consult" at 65 in their store's currency, assigned to a
+      instructor with Tue/Thu evening hours.
+      Intent: price the service in the LIVE site currency (read via the site-properties API) instead of
+      assuming USD, and confirm the instructor has working hours before finishing.
+
+      Pass if the response:
+      - reads the live site currency (site-properties / paymentCurrency) and prices 65 in that currency, AND
+      - assigns an instructor and confirms that instructor has working hours before treating the service as
+        bookable, AND
+      - creates an APPOINTMENT service via the Wix Bookings services API.
+
+      Fail if the response:
+      - hard-codes USD without checking the site currency, OR
+      - skips the instructor working-hours check, OR
+      - is generic with no Wix Bookings / site-properties API methods.

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-currency.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-currency.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   Thursday evenings. The number is the price — use my store's currency.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-currency.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-currency.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   Thursday evenings. The number is the price — use my store's currency.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-gate.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-gate.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   for now — I'll add someone later. Just get the service set up.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-gate.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-gate.yml
@@ -1,0 +1,32 @@
+name: bookings/smb-create-appointment-service-gate
+description: >-
+  Verifies the agent reads the smb-create-appointment-service skill and REFUSES to finish a
+  staff-less APPOINTMENT service, asking for an instructor with working hours instead of saving a shell.
+triggerPrompt: >-
+  Just create a "Deep Tissue Massage" appointment service, 50 minutes, $90. Don't worry about staff
+  for now — I'll add someone later. Just get the service set up.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-create-appointment-service
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The owner asked to create a "Deep Tissue Massage" appointment service but explicitly said to
+      skip assigning staff for now.
+      Intent: the skill must refuse to finish a non-bookable APPOINTMENT service — an APPOINTMENT with no
+      assigned instructor (or no working hours) is not bookable.
+
+      Pass if the response:
+      - does NOT report a finished/bookable service, AND
+      - explains that an APPOINTMENT service needs at least one instructor with working hours to be
+        bookable, AND
+      - asks the owner to assign an instructor (or to set one up) before completing.
+
+      Fail if the response:
+      - creates and reports success on a staff-less APPOINTMENT service (a non-bookable shell), OR
+      - silently proceeds without surfacing the missing-instructor problem.

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-gate.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-gate.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   for now — I'll add someone later. Just get the service set up.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-happy.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   assigned to an instructor who works regular weekday hours. Make sure members can actually book it.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-happy.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   assigned to an instructor who works regular weekday hours. Make sure members can actually book it.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-create-appointment-service-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-create-appointment-service-happy.yml
@@ -1,0 +1,35 @@
+name: bookings/smb-create-appointment-service-happy
+description: >-
+  Verifies the agent reads the smb-create-appointment-service skill and creates a bookable
+  APPOINTMENT service, assigning an instructor who has working hours (never a non-bookable shell).
+triggerPrompt: >-
+  Create a 60-minute private personal-training session called "Personal Training" priced at $77,
+  assigned to an instructor who works regular weekday hours. Make sure members can actually book it.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-create-appointment-service
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The owner asked to create a bookable 60-min "Personal Training" appointment service at $77,
+      assigned to an instructor with working hours.
+      Intent: create an APPOINTMENT-type Wix Bookings service that is actually bookable — assigned to a
+      instructor (staff member) whose schedule has working hours.
+
+      Pass if the response:
+      - creates (or clearly prepares + gets approval to create) an APPOINTMENT service named
+        "Personal Training", 60 min, $77, AND
+      - assigns an instructor/staff member and verifies that instructor has working hours before treating the
+        service as bookable (querying staff and the staff schedule/working hours), AND
+      - uses the Wix Bookings services create API (e.g. bulk create services) with type APPOINTMENT.
+
+      Fail if the response:
+      - reports the service as done without any assigned instructor, OR
+      - never checks the instructor's working hours / availability, OR
+      - creates a CLASS or COURSE instead of an APPOINTMENT, OR
+      - is generic with no Wix Bookings API methods.

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-approval.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-approval.yml
@@ -1,0 +1,27 @@
+name: bookings/smb-draft-cancellation-notification-approval
+description: >-
+  Verifies the agent reads the smb-draft-cancellation-notification skill and waits for owner approval
+  before sending any cancellation message to the member.
+triggerPrompt: >-
+  Cancel member Maya's class with instructor Dana and message her about it right now.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-draft-cancellation-notification
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The owner asked to cancel Maya's class with Dana and message her "right now."
+      Intent: even under time pressure, the skill drafts the cancellation+rebook message and gets owner
+      approval before sending (cancellation tone is high-stakes; outbound messages need confirmation).
+
+      Pass if the response:
+      - drafts the message and presents it for the owner to approve/edit BEFORE sending, AND
+      - does not claim to have already sent it to the member without approval.
+
+      Fail if the response:
+      - sends (or claims to send) the message to the member with no approval step.

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-approval.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-approval.yml
@@ -6,7 +6,7 @@ triggerPrompt: >-
   Cancel member Maya's class with instructor Dana and message her about it right now.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-approval.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-approval.yml
@@ -6,7 +6,7 @@ triggerPrompt: >-
   Cancel member Maya's class with instructor Dana and message her about it right now.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-happy.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   out sick. Draft a message to let Maya know and help her rebook.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-happy.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   out sick. Draft a message to let Maya know and help her rebook.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-happy.yml
@@ -1,0 +1,35 @@
+name: bookings/smb-draft-cancellation-notification-happy
+description: >-
+  Verifies the agent reads the smb-draft-cancellation-notification skill and drafts a business-side
+  apology that names the instructor and proposes concrete rebook slots from that instructor's availability.
+triggerPrompt: >-
+  We had to cancel member Maya's class with instructor Dana tomorrow because Dana is
+  out sick. Draft a message to let Maya know and help her rebook.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-draft-cancellation-notification
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The owner had to cancel member Maya's class with instructor Dana (Dana is sick) and wants to notify
+      Maya and help her rebook.
+      Intent: draft a business-side apology that names the instructor and offers 2-3 concrete rebook slots
+      from the same instructor's real upcoming availability, for owner approval before sending.
+
+      Pass if the response:
+      - apologizes for a business-side cancellation, AND
+      - names the instructor (Dana), AND
+      - proposes 2-3 specific rebook slots (and indicates it would pull them from the instructor's real
+        availability, e.g. via an availability query), AND
+      - presents the draft for owner approval rather than sending immediately.
+
+      Fail if the response:
+      - is a generic "your booking was canceled" with no apology or no concrete slots, OR
+      - does not name the instructor, OR
+      - silently swaps to a different instructor without saying so, OR
+      - sends without any owner-approval step.

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-scope.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-scope.yml
@@ -1,0 +1,29 @@
+name: bookings/smb-draft-cancellation-notification-scope
+description: >-
+  Verifies the agent reads the smb-draft-cancellation-notification skill and does NOT send a
+  business-side apology when the member canceled the class themselves.
+triggerPrompt: >-
+  Member Maya just canceled her own class with instructor Dana for tomorrow. Let her
+  know we got it.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-draft-cancellation-notification
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The member (Maya) canceled her own class with instructor Dana. The owner wants to acknowledge it.
+      Intent: this is a member-initiated cancellation, so no business-side apology is owed — a neutral
+      acknowledgment (optionally offering to rebook) is correct.
+
+      Pass if the response:
+      - recognizes this as member-initiated and does NOT apologize as if the business cancelled, AND
+      - confirms/acknowledges the cancellation neutrally (optionally offering rebooking).
+
+      Fail if the response:
+      - sends an apologetic "sorry we had to cancel" message that does not apply here, OR
+      - treats it as a business-side cancellation.

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-scope.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-scope.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   know we got it.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-scope.yml
+++ b/yaml/wix-manage-evals/bookings/smb-draft-cancellation-notification-scope.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   know we got it.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-approval.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-approval.yml
@@ -1,0 +1,27 @@
+name: bookings/smb-turn-intake-form-into-first-booking-approval
+description: >-
+  Verifies the agent reads the smb-turn-intake-form-into-first-booking skill and waits for owner
+  approval before sending the follow-up to the lead.
+triggerPrompt: >-
+  Intake just came in from Jordan Lee (jordan@example.com), wants personal training, free weekday
+  evenings — send them a follow-up.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-turn-intake-form-into-first-booking
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The owner asked to "send" a follow-up to a new intake lead (Jordan Lee).
+      Intent: the skill drafts the follow-up with proposed slots and pauses for owner approval before
+      actually sending (warm leads still get an owner review).
+
+      Pass if the response:
+      - drafts the follow-up with proposed slots and presents it for owner approval BEFORE sending.
+
+      Fail if the response:
+      - sends (or claims to send) the follow-up to the lead with no approval step.

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-approval.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-approval.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   evenings — send them a follow-up.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-approval.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-approval.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   evenings — send them a follow-up.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-happy.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   training, available weekday evenings. Follow up to get them booked.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-happy.yml
@@ -1,0 +1,33 @@
+name: bookings/smb-turn-intake-form-into-first-booking-happy
+description: >-
+  Verifies the agent reads the smb-turn-intake-form-into-first-booking skill and turns a fresh intake
+  submission into a contact + an owner-approved follow-up proposing specific bookable slots.
+triggerPrompt: >-
+  A new lead just submitted our intake form: name Jordan Lee, jordan@example.com, interested in personal
+  training, available weekday evenings. Follow up to get them booked.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-turn-intake-form-into-first-booking
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      A new intake submission came in (Jordan Lee, jordan@example.com, wants personal training, free
+      weekday evenings). The owner wants to follow up to drive a first booking.
+      Intent: find/create the contact, match the interest + availability to the real schedule, propose
+      2-3 specific weekday-evening slots, and draft an owner-approved follow-up.
+
+      Pass if the response:
+      - finds or creates a contact for Jordan (contacts API), AND
+      - matches "personal training" to a real service and queries availability for weekday-evening slots, AND
+      - proposes 2-3 specific slots in the lead's window, AND
+      - drafts the follow-up for owner approval before sending.
+
+      Fail if the response:
+      - sends a generic "thanks for your interest" with no concrete slots, OR
+      - skips contact handling, OR
+      - sends without an owner-approval step.

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-happy.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-happy.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   training, available weekday evenings. Follow up to get them booked.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-nomatch.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-nomatch.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   we don't run anything that early. Follow up.
 tags: [bookings]
 siteSetup:
-  templateId: scheduler
+  templateId: bookings-editor
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-nomatch.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-nomatch.yml
@@ -1,0 +1,30 @@
+name: bookings/smb-turn-intake-form-into-first-booking-nomatch
+description: >-
+  Verifies the agent reads the smb-turn-intake-form-into-first-booking skill and, when nothing matches
+  the lead's requested window, proposes nearest real alternatives instead of inventing slots.
+triggerPrompt: >-
+  New intake just came in: Sam Rivera, sam@example.com, wants a weekday 6am personal-training slot — but
+  we don't run anything that early. Follow up.
+tags: [bookings]
+siteSetup:
+  templateId: scheduler
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/smb-turn-intake-form-into-first-booking
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      A new intake (Sam Rivera) wants a weekday 6am slot that the business does not offer.
+      Intent: handle the no-match gracefully — do not fabricate availability; propose the nearest real
+      alternatives and say the requested time isn't available, or flag the gap to the owner.
+
+      Pass if the response:
+      - does NOT invent 6am slots that don't exist, AND
+      - either proposes the closest real available slots (and notes the requested time isn't offered) or
+        flags the gap to the owner for a decision.
+
+      Fail if the response:
+      - fabricates 6am availability, OR
+      - dead-ends with "no times available" and offers no alternative or owner hand-off.

--- a/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-nomatch.yml
+++ b/yaml/wix-manage-evals/bookings/smb-turn-intake-form-into-first-booking-nomatch.yml
@@ -7,7 +7,7 @@ triggerPrompt: >-
   we don't run anything that early. Follow up.
 tags: [bookings]
 siteSetup:
-  templateId: bookings-editor
+  templateId: bookings-harmony
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage/bookings/documentation.yaml
+++ b/yaml/wix-manage/bookings/documentation.yaml
@@ -46,3 +46,16 @@ apiDoc:
       title: Create Course Service
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
       tags: [bookings]
+    # --- SMB eval pilot (frozen fitness/US cohort; not for merge) ---
+    - file: ../../../skills/wix-manage/references/bookings/smb-create-appointment-service.md
+      title: SMB Create Appointment Service
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/smb-draft-cancellation-notification.md
+      title: SMB Draft Cancellation Notification
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]
+    - file: ../../../skills/wix-manage/references/bookings/smb-turn-intake-form-into-first-booking.md
+      title: SMB Turn Intake Form Into First Booking
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [bookings]


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — eval-only, will be closed after the pilot

These are **frozen `fitness/US` snapshots** of skills from `wix-private/auto-skills-generator`, added only so EvalForge can evaluate them against this **unmerged** branch via `skillsPr=<headSha>`. They are not intended to merge into `wix/skills`.

## What's here
- **3 skills** (`skills/wix-manage/references/bookings/smb-*.md`), generated by `migrate-to-evalforge-format.mjs`: parameters resolved for `(fitness, us)`, **platform-neutral** (`required_capabilities`, no embedded Wix endpoints — the Wix MCP supplies the "how").
  - `smb-create-appointment-service` — refuses to finish until an instructor with working hours is assigned.
  - `smb-draft-cancellation-notification` — business-side apology, names the instructor, concrete rebook slots.
  - `smb-turn-intake-form-into-first-booking` — intake → matched slots → owner-approved follow-up.
- **9 scenarios** (`yaml/wix-manage-evals/bookings/smb-*.yml`), 3 per skill — each a `ReadFullDocsArticle` tool gate on the skill's doc URL + a Pass/Fail `llm_judge`.
- Registered in `documentation.yaml` + `SKILL.md` under tag `[bookings]`; `smb-` prefix avoids colliding with the existing platform recipes.

## Purpose
First EvalForge pilot for the SMB skills catalog (the §8 eval-harness loop). Goal: run the `skill-eval` gate (coverage → schema → execution) and read per-scenario pass/fail, then iterate.