### PR TITLE
Add eval scenario token budget gate

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34226,7 +34226,9 @@ exports.formatEvalTimeout = formatEvalTimeout;
 exports.formatNoChanges = formatNoChanges;
 exports.formatComparisonResult = formatComparisonResult;
 exports.formatComparisonTimeout = formatComparisonTimeout;
+exports.formatTokenBudgetExceeded = formatTokenBudgetExceeded;
 const evalforge_1 = __nccwpck_require__(280);
+const token_budget_1 = __nccwpck_require__(5984);
 exports.COMMENT_MARKER = '<!-- evalforge-yaml-gate-action -->';
 const HEADING = 'EvalForge YAML Gate';
 function render(icon, label, body) {
@@ -34351,6 +34353,21 @@ function formatComparisonResult(result, projectId) {
 }
 function formatComparisonTimeout(comparisonGroupId, blocking) {
     return render(blocking ? '⏱' : '⚠️', 'Comparison Timed Out', [`comparisonGroupId: ${comparisonGroupId}`]);
+}
+function formatTokenBudgetExceeded(violations, projectId) {
+    const lines = [
+        'These scenarios exceeded their configured top-level `maxTokens` budget on the PR run:',
+        '',
+        '| Scenario | Max tokens | PR tokens | Prod tokens | PR run |',
+        '|---|---:|---:|---:|---|',
+    ];
+    for (const v of violations) {
+        const run = projectId && v.prRunId
+            ? `[${v.prRunId}](${(0, evalforge_1.evalRunUrl)(projectId, v.prRunId, v.prRunName)})`
+            : '—';
+        lines.push(`| ${v.scenarioName} | ${(0, token_budget_1.formatTokenCount)(v.maxTokens)} | ${(0, token_budget_1.formatTokenCount)(v.prTokens)} | ${(0, token_budget_1.formatTokenCount)(v.prodTokens)} | ${run} |`);
+    }
+    return render('❌', 'Token Budget Exceeded', lines);
 }
 
 
@@ -35129,6 +35146,7 @@ const eval_pipeline_1 = __nccwpck_require__(3942);
 const workspace_1 = __nccwpck_require__(9620);
 const paths_1 = __nccwpck_require__(6621);
 const comment_1 = __nccwpck_require__(3116);
+const token_budget_1 = __nccwpck_require__(5984);
 function allScenariosRequired(result) {
     return result.scenarios.length > 0 && result.scenarios.every(s => s.required);
 }
@@ -35255,6 +35273,12 @@ async function runGate() {
                 core.info(`${s.scenarioName} [without draft tag]: ${(0, evalforge_1.evalRunUrl)(config.projectId, s.without.runId, s.without.name)}`);
         }
         await comment((0, comment_1.formatComparisonResult)(done, config.projectId));
+        const tokenBudgetViolations = (0, token_budget_1.findTokenBudgetViolations)(done.result.scenarios ?? [], headScenarios);
+        if (tokenBudgetViolations.length > 0) {
+            await comment((0, comment_1.formatTokenBudgetExceeded)(tokenBudgetViolations, config.projectId));
+            (0, github_1.fail)((0, token_budget_1.formatTokenBudgetFailureMessage)(tokenBudgetViolations), config.blocking);
+            return;
+        }
         if (config.autoApprove && allScenariosRequired(done.result)) {
             await octokit.rest.pulls.createReview({
                 owner: config.owner,
@@ -35748,6 +35772,7 @@ exports.ScenarioSchema = zod_1.z.object({
     description: zod_1.z.string(),
     triggerPrompt: zod_1.z.string().min(10),
     tags: zod_1.z.array(zod_1.z.string().min(1)).min(1).refine(tags => tags.every(t => !exports.RESERVED_TAG_PREFIXES.some(p => t.startsWith(p))), { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*) — the action manages those' }),
+    maxTokens: zod_1.z.number().int().positive().optional(),
     assertions: zod_1.z.array(AssertionSchema).min(1),
     siteSetup: SiteSetupSchema.optional(),
 }).strict().superRefine((data, ctx) => {
@@ -35851,6 +35876,46 @@ function diffSyncPlan(input) {
         }
     }
     return { actions, errors };
+}
+
+
+/***/ }),
+
+/***/ 5984:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.findTokenBudgetViolations = findTokenBudgetViolations;
+exports.formatTokenBudgetFailureMessage = formatTokenBudgetFailureMessage;
+exports.formatTokenCount = formatTokenCount;
+function findTokenBudgetViolations(comparisons, scenarios) {
+    const violations = [];
+    for (const comparison of comparisons) {
+        const maxTokens = scenarios.get(comparison.scenarioName)?.scenario.maxTokens;
+        if (maxTokens === undefined || comparison.with.totalTokens <= maxTokens)
+            continue;
+        violations.push({
+            scenarioName: comparison.scenarioName,
+            maxTokens,
+            prTokens: comparison.with.totalTokens,
+            prodTokens: comparison.without.totalTokens,
+            prRunId: comparison.with.runId,
+            prRunName: comparison.with.name,
+        });
+    }
+    return violations;
+}
+function formatTokenBudgetFailureMessage(violations) {
+    if (violations.length === 1) {
+        const v = violations[0];
+        return `Token budget exceeded for ${v.scenarioName}: PR used ${formatTokenCount(v.prTokens)} tokens, max is ${formatTokenCount(v.maxTokens)}`;
+    }
+    return `Token budget exceeded for ${violations.length} scenarios: ${violations.map(v => v.scenarioName).join(', ')}`;
+}
+function formatTokenCount(tokens) {
+    return Math.round(tokens).toLocaleString('en-US');
 }
 
 

--- a/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
@@ -4,6 +4,7 @@ import type { SyncError } from './sync';
 import type { EvalRunStatus } from './evalforge';
 import { evalRunUrl } from './evalforge';
 import type { CompareGroupComplete, ScenarioComparison } from './eval-pipeline';
+import { formatTokenCount, type TokenBudgetViolation } from './token-budget';
 
 export const COMMENT_MARKER = '<!-- evalforge-yaml-gate-action -->';
 const HEADING = 'EvalForge YAML Gate';
@@ -148,4 +149,22 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
 
 export function formatComparisonTimeout(comparisonGroupId: string, blocking: boolean): string {
   return render(blocking ? '⏱' : '⚠️', 'Comparison Timed Out', [`comparisonGroupId: ${comparisonGroupId}`]);
+}
+
+export function formatTokenBudgetExceeded(violations: TokenBudgetViolation[], projectId?: string): string {
+  const lines = [
+    'These scenarios exceeded their configured top-level `maxTokens` budget on the PR run:',
+    '',
+    '| Scenario | Max tokens | PR tokens | Prod tokens | PR run |',
+    '|---|---:|---:|---:|---|',
+  ];
+
+  for (const v of violations) {
+    const run = projectId && v.prRunId
+      ? `[${v.prRunId}](${evalRunUrl(projectId, v.prRunId, v.prRunName)})`
+      : '—';
+    lines.push(`| ${v.scenarioName} | ${formatTokenCount(v.maxTokens)} | ${formatTokenCount(v.prTokens)} | ${formatTokenCount(v.prodTokens)} | ${run} |`);
+  }
+
+  return render('❌', 'Token Budget Exceeded', lines);
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -15,8 +15,9 @@ import type { ComparisonGroupResult } from './eval-pipeline';
 import {
   formatForeignDraftConflicts,
   formatLoadErrors, formatNoChanges, formatOrphanedMds, formatServiceError, formatUncovered,
-  formatComparisonResult, formatComparisonTimeout, formatTooManyNewSkills,
+  formatComparisonResult, formatComparisonTimeout, formatTokenBudgetExceeded, formatTooManyNewSkills,
 } from './comment';
+import { findTokenBudgetViolations, formatTokenBudgetFailureMessage } from './token-budget';
 
 type Commenter = ReturnType<typeof makeCommenter>;
 
@@ -164,6 +165,12 @@ export async function runGate(): Promise<void> {
       if (s.without.runId) core.info(`${s.scenarioName} [without draft tag]: ${evalRunUrl(config.projectId, s.without.runId, s.without.name)}`);
     }
     await comment(formatComparisonResult(done, config.projectId));
+    const tokenBudgetViolations = findTokenBudgetViolations(done.result.scenarios ?? [], headScenarios);
+    if (tokenBudgetViolations.length > 0) {
+      await comment(formatTokenBudgetExceeded(tokenBudgetViolations, config.projectId));
+      fail(formatTokenBudgetFailureMessage(tokenBudgetViolations), config.blocking);
+      return;
+    }
     if (config.autoApprove && allScenariosRequired(done.result)) {
       await octokit.rest.pulls.createReview({
         owner: config.owner,

--- a/.github/actions/evalforge-yaml-gate/src/utils/schema.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/schema.ts
@@ -105,6 +105,7 @@ export const ScenarioSchema = z.object({
     tags => tags.every(t => !RESERVED_TAG_PREFIXES.some(p => t.startsWith(p))),
     { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*) — the action manages those' },
   ),
+  maxTokens: z.number().int().positive().optional(),
   assertions: z.array(AssertionSchema).min(1),
   siteSetup: SiteSetupSchema.optional(),
 }).strict().superRefine((data, ctx) => {

--- a/.github/actions/evalforge-yaml-gate/src/utils/token-budget.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/token-budget.ts
@@ -1,0 +1,47 @@
+import type { LoadedScenario } from './evals';
+import type { ScenarioComparison } from './eval-pipeline';
+
+export type TokenBudgetViolation = {
+  scenarioName: string;
+  maxTokens: number;
+  prTokens: number;
+  prodTokens: number;
+  prRunId?: string;
+  prRunName?: string;
+};
+
+export function findTokenBudgetViolations(
+  comparisons: ScenarioComparison[],
+  scenarios: Map<string, LoadedScenario>,
+): TokenBudgetViolation[] {
+  const violations: TokenBudgetViolation[] = [];
+
+  for (const comparison of comparisons) {
+    const maxTokens = scenarios.get(comparison.scenarioName)?.scenario.maxTokens;
+    if (maxTokens === undefined || comparison.with.totalTokens <= maxTokens) continue;
+
+    violations.push({
+      scenarioName: comparison.scenarioName,
+      maxTokens,
+      prTokens: comparison.with.totalTokens,
+      prodTokens: comparison.without.totalTokens,
+      prRunId: comparison.with.runId,
+      prRunName: comparison.with.name,
+    });
+  }
+
+  return violations;
+}
+
+export function formatTokenBudgetFailureMessage(violations: TokenBudgetViolation[]): string {
+  if (violations.length === 1) {
+    const v = violations[0];
+    return `Token budget exceeded for ${v.scenarioName}: PR used ${formatTokenCount(v.prTokens)} tokens, max is ${formatTokenCount(v.maxTokens)}`;
+  }
+
+  return `Token budget exceeded for ${violations.length} scenarios: ${violations.map(v => v.scenarioName).join(', ')}`;
+}
+
+export function formatTokenCount(tokens: number): string {
+  return Math.round(tokens).toLocaleString('en-US');
+}

--- a/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
@@ -82,4 +82,23 @@ describe('comment formatters', () => {
       expect(out).toContain(`\`${file}\``);
     });
   });
+
+  it('formatTokenBudgetExceeded lists budget details and the PR run link', () => {
+    const out = c.formatTokenBudgetExceeded([{
+      scenarioName: 'ecommerce/ecom-load-context',
+      maxTokens: 25_000,
+      prTokens: 31_420,
+      prodTokens: 18_000,
+      prRunId: 'run-pr',
+      prRunName: 'PR run',
+    }], 'project-1');
+
+    expect(out).toContain('Token Budget Exceeded');
+    expect(out).toContain('ecommerce/ecom-load-context');
+    expect(out).toContain('25,000');
+    expect(out).toContain('31,420');
+    expect(out).toContain('18,000');
+    expect(out).toContain('run-pr');
+    expect(out).toContain(c.COMMENT_MARKER);
+  });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/schema.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/schema.test.ts
@@ -19,6 +19,17 @@ describe('parseScenario', () => {
     expect(s.tags).toEqual(['blog']);
     expect(s.assertions).toHaveLength(1);
   });
+  it('accepts a top-level maxTokens budget', () => {
+    const s = parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog]\nmaxTokens: 25000'));
+    expect(s.maxTokens).toBe(25000);
+  });
+  it('rejects non-positive top-level maxTokens budgets', () => {
+    expect(() => parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog]\nmaxTokens: 0'))).toThrow(/maxTokens/);
+    expect(() => parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog]\nmaxTokens: -1'))).toThrow(/maxTokens/);
+  });
+  it('rejects non-integer top-level maxTokens budgets', () => {
+    expect(() => parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog]\nmaxTokens: 1.5'))).toThrow(/maxTokens/);
+  });
   it('rejects missing required fields', () => {
     expect(() => parseScenario('name: foo')).toThrow();
   });

--- a/.github/actions/evalforge-yaml-gate/tests/token-budget.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/token-budget.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type { LoadedScenario } from '../src/utils/evals';
+import type { ScenarioComparison } from '../src/utils/eval-pipeline';
+import { findTokenBudgetViolations, formatTokenBudgetFailureMessage } from '../src/utils/token-budget';
+
+function loadedScenario(name: string, maxTokens?: number): LoadedScenario {
+  return {
+    path: `yaml/wix-manage-evals/${name}.yml`,
+    scenario: {
+      name,
+      description: 'description',
+      triggerPrompt: 'Do the scenario task',
+      tags: ['stores'],
+      maxTokens,
+      assertions: [{ tool: 'ReadFullDocsArticle' }],
+    },
+  };
+}
+
+function comparison(name: string, prTokens: number, prodTokens = 1000): ScenarioComparison {
+  return {
+    scenarioId: `id-${name}`,
+    scenarioName: name,
+    required: true,
+    reason: 'reason',
+    with: {
+      runId: `pr-${name}`,
+      name: 'PR run',
+      passed: 1,
+      failed: 0,
+      totalCostUsd: 0.1,
+      totalTokens: prTokens,
+      durationMs: 1000,
+      assertions: [],
+    },
+    without: {
+      runId: `prod-${name}`,
+      name: 'prod run',
+      passed: 1,
+      failed: 0,
+      totalCostUsd: 0.1,
+      totalTokens: prodTokens,
+      durationMs: 1000,
+      assertions: [],
+    },
+    pairwiseJudgement: {
+      winner: 'tie',
+      confidence: 'high',
+      reasoning: 'same',
+    },
+  };
+}
+
+describe('token budgets', () => {
+  it('passes when no budget is configured', () => {
+    const scenarios = new Map([['stores/no-budget', loadedScenario('stores/no-budget')]]);
+    expect(findTokenBudgetViolations([comparison('stores/no-budget', 50_000)], scenarios)).toEqual([]);
+  });
+
+  it('passes when PR tokens equal the configured max', () => {
+    const scenarios = new Map([['stores/equal', loadedScenario('stores/equal', 25_000)]]);
+    expect(findTokenBudgetViolations([comparison('stores/equal', 25_000)], scenarios)).toEqual([]);
+  });
+
+  it('fails when PR tokens exceed the configured max and includes the scenario name', () => {
+    const scenarios = new Map([['stores/over-budget', loadedScenario('stores/over-budget', 25_000)]]);
+    const violations = findTokenBudgetViolations([comparison('stores/over-budget', 31_420)], scenarios);
+
+    expect(violations).toMatchObject([{
+      scenarioName: 'stores/over-budget',
+      maxTokens: 25_000,
+      prTokens: 31_420,
+    }]);
+    expect(formatTokenBudgetFailureMessage(violations))
+      .toBe('Token budget exceeded for stores/over-budget: PR used 31,420 tokens, max is 25,000');
+  });
+
+  it('includes all scenario names in the multi-failure message', () => {
+    const scenarios = new Map([
+      ['ecommerce/ecom-load-context', loadedScenario('ecommerce/ecom-load-context', 25_000)],
+      ['stores/create-product', loadedScenario('stores/create-product', 12_000)],
+    ]);
+    const violations = findTokenBudgetViolations([
+      comparison('ecommerce/ecom-load-context', 31_420),
+      comparison('stores/create-product', 12_001),
+    ], scenarios);
+
+    expect(formatTokenBudgetFailureMessage(violations))
+      .toBe('Token budget exceeded for 2 scenarios: ecommerce/ecom-load-context, stores/create-product');
+  });
+
+  it('reports prod tokens but does not use them to determine failure', () => {
+    const scenarios = new Map([['stores/prod-over', loadedScenario('stores/prod-over', 25_000)]]);
+    const violations = findTokenBudgetViolations([comparison('stores/prod-over', 20_000, 40_000)], scenarios);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Each scenario's `name` field must be unique across the whole `yaml/wix-manage-ev
 | `description` | One or two sentences describing what the scenario verifies. |
 | `triggerPrompt` | The natural-language request you'd expect a real user to make. Minimum 10 characters. |
 | `tags` | An array of one or more tags. Must include a production tag for the area (e.g. `[domains]`, `[stores]`, `[bookings]`). |
+| `maxTokens` | Optional top-level PR-run token budget for this scenario. If the PR eval run exceeds this total token count, the GitHub Actions gate fails. |
 | `assertions` | A non-empty array of assertions that decide whether the scenario passed. The schema requires at least one; you should include both a `tool` assertion (proves the skill was invoked) and an `llm_judge` assertion (proves the response was correct) — see below. |
 
 ### Assertions to include
@@ -92,6 +93,7 @@ name: domains/domain-search-and-purchase
 description: Verifies the agent reads the domain-search-and-purchase docs when asked about searching for and purchasing a domain via the Wix API.
 triggerPrompt: How do I programmatically search for an available domain on Wix and then purchase it? Please reference the relevant API methods.
 tags: [domains]
+maxTokens: 25000
 assertions:
   - tool: ReadFullDocsArticle
     params:
@@ -112,6 +114,8 @@ assertions:
       - hallucinates endpoints not in the Wix Domains Management API, OR
       - describes a different Wix feature (e.g. domain connection rather than purchase).
 ```
+
+Top-level `maxTokens` is enforced by this repository's GitHub Actions gate after the PR-vs-production eval comparison finishes. It applies to the PR run's total tokens for the whole scenario. This is different from `llm_judge.maxTokens`, which is passed to the judge model as an output/config limit for that assertion only.
 
 ### Site provisioning (optional)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Run the [`release-bump`](.github/workflows/release-bump.yml) workflow from the *
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding new skills.
 
+### Eval Token Budgets
+
+Eval scenarios under `yaml/wix-manage-evals/` may define a top-level `maxTokens` value. The GitHub Actions eval gate compares that budget against the PR run's total tokens for the scenario and fails the PR check when the budget is exceeded. This gate-owned field is separate from `llm_judge.maxTokens`, which only configures the judge assertion.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Add top-level `maxTokens` support for eval scenario YAML as a gate-owned PR token budget
- Enforce budgets after PR-vs-production eval comparison using PR-side `totalTokens`
- Post a `Token Budget Exceeded` PR comment with scenario-level details and fail the check when blocking is enabled
- Document the distinction between top-level `maxTokens` and `llm_judge.maxTokens`

## Testing
- `node .yarn/releases/yarn-4.10.0.cjs typecheck`
- `node .yarn/releases/yarn-4.10.0.cjs test`
- `node .yarn/releases/yarn-4.10.0.cjs build`
- `git diff --check`