### PR TITLE
feat(wix-headless): cross-platform environment setup (CODEAI-687)

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless
-description: "Build a complete Wix Managed Headless site from a single prompt, OR connect an existing project (HTML/JSX/Vite app, Claude Design output, etc.) to Wix Headless for hosting + Business Solutions. Entry point for both: (1) new-site requests — runs discovery, design, feature wiring, and preview; and (2) existing-project requests — runs `npm create @wix/new@latest init`, analyzes the project for needed Business Solutions, installs apps, **wires the Wix SDK into the existing source files so each installed app actually powers its corresponding feature**, and releases. Triggers: build me a site, create a website, make me a website, new website, online store, I want to sell X, start a business online, launch a site, ecommerce, portfolio, business website, sell online, online shop, take bookings, book appointments, appointment scheduling, let clients book online, site for my salon/spa/clinic/studio, sign up for classes or sessions, connect this to Wix Headless, add Wix Headless to this project, host this on Wix, deploy this to Wix, implement the features of this project using Wix Headless. Use this skill instead of the WixSiteBuilder MCP tool for new-site requests."
+description: "Build a complete Wix Managed Headless site from a single prompt, OR connect an existing project (HTML/JSX/Vite app, Claude Design output, etc.) to Wix Headless for hosting + Business Solutions. Entry point for both: (1) new-site requests — runs discovery, design, feature wiring, and preview; and (2) existing-project requests — runs `npm create @wix/new@latest init`, analyzes the project for needed Business Solutions, installs apps, **wires the Wix SDK into the existing source files so each installed app actually powers its corresponding feature**, and releases. Triggers: build me a site, create a website, make me a website, new website, online store, I want to sell X, start a business online, launch a site, ecommerce, portfolio, business website, sell online, online shop, take bookings, book appointments, appointment scheduling, let clients book online, site for my salon/spa/clinic/studio, sign up for classes or sessions, connect this to Wix Headless, add Wix Headless to this project, host this on Wix, deploy this to Wix, implement the features of this project using Wix Headless, set up my machine for Wix Headless, get my environment ready for Wix Headless, install the Wix CLI, what do I need to build a headless site. Use this skill instead of the WixSiteBuilder MCP tool for new-site requests."
 allowed-tools:
   - Bash(cd *)
   - Bash(npx @wix/cli@latest *)
@@ -10,6 +10,13 @@ allowed-tools:
   - Bash(npm run *)
   - Bash(node *)
   - Bash(bash *)
+  - Bash(powershell *)
+  - Bash(pwsh *)
+  - Bash(uname *)
+  - Bash(git *)
+  - Bash(xcode-select *)
+  - Bash(brew install *)
+  - Bash(winget install *)
   - Bash(curl *)
   - Bash(ls *)
   - Bash(grep *)
@@ -44,6 +51,7 @@ Your CWD at runtime is the **project directory, which is also the site-root** �
 | Pre-approval funnel (plan; router on OPERATION → operation files) | `<SKILL_ROOT>/references/PLAN.md` → `PLAN-create.md` (create) / `PLAN-connect.md` (connect) |
 | Post-approval build (router on FRAMEWORK → framework files) | `<SKILL_ROOT>/references/BUILD.md` → `BUILD-astro.md` (`frontendBuild: wix`) / `BUILD-own-build.md` (`frontendBuild: none`/`own`) |
 | Seed recipe map (human ref) | `<SKILL_ROOT>/references/seed-recipes.md` |
