### PR TITLE
feat(wix-manage/ecommerce/abandoned-carts): add Abandoned Carts dispatcher + 4 leaf skills + EvalForge coverage

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -124,6 +124,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 - **Any sales/business improvement request** (boost sales, promotions, help my business, holiday deals, improve revenue, discounts, shipping, coupons, clearance) → use [Recommend: eCommerce Strategy](references/ecommerce/recommend-ecommerce-strategy.md). This is the **default entry point** — it analyzes ALL domains (discounts, shipping) and generates cross-domain recommendations. Do NOT ask clarifying questions.
 - **Pricing & promotions** (coupons, discount rules, ribbons, sales) → use the [Pricing & Promotions](references/ecommerce/ecom-pricing.md) dispatcher.
 - **Shipping setup** (rates, regions, pickup, free shipping, fix coverage) → use the [Shipping](references/ecommerce/ecom-shipping.md) dispatcher.
+- **Abandoned carts** (recovery emails, recovery links, recovery health, troubleshoot recovery) → use the [Abandoned Carts](references/ecommerce/ecom-abandoned-carts.md) dispatcher.
 
 ### [eCommerce: Load Context](references/ecommerce/ecom-load-context.md)
 **L1 loader** — loads general site data (siteId, country, currency, industry, catalog analytics) needed by every eCommerce category. Each category dispatcher loads this before tag-matching; runs once per session.
@@ -136,6 +137,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Shipping](references/ecommerce/ecom-shipping.md)
 **Dispatcher** — routes shipping-setup requests (rates, regions, pickup, free shipping, fix coverage, optimize rates) to the right leaf recipe. The Shipping Options + Delivery Profiles APIs have no public docs page; `ecom-shipping-api.md` is the authoritative inline reference.
+
+### [Abandoned Carts](references/ecommerce/ecom-abandoned-carts.md)
+**Dispatcher** — routes post-abandonment recovery requests (recovery emails, recovery links, recovery health, troubleshooting recovery) to the right leaf recipe. Merchants often say "abandoned carts"; the API entity is **Abandoned Checkout**. Recovery emails are configured via Wix Dashboard automation; recovery links are generated via the Abandoned Checkout API.
 
 <details>
 <summary>Internal skills (loaded automatically by the dispatchers / orchestrator above — do NOT use directly)</summary>
@@ -155,6 +159,12 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 - [Optimize Rates](references/ecommerce/shipping/ecom-shipping-optimize-rates.md)
 - [Fix Coverage Gaps](references/ecommerce/shipping/ecom-shipping-fix-coverage.md)
 - [API Reference](references/ecommerce/shipping/ecom-shipping-api.md) — inline spec for Shipping Options + Delivery Profiles
+
+#### Abandoned Carts leaves (loaded by the Abandoned Carts dispatcher)
+- [Recover via Email](references/ecommerce/abandoned-carts/ecom-abandoned-carts-recover-email.md) — Wix Dashboard automation setup (no public API for the recurring send)
+- [Recovery Link](references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-link.md) — one-off resume-checkout link via the Abandoned Checkout API
+- [Recovery Health](references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-health.md) — periodic recovery-performance monitor
+- [Troubleshoot Recovery](references/ecommerce/abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.md) — diagnostic when emails aren't sending or links aren't working
 
 #### Cross-cutting tracking
 - [API: Recommendation Tracking](references/ecommerce/api-recommendation-tracking.md) — load BEFORE generating any recommendation; persists PROPOSED state and tracks MarkExecuting → MarkDone/MarkFailed.

