### PR TITLE
Remove redundant context checks from booking service recipes

### DIFF
--- a/skills/wix-manage/references/bookings/create-appointment-service.md
+++ b/skills/wix-manage/references/bookings/create-appointment-service.md
@@ -13,7 +13,6 @@ description: "Create an appointment booking service — e.g. 'set up consultatio
 
 ## Prerequisites
 
-- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`). Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install if missing.
 - For full API field definitions, validation rules, and troubleshooting, see [Create and Update Booking Services](./create-and-update-booking-services.md)
 
 ---
@@ -47,16 +46,7 @@ curl -X POST 'https://www.wixapis.com/bookings/v2/categories/query' \
   -d '{ "query": {} }'
 ```
 
-### 1c. Get Site Currency
-
-```bash
-curl -X GET 'https://www.wixapis.com/site-properties/v4/properties' \
-  -H 'Authorization: <AUTH>'
-```
-
-Extract `properties.paymentCurrency`. Fall back to `USD` if unavailable.
-
-### 1d. Query Existing Services (Duplicate Check)
+### 1c. Query Existing Services (Duplicate Check)
 
 ```bash
 curl -X POST 'https://www.wixapis.com/bookings/v2/services/query' \
@@ -82,7 +72,6 @@ For any fields the user did not explicitly specify:
 
 ### Pricing (if not specified)
 
-- Use the site's currency from Step 1c
 - If user specifies a price → `rateType: "FIXED"`
 - If user says "free" → `rateType: "NO_FEE"`, `options.inPerson: true`, `options.online: false`
 - If no price mentioned → infer from context (consultations ~$50-100, sessions ~$30-60) or default to free
@@ -136,7 +125,7 @@ curl -X POST 'https://www.wixapis.com/bookings/v2/bulk/services/create' \
         "rateType": "FIXED",
         "options": { "online": true, "inPerson": false },
         "fixed": {
-          "price": { "value": "<PRICE>", "currency": "<CURRENCY>" }
+          "price": { "value": "<PRICE>" }
         }
       },
       "category": {
@@ -213,7 +202,6 @@ Provide a summary including:
 
 | Error | Cause | Action |
 |---|---|---|
-| 428 "App not installed" | Bookings not installed | Install using [Install Wix Apps](../app-installation/install-wix-apps.md) |
 | 400 "staffMemberIds required" | No staff assigned | Query staff; if none exist, create one via [Bookings Staff Setup](./bookings-staff-setup.md) |
 | 400 "INVALID_PAYMENT_OPTIONS" | Payment misconfigured | Free: `inPerson: true`, `online: false`. Paid: price > 0 |
 | 403 | Permission denied | Inform user they lack permission |
@@ -249,6 +237,5 @@ Provide a summary including:
 - [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category)
 - [Query Staff Members](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/query-staff-members)
 - [Create Staff Member](https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/create-staff-member)
-- [Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-management/site-properties/properties/read)
 - [About Service Types](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types)
 - [About Service Payments](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-payments)

--- a/skills/wix-manage/references/bookings/create-booking-service-from-prompt.md
+++ b/skills/wix-manage/references/bookings/create-booking-service-from-prompt.md
@@ -10,13 +10,6 @@ description: "Create a booking service from a user prompt — e.g. 'create a yog
 - User describes a service they want to create using natural language (e.g., "create a yoga class for $50", "set up consultation sessions", "add a personal training appointment")
 - The intent is autonomous creation — fill in reasonable defaults rather than asking the user for every field
 
-## Prerequisites
-
-- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
-- If Bookings is not installed, use [Install Wix Apps](../app-installation/install-wix-apps.md) to install it first
-
----
-
 ## Step 1: Determine Service Type
 
 | User mentions | Type | Recipe |
@@ -30,7 +23,7 @@ description: "Create a booking service from a user prompt — e.g. 'create a yog
 
 Once the service type is determined, follow the corresponding recipe linked above. Each recipe covers:
 
-1. Gathering business context (staff, categories, currency, duplicate check)
+1. Gathering business context (staff where required, categories, duplicate check)
 2. Applying type-specific defaults (pricing, capacity, duration, staff assignment)
 3. Creating the service via `bulkCreateServices`
 4. Navigating to the service form for user review

--- a/skills/wix-manage/references/bookings/create-class-service.md
+++ b/skills/wix-manage/references/bookings/create-class-service.md
@@ -14,7 +14,6 @@ description: "Create a class booking service — e.g. 'create a yoga class for $
 
 ## Prerequisites
 
-- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`). Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install if missing.
 - For full API field definitions, validation rules, and troubleshooting, see [Create and Update Booking Services](./create-and-update-booking-services.md)
 
 ---
