### PR TITLE
feat(eval-gate): pass commitSha and skillsRepo to eval-pipeline run-c…

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34690,8 +34690,8 @@ class EvalPipelineClient {
         }
         return res.json();
     }
-    async runComparison(tags, agentName) {
-        return this.post('/run-comparison', { tags, agentName });
+    async runComparison(tags, agentName, commitSha, skillsRepo) {
+        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo });
     }
     async compareGroup(comparisonGroupId) {
         return this.post('/compare-group', { comparisonGroupId });
@@ -35101,6 +35101,7 @@ async function runGate() {
     const workspace = (0, workspace_1.workspaceRoot)();
     const draftTag = (0, evalforge_1.draftTagFor)(`${config.owner}/${config.repo}`, config.prNumber);
     core.info(`EvalForge YAML gate — PR #${config.prNumber}`);
+    core.info(`MCP params — skillsRepo: ${config.mcpSkillsRepo}, headSha: ${config.headSha}`);
     const evalforge = new evalforge_1.EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
     const versionLabel = `pr-${config.prNumber}-${config.headSha.slice(0, 7)}`;
     const mcpVersion = await guardedCall(() => evalforge.ensureMcpVersion(config.mcpId, config.projectId, versionLabel, config.prNumber, config.headSha, config.mcpSkillsRepo), 'Could not create MCP version', comment, config);
@@ -35194,7 +35195,7 @@ async function runGate() {
         return;
     }
     const pipeline = new eval_pipeline_1.EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
-    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName), 'Could not start eval pipeline comparison', comment, config);
+    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo), 'Could not start eval pipeline comparison', comment, config);
     if (!comparison)
         return;
     core.info(`Eval pipeline comparison started: comparisonGroupId=${comparison.comparisonGroupId}`);

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -101,8 +101,8 @@ export class EvalPipelineClient {
     return res.json() as Promise<T>;
   }
 
-  async runComparison(tags: string[], agentName: string): Promise<ComparisonResult> {
-    return this.post<ComparisonResult>('/run-comparison', { tags, agentName });
+  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string): Promise<ComparisonResult> {
+    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo });
   }
 
   async compareGroup(comparisonGroupId: string): Promise<CompareGroupStatus> {

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -32,6 +32,7 @@ export async function runGate(): Promise<void> {
   const draftTag = draftTagFor(`${config.owner}/${config.repo}`, config.prNumber);
 
   core.info(`EvalForge YAML gate — PR #${config.prNumber}`);
+  core.info(`MCP params — skillsRepo: ${config.mcpSkillsRepo}, headSha: ${config.headSha}`);
 
   const evalforge = new EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
   const versionLabel = `pr-${config.prNumber}-${config.headSha.slice(0, 7)}`;
@@ -140,7 +141,7 @@ export async function runGate(): Promise<void> {
 
   const pipeline = new EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
   const comparison = await guardedCall(
-    () => pipeline.runComparison([draftTag], config.agentName),
+    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo),
     'Could not start eval pipeline comparison', comment, config,
   );
   if (!comparison) return;


### PR DESCRIPTION
…omparison

Aligns with ax-tools evalforge-pipeline PR #217 — the /run-comparison endpoint now creates mcp-with (?skillsCommitHash+skillsRepo) and mcp-without (plain prod) internally, so we forward config.headSha and config.mcpSkillsRepo from the action. Also logs both values at startup.