### PR TITLE
feat(eval-gate): filter EvalForge scenario lookups

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34168,7 +34168,7 @@ async function runCleanup() {
     await (0, pr_cleanup_1.deletePrMcpVersions)(evalforge, config.mcpId, config.projectId, config.prNumber);
     let remote;
     try {
-        remote = await evalforge.listTestScenarios(config.projectId);
+        remote = await evalforge.listTestScenarios(config.projectId, { tags: [draftTag] });
     }
     catch (e) {
         core.warning(`listTestScenarios failed: ${errMsg(e)}`);
@@ -34901,8 +34901,10 @@ exports.evalRunUrl = evalRunUrl;
 exports.draftTagFor = draftTagFor;
 exports.parseDraftTag = parseDraftTag;
 exports.isHttpError = isHttpError;
+exports.uniqueRemoteScenarios = uniqueRemoteScenarios;
 const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
+const MAX_TEST_SCENARIO_NAMES_PER_REQUEST = 50;
 exports.TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'];
 exports.DRAFT_PREFIX = 'draft:';
 // Human-facing EvalForge results page (distinct from the REST `baseUrl` the client calls).
@@ -34920,6 +34922,15 @@ function parseDraftTag(tag) {
 }
 function isHttpError(e) {
     return e instanceof Error && typeof e.status === 'number';
+}
+/**
+ * Deduplicates scenarios returned by multiple filtered EvalForge list calls.
+ */
+function uniqueRemoteScenarios(scenarios) {
+    const byId = new Map();
+    for (const scenario of scenarios)
+        byId.set(scenario.id, scenario);
+    return [...byId.values()];
 }
 class EvalForgeClient {
     baseUrl;
@@ -34993,9 +35004,17 @@ class EvalForgeClient {
             return existing;
         }
     }
-    async listTestScenarios(projectId) {
+    /**
+     * Lists test scenarios, optionally narrowing the REST response by scenario name and/or tag.
+     */
+    async listTestScenarios(projectId, filters = {}) {
+        if ((filters.names?.length ?? 0) > MAX_TEST_SCENARIO_NAMES_PER_REQUEST) {
+            const chunks = chunk(filters.names, MAX_TEST_SCENARIO_NAMES_PER_REQUEST);
+            const batches = await Promise.all(chunks.map(names => this.listTestScenarios(projectId, { ...filters, names })));
+            return uniqueRemoteScenarios(batches.flat());
+        }
         // EvalForge returns `tags: undefined` for untagged scenarios — normalize so callers can assume `string[]`.
-        const raw = await this.request('GET', `/projects/${enc(projectId)}/test-scenarios`);
+        const raw = await this.request('GET', testScenariosPath(projectId, filters));
         return raw.map(s => ({ ...s, tags: s.tags ?? [] }));
     }
     async createTestScenario(projectId, body, tags) {
@@ -35023,6 +35042,21 @@ class EvalForgeClient {
 exports.EvalForgeClient = EvalForgeClient;
 function enc(segment) {
     return encodeURIComponent(segment);
+}
+function testScenariosPath(projectId, filters) {
+    const params = new URLSearchParams();
+    for (const name of filters.names ?? [])
+        params.append('name', name);
+    for (const tag of filters.tags ?? [])
+        params.append('tags', tag);
+    const query = params.toString();
+    return `/projects/${enc(projectId)}/test-scenarios${query ? `?${query}` : ''}`;
+}
+function chunk(items, size) {
+    const chunks = [];
+    for (let i = 0; i < items.length; i += size)
+        chunks.push(items.slice(i, i + size));
+    return chunks;
 }
 
 
@@ -35114,6 +35148,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35131,6 +35166,17 @@ const paths_1 = __nccwpck_require__(6621);
 const comment_1 = __nccwpck_require__(3116);
 function allScenariosRequired(result) {
     return result.scenarios.length > 0 && result.scenarios.every(s => s.required);
+}
+/**
+ * Computes the smallest remote scenario lookup needed to sync this PR.
+ */
+function remoteScenarioFiltersForGate(input) {
+    const names = new Set(input.changedHead.keys());
+    for (const [name] of input.base) {
+        if (!input.head.has(name))
+            names.add(name);
+    }
+    return { names: [...names].sort(), tags: [input.draftTag] };
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35195,7 +35241,8 @@ async function runGate() {
         if (changedEvalPaths.has(ls.path))
             changedHeadScenarios.set(name, ls);
     }
-    const remote = await guardedCall(() => evalforge.listTestScenarios(config.projectId), 'Could not reach EvalForge', comment, config);
+    const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
+    const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)
         return;
     const plan = (0, sync_1.diffSyncPlan)({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, remote, draftTag });
@@ -35276,6 +35323,13 @@ async function runGate() {
         await comment((0, comment_1.formatServiceError)('Eval pipeline comparison failed', config.blocking));
         (0, github_1.fail)('Eval pipeline comparison failed', config.blocking);
     }
+}
+async function listRemoteScenariosForGate(evalforge, projectId, filters) {
+    const [byName, byDraftTag] = await Promise.all([
+        filters.names.length > 0 ? evalforge.listTestScenarios(projectId, { names: filters.names }) : Promise.resolve([]),
+        evalforge.listTestScenarios(projectId, { tags: filters.tags }),
+    ]);
+    return (0, evalforge_1.uniqueRemoteScenarios)([...byName, ...byDraftTag]);
 }
 async function guardedCall(fn, userMessage, comment, config) {
     try {
@@ -35551,16 +35605,26 @@ async function runPromote() {
     const workspace = (0, workspace_1.workspaceRoot)();
     // Cleanup workflow no longer fires on merged PRs — promote owns MCP version teardown.
     await (0, pr_cleanup_1.deletePrMcpVersions)(evalforge, config.mcpId, config.projectId, config.prNumber);
+    const headScenarios = loadEvalsWithWarnings(workspace);
+    const baseEvals = loadEvalsWithWarnings(node_path_1.posix.join(workspace, paths_1.BASE_WORKSPACE_SUBDIR));
+    const deletedScenarioNames = [...baseEvals.keys()]
+        .filter(name => !headScenarios.has(name))
+        .sort();
     let remote;
     try {
-        remote = await evalforge.listTestScenarios(config.projectId);
+        const [drafts, deleted] = await Promise.all([
+            evalforge.listTestScenarios(config.projectId, { tags: [draftTag] }),
+            deletedScenarioNames.length > 0
+                ? evalforge.listTestScenarios(config.projectId, { names: deletedScenarioNames })
+                : Promise.resolve([]),
+        ]);
+        remote = (0, evalforge_1.uniqueRemoteScenarios)([...drafts, ...deleted]);
     }
     catch (e) {
         core.warning(`listTestScenarios failed: ${e instanceof Error ? e.message : String(e)}`);
         return;
     }
     const remoteByName = new Map(remote.map(r => [r.name, r]));
-    const headScenarios = loadEvalsWithWarnings(workspace);
     let promoted = 0;
     let droppedDrafts = 0;
     for (const s of remote) {
@@ -35590,7 +35654,6 @@ async function runPromote() {
             core.warning(`Promote failed for ${s.name}: ${e instanceof Error ? e.message : String(e)}`);
         }
     }
-    const baseEvals = loadEvalsWithWarnings(node_path_1.posix.join(workspace, paths_1.BASE_WORKSPACE_SUBDIR));
     for (const [name] of baseEvals) {
         if (headScenarios.has(name))
             continue;

--- a/.github/actions/evalforge-yaml-gate/src/utils/cleanup.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/cleanup.ts
@@ -46,7 +46,7 @@ export async function runCleanup(): Promise<void> {
 
   let remote: RemoteScenario[];
   try {
-    remote = await evalforge.listTestScenarios(config.projectId);
+    remote = await evalforge.listTestScenarios(config.projectId, { tags: [draftTag] });
   } catch (e) {
     core.warning(`listTestScenarios failed: ${errMsg(e)}`);
     return;

--- a/.github/actions/evalforge-yaml-gate/src/utils/evalforge.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/evalforge.ts
@@ -2,6 +2,7 @@ export type HttpError = Error & { status: number };
 
 const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
+const MAX_TEST_SCENARIO_NAMES_PER_REQUEST = 50;
 
 export const TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'] as const;
 export type RunStatus = 'pending' | 'running' | typeof TERMINAL_RUN_STATUSES[number];
@@ -12,6 +13,10 @@ import type { EvalForgeBody } from './evalforge-mapper';
 
 export type RemoteScenario = { id: string; name: string; tags: string[] };
 export type ScenarioBody = EvalForgeBody;
+export type ListTestScenarioFilters = {
+  names?: string[];
+  tags?: string[];
+};
 
 export type EvalRunInput = {
   name: string;
@@ -61,6 +66,15 @@ export function parseDraftTag(tag: string): { repo: string; prNumber: number } |
 
 export function isHttpError(e: unknown): e is HttpError {
   return e instanceof Error && typeof (e as { status?: unknown }).status === 'number';
+}
+
+/**
+ * Deduplicates scenarios returned by multiple filtered EvalForge list calls.
+ */
+export function uniqueRemoteScenarios(scenarios: RemoteScenario[]): RemoteScenario[] {
+  const byId = new Map<string, RemoteScenario>();
+  for (const scenario of scenarios) byId.set(scenario.id, scenario);
+  return [...byId.values()];
 }
 
 export class EvalForgeClient {
@@ -158,9 +172,19 @@ export class EvalForgeClient {
     }
   }
 
-  async listTestScenarios(projectId: string): Promise<RemoteScenario[]> {
+  /**
+   * Lists test scenarios, optionally narrowing the REST response by scenario name and/or tag.
+   */
+  async listTestScenarios(projectId: string, filters: ListTestScenarioFilters = {}): Promise<RemoteScenario[]> {
+    if ((filters.names?.length ?? 0) > MAX_TEST_SCENARIO_NAMES_PER_REQUEST) {
+      const chunks = chunk(filters.names!, MAX_TEST_SCENARIO_NAMES_PER_REQUEST);
+      const batches = await Promise.all(
+        chunks.map(names => this.listTestScenarios(projectId, { ...filters, names })),
+      );
+      return uniqueRemoteScenarios(batches.flat());
+    }
     // EvalForge returns `tags: undefined` for untagged scenarios — normalize so callers can assume `string[]`.
-    const raw = await this.request<RemoteScenario[]>('GET', `/projects/${enc(projectId)}/test-scenarios`);
+    const raw = await this.request<RemoteScenario[]>('GET', testScenariosPath(projectId, filters));
     return raw.map(s => ({ ...s, tags: s.tags ?? [] }));
   }
 
@@ -195,4 +219,18 @@ export class EvalForgeClient {
 
 function enc(segment: string): string {
   return encodeURIComponent(segment);
+}
+
+function testScenariosPath(projectId: string, filters: ListTestScenarioFilters): string {
+  const params = new URLSearchParams();
+  for (const name of filters.names ?? []) params.append('name', name);
+  for (const tag of filters.tags ?? []) params.append('tags', tag);
+  const query = params.toString();
+  return `/projects/${enc(projectId)}/test-scenarios${query ? `?${query}` : ''}`;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size));
+  return chunks;
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -7,7 +7,7 @@ import { loadEvals, type LoadedScenario } from './evals';
 import { canonicalDocUrl } from './doc-url';
 import { computeCoverage } from './coverage';
 import { diffSyncPlan } from './sync';
-import { EvalForgeClient, draftTagFor, evalRunUrl } from './evalforge';
+import { EvalForgeClient, draftTagFor, evalRunUrl, uniqueRemoteScenarios, type RemoteScenario } from './evalforge';
 import { EvalPipelineClient, pollUntilComparisonDone, ComparisonTimeoutError } from './eval-pipeline';
 import { workspaceRoot } from './workspace';
 import { BASE_WORKSPACE_SUBDIR } from './paths';
@@ -22,6 +22,27 @@ type Commenter = ReturnType<typeof makeCommenter>;
 
 function allScenariosRequired(result: ComparisonGroupResult): boolean {
   return result.scenarios.length > 0 && result.scenarios.every(s => s.required);
+}
+
+export type RemoteScenarioFilters = {
+  names: string[];
+  tags: string[];
+};
+
+/**
+ * Computes the smallest remote scenario lookup needed to sync this PR.
+ */
+export function remoteScenarioFiltersForGate(input: {
+  changedHead: Map<string, LoadedScenario>;
+  head: Map<string, LoadedScenario>;
+  base: Map<string, LoadedScenario>;
+  draftTag: string;
+}): RemoteScenarioFilters {
+  const names = new Set<string>(input.changedHead.keys());
+  for (const [name] of input.base) {
+    if (!input.head.has(name)) names.add(name);
+  }
+  return { names: [...names].sort(), tags: [input.draftTag] };
 }
 
 export async function runGate(): Promise<void> {
@@ -100,8 +121,9 @@ export async function runGate(): Promise<void> {
     if (changedEvalPaths.has(ls.path)) changedHeadScenarios.set(name, ls);
   }
 
+  const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
   const remote = await guardedCall(
-    () => evalforge.listTestScenarios(config.projectId),
+    () => listRemoteScenariosForGate(evalforge, config.projectId, filters),
     'Could not reach EvalForge', comment, config,
   );
   if (!remote) return;
@@ -185,6 +207,18 @@ export async function runGate(): Promise<void> {
     fail('Eval pipeline comparison failed', config.blocking);
   }
 
+}
+
+async function listRemoteScenariosForGate(
+  evalforge: EvalForgeClient,
+  projectId: string,
+  filters: RemoteScenarioFilters,
+): Promise<RemoteScenario[]> {
+  const [byName, byDraftTag] = await Promise.all([
+    filters.names.length > 0 ? evalforge.listTestScenarios(projectId, { names: filters.names }) : Promise.resolve([]),
+    evalforge.listTestScenarios(projectId, { tags: filters.tags }),
+  ]);
+  return uniqueRemoteScenarios([...byName, ...byDraftTag]);
 }
 
 async function guardedCall<T>(

--- a/.github/actions/evalforge-yaml-gate/src/utils/promote.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/promote.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { posix } from 'node:path';
 import { getSimpleConfig } from './config';
-import { EvalForgeClient, DRAFT_PREFIX, draftTagFor } from './evalforge';
+import { EvalForgeClient, DRAFT_PREFIX, draftTagFor, uniqueRemoteScenarios } from './evalforge';
 import { loadEvals, type LoadedScenario } from './evals';
 import { toScenarioBody } from './sync';
 import { deletePrMcpVersions } from './pr-cleanup';
@@ -17,16 +17,27 @@ export async function runPromote(): Promise<void> {
   // Cleanup workflow no longer fires on merged PRs — promote owns MCP version teardown.
   await deletePrMcpVersions(evalforge, config.mcpId, config.projectId, config.prNumber);
 
+  const headScenarios = loadEvalsWithWarnings(workspace);
+  const baseEvals = loadEvalsWithWarnings(posix.join(workspace, BASE_WORKSPACE_SUBDIR));
+  const deletedScenarioNames = [...baseEvals.keys()]
+    .filter(name => !headScenarios.has(name))
+    .sort();
+
   let remote;
   try {
-    remote = await evalforge.listTestScenarios(config.projectId);
+    const [drafts, deleted] = await Promise.all([
+      evalforge.listTestScenarios(config.projectId, { tags: [draftTag] }),
+      deletedScenarioNames.length > 0
+        ? evalforge.listTestScenarios(config.projectId, { names: deletedScenarioNames })
+        : Promise.resolve([]),
+    ]);
+    remote = uniqueRemoteScenarios([...drafts, ...deleted]);
   } catch (e) {
     core.warning(`listTestScenarios failed: ${e instanceof Error ? e.message : String(e)}`);
     return;
   }
   const remoteByName = new Map(remote.map(r => [r.name, r]));
 
-  const headScenarios = loadEvalsWithWarnings(workspace);
   let promoted = 0;
   let droppedDrafts = 0;
 
@@ -55,7 +66,6 @@ export async function runPromote(): Promise<void> {
     }
   }
 
-  const baseEvals = loadEvalsWithWarnings(posix.join(workspace, BASE_WORKSPACE_SUBDIR));
   for (const [name] of baseEvals) {
     if (headScenarios.has(name)) continue;
     const r = remoteByName.get(name);

--- a/.github/actions/evalforge-yaml-gate/tests/evalforge.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/evalforge.test.ts
@@ -43,6 +43,49 @@ describe('EvalForgeClient — test-scenarios', () => {
     expect(r).toEqual([{ id: 'a', name: 'x', tags: ['t'] }]);
   });
 
+  it('listTestScenarios appends repeated name and tags filters', async () => {
+    mockFetch(({ url, method }) => {
+      expect(method).toBe('GET');
+      const parsed = new URL(url);
+      expect(parsed.pathname).toBe('/projects/P/test-scenarios');
+      expect(parsed.searchParams.getAll('name')).toEqual(['blog/a', 'stores/product setup']);
+      expect(parsed.searchParams.getAll('tags')).toEqual(['draft:wix/skills#42', 'stores']);
+      return { status: 200, body: [{ id: 'a', name: 'blog/a' }] };
+    });
+    const c = new EvalForgeClient(URL_BASE, APP_ID, APP_SECRET);
+    const r = await c.listTestScenarios('P', {
+      names: ['blog/a', 'stores/product setup'],
+      tags: ['draft:wix/skills#42', 'stores'],
+    });
+    expect(r).toEqual([{ id: 'a', name: 'blog/a', tags: [] }]);
+  });
+
+  it('listTestScenarios splits large name filters into bounded requests', async () => {
+    const calls: string[][] = [];
+    mockFetch(({ url, method }) => {
+      expect(method).toBe('GET');
+      const names = new URL(url).searchParams.getAll('name');
+      calls.push(names);
+      expect(names.length).toBeLessThanOrEqual(50);
+      return {
+        status: 200,
+        body: [
+          { id: 'shared', name: 'blog/shared', tags: ['blog'] },
+          { id: `call-${calls.length}`, name: names[0], tags: ['blog'] },
+        ],
+      };
+    });
+    const c = new EvalForgeClient(URL_BASE, APP_ID, APP_SECRET);
+    const names = Array.from({ length: 51 }, (_, i) => `blog/${i}`);
+
+    const r = await c.listTestScenarios('P', { names });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toHaveLength(50);
+    expect(calls[1]).toEqual(['blog/50']);
+    expect(r.map(s => s.id)).toEqual(['shared', 'call-1', 'call-2']);
+  });
+
   it('createTestScenario POSTs body+projectId+tags and returns id', async () => {
     mockFetch(({ url, method, body }) => {
       expect(method).toBe('POST');

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { remoteScenarioFiltersForGate } from '../src/utils/gate';
+import type { LoadedScenario } from '../src/utils/evals';
+import type { Scenario } from '../src/utils/schema';
+
+const scenario = (name: string): LoadedScenario => ({
+  path: `yaml/wix-manage-evals/${name}.yml`,
+  scenario: {
+    name,
+    description: '',
+    triggerPrompt: '0123456789',
+    tags: ['blog'],
+    assertions: [{ tool: 'T', params: { url: `https://x.com/${name}` } }],
+  } satisfies Scenario,
+});
+
+describe('remoteScenarioFiltersForGate', () => {
+  it('requests changed scenario names, deleted base scenario names, and this PR draft tag', () => {
+    const filters = remoteScenarioFiltersForGate({
+      changedHead: new Map([
+        ['blog/changed', scenario('blog/changed')],
+        ['stores/changed', scenario('stores/changed')],
+      ]),
+      head: new Map([
+        ['blog/changed', scenario('blog/changed')],
+        ['stores/changed', scenario('stores/changed')],
+        ['blog/unchanged', scenario('blog/unchanged')],
+      ]),
+      base: new Map([
+        ['blog/changed', scenario('blog/changed')],
+        ['blog/deleted', scenario('blog/deleted')],
+        ['blog/unchanged', scenario('blog/unchanged')],
+      ]),
+      draftTag: 'draft:wix/skills#42',
+    });
+
+    expect(filters).toEqual({
+      names: ['blog/changed', 'blog/deleted', 'stores/changed'],
+      tags: ['draft:wix/skills#42'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add name/tag filters to EvalForge test scenario listing
- use targeted scenario fetches in gate, cleanup, and promote flows
- chunk large name-filter requests and rebuild the bundled action

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/ncc build src/index.ts -o dist
- git diff --check