@@ -32,16 +31,7 @@ curl -X POST 'https://www.wixapis.com/bookings/v2/categories/query' \
   -d '{ "query": {} }'
 ```
 
-### 1b. Get Site Currency
-
-```bash
-curl -X GET 'https://www.wixapis.com/site-properties/v4/properties' \
-  -H 'Authorization: <AUTH>'
-```
-
-Extract `properties.paymentCurrency`. Fall back to `USD` if unavailable.
-
-### 1c. Query Existing Services (Duplicate Check)
+### 1b. Query Existing Services (Duplicate Check)
 
 ```bash
 curl -X POST 'https://www.wixapis.com/bookings/v2/services/query' \
@@ -67,7 +57,6 @@ For any fields the user did not explicitly specify:
 
 ### Pricing (if not specified)
 
-- Use the site's currency from Step 1b
 - If user specifies a price → `rateType: "FIXED"` (per session)
 - If user says "free" → `rateType: "NO_FEE"`, `options.inPerson: true`, `options.online: false`
 - If no price mentioned → infer from context (yoga/fitness classes ~$15-30, art/music ~$20-40) or default to free
@@ -118,7 +107,7 @@ curl -X POST 'https://www.wixapis.com/bookings/v2/bulk/services/create' \
         "rateType": "FIXED",
         "options": { "online": true, "inPerson": false },
         "fixed": {
-          "price": { "value": "<PRICE>", "currency": "<CURRENCY>" }
+          "price": { "value": "<PRICE>" }
         }
       },
       "category": {
@@ -193,7 +182,6 @@ Provide a summary including:
 
 | Error | Cause | Action |
 |---|---|---|
-| 428 "App not installed" | Bookings not installed | Install using [Install Wix Apps](../app-installation/install-wix-apps.md) |
 | 400 "INVALID_PAYMENT_OPTIONS" | Payment misconfigured | Free: `inPerson: true`, `online: false`. Paid: price > 0 |
 | 403 | Permission denied | Inform user they lack permission |
 
@@ -228,6 +216,5 @@ Provide a summary including:
 - [Query Categories](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories)
 - [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category)
 - [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)
-- [Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-management/site-properties/properties/read)
 - [About Service Types](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types)
 - [About Service Payments](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-payments)

--- a/skills/wix-manage/references/bookings/create-course-service.md
+++ b/skills/wix-manage/references/bookings/create-course-service.md
@@ -14,7 +14,6 @@ description: "Create a course booking service — e.g. 'create a 6-week photogra
 
 ## Prerequisites
 
-- **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`). Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install if missing.
 - For full API field definitions, validation rules, and troubleshooting, see [Create and Update Booking Services](./create-and-update-booking-services.md)
 
 ---
@@ -32,16 +31,7 @@ curl -X POST 'https://www.wixapis.com/bookings/v2/categories/query' \
   -d '{ "query": {} }'
 ```
 
-### 1b. Get Site Currency
-
-```bash
-curl -X GET 'https://www.wixapis.com/site-properties/v4/properties' \
-  -H 'Authorization: <AUTH>'
-```
-
-Extract `properties.paymentCurrency`. Fall back to `USD` if unavailable.
-
-### 1c. Query Existing Services (Duplicate Check)
+### 1b. Query Existing Services (Duplicate Check)
 
 ```bash
 curl -X POST 'https://www.wixapis.com/bookings/v2/services/query' \
@@ -67,7 +57,6 @@ For any fields the user did not explicitly specify:
 
 ### Pricing (if not specified)
 
-- Use the site's currency from Step 1b
 - If user specifies a price → `rateType: "FIXED"` (for the entire course)
 - If user says "free" → `rateType: "NO_FEE"`, `options.inPerson: true`, `options.online: false`
 - If no price mentioned → infer from context (workshops ~$100-300, training programs ~$200-500, bootcamps ~$150-400) or default to free
@@ -120,7 +109,7 @@ curl -X POST 'https://www.wixapis.com/bookings/v2/bulk/services/create' \
         "rateType": "FIXED",
         "options": { "online": true, "inPerson": false },
         "fixed": {
-          "price": { "value": "<PRICE>", "currency": "<CURRENCY>" }
+          "price": { "value": "<PRICE>" }
         }
       },
       "category": {
@@ -197,7 +186,6 @@ Provide a summary including:
 
 | Error | Cause | Action |
 |---|---|---|
-| 428 "App not installed" | Bookings not installed | Install using [Install Wix Apps](../app-installation/install-wix-apps.md) |
 | 400 "INVALID_PAYMENT_OPTIONS" | Payment misconfigured | Free: `inPerson: true`, `online: false`. Paid: price > 0 |
 | 403 | Permission denied | Inform user they lack permission |
 
@@ -232,6 +220,5 @@ Provide a summary including:
 - [Query Categories](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/query-categories)
 - [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category)
 - [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)
-- [Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-management/site-properties/properties/read)
 - [About Service Types](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-types)
 - [About Service Payments](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/about-service-payments)

--- a/yaml/wix-manage-evals/bookings/create-service-recipes.yml
+++ b/yaml/wix-manage-evals/bookings/create-service-recipes.yml
@@ -1,0 +1,45 @@
+name: bookings/create-service-recipes
+description: >-
+  Verifies the agent reads the prompt router and the appointment, class, and
+  course service creation recipes without redundant dynamic-context checks.
+triggerPrompt: >-
+  Use the Wix Bookings create-service prompt recipe and the appointment, class,
+  and course service recipes to explain how to create three services: a 60 minute
+  strategy consultation for $75, a yoga class for $25 with room for 12 people,
+  and a 6 week photography course for $300. Which recipe applies to each and what
+  are the key create-service fields?
+tags: [bookings]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-booking-service-from-prompt
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-appointment-service
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-class-service
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-course-service
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked how to create appointment, class, and course booking services from prompts.
+      Intent: route each prompt to the correct create-service recipe and summarize the key fields without redundant dynamic-context checks.
+
+      Pass if the response:
+      - routes the consultation to `APPOINTMENT`, the yoga class to `CLASS`, and the photography course to `COURSE`, AND
+      - mentions appointment-specific fields such as staff `resourceId` values and session duration, AND
+      - mentions class/course-specific fields such as `defaultCapacity`, AND
+      - explains that class/course services do not use `staffMemberIds` or appointment `sessionDurations`, AND
+      - does not tell the user to call Site Properties / `properties.paymentCurrency` for currency, AND
+      - does not tell the user to call List Installed Apps or install Wix Bookings before creating the services.
+
+      Fail if the response:
+      - routes any service to the wrong service type, OR
+      - instructs the user to fetch site currency from Site Properties, OR
+      - instructs the user to verify/install the Wix Bookings app as part of these recipes, OR
+      - tells the user to provide, infer, or fall back to a currency for the paid service examples, OR
+      - omits the required appointment or class/course-specific fields.


### PR DESCRIPTION
## Summary
- Remove installed-app verification guidance from the create booking service prompt router and type-specific service creation recipes because installed apps are already in dynamic context
- Remove Site Properties currency lookup guidance from the appointment, class, and course service creation recipes
- Remove currency selection/defaulting from paid service examples so recipes do not use dynamic-context currency, prompt currency, or USD fallback
- Add one combined booking eval scenario to cover the four changed recipe docs for the EvalForge YAML gate

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' yaml/wix-manage-evals/bookings/*.yml`\n- `git diff --exit-code origin/main -- skills/wix-manage/references/bookings/create-and-update-booking-services.md`\n- `rg -n "currency|CURRENCY|USD|paymentCurrency|Site Properties|site properties|properties/v4|Bookings app installed|List Installed Apps|Install Wix Apps|App not installed" <changed create-service docs>`