### PR TITLE
ci(eval-gate): always report the gate check so it can be required

### DIFF
--- a/.github/workflows/evalforge-yaml-gate.yml
+++ b/.github/workflows/evalforge-yaml-gate.yml
@@ -4,21 +4,42 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'skills/wix-manage/references/**'
-      - 'yaml/wix-manage/**'
-      - 'yaml/wix-manage-evals/**'
 
 concurrency:
   group: evalforge-yaml-gate-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  # Always runs on every PR so the `gate` check is never "missing". Decides whether
+  # the PR touches the YAML/docs that the gate evaluates. When it doesn't, `gate` is
+  # skipped — and a skipped job counts as a pass for a required status check, so
+  # unrelated PRs are never wedged on a check that never reported.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          if echo "$files" | grep -qE '^(skills/wix-manage/references/|yaml/wix-manage/|yaml/wix-manage-evals/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   gate:
+    needs: changes
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ needs.changes.outputs.relevant == 'true' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## What

Moves the path filter out of the `evalforge-yaml-gate` workflow trigger and into a lightweight `changes` job that runs on **every** PR to `main`. The `gate` job now `needs: changes` and only runs when the PR touches the watched paths (`skills/wix-manage/references/**`, `yaml/wix-manage/**`, `yaml/wix-manage-evals/**`); otherwise it's skipped.

## Why

To make `gate` enforceable as a **required status check** on `main`. With the old workflow-level `paths:` filter, PRs that don't touch those paths never trigger the workflow, so the required check would never report and GitHub would block the PR on a perpetually "Expected" status.

A skipped job counts as a **pass** for a required status check, so the check now reports on every PR (pass / fail / skip) and unrelated PRs are never wedged.

## Note

This PR only touches `.github/workflows/`, so it's also a live test: the `changes` job should output `relevant=false` and `gate` should report **skipped → pass**. Once that's confirmed, `gate` can be added as a required check (repo ruleset or via the org ruleset owners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)