--- a/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recover-email.md
+++ b/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recover-email.md
@@ -1,0 +1,81 @@
+---
+name: "Abandoned Carts: Recover via Email"
+description: Sets up automated abandoned-cart / abandoned-checkout recovery emails. Covers Wix Dashboard automation, send timing, email content, eligibility, recovery-rate benchmarks, and when to use API-generated recovery links instead.
+---
+
+# Recover Abandoned Carts via Email
+
+Set up an automated email that follows up with shoppers who started but did not finish checkout. This is the **email-recovery** lever. If the merchant wants to fix why shoppers leave during checkout, route to [Reduce Abandonment](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/checkout-reduce-abandonment).
+
+Merchants often say "abandoned carts"; the public API calls them **Abandoned Checkouts**.
+
+> **Where this is configured.** The recurring recovery email automation is a built-in Wix automation set up in the Dashboard. The trigger -> send path is not a verified TPA-public API. Use Analytics APIs for reporting questions. Use the Abandoned Checkout API for record-level verification, automation activity inspection, or redirecting a shopper back to checkout for custom flows.
+
+## API and Dashboard status
+
+| Capability | Route | Status |
+|---|---|---|
+| Configure recurring abandoned-cart email automation | Wix Dashboard -> Marketing -> Automations | Dashboard-managed |
+| Measure recovery performance or abandoned-cart trends | Analytics Data API / Semantic Model API | Site Analytics read |
+| Inspect specific buyer/status/activity fields | `POST https://www.wixapis.com/ecom/v1/abandoned-checkout/query` | TPA-public, drill-down |
+| Redirect shopper back to checkout for a one-off custom message | `GET https://www.wixapis.com/ecom/v1/abandoned-checkout/{abandonedCheckoutId}/redirect-to-checkout?metasiteId={metasiteId}` | TPA-public |
+
+## Required APIs for verification only
+
+- `POST https://www.wixapis.com/ecom/v1/abandoned-checkout/query` — list eligible abandoned checkouts, filter by date/status/buyer, and inspect automation `activities` when available.
+- `GET https://www.wixapis.com/ecom/v1/abandoned-checkout/{abandonedCheckoutId}` — verify a specific checkout before using it in a custom recovery flow.
+
+## Prerequisites
+
+- Wix Stores or another eCommerce solution is installed.
+- A sender email / verified business email is connected.
+- Checkout captures a customer email. Guest checkouts without an email cannot be recovered by email.
+
+## Step 1: Enable the abandoned-cart automation
+
+Direct the merchant to the built-in automation:
+
+> **Wix Dashboard -> Marketing -> Automations**. Find the pre-built **Recover abandoned carts** automation and turn it on. If it does not exist, create a new automation with:
+> - **Trigger:** Abandoned checkout / cart (eCommerce)
+> - **Action:** Send an email to the shopper
+
+## Step 2: Set the send timing
+
+| Timing | Use | Notes |
+|---|---|---|
+| 1 hour after abandonment | Single-email default | Catches distracted shoppers while intent is fresh |
+| 1 hour + 24 hours | Higher recovery | Second nudge for price or shipping hesitation |
+| +72 hours with incentive | Optional third email | Only if margins allow a small discount |
+
+Avoid sending more than about three emails. Beyond that, unsubscribes usually outweigh recoveries.
+
+## Step 3: Write the recovery email
+
+Include, in priority order:
+
+1. Cart contents, such as product image and name.
+2. A clear "Complete your order" button.
+3. Reassurance, such as shipping policy, return policy, or support contact.
+4. Optional incentive, such as a small discount or free-shipping nudge.
+
+## Step 4: Eligibility and guardrails
+
+- **Consent:** Respect marketing opt-out flags.
+- **No double-send:** Do not send recovery email for checkouts that converted.
+- **Discount stacking:** If the email includes an incentive, confirm it will not stack with existing automatic discounts.
+- **Email captured only:** If the checkout did not capture an email, use broader checkout optimization instead of email recovery.
+
+## Measurement
+
+- **Recovery rate** = recovered abandoned checkouts / abandoned checkouts that were eligible for recovery.
+- Use Analytics APIs for recovery performance, abandonment trends, and reporting. For custom reports, discover the relevant Semantic Model fields first and do not invent a ready-made "recovery rate" field unless the analytics model exposes it.
+- Use 5-15% as a rough benchmark, but do not claim any API returns a single ready-made "recovery rate" field unless it is present in the data you queried.
+- Track over 30 days. If recovery is below 5%, revisit timing, subject line, cart rendering, eligibility, and whether the checkout redirect still works.
+
+## API-assisted path
+
+For a custom recovery flow, use [Generate a recovery link / resume checkout](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-link). Prefer the Dashboard automation for recurring email sends because it handles consent, throttling, and send orchestration.
+
+## Audit note
+
+This file is not redundant with the public API docs because the public API does not configure Wix Automations. The value of this skill is the Dashboard/API boundary, timing guidance, eligibility guardrails, and when to switch to the API-assisted recovery-link recipe.