+| Environment readiness (audit → install → auth) | `<SKILL_ROOT>/references/shared/ENVIRONMENT.md` (scripts: `scripts/audit-env.sh`, `scripts/audit-env.ps1`) |
 | Auth + REST headers | `<SKILL_ROOT>/references/shared/AUTHENTICATION.md` |
 | Public doc endpoints | `<SKILL_ROOT>/references/shared/DOCS_SEARCH.md` |
 | Return contract | `<SKILL_ROOT>/references/shared/RETURN_CONTRACT.md` |

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -48,9 +48,27 @@ These flow into:
 - **Bootstrap is (operation × framework)-keyed** (`BUILD.md` § "Bootstrap cell"): create+astro runs `scaffold.sh --frontend astro`; create+own runs the framework's own create command (`npm create vite`/…) then `init`; connect (own/none) does **not** scaffold — it bootstraps via `npm create @wix/new@latest init` over the brought-in/scaffolded source.
 - Orchestrator session scratch — every downstream branch reads the scratch values. For `connect`, the frontend track runs the connect flow (`references/custom/INSTRUCTIONS.md`); the create-only project-prep (`seed-utilities.sh`) and the Designer/Composer do not run. (Business-track steps — app install, seeders — never read these fields.)
 
-## Pre-flight — Verify CLI auth (BEFORE any user-facing question)
+## Pre-flight — Verify environment + CLI auth (BEFORE any user-facing question)
 
