### PR TITLE
fix(wix-headless): stop compose.mjs leaking partial .product-grid into global.css (CODEAI-696)

### DIFF
--- a/skills/wix-headless/references/astro/stores/COMPONENTS_CSS.md
+++ b/skills/wix-headless/references/astro/stores/COMPONENTS_CSS.md
@@ -61,7 +61,7 @@ The boundary: **rules referenced by exactly one pack's TSX live in that pack's s
 
 Before writing your file, **read `src/styles/global.css`** and grep for any class your scope owns. Stores-specific rules sometimes leak into the designer's foundation:
 
-- `.product-grid` and `body[data-navigating="true"] .product-grid` — designer drift; should be in `components-stores.css`, not `global.css`.
+- `.product-grid` and `body[data-navigating="true"] .product-grid` — owned solely by `components-stores.css`; `compose.mjs` no longer ships them in `global.css`. If you still find them in the foundation (e.g. designer drift), they don't belong there.
 - Any `.product-card-*` rule.
 - Any `.offer-callout-*` rule.
 - Any contract class that maps to a key in `contractKeys.scoped.stores`.

--- a/skills/wix-headless/scripts/compose.mjs
+++ b/skills/wix-headless/scripts/compose.mjs
@@ -516,16 +516,6 @@ ${themeBlock}
   transition: transform 200ms ease, opacity 240ms ease 60ms;
 }
 
-/* Dim the product grid while ClientRouter fetches/swaps for immediate feedback. */
-body[data-navigating="true"] .product-grid {
-  opacity: 0.55;
-  transition: opacity 140ms ease;
-  pointer-events: none;
-}
-.product-grid {
-  transition: opacity 200ms ease;
-}
-
 /* ── Navigation submenu + CategoryRail/pagination (stores pack) ───────────────
    These reference declared tokens and stay inert when stores is not loaded (no
    markup uses them), so they ship unconditionally as fixed bulk. */


### PR DESCRIPTION
## What

Removes the partial `.product-grid` rules from the `global.css` bulk that `compose.mjs` inlines.

```diff
-/* Dim the product grid while ClientRouter fetches/swaps for immediate feedback. */
-body[data-navigating="true"] .product-grid { opacity: 0.55; … }
-.product-grid { transition: opacity 200ms ease; }   /* ← no display:grid */
```

## Why

`compose.mjs` shipped a **partial** `.product-grid` into the designer foundation (`global.css`) — only `transition: opacity`, no `display: grid`. The stores components agent then re-declares the **complete** rule in `components-stores.css`, which wins only because `Layout.astro` imports it after `global.css`.

Consequences:
- Dead, conflicting stub in `global.css` (editing it there does nothing) — a maintenance trap.
- The exact *"same class behaves differently per page"* hazard `shared/STYLING.md` warns about; renders correctly today only via import order + the agent's override.
- Surfaced at build time as a self-reported `GLOBAL_CSS_LEAK`, and already flagged in `astro/stores/COMPONENTS_CSS.md` as *"designer drift; should be in components-stores.css, not global.css."*

`.product-grid` is used by exactly one pack (**stores**), which always writes `components-stores.css` and already owns **both** the layout rule and the `body[data-navigating]` dim variant. So `components-stores.css` becomes the sole owner — **no behavior change**, matching the documented ownership model.

## Not a regression from the no-templates work

The same partial rule shipped on `main` in `references/astro/templates/global.css`; #437 inlined that skeleton **byte-for-byte** into `compose.mjs`. This PR removes it at the now-single source.

## Scope / base

Stacked on `feat/codeai-696-no-templates` (#437) so the no-templates e2e flow can be tested with the fix in place. `compose.mjs` is the only emitter on this branch; `main` carries the same leak in its template skeleton and would need the equivalent deletion there once #437 lands.

## Changes
- `scripts/compose.mjs` — drop the two `.product-grid` rules from the inlined `global.css` bulk.
- `references/astro/stores/COMPONENTS_CSS.md` — update the leak-audit note to reflect that `compose.mjs` no longer ships these.

## Validation
- `node --check scripts/compose.mjs` passes.
- No `.product-grid` remains in `compose.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)