--- a/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-health.md
+++ b/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-health.md
@@ -1,0 +1,93 @@
+---
+name: "Abandoned Carts: Recovery Health"
+description: Monitors abandoned-checkout recovery health by comparing abandoned-checkout volume, recovery rate, automation state, and common failure signals. Routes root causes to checkout, shipping, pricing, or recovery troubleshooting.
+---
+
+# Recovery Health Monitor
+
+Use this for periodic or on-demand health checks of abandoned-checkout recovery. The goal is to spot whether recovery is underperforming and identify the likely reason.
+
+Merchants often say "abandoned carts"; the API entity is **Abandoned Checkout**. For information, reporting, and trend questions, use Analytics APIs first. Use the Abandoned Checkout API for record-level drill-down and recovery-link verification.
+
+## Required APIs and inferred metrics
+
+| Measurement | Source | Status |
+|---|---|---|
+| Abandoned checkout count / trend | Analytics Data API or Semantic Model API | Site Analytics read; Semantic Model API is Developer Preview |
+| Conversion/recovery performance | Semantic Model API, after discovering available measures and dimensions | Site Analytics read; do not invent field names |
+| Automation activity signals | `activities` on abandoned checkout objects, when Wix Automations populated them | TPA-public read, Dashboard-configured |
+| Redirect/link usability | `GET /ecom/v1/abandoned-checkout/{abandonedCheckoutId}/redirect-to-checkout?metasiteId={metasiteId}` | TPA-public |
+| Record-level abandoned checkout evidence | `POST /ecom/v1/abandoned-checkout/query` or `/search` | TPA-public, drill-down only |
+| Recovered count / recovery rate | Analytics model fields if available; otherwise infer from abandoned checkout status/activity plus order/recovery attribution if present | Do not claim a single guaranteed field |
+| Automation enabled/configured | Wix Dashboard -> Marketing -> Automations | Dashboard-managed |
+
+## What to measure
+
+Collect enough data to answer:
+
+- How many abandoned checkouts happened in the period?
+- How many were recovered?
+- Did abandonment spike compared with a trailing baseline?
+- Did recovery rate drop compared with a trailing baseline?
+- Are recovery emails or links enabled and usable?
+
+Use this rough benchmark:
+
+- **Healthy:** recovery rate is stable and generally in the 5-15% range.
+- **Warning:** recovery rate drops materially, abandonment spikes, or eligible abandoned checkouts are not receiving recovery.
+- **Critical:** recovery links fail, automation is disabled, or checkout cannot complete.
+
+## Analytics checks
+
+For information queries such as "how many abandoned carts", "did recovery drop", or "show a report", use Analytics APIs before record lookup:
+
+```http
+GET https://www.wixapis.com/analytics/v2/site-analytics/data
+POST https://www.wixapis.com/analytics/semantic-model/v3/semantic-models/query-data
+```
+
+Use `analytics/v2/site-analytics/data` for available high-level site measurements. Use the Semantic Model API for custom abandoned-cart or funnel reports: discover the relevant model and fields first, include the required `interval`, and do not invent measure or dimension names. The Semantic Model API can return up to 1,000 rows per query; page when needed.
+
+## Record-level checks
+
+Use Abandoned Checkout API query/search only after the analytics question needs record-level evidence, sample checkouts, or link verification:
+
+```http
+POST https://www.wixapis.com/ecom/v1/abandoned-checkout/query
+```
+
+Query can return up to 100 abandoned checkouts per request, so page through the full period before sampling records. When available, cross-check recovered orders against abandoned checkout IDs, status/activity fields, or recovery attribution.
+
+## Dashboard checks
+
+Recovery email automation is Dashboard-managed. Ask the merchant to confirm:
+
+- the automation is active
+- the trigger is abandoned checkout / cart
+- sender email is valid
+- email content includes a recovery CTA
+- no condition accidentally excludes eligible shoppers
+
+## Root-cause routing
+
+Route the likely cause:
+
+- Recovery automation off or misconfigured -> [Troubleshoot Abandoned-Cart Recovery](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-troubleshoot-recovery)
+- Recovery links fail -> [Generate a Recovery Link](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-link)
+- Abandonment spike at delivery step -> [Checkout & Cart](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/checkout-cart) and shipping coverage/rate checks
+- Incentive or discount issue -> [Pricing & Promotions](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-promotions)
+
+## Report
+
+Return:
+
+- status: OK, WARNING, or CRITICAL
+- abandoned checkout volume or trend from Analytics APIs
+- recovery rate if available, otherwise say which source data is missing
+- change versus baseline
+- top suspected cause
+- one next action
+
+## Audit note
+
+This file is not redundant with the API docs because it defines the health rubric, baseline comparison, Dashboard/manual checks, Analytics/API boundary, and root-cause routing. It must stay honest about inferred metrics: if Analytics models or API data do not expose recovery attribution directly, report volume and evidence instead of fabricating a recovery rate.

--- a/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-link.md
+++ b/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-link.md
@@ -1,0 +1,89 @@
+---
+name: "Abandoned Carts: Recovery Link"
+description: Generates a one-click recovery link for an abandoned checkout using the Abandoned Checkout API. Covers listing abandoned checkouts, selecting the correct abandonedCheckoutId, and redirecting the shopper back to checkout.
+---
+
+# Generate a Recovery Link
+
+Use this when the merchant wants a one-off link that returns a shopper to the checkout they abandoned. For recurring automated emails, use [Recover Abandoned Carts via Email](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recover-via-email).
+
+Merchants often say "abandoned cart"; the API entity is **Abandoned Checkout**.
+
+## Required APIs
+
+- `POST https://www.wixapis.com/ecom/v1/abandoned-checkout/query` — list abandoned checkouts. The public docs say query can return up to 100 abandoned checkouts per request and supports filters such as `status`, `createdDate`, `updatedDate`, and buyer identifiers.
+- `GET https://www.wixapis.com/ecom/v1/abandoned-checkout/{abandonedCheckoutId}` — retrieve and verify one abandoned checkout.
+- `GET https://www.wixapis.com/ecom/v1/abandoned-checkout/{abandonedCheckoutId}/redirect-to-checkout?metasiteId={metasiteId}` — redirect the caller to the checkout page. The response is a redirect response, not a normal JSON "create link" object.
+
+Authentication: the Abandoned Checkout docs require a Wix app or Wix user identity. Permission: `Read Orders`.
+
+## Step 1: Find the abandoned checkout
+
+Use the query endpoint for a simple list:
+
+```http
+POST https://www.wixapis.com/ecom/v1/abandoned-checkout/query
+```
+
+Example filter:
+
+```json
+{
+  "query": {
+    "filter": {
+      "status": "ABANDONED"
+    },
+    "cursorPaging": {
+      "limit": 50
+    }
+  }
+}
+```
+
+Use `/ecom/v1/abandoned-checkout/search` when the merchant needs richer filters, such as customer email, date range, cart value, or sort order.
+
+## Step 2: Confirm the target checkout
+
+Before generating a link, confirm the abandoned checkout matches the merchant's intended shopper or order context:
+
+- buyer/contact email or contact ID
+- cart total
+- created or updated timestamp
+- abandoned checkout `id`
+- site or `metasiteId` context needed for redirect
+
+Do not generate a link for a checkout that already converted.
+
+## Step 3: Redirect to checkout
+
+```http
+GET https://www.wixapis.com/ecom/v1/abandoned-checkout/{abandonedCheckoutId}/redirect-to-checkout?metasiteId={metasiteId}
+```
+
+The response is expected to be an HTTP redirect, usually `302`, with the checkout URL in the `Location` header. Use the redirected URL in the merchant's own message, support reply, or recovery email CTA only after confirming it belongs to the intended shopper/checkout.
+
+Example response shape:
+
+```json
+{
+  "statusCode": 302,
+  "headers": [
+    {
+      "key": "Location",
+      "value": "https://example.wixsite.com/store/checkout?appSectionParams=..."
+    }
+  ]
+}
+```
+
+## Guardrails
+
+- Confirm the shopper can be contacted before sharing a recovery link.
+- Treat the link as shopper-specific. Do not publish it broadly.
+- If the merchant wants recurring sends, route to the Dashboard automation recipe instead of trying to build an email scheduler here.
+- If the API returns a redirect response, extract the `Location` header. Do not invent a `checkoutUrl` or `recoveryUrl` field if the response did not return one.
+- If no `Location` header is present, return the status code and headers you received and route to troubleshooting.
+
+## Audit note
+
+This file is not redundant with the API docs because it adds selection guardrails, the merchant-facing recovery-message boundary, and the critical response-shape detail: redirect-to-checkout is a `GET` redirect flow, not a JSON link-generation action.