-The first Wix touch is the post-approval project bootstrap — create/astro: `scaffold.sh` → `npm create @wix/new@latest headless`; connect: `npm create @wix/new@latest init` — which creates a business + project against the user's Wix account and so requires an active CLI session. Without one it fails — and because the bootstrap runs **after** approval (`BUILD-astro.md` run-step 0 / the connect bootstrap cell, `BUILD.md` § "Bootstrap cell"), a logged-out user wouldn't find out until they'd done discovery *and* approved, only to have it fail immediately. Run the auth check foreground here (both operations) so a logged-out user sees the login prompt first.
+Two checks run foreground here, in order, both before any `AskUserQuestion`: **(1) the toolchain is ready**, then **(2) the CLI is authenticated**. Doing them up front means a machine that's missing Node or logged out finds out *first* — not after discovery + approval, when the post-approval bootstrap (`scaffold.sh` / `npm create @wix/new@latest init`) would otherwise fail immediately.
+
+### 1. Environment audit
+
+Run the OS-appropriate audit script (read-only, fast, no installs):
+
+```bash
+bash <SKILL_ROOT>/scripts/audit-env.sh                                            # macOS / Linux
+powershell -NoProfile -ExecutionPolicy Bypass -File <SKILL_ROOT>\scripts\audit-env.ps1   # Windows
+```
+
+- **All requirements green** (Node `present` && `ok`, npm, git, git identity, macOS CLT) → go to the CLI-auth check below.
+- **Any gap** → open [`shared/ENVIRONMENT.md`](shared/ENVIRONMENT.md) and run its install-with-consent flow, then resume here. Don't push past a stale Node (`present:true, ok:false`) — the build will break later if you do.
+
+(`<SKILL_ROOT>` is the absolute path you bound from `SKILL.md`; see `SKILL.md` § "Path resolution".)
+
+### 2. CLI auth
+
+The post-approval bootstrap creates a business + project against the user's Wix account, so it requires an active CLI session:
 
 ```bash
 npx @wix/cli@latest whoami >/dev/null 2>&1

--- a/skills/wix-headless/references/shared/AUTHENTICATION.md
+++ b/skills/wix-headless/references/shared/AUTHENTICATION.md
@@ -4,6 +4,7 @@ Every Wix API call this skill makes goes through `@wix/cli` + `curl` — no MCP,
 
 ## Prerequisites
 
+- A ready toolchain: **Node ≥ 20.11.0**, npm, and **git** (with `user.name`/`user.email` set). This is verified by the Discovery pre-flight's environment audit; the install-with-consent flow for any gap is owned by [`shared/ENVIRONMENT.md`](./ENVIRONMENT.md).
 - `@wix/cli` resolvable via `npx`. The scaffold installs it project-local, so `npx @wix/cli …` works without a global install.
 - An authenticated CLI session. Test with `npx @wix/cli@latest whoami` — exits **0** when logged in (prints the authenticated email + user id), **non-zero** when logged out.
 

--- a/skills/wix-headless/references/shared/ENVIRONMENT.md
+++ b/skills/wix-headless/references/shared/ENVIRONMENT.md
@@ -1,0 +1,138 @@
+# Environment readiness
+
+The rest of this skill assumes a machine that can already run the build: a modern **Node**, **npm**, **git** (with an identity), and an authenticated **Wix CLI**. This file owns getting there — **audit → install (with consent) → authenticate** — across **macOS, Linux, and Windows/PowerShell**. It runs once, early, and is idempotent: re-running it on a ready machine is a no-op that just re-confirms.
+
+Two entry points open this file:
+
+1. **The Discovery pre-flight** (`DISCOVERY.md` § "Pre-flight") runs the audit script before any user-facing question. All green → it proceeds straight to the CLI-auth check. Any gap → it opens this file.
+2. **A direct setup request** — *"set up my machine for Wix Headless"*, *"install the Wix CLI"*, *"what do I need to build a headless site"*. Run the full flow below, then hand back to the build flow (or stop, if the user only asked to get set up).
+
+This file **does not scaffold or build** — that's `BUILD.md`. Its job ends when the machine is ready and logged in.
+
+---
+
+## Phase 0 — Detect OS, pick the audit script
+
+```bash
+uname -s 2>/dev/null || echo Windows
+```
+
+- `Darwin` → macOS, `Linux` → Linux → run **`scripts/audit-env.sh`**.
+- Anything else (or the command not found) → Windows → run **`scripts/audit-env.ps1`**.
+
+Both scripts emit the **same** one-line JSON shape, so everything downstream is platform-agnostic.
+
+---
+
+## Phase 1 — Audit (read-only)
+
+Run the matching script with `Bash`. It only probes local tools (no installs, no network), so it's fast and safe.
+
+```bash
+# macOS / Linux
+bash <SKILL_ROOT>/scripts/audit-env.sh
+
+# Windows — -ExecutionPolicy Bypass avoids a blocked-script error on locked-down machines.
+# Prefer pwsh (PowerShell 7+) when present; fall back to powershell (Windows PowerShell 5.1).
+powershell -NoProfile -ExecutionPolicy Bypass -File <SKILL_ROOT>\scripts\audit-env.ps1
+```
+
+Output (single line):
+
+```json
+{"os":"darwin","node":{"present":true,"version":"22.19.0","ok":true},
+ "npm":{"present":true,"version":"10.9.3"},
+ "git":{"present":true,"version":"2.47.0"},
+ "gitIdentity":{"nameSet":true,"emailSet":true},
+ "xcodeCLT":{"present":true},"minNode":"20.11.0"}
+```
+
+Read it as a checklist. **A requirement is satisfied only when:**
+
+| Field | Ready when | Why it matters |
+|---|---|---|
+| `node.present` && `node.ok` | Node ≥ **20.11.0** | The `@wix/cli` scaffold + astro toolchain need it. `present:true, ok:false` = installed **but too old** — the dangerous case to eyeball past. |
+| `npm.present` | npm resolves | Drives every install + the scaffold. Ships with Node; absent usually means a broken Node install. |
+| `git.present` | git resolves | `npm create @wix/new` initializes a repo. |
+| `gitIdentity.nameSet` && `gitIdentity.emailSet` | both set | Without them the first commit fails with *"Author identity unknown"*. |
+| `xcodeCLT.present` (macOS only; `null` elsewhere) | CLT installed | Provides git + compilers for native npm modules on macOS. |
+
+`wix whoami` (logged-in state) is **not** in this script — it's the existing CLI-auth check in `DISCOVERY.md` § "Pre-flight" / `shared/AUTHENTICATION.md`. Audit covers the toolchain; auth covers the session.
+
+Report a short readiness table to the user, then go to Phase 2 only for the rows that aren't ready.
+
+---
+
+## Phase 2 — Install what's missing (with consent)
+
+For each gap, follow the same loop: **show → consent → run → re-verify.**
+
+1. **Show** the user the exact command for their OS (from the matrix below) and what it does.
+2. **Get consent.** Installing system tools mutates their machine — never run an installer without an explicit yes. Multiple gaps: list them together so the user approves once.
+3. **Run** it (foreground; installers are interactive and can take minutes).
+4. **Re-verify** by re-running the audit script. Trust the JSON, not the installer's exit chatter.
+
+> **The PATH caveat (especially Windows).** A freshly installed tool often isn't on `PATH` until a **new shell** is opened — the current agent shell won't see it. When a post-install re-audit still reports the tool missing, **do not loop on installs**. Tell the user: *"Installed — open a new terminal and tell me to re-check,"* and stop. This is the single most common Windows failure mode (`winget`/nvm-windows both update `PATH` for *future* shells only).
+
+### Install matrix
+
+**Node.js (≥ 20.11.0)** — also delivers npm.
+
+| OS | Preferred | Alternatives |
+|---|---|---|
+| macOS | `brew install node@20` (or `nvm install 20`) | Installer from nodejs.org |
+| Windows | `winget install OpenJS.NodeJS.LTS` | [nvm-windows](https://github.com/coreybutler/nvm-windows) (`nvm install lts`); installer from nodejs.org |
+| Linux | `nvm install 20` (recommended) | distro: `sudo apt-get install -y nodejs npm` — but distro Node is often **too old**; prefer nvm or [NodeSource](https://github.com/nodesource/distributions) |
+
+After install, confirm with the audit script (checks the version gate too), not just `node -v` by eye.
+
+**Git**
+
+| OS | Command |
+|---|---|
+| macOS | `xcode-select --install` (also installs the CLT), or `brew install git` |
+| Windows | `winget install Git.Git`, or the installer from git-scm.com |
+| Linux | `sudo apt-get install -y git` (or the distro equivalent — `dnf`, `pacman`, …) |
+
+**Git identity** (OS-agnostic; only if `nameSet`/`emailSet` is false) — ask the user for their name + email, then:
+
+```bash
+git config --global user.name  "Their Name"
+git config --global user.email "their@email.com"
+```
+
+**macOS Command Line Tools** (only if `xcodeCLT.present` is false): `xcode-select --install` (opens a GUI installer — the user clicks through; wait for them, then re-audit).
+
+**Wix CLI** — **nothing to install.** The skill always invokes it as `npx @wix/cli@latest …`, which fetches a project-local copy on first use (~3–5 s). Do not `npm i -g @wix/cli`. Authentication is Phase 3.
+
+### Windows / PowerShell gotchas
+
+The roughest surface — handle these explicitly:
+
+- **`winget` missing.** Comes with App Installer on Windows 10 1709+ / 11; older or stripped images lack it. If `winget` isn't found, fall back to nvm-windows or the nodejs.org / git-scm.com installers rather than retrying `winget`.
+- **PATH needs a new shell.** See the caveat above — the #1 cause of "I installed it but you still say it's missing."
+- **Script execution policy.** Always launch the audit via `-ExecutionPolicy Bypass` (as shown). Don't tell the user to weaken their machine-wide policy.
+- **`pwsh` vs `powershell`.** PowerShell 7+ (`pwsh`) and Windows PowerShell 5.1 (`powershell`) both run the audit. Prefer `pwsh` when present.
+- **Avoid Git Bash / WSL assumptions.** Detect the real shell (Phase 0) and use the PowerShell path on Windows; don't assume a bash-compatible environment exists.
+
+---
+
+## Phase 3 — Authenticate
+
+Once the toolchain is ready, ensure an authenticated CLI session. **Do not re-implement the login flow here** — it's owned by [`shared/AUTHENTICATION.md`](./AUTHENTICATION.md):
+
+```bash
+npx @wix/cli@latest whoami >/dev/null 2>&1   # exit 0 = logged in
+```
+
+Non-zero → run the agent-driven `npx @wix/cli@latest login` flow (background run, parse the `awaiting_user` event, surface URL + code in plain prose, wait for completion) exactly as `shared/AUTHENTICATION.md` § "`wix login` from a non-interactive agent" documents. The Discovery pre-flight already runs this check; this phase only matters when the user invoked setup directly.
+
+---
+
+## Phase 4 — Ready
+
+Confirm a final all-green audit + `whoami` exit 0, then summarize what's installed and that they're logged in. Hand back to the build flow:
+
+- Opened from the **Discovery pre-flight** → return; Discovery continues from where it paused.
+- Opened from a **direct setup request** that also wants a site built → continue into the normal run (open `PLAN.md`).
+- Opened from a **setup-only request** → stop here; the machine is ready for a future build.

--- a/skills/wix-headless/scripts/audit-env.ps1
+++ b/skills/wix-headless/scripts/audit-env.ps1
@@ -1,0 +1,89 @@
+<#
+  Read-only environment audit for Wix Headless (Windows / PowerShell).
+
+  Emits ONE compact JSON line to stdout describing what's installed and whether
+  it meets the bar. Does NOT install anything and does NOT hit the network — it
+  only probes local tools, so it's safe to run on every pre-flight.
+
+  Node gate: >= 20.11.0 (the floor the @wix/cli scaffold + astro toolchain need).
+
+  Companion: scripts/audit-env.sh (macOS / Linux) emits the IDENTICAL JSON shape.
+  references/shared/ENVIRONMENT.md parses one shape for both.
+
+  Usage (from an agent; -ExecutionPolicy Bypass avoids a blocked-script error):
+    powershell -NoProfile -ExecutionPolicy Bypass -File <SKILL_ROOT>\scripts\audit-env.ps1
+    # PowerShell 7+:
+    pwsh       -NoProfile -ExecutionPolicy Bypass -File <SKILL_ROOT>\scripts\audit-env.ps1
+
+  Output shape (single line; "xcodeCLT" is always null on Windows):
+    {"os":"windows","node":{"present":true,"version":"22.3.0","ok":true},
+     "npm":{"present":true,"version":"10.8.1"},
+     "git":{"present":true,"version":"2.45.1"},
+     "gitIdentity":{"nameSet":true,"emailSet":true},
+     "xcodeCLT":null,"minNode":"20.11.0"}
+#>
+$ErrorActionPreference = 'SilentlyContinue'
+$ProgressPreference    = 'SilentlyContinue'
+
+$minNode = '20.11.0'
+
+function Test-Cmd($name) { [bool](Get-Command $name -ErrorAction SilentlyContinue) }
+
+# Numeric MAJOR.MINOR.PATCH compare: is $have >= $min ?
+function Test-SemverGE($have, $min) {
+  $h = ($have -split '[.-]'); $m = ($min -split '\.')
+  for ($i = 0; $i -lt 3; $i++) {
+    $hi = 0; $mi = 0
+    [void][int]::TryParse(($h[$i]), [ref]$hi)
+    [void][int]::TryParse(($m[$i]), [ref]$mi)
+    if ($hi -gt $mi) { return $true }
+    if ($hi -lt $mi) { return $false }
+  }
+  return $true
+}
+
+# --- node (+ semver gate) ---
+$nodePresent = Test-Cmd node
+$nodeVersion = ''
+$nodeOk      = $false
+if ($nodePresent) {
+  $raw = (& node -v) 2>$null
+  if ($raw) {
+    $nodeVersion = ($raw -replace '^v', '')
+    $nodeOk      = Test-SemverGE $nodeVersion $minNode
+  }
+}
+
+# --- npm ---
+$npmPresent = Test-Cmd npm
+$npmVersion = ''
+if ($npmPresent) { $npmVersion = (& npm -v) 2>$null }
+
+# --- git ---
+$gitPresent = Test-Cmd git
+$gitVersion = ''
+if ($gitPresent) {
+  $gv = (& git --version) 2>$null      # "git version 2.45.1.windows.1"
+  if ($gv -match '(\d+\.\d+\.\d+)') { $gitVersion = $Matches[1] }
+}
+
+# --- git identity ---
+$nameSet  = $false
+$emailSet = $false
+if ($gitPresent) {
+  $nameSet  = -not [string]::IsNullOrWhiteSpace(((& git config --global user.name)  2>$null))
+  $emailSet = -not [string]::IsNullOrWhiteSpace(((& git config --global user.email) 2>$null))
+}
+
+$inv = [ordered]@{
+  os          = 'windows'
+  node        = [ordered]@{ present = [bool]$nodePresent; version = "$nodeVersion"; ok = [bool]$nodeOk }
+  npm         = [ordered]@{ present = [bool]$npmPresent;  version = "$npmVersion" }
+  git         = [ordered]@{ present = [bool]$gitPresent;  version = "$gitVersion" }
+  gitIdentity = [ordered]@{ nameSet = [bool]$nameSet;     emailSet = [bool]$emailSet }
+  xcodeCLT    = $null   # macOS-only concept; always null on Windows
+  minNode     = $minNode
+}
+
+# -Compress => single line, matching the .sh output.
+$inv | ConvertTo-Json -Compress -Depth 4

--- a/skills/wix-headless/scripts/audit-env.sh
+++ b/skills/wix-headless/scripts/audit-env.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Read-only environment audit for Wix Headless (macOS / Linux).
+#
+# Emits ONE compact JSON line to stdout describing what's installed and whether
+# it meets the bar. Does NOT install anything and does NOT hit the network — it
+# only probes local tools, so it's safe to run on every pre-flight (~tens of ms).
+#
+# Node gate: >= 20.11.0 (the floor the @wix/cli scaffold + astro toolchain need).
+#
+# Companion: scripts/audit-env.ps1 (Windows / PowerShell) emits the IDENTICAL
+# JSON shape. references/shared/ENVIRONMENT.md parses one shape for both.
+#
+# Usage:
+#   bash <SKILL_ROOT>/scripts/audit-env.sh
+#
+# Output shape (single line):
+#   {"os":"darwin","node":{"present":true,"version":"22.3.0","ok":true},
+#    "npm":{"present":true,"version":"10.8.1"},
+#    "git":{"present":true,"version":"2.45.1"},
+#    "gitIdentity":{"nameSet":true,"emailSet":true},
+#    "xcodeCLT":{"present":true},"minNode":"20.11.0"}
+# On non-macOS, "xcodeCLT" is null.
+set -u
+
+MIN_NODE="20.11.0"
+
+has()   { command -v "$1" >/dev/null 2>&1; }
+jbool() { if [ "${1:-0}" = "1" ]; then printf 'true'; else printf 'false'; fi; }
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  Darwin) os="darwin" ;;
+  Linux)  os="linux" ;;
+  *)      os="unknown" ;;
+esac
+
+# --- node (+ semver gate, MAJOR.MINOR.PATCH numeric compare) ---
+node_present=0; node_version=""; node_ok=0
+if has node; then
+  node_present=1
+  node_version="$(node -v 2>/dev/null | sed 's/^v//')"
+  if [ -n "$node_version" ]; then
+    node_ok="$(awk -v v="$node_version" -v m="$MIN_NODE" 'BEGIN{
+      split(v,a,/[.-]/); split(m,b,".");
+      for(i=1;i<=3;i++){ai=a[i]+0; bi=b[i]+0;
+        if(ai>bi){print 1; exit} if(ai<bi){print 0; exit}}
+      print 1}')"
+  fi
+fi
+
+# --- npm ---
+npm_present=0; npm_version=""
+if has npm; then npm_present=1; npm_version="$(npm -v 2>/dev/null)"; fi
+
+# --- git ---
+git_present=0; git_version=""
+if has git; then
+  git_present=1
+  git_version="$(git --version 2>/dev/null | awk '{print $3}')"
+fi
+
+# --- git identity (only meaningful when git is present) ---
+name_set=0; email_set=0
+if [ "$git_present" = "1" ]; then
+  [ -n "$(git config --global user.name 2>/dev/null)" ]  && name_set=1
+  [ -n "$(git config --global user.email 2>/dev/null)" ] && email_set=1
+fi
+
+# --- macOS Command Line Tools (git + compilers for native modules) ---
+clt_json="null"
+if [ "$os" = "darwin" ]; then
+  clt_present=0
+  if xcode-select -p >/dev/null 2>&1; then clt_present=1; fi
+  clt_json="{\"present\":$(jbool "$clt_present")}"
+fi
+
+printf '{'
+printf '"os":"%s",' "$os"
+printf '"node":{"present":%s,"version":"%s","ok":%s},' "$(jbool "$node_present")" "$node_version" "$(jbool "$node_ok")"
+printf '"npm":{"present":%s,"version":"%s"},' "$(jbool "$npm_present")" "$npm_version"
+printf '"git":{"present":%s,"version":"%s"},' "$(jbool "$git_present")" "$git_version"
+printf '"gitIdentity":{"nameSet":%s,"emailSet":%s},' "$(jbool "$name_set")" "$(jbool "$email_set")"
+printf '"xcodeCLT":%s,' "$clt_json"
+printf '"minNode":"%s"' "$MIN_NODE"
+printf '}\n'


### PR DESCRIPTION
## What

Adds an **environment-readiness layer** to the `wix-headless` skill: audit → install-with-consent → authenticate, working across **macOS, Linux, and Windows/PowerShell**.

Resolves [CODEAI-687](https://wix.atlassian.net/browse/CODEAI-687), inspired by [`Yoavcwix/headless-setup-skill`](https://github.com/Yoavcwix/headless-setup-skill).

## Why

The build skill assumed a ready machine — it never checked Node version / npm / git / git identity before scaffolding, so a too-old Node or missing git only surfaced *after* discovery + approval, when the bootstrap failed. And every script was bash-only, so **Windows/PowerShell users had no real path** (the explicit gap the ticket calls out: *"Mac works well; Windows still needs work"*).

## Placement decision

Per `CONTRIBUTING.md` § "Skill Placement" (*"Do not add a new top-level folder under `skills/` by default … add … a new skill reference inside an existing skill. New top-level skills should only be added by repository admins."*), this is built **inside `skills/wix-headless/`** as a reference + scripts — **not** a new top-level skill. So: no manifest changes, no admin gate, and no eval scenarios (the eval gate only covers `skills/wix-manage/references/**`).

## Changes

- **`references/shared/ENVIRONMENT.md`** *(new)* — audit → install-with-consent → auth flow; per-OS install matrix (Node ≥ 20.11.0, git, git identity, macOS CLT); **Windows/PowerShell gotchas** (winget availability, PATH-needs-a-new-shell, execution policy, `pwsh` vs `powershell`).
- **`scripts/audit-env.sh`** + **`scripts/audit-env.ps1`** *(new)* — read-only, offline probes emitting **one identical JSON shape**; deterministic Node semver gate.
- **`references/DISCOVERY.md`** — pre-flight now audits the toolchain before the CLI-auth check, opening `ENVIRONMENT.md` on any gap.
- **`references/shared/AUTHENTICATION.md`**, **`SKILL.md`** — prereq pointer, path-table row, setup-oriented triggers, `allowed-tools` for the audit/install commands.

## Verification

- ✅ **macOS** — `audit-env.sh` emits valid JSON; Node semver gate verified across boundary cases (18.x/20.10.x → fail, 20.11.0/+ → pass, prerelease handled).
- ⚠️ **Windows** — `audit-env.ps1` written but **needs manual QA on a Windows box** (`pwsh` not available on the dev Mac). This is the ticket's explicit "Windows needs work" item.
- Auth flow unchanged; reuses the existing `wix login` background flow rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)