--- a/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.md
+++ b/skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.md
@@ -1,0 +1,94 @@
+---
+name: "Abandoned Carts: Troubleshoot Recovery"
+description: Diagnoses abandoned-cart recovery flows that are not sending, not generating usable links, or not recovering shoppers. Covers Dashboard automation checks, email eligibility, Abandoned Checkout API checks, and recovery-rate triage.
+---
+
+# Troubleshoot Abandoned-Cart Recovery
+
+Use this when a merchant says abandoned-cart recovery is enabled but messages are not sending, links are not working, or recovery performance is weak.
+
+Merchants often say "abandoned cart"; the public API entity is **Abandoned Checkout**.
+
+## Required APIs and Dashboard checks
+
+| Area | Check | Status |
+|---|---|---|
+| Dashboard automation | Automation active, trigger/action configured, sender valid, conditions not excluding shoppers | Dashboard-managed |
+| Information/reporting | Analytics Data API or Semantic Model API for counts, trends, and recovery performance | Site Analytics read |
+| Abandoned checkout lookup | `POST /ecom/v1/abandoned-checkout/query` or `/search` for record-level drill-down | TPA-public |
+| Single checkout verification | `GET /ecom/v1/abandoned-checkout/{abandonedCheckoutId}` | TPA-public |
+| Checkout redirect | `GET /ecom/v1/abandoned-checkout/{abandonedCheckoutId}/redirect-to-checkout?metasiteId={metasiteId}` | TPA-public |
+
+## Step 1: Identify the recovery path
+
+Ask which recovery path the merchant is using:
+
+- **Dashboard automation:** Wix sends abandoned-cart emails automatically.
+- **API-assisted recovery:** An external email/message includes a recovery link generated from the Abandoned Checkout API.
+
+If they are unsure, start with Dashboard automation checks.
+
+## Step 2: Branch by likely failure point
+
+| Symptom | Likely branch | First check |
+|---|---|---|
+| Emails are not sending | Dashboard automation | Automation active, trigger is abandoned checkout/cart, sender valid |
+| Emails send but customers cannot return | API/link path | Redirect endpoint returns `302` with a `Location` header |
+| Few shoppers are eligible | Eligibility | Email/contact captured, not opted out, checkout still abandoned |
+| Recovery is low but technically working | Performance | Timing, content, shipping/payment/tax surprises |
+
+## Step 3: Check Dashboard automation
+
+For Dashboard automation issues, ask the merchant to verify:
+
+- The automation is active.
+- The trigger is abandoned checkout / cart, not checkout started.
+- The send action has a valid sender email.
+- The email content includes a clear recovery CTA.
+- There is no audience, segment, or condition that excludes most abandoned checkouts.
+
+## Step 4: Check eligibility
+
+Recovery only works when there is enough shopper context:
+
+- The checkout captured an email or contact.
+- The shopper did not opt out.
+- The checkout did not later convert.
+- The store did not delete or materially change the cart contents in a way that breaks the return path.
+
+## Step 5: Check the API path
+
+If the merchant is generating links programmatically:
+
+1. Query abandoned checkouts with `POST /ecom/v1/abandoned-checkout/query` or `/search`.
+2. Confirm the chosen abandoned checkout is still abandoned.
+3. Redirect with `GET /ecom/v1/abandoned-checkout/{abandonedCheckoutId}/redirect-to-checkout?metasiteId={metasiteId}`.
+4. Confirm the response is a redirect, usually `302`, and extract the checkout URL from the `Location` header.
+5. Test the returned URL before sending it to shoppers.
+
+If the generated link works but emails do not send, the issue is in the email channel, not the Abandoned Checkout API.
+
+## Step 6: Triage weak recovery performance
+
+If emails send and links work but recovery is low:
+
+- Use Analytics APIs to compare abandoned-cart volume, conversion/recovery performance, and current-period trend against the baseline.
+- Compare recovery rate against a rough 5-15% benchmark only when the analytics model or source data supports that metric.
+- Check timing. One hour after abandonment is usually a good first send.
+- Check whether cart contents render in the message.
+- Check whether shipping cost, payment failure, or tax surprises caused the abandonment.
+- If abandonment is rising broadly, route to [Recovery Health Monitor](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-health) or checkout troubleshooting.
+
+## Response shape
+
+Return a short diagnosis with:
+
+- recovery path used
+- likely failure point
+- evidence checked
+- next action
+- whether the fix is Dashboard, API, checkout, shipping, or pricing related
+
+## Audit note
+
+This file is not redundant with API docs because it connects Dashboard automation failures, Abandoned Checkout API verification, eligibility checks, and cross-category root-cause routing into one diagnostic tree.

--- a/skills/wix-manage/references/ecommerce/ecom-abandoned-carts.md
+++ b/skills/wix-manage/references/ecommerce/ecom-abandoned-carts.md
@@ -1,0 +1,65 @@
+---
+name: "Abandoned Carts"
+description: Abandoned Carts boundary owner — post-abandonment recovery, recovery emails, recovery links, recovery troubleshooting, recovery health. **Always load this dispatcher first when a question touches both post-abandonment recovery and live checkout (drop-off, config, troubleshooting)** — the rules for which side owns each topic live in this file, not in this README line.
+---
+
+# Abandoned Carts
+
+Recover shoppers who already left checkout. Merchants often say "abandoned carts"; the Wix API surface calls these **Abandoned Checkouts**. Use this category for abandoned-checkout recovery emails, recovery links, recovery troubleshooting, and recovery performance monitoring.
+
+For information and reporting queries, prefer **Analytics APIs**. Use the Abandoned Checkout API only when the agent needs to inspect or act on specific abandoned checkout records.
+
+> **Routing rule (READ FIRST).** Any merchant query that mentions BOTH a post-abandonment topic (recover shoppers who already left, abandoned-cart email, recovery link, recovery rate, recovery automation) AND a live-checkout topic (drop-off, can't-complete-checkout, checkout policies, guest checkout, minimum order) MUST be answered by loading this dispatcher first AND [Checkout & Cart](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/checkout-cart). Do NOT route mixed recovery + live-checkout questions from the WixREADME index alone; the binding decision lives here.
+
+**Abandoned carts is NOT:**
+- Reducing live checkout drop-off before the shopper leaves -> see **Checkout & Cart**.
+- Shipping cost or delivery-step friction -> see **Shipping**.
+- Discounts and incentives used in recovery emails -> see **Pricing & Promotions**.
+
+> **Before dispatching** - confirm MerchantContext is loaded. If `siteData.country` is not in your conversation context, load it via [Load Merchant Context](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/e-commerce-load-context). Skip if already loaded.
+>
+> **Promotion dispatch.** Score each entry below by the merchant's query -> `intent:*` tags. Load the highest-scoring entry. No match -> base recipe.
+>
+> **Hard guardrail — the recurring abandoned-cart recovery email is Dashboard-only.** Configuring the recurring recovery automation is **NOT** TPA-public via the Automations V2 API. Do NOT call `https://www.wixapis.com/automations-service/v2/automations/{id}` (POST or PATCH) to create or update the recovery automation — those calls reject built-in templates with `INVALID_ORIGIN_TYPE` (HTTP 400). If a sub-recipe slug below returns a transient 404 (rawdocs ingestion delay), do NOT improvise via the Automations API — instead route the merchant to **Wix Dashboard → Marketing → Automations → "Recover abandoned carts"** and retry the sub-recipe slug once. The only TPA-public Abandoned-Checkout APIs are: `POST /ecom/v1/abandoned-checkout/query` (read-only) and `GET /ecom/v1/abandoned-checkout/{id}/redirect-to-checkout` (one-off custom recovery links).
+
+### Recovery actions
+
+> - [Recover abandoned carts via email](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recover-via-email) — tags: `[intent:recover-email]` · priority 0 · *Dashboard-configured automation; Abandoned Checkout API can verify eligibility/activity but does not configure recurring sends*
+> - [Generate a recovery link / resume checkout](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-link) — tags: `[intent:recovery-link]` · priority 0 · *Abandoned Checkout API: find checkout, confirm target, redirect to checkout*
+
+### Diagnose and monitor
+
+> - [Troubleshoot abandoned-cart recovery](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-troubleshoot-recovery) — tags: `[intent:troubleshoot-recovery]` · priority 0
+> - [Recovery health monitor](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-health) — tags: `[intent:recovery-health]` · priority 0
+
+### Info
+
+> - [Abandoned-cart analytics and reports](https://dev.wix.com/docs/api-reference/business-management/analytics/semantic-models/query-semantic-model-data) — tags: `[intent:view-abandoned]`, `[intent:information]`, `[intent:reporting]` · priority 0 · **Analytics API route, no dedicated skill**. Use Analytics Data API or Semantic Model API for counts, trends, conversion/recovery performance, and reporting. Use Abandoned Checkout API only for drilling into specific records after the analytics question is scoped.
+
+### API boundary
+
+| Merchant need | Preferred surface |
+|---|---|
+| "How many abandoned carts did I have?" | Analytics APIs |
+| "Did abandonment/recovery trend change?" | Analytics APIs |
+| "Show abandoned-cart report by date or channel" | Semantic Model API, after discovering available fields |
+| "Find this shopper's abandoned checkout" | Abandoned Checkout API query/search |
+| "Generate a link to resume checkout" | Abandoned Checkout API redirect endpoint |
+
+## Tag matching examples
+
+| Merchant query | Match |
+|---|---|
+| "Show me abandoned carts from this week" | Analytics API route: `intent:view-abandoned` |
+| "Create an automated abandoned cart email" | `ecom-abandoned-carts-recover-email` via `intent:recover-email` |
+| "Send this customer a link to finish checkout" | `ecom-abandoned-carts-recovery-link` via `intent:recovery-link` |
+| "My abandoned cart emails are not sending" | `ecom-abandoned-carts-troubleshoot-recovery` via `intent:troubleshoot-recovery` |
+| "Did abandoned checkout recovery get worse this month?" | `ecom-abandoned-carts-recovery-health` via `intent:recovery-health` |
+
+## Base recipe
+
+If nothing matches, ask **one** clarifying question:
+
+> "Do you want to **view abandoned checkouts**, **recover them with emails or links**, or **troubleshoot/monitor** recovery performance?"
+
+Map the answer to an `intent:*` tag and re-dispatch. If the merchant is asking how to stop customers from leaving checkout in the first place, route to **Checkout & Cart** instead.

--- a/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-recover-email.yml
+++ b/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-recover-email.yml
@@ -1,0 +1,30 @@
+name: ecommerce/abandoned-carts/recover-email
+description: Customers keep abandoning their cart — can you set up automatic emails to win them back?
+triggerPrompt: |
+  Customers keep adding things to cart and then disappearing. Can you set up automatic emails that follow up with them so I can win some of them back?
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recover-via-email
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Recurring abandoned-cart recovery emails on Wix are configured via a **Dashboard automation** (Marketing → Automations → "Recover abandoned carts"). There is no public API for the recurring send — the agent must direct the merchant to the Dashboard. The Abandoned Checkout API is read-only here (used to verify state or build a custom one-off, not to send the recurring email).
+
+      Pass if ALL of these are true:
+        1. The agent dispatched to the `abandoned-carts-recover-via-email` recipe.
+        2. It directed the merchant to **Wix Dashboard → Marketing → Automations** and named the pre-built "Recover abandoned carts" automation (or instructed them to create one with trigger = abandoned checkout/cart, action = send email).
+        3. It surfaced concrete setup guidance the merchant can act on — at least TWO of: send timing (e.g. 1h / 1h+24h / +72h with incentive), email content priorities (cart contents, "Complete your order" CTA, reassurance/policy, optional incentive), eligibility/guardrails (consent, no-double-send after conversion, discount stacking, email captured).
+        4. For measurement, it points to **Analytics APIs** (not the Abandoned Checkout query endpoint) as the source of recovery rate / trends.
+
+      Fail if ANY of these are true:
+        - The agent claimed a public API sends the recurring recovery email automatically.
+        - It dispatched to the live-checkout `reduce-abandonment` skill instead of post-abandonment recovery.
+        - It described "configure the email via the API" without mentioning the Dashboard automation.
+        - It treated this as a Pricing/Promotions task (discount-to-win-back) without first setting up the recovery email.
+        - It only described the recipe in abstract terms without naming the specific Dashboard path or any concrete setup field (timing, content, eligibility).

--- a/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-health.yml
+++ b/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-health.yml
@@ -1,0 +1,30 @@
+name: ecommerce/abandoned-carts/recovery-health
+description: How's my abandoned-cart recovery doing — is it working or is something off?
+triggerPrompt: |
+  Can you check how my abandoned-cart recovery is doing? I want to know if it's working or if performance has dropped.
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-health
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The merchant asked the agent to check recovery health on a **fresh `stores-v3-editor` template with no abandoned-checkout history**. The reads return a known empty state: zero abandoned checkouts in the query, no recent automation activity, no recovery events to measure. The correct finding is: "there's no recovery activity yet — set up the Dashboard automation if you haven't, and there's no data to benchmark until carts actually start being abandoned."
+
+      Pass if ALL of these are true:
+        1. The agent dispatched to the `abandoned-carts-recovery-health` recipe.
+        2. It actually queried `POST /ecom/v1/abandoned-checkout/query` (and/or the Analytics surface) to inspect state — NOT just answered from generic knowledge.
+        3. It correctly recognized the empty state: no abandoned checkouts, no recovery activity to measure on this site yet.
+        4. It recommended the right next step: confirm/set up the Dashboard recovery-email automation (route to `abandoned-carts-recover-via-email`), and re-check once shoppers have actually started abandoning.
+        5. For metrics framing, it used **Analytics APIs** as the canonical source for recovery rate / volume / trends (the Abandoned Checkout query endpoint is acceptable for record-level drill-down but not the primary reporting surface).
+
+      Fail if ANY of these are true:
+        - The agent answered without making any read calls — pure narration.
+        - It hallucinated metrics (e.g. "your recovery rate is 8%") despite there being no data on a fresh template.
+        - It claimed recovery was "broken" or proposed a fix before surfacing that there is no data to measure.
+        - It routed the question to Checkout & Cart (live drop-off prevention) instead of Abandoned Carts.

--- a/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-link.yml
+++ b/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-link.yml
@@ -1,0 +1,31 @@
+name: ecommerce/abandoned-carts/recovery-link
+description: Send a recent abandoner a link back to their cart.
+triggerPrompt: |
+  Can you grab the most recent shopper who left their cart and give me a link I can send them to finish their order?
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-recovery-link
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The merchant asked the agent to generate a recovery link on a **fresh `stores-v3-editor` template with no abandoned checkouts**. The correct skill behavior is the **guardrail path** — query for abandoned checkouts, find zero, and explain to the merchant that there's nothing to recover yet (rather than fabricate an id or skip the lookup).
+
+      Pass if ALL of these are true:
+        1. The agent dispatched to the `abandoned-carts-recovery-link` recipe.
+        2. It actually called `POST /ecom/v1/abandoned-checkout/query` (or the `search` variant) to look up abandoned checkouts.
+        3. It correctly recognized the empty result and surfaced "no abandoned checkouts on this store yet — no link can be generated until a shopper actually abandons one".
+        4. It explained the intended happy path so the merchant knows what to expect next: confirm the target checkout (buyer email, cart total, abandoned-checkout `id`, metasiteId), then call `GET /ecom/v1/abandoned-checkout/{id}/redirect-to-checkout?metasiteId=…` and use the `Location` header from the redirect response as the link.
+        5. It stopped before fabricating a link / abandoned-checkout id that doesn't exist.
+
+      Fail if ANY of these are true:
+        - The agent fabricated an abandoned-checkout `id` and called the redirect endpoint anyway.
+        - It described the recipe without making the query call.
+        - It dispatched to the Dashboard email automation skill (`recover-email`) instead — the merchant asked for a one-off link, not recurring email.
+        - It treated "no abandoned checkouts" as a failure or proposed creating one synthetically.
+        - It omitted the `metasiteId` requirement on the redirect call.

--- a/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.yml
+++ b/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.yml
@@ -1,0 +1,32 @@
+name: ecommerce/abandoned-carts/troubleshoot-recovery
+description: My abandoned-cart recovery emails are enabled but no one's coming back — help me figure out why.
+triggerPrompt: |
+  I turned on abandoned-cart recovery emails a while ago but barely anyone's coming back to finish their order. Don't change anything yet — just walk me through how you'd figure out what's going wrong. I want to see your plan first.
+tags: [ecommerce]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts-troubleshoot-recovery
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      **Exception to the action-oriented pattern.** The merchant explicitly asked for a diagnostic plan only — no API calls, no fixes. We are evaluating plan quality, not execution. (The store's actual recovery state is unknown to this test, which is why we test the plan.)
+
+      Pass if ALL of these are true:
+        1. The agent dispatched to the `abandoned-carts-troubleshoot-recovery` recipe.
+        2. The plan starts by **identifying the recovery path** the merchant is using — Dashboard automation vs API-assisted recovery — and asks if unsure rather than guessing.
+        3. The plan covers the documented branches in a sensible order:
+           a. **Dashboard automation checks** — automation active, trigger = abandoned checkout/cart (not checkout-started), sender email valid, recovery CTA in body, no exclusion segment.
+           b. **Eligibility checks** — email/contact captured, opt-out flags, post-conversion exclusion, cart-mutation impact.
+           c. **API-link path checks** — redirect endpoint returns `302` with a `Location` header (when API-assisted).
+           d. **Weak-performance triage** — timing, content, shipping/payment/tax surprises.
+        4. For weak-performance / reporting questions inside the plan, it points to **Analytics APIs** as the source of counts and trends, not the Abandoned Checkout query endpoint as a reporting surface (that endpoint is for record-level drill-down).
+        5. The plan respects the "don't change anything yet" constraint — no fix proposed before the merchant has confirmed the root cause.
+
+      Fail if ANY of these are true:
+        - The plan gives only generic marketing advice (better subject lines, stronger CTA) without any of the documented branches.
+        - It jumps to a single root cause without first identifying which recovery path the merchant is on.
+        - It routes the issue to live-checkout drop-off troubleshooting (`checkout-troubleshoot-dropoff`).
+        - It uses the Abandoned Checkout query endpoint as the primary recovery-rate / trend reporting source.
+        - It starts making mutating API calls or "fixing" things despite the merchant asking for a plan only.

--- a/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts.yml
+++ b/yaml/wix-manage-evals/ecommerce/abandoned-carts/ecom-abandoned-carts.yml
@@ -1,0 +1,25 @@
+name: ecommerce/ecom-abandoned-carts
+description: Some shoppers added stuff to cart and never finished — help me decide whether to chase them with emails or links.
+triggerPrompt: For my site Gracia (331d0c05-2ab0-4edb-91a6-4078c7e500b9) Some shoppers added stuff to cart and never finished. Can you show me what's been abandoned and help me decide whether to chase them with emails or send them a link back to checkout?
+tags: [ecommerce]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/abandoned-carts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The merchant asked about **post-abandonment recovery** — finding abandoned checkouts and choosing between recovery email vs recovery link. This is a routing test for the Abandoned Carts dispatcher.
+
+      Pass if the response:
+        - Treats this as post-shopper-leaves recovery (Abandoned Carts category), distinct from live checkout drop-off prevention (Checkout & Cart).
+        - References looking up abandoned checkouts via the Abandoned Checkout API AND at least one of the recovery paths owned by this category — Recover via Email, Recovery Link, Troubleshoot Recovery, or Recovery Health.
+        - Optionally points the merchant at one of the leaf skills for next steps.
+
+      Fail if the response:
+        - Treats abandoned-cart recovery as owned by Checkout & Cart (live drop-off prevention).
+        - Routes the merchant to Pricing/Promotions for "discount to win them back" without first sending them to the recovery path.
+        - Conflates live checkout drop-off with post-shopper-leaves recovery.
+
+      Topic-completeness beyond one or two recovery paths is NOT required — judge the boundary (Abandoned Carts vs Checkout) and the lookup endpoint, not the breadth.

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -136,6 +136,35 @@ apiDoc:
       tags: [ecommerce]
 
     # ============================================================
+    # Abandoned carts category
+    # ============================================================
+
+    - file: ../../../skills/wix-manage/references/ecommerce/ecom-abandoned-carts.md
+      title: "Abandoned Carts"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+
+    - file: ../../../skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recover-email.md
+      title: "Abandoned Carts: Recover via Email"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+
+    - file: ../../../skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-link.md
+      title: "Abandoned Carts: Recovery Link"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+
+    - file: ../../../skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.md
+      title: "Abandoned Carts: Troubleshoot Recovery"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+
+    - file: ../../../skills/wix-manage/references/ecommerce/abandoned-carts/ecom-abandoned-carts-recovery-health.md
+      title: "Abandoned Carts: Recovery Health"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+
+    # ============================================================
     # Carry-forward root orchestrator (not yet in routing tree)
     # The strategy orchestrator is preserved at its main-branch URL.
     # ABANDONED_CART branch removed; classification falls back to the


### PR DESCRIPTION
## Summary

Adds the **Abandoned Carts** category to `wix-manage` eCommerce routing, split out from #366 (PR #366 had the more iterated version; PR #423 only included the dispatcher + recovery-health). Authored against the new test-pattern selector (see wix-private/ecom-ai-agents#56).

### Skills

| Skill | Type | What it does |
|---|---|---|
| `ecom-abandoned-carts.md` | Dispatcher | Boundary owner — post-abandonment recovery vs live-checkout drop-off |
| `abandoned-carts/ecom-abandoned-carts-recover-email.md` | Dashboard guidance | Wix Dashboard → Marketing → Automations → "Recover abandoned carts" (no public API for the recurring send) |
| `abandoned-carts/ecom-abandoned-carts-recovery-link.md` | Action | One-off resume-checkout link via Abandoned Checkout API (query → confirm → redirect) |
| `abandoned-carts/ecom-abandoned-carts-recovery-health.md` | Read-only monitor | Periodic recovery-performance health check |
| `abandoned-carts/ecom-abandoned-carts-troubleshoot-recovery.md` | Diagnostic | Multi-branch tree: path → automation → eligibility → API link → performance |

### Routing

- `skills/wix-manage/SKILL.md` — Abandoned Carts routing bullet + `### [Abandoned Carts]` dispatcher block + leaves list inside the existing `<details>` block.
- `yaml/wix-manage/ecommerce/documentation.yaml` — Abandoned Carts category block (5 entries) after Shipping.

### EvalForge coverage (5 scenarios)

Authored against the test-pattern selector. Tests are merchant-voice and verify execution where possible.

| YAML | Template | Pattern | Verifies |
|---|---|---|---|
| `ecom-abandoned-carts.yml` | – | Routing | Boundary (Abandoned Carts vs Checkout) + at least one recovery sub-path |
| `recover-email.yml` | ✓ | **1-G (dashboard guidance)** | Directs to Wix Dashboard Marketing→Automations, surfaces timing/content/eligibility, Analytics APIs for measurement |
| `recovery-health.yml` | ✓ | **2 (empty-state)** | Runs the read calls, recognizes "no abandoned checkouts yet", recommends setting up the Dashboard automation |
| `recovery-link.yml` | ✓ | **1-G (guard path)** | Queries first, finds zero results, explains why no link can be generated — stops before fabricating an id |
| `troubleshoot-recovery.yml` | – | **3 (plan-only exception)** | Plan covers path identification + automation + eligibility + API link + perf branches; respects "don't change anything yet" |

The templated tests use `stores-v3-editor` (fresh site = no abandoned-checkout history = deterministic outcome for each pattern). The plan-only troubleshoot test stays Gracia-anchored because no API mutations are needed.

## Test plan

- [ ] EvalForge YAML gate runs on this PR (`draft:wix/skills#<this-pr>` tag applied automatically)
- [ ] Templated tests provision a fresh `stores-v3-editor` and tear it down
- [ ] `recover-email` agent names the Dashboard Marketing → Automations path (no API-mutation hallucination)
- [ ] `recovery-health` and `recovery-link` agents call `POST /ecom/v1/abandoned-checkout/query`, recognize the empty result, and respond per the guard / empty-state behavior
- [ ] `troubleshoot-recovery` agent produces a multi-branch plan without making mutating calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)