### PR TITLE
feat(eval-gate): tag scenarios with code origin and repo

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34149,14 +34149,14 @@ const paths_1 = __nccwpck_require__(6621);
 // Pure: decide what to do with each draft-tagged scenario on PR close-without-merge.
 // If the scenario's name matches one in the base SHA's evals, it pre-existed our PR — RESTORE
 // it from the base YAML's state. Otherwise it was a PR-only draft — DELETE it.
-function planCleanup(remote, baseEvals, draftTag) {
+function planCleanup(remote, baseEvals, draftTag, repo) {
     const actions = [];
     for (const s of remote) {
         if (!s.tags.includes(draftTag))
             continue;
         const baseLs = baseEvals.get(s.name);
         actions.push(baseLs
-            ? { kind: 'RESTORE', id: s.id, name: s.name, body: (0, sync_1.toScenarioBody)(baseLs.scenario), tags: baseLs.scenario.tags }
+            ? { kind: 'RESTORE', id: s.id, name: s.name, body: (0, sync_1.toScenarioBody)(baseLs.scenario), tags: (0, evalforge_1.withManagedTags)(baseLs.scenario.tags, repo) }
             : { kind: 'DELETE', id: s.id, name: s.name });
     }
     return actions;
@@ -34178,7 +34178,7 @@ async function runCleanup() {
     const { scenarios: baseEvals, errors: baseErrs } = (0, evals_1.loadEvals)(baseRoot);
     for (const e of baseErrs)
         core.warning(`Base SHA eval issue at ${baseRoot}/${e.path}: ${e.message}`);
-    const plan = planCleanup(remote, baseEvals, draftTag);
+    const plan = planCleanup(remote, baseEvals, draftTag, `${config.owner}/${config.repo}`);
     const summary = plan.reduce((a, p) => ({ ...a, [p.kind]: (a[p.kind] ?? 0) + 1 }), {});
     core.info(`Cleanup plan: ${plan.length} action(s) — RESTORE=${summary.RESTORE ?? 0} DELETE=${summary.DELETE ?? 0}`);
     for (const a of plan)
@@ -34913,10 +34913,13 @@ function jsonifyMaybe(v) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.EvalForgeClient = exports.DRAFT_PREFIX = exports.TERMINAL_RUN_STATUSES = void 0;
+exports.EvalForgeClient = exports.REPO_PREFIX = exports.CODE_TAG = exports.DRAFT_PREFIX = exports.TERMINAL_RUN_STATUSES = void 0;
 exports.evalRunUrl = evalRunUrl;
 exports.draftTagFor = draftTagFor;
 exports.parseDraftTag = parseDraftTag;
+exports.repoTagFor = repoTagFor;
+exports.managedTagsFor = managedTagsFor;
+exports.withManagedTags = withManagedTags;
 exports.isHttpError = isHttpError;
 exports.uniqueRemoteScenarios = uniqueRemoteScenarios;
 const MCP_URL = 'https://mcp.wix.com/mcp';
@@ -34936,6 +34939,28 @@ function draftTagFor(repo, prNumber) {
 function parseDraftTag(tag) {
     const m = tag.match(/^draft:([^#]+)#(\d+)$/);
     return m ? { repo: m[1], prNumber: Number(m[2]) } : null;
+}
+// Tags the action stamps on every scenario it manages — they record that a scenario was authored
+// in code and which repo it came from, and (unlike draft tags) they survive promotion. Reserved:
+// authors can't set them in YAML (see schema) since the action owns them.
+exports.CODE_TAG = 'created-via-code';
+exports.REPO_PREFIX = 'repo:';
+/** Repo-origin tag for a code-managed scenario, e.g. `repo:wix/skills`. */
+function repoTagFor(repo) {
+    return `${exports.REPO_PREFIX}${repo}`;
+}
+/** The managed tags stamped on every scenario authored from `repo` via code. */
+function managedTagsFor(repo) {
+    return [exports.CODE_TAG, repoTagFor(repo)];
+}
+/** Returns `tags` with the managed code-origin tags ensured present — order-preserving and deduped. */
+function withManagedTags(tags, repo) {
+    const result = [...tags];
+    for (const tag of managedTagsFor(repo)) {
+        if (!result.includes(tag))
+            result.push(tag);
+    }
+    return result;
 }
 function isHttpError(e) {
     return e instanceof Error && typeof e.status === 'number';
@@ -35263,7 +35288,7 @@ async function runGate() {
     const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)
         return;
-    const plan = (0, sync_1.diffSyncPlan)({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, remote, draftTag });
+    const plan = (0, sync_1.diffSyncPlan)({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, remote, draftTag, repo: `${config.owner}/${config.repo}` });
     if (plan.errors.length > 0) {
         await comment((0, comment_1.formatForeignDraftConflicts)(plan.errors, { owner: config.owner, repo: config.repo }));
         (0, github_1.fail)(`Scenario(s) held by other PRs: ${plan.errors.map(e => e.name).join(', ')}`, config.blocking);
@@ -35625,7 +35650,8 @@ const workspace_1 = __nccwpck_require__(9620);
 async function runPromote() {
     const config = (0, config_1.getSimpleConfig)();
     const evalforge = new evalforge_1.EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
-    const draftTag = (0, evalforge_1.draftTagFor)(`${config.owner}/${config.repo}`, config.prNumber);
+    const repo = `${config.owner}/${config.repo}`;
+    const draftTag = (0, evalforge_1.draftTagFor)(repo, config.prNumber);
     const workspace = (0, workspace_1.workspaceRoot)();
     // Cleanup workflow no longer fires on merged PRs — promote owns MCP version teardown.
     await (0, pr_cleanup_1.deletePrMcpVersions)(evalforge, config.mcpId, config.projectId, config.prNumber);
@@ -35670,9 +35696,10 @@ async function runPromote() {
             continue;
         }
         try {
-            await evalforge.updateTestScenario(config.projectId, s.id, (0, sync_1.toScenarioBody)(ls.scenario), ls.scenario.tags);
+            const tags = (0, evalforge_1.withManagedTags)(ls.scenario.tags, repo);
+            await evalforge.updateTestScenario(config.projectId, s.id, (0, sync_1.toScenarioBody)(ls.scenario), tags);
             promoted++;
-            core.info(`Promoted ${s.name}: tags = ${JSON.stringify(ls.scenario.tags)}`);
+            core.info(`Promoted ${s.name}: tags = ${JSON.stringify(tags)}`);
         }
         catch (e) {
             core.warning(`Promote failed for ${s.name}: ${e instanceof Error ? e.message : String(e)}`);
@@ -35748,7 +35775,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ScenarioSchema = exports.RESERVED_TAG_PREFIXES = void 0;
+exports.ScenarioSchema = exports.RESERVED_TAGS = exports.RESERVED_TAG_PREFIXES = void 0;
 exports.isLlmJudge = isLlmJudge;
 exports.isApiCall = isApiCall;
 exports.isCost = isCost;
@@ -35757,8 +35784,10 @@ exports.isToolCall = isToolCall;
 exports.parseScenario = parseScenario;
 const zod_1 = __nccwpck_require__(924);
 const jsYaml = __importStar(__nccwpck_require__(4281));
+const evalforge_1 = __nccwpck_require__(280);
 const NamePattern = /^[a-z0-9][a-z0-9/_-]*$/;
-exports.RESERVED_TAG_PREFIXES = ['draft:', 'pending:', 'rejected:'];
+exports.RESERVED_TAG_PREFIXES = ['draft:', 'pending:', 'rejected:', evalforge_1.REPO_PREFIX];
+exports.RESERVED_TAGS = [evalforge_1.CODE_TAG];
 const ParamScalarSchema = zod_1.z.union([zod_1.z.string(), zod_1.z.number(), zod_1.z.boolean()]);
 const ParamValueSchema = zod_1.z.union([
     ParamScalarSchema,
@@ -35834,7 +35863,7 @@ exports.ScenarioSchema = zod_1.z.object({
     name: zod_1.z.string().min(1).regex(NamePattern, 'name must match /^[a-z0-9][a-z0-9/_-]*$/'),
     description: zod_1.z.string(),
     triggerPrompt: zod_1.z.string().min(10),
-    tags: zod_1.z.array(zod_1.z.string().min(1)).min(1).refine(tags => tags.every(t => !exports.RESERVED_TAG_PREFIXES.some(p => t.startsWith(p))), { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*) — the action manages those' }),
+    tags: zod_1.z.array(zod_1.z.string().min(1)).min(1).refine(tags => tags.every(t => !exports.RESERVED_TAG_PREFIXES.some(p => t.startsWith(p)) && !exports.RESERVED_TAGS.some(r => t === r)), { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*, repo:*) or reserved tags (created-via-code) — the action manages those' }),
     maxTokens: zod_1.z.number().int().positive().optional(),
     assertions: zod_1.z.array(AssertionSchema).min(1),
     siteSetup: SiteSetupSchema.optional(),
@@ -35896,6 +35925,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toScenarioBody = toScenarioBody;
 exports.diffSyncPlan = diffSyncPlan;
 const evalforge_mapper_1 = __nccwpck_require__(7648);
+const evalforge_1 = __nccwpck_require__(280);
 function toScenarioBody(s) {
     return (0, evalforge_mapper_1.toEvalForgeBody)(s);
 }
@@ -35903,14 +35933,14 @@ function foreignDraftTags(tags, myTag) {
     return tags.filter(t => t.startsWith('draft:') && t !== myTag);
 }
 function diffSyncPlan(input) {
-    const { changedHead, head, base, remote, draftTag } = input;
+    const { changedHead, head, base, remote, draftTag, repo } = input;
     const remoteByName = new Map(remote.map(r => [r.name, r]));
     const actions = [];
     const errors = [];
     for (const [name, ls] of changedHead) {
         const r = remoteByName.get(name);
         if (!r) {
-            actions.push({ kind: 'CREATE', name, body: toScenarioBody(ls.scenario), tags: [draftTag] });
+            actions.push({ kind: 'CREATE', name, body: toScenarioBody(ls.scenario), tags: (0, evalforge_1.withManagedTags)([draftTag], repo) });
             continue;
         }
         const foreign = foreignDraftTags(r.tags, draftTag);
@@ -35918,7 +35948,7 @@ function diffSyncPlan(input) {
             errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: ls.path });
             continue;
         }
-        actions.push({ kind: 'UPDATE', id: r.id, name, body: toScenarioBody(ls.scenario), tags: [draftTag] });
+        actions.push({ kind: 'UPDATE', id: r.id, name, body: toScenarioBody(ls.scenario), tags: (0, evalforge_1.withManagedTags)([draftTag], repo) });
     }
     for (const [name, ls] of base) {
         if (head.has(name))

--- a/.github/actions/evalforge-yaml-gate/src/utils/cleanup.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/cleanup.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { posix } from 'node:path';
 import { getSimpleConfig } from './config';
-import { EvalForgeClient, draftTagFor, type RemoteScenario, type ScenarioBody } from './evalforge';
+import { EvalForgeClient, draftTagFor, withManagedTags, type RemoteScenario, type ScenarioBody } from './evalforge';
 import { deletePrMcpVersions } from './pr-cleanup';
 import { loadEvals, type LoadedScenario } from './evals';
 import { toScenarioBody } from './sync';
@@ -25,13 +25,14 @@ export function planCleanup(
   remote: RemoteScenario[],
   baseEvals: Map<string, LoadedScenario>,
   draftTag: string,
+  repo: string,
 ): CleanupAction[] {
   const actions: CleanupAction[] = [];
   for (const s of remote) {
     if (!s.tags.includes(draftTag)) continue;
     const baseLs = baseEvals.get(s.name);
     actions.push(baseLs
-      ? { kind: 'RESTORE', id: s.id, name: s.name, body: toScenarioBody(baseLs.scenario), tags: baseLs.scenario.tags }
+      ? { kind: 'RESTORE', id: s.id, name: s.name, body: toScenarioBody(baseLs.scenario), tags: withManagedTags(baseLs.scenario.tags, repo) }
       : { kind: 'DELETE', id: s.id, name: s.name });
   }
   return actions;
@@ -56,7 +57,7 @@ export async function runCleanup(): Promise<void> {
   const { scenarios: baseEvals, errors: baseErrs } = loadEvals(baseRoot);
   for (const e of baseErrs) core.warning(`Base SHA eval issue at ${baseRoot}/${e.path}: ${e.message}`);
 
-  const plan = planCleanup(remote, baseEvals, draftTag);
+  const plan = planCleanup(remote, baseEvals, draftTag, `${config.owner}/${config.repo}`);
   const summary = plan.reduce((a, p) => ({ ...a, [p.kind]: (a[p.kind] ?? 0) + 1 }), {} as Record<string, number>);
   core.info(`Cleanup plan: ${plan.length} action(s) — RESTORE=${summary.RESTORE ?? 0} DELETE=${summary.DELETE ?? 0}`);
 

--- a/.github/actions/evalforge-yaml-gate/src/utils/evalforge.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/evalforge.ts
@@ -64,6 +64,31 @@ export function parseDraftTag(tag: string): { repo: string; prNumber: number } |
   return m ? { repo: m[1], prNumber: Number(m[2]) } : null;
 }
 
+// Tags the action stamps on every scenario it manages — they record that a scenario was authored
+// in code and which repo it came from, and (unlike draft tags) they survive promotion. Reserved:
+// authors can't set them in YAML (see schema) since the action owns them.
+export const CODE_TAG = 'created-via-code';
+export const REPO_PREFIX = 'repo:';
+
+/** Repo-origin tag for a code-managed scenario, e.g. `repo:wix/skills`. */
+export function repoTagFor(repo: string): string {
+  return `${REPO_PREFIX}${repo}`;
+}
+
+/** The managed tags stamped on every scenario authored from `repo` via code. */
+export function managedTagsFor(repo: string): string[] {
+  return [CODE_TAG, repoTagFor(repo)];
+}
+
+/** Returns `tags` with the managed code-origin tags ensured present — order-preserving and deduped. */
+export function withManagedTags(tags: string[], repo: string): string[] {
+  const result = [...tags];
+  for (const tag of managedTagsFor(repo)) {
+    if (!result.includes(tag)) result.push(tag);
+  }
+  return result;
+}
+
 export function isHttpError(e: unknown): e is HttpError {
   return e instanceof Error && typeof (e as { status?: unknown }).status === 'number';
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -129,7 +129,7 @@ export async function runGate(): Promise<void> {
   );
   if (!remote) return;
 
-  const plan = diffSyncPlan({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, remote, draftTag });
+  const plan = diffSyncPlan({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, remote, draftTag, repo: `${config.owner}/${config.repo}` });
   if (plan.errors.length > 0) {
     await comment(formatForeignDraftConflicts(plan.errors, { owner: config.owner, repo: config.repo }));
     fail(`Scenario(s) held by other PRs: ${plan.errors.map(e => e.name).join(', ')}`, config.blocking);

--- a/.github/actions/evalforge-yaml-gate/src/utils/promote.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/promote.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { posix } from 'node:path';
 import { getSimpleConfig } from './config';
-import { EvalForgeClient, DRAFT_PREFIX, draftTagFor, uniqueRemoteScenarios } from './evalforge';
+import { EvalForgeClient, DRAFT_PREFIX, draftTagFor, uniqueRemoteScenarios, withManagedTags } from './evalforge';
 import { loadEvals, type LoadedScenario } from './evals';
 import { toScenarioBody } from './sync';
 import { deletePrMcpVersions } from './pr-cleanup';
@@ -11,7 +11,8 @@ import { workspaceRoot } from './workspace';
 export async function runPromote(): Promise<void> {
   const config = getSimpleConfig();
   const evalforge = new EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
-  const draftTag = draftTagFor(`${config.owner}/${config.repo}`, config.prNumber);
+  const repo = `${config.owner}/${config.repo}`;
+  const draftTag = draftTagFor(repo, config.prNumber);
   const workspace = workspaceRoot();
 
   // Cleanup workflow no longer fires on merged PRs — promote owns MCP version teardown.
@@ -58,9 +59,10 @@ export async function runPromote(): Promise<void> {
       continue;
     }
     try {
-      await evalforge.updateTestScenario(config.projectId, s.id, toScenarioBody(ls.scenario), ls.scenario.tags);
+      const tags = withManagedTags(ls.scenario.tags, repo);
+      await evalforge.updateTestScenario(config.projectId, s.id, toScenarioBody(ls.scenario), tags);
       promoted++;
-      core.info(`Promoted ${s.name}: tags = ${JSON.stringify(ls.scenario.tags)}`);
+      core.info(`Promoted ${s.name}: tags = ${JSON.stringify(tags)}`);
     } catch (e) {
       core.warning(`Promote failed for ${s.name}: ${e instanceof Error ? e.message : String(e)}`);
     }

--- a/.github/actions/evalforge-yaml-gate/src/utils/schema.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod';
 import * as jsYaml from 'js-yaml';
+import { CODE_TAG, REPO_PREFIX } from './evalforge';
 
 const NamePattern = /^[a-z0-9][a-z0-9/_-]*$/;
-export const RESERVED_TAG_PREFIXES = ['draft:', 'pending:', 'rejected:'] as const;
+export const RESERVED_TAG_PREFIXES = ['draft:', 'pending:', 'rejected:', REPO_PREFIX] as const;
+export const RESERVED_TAGS = [CODE_TAG] as const;
 
 const ParamScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 
@@ -102,8 +104,9 @@ export const ScenarioSchema = z.object({
   description: z.string(),
   triggerPrompt: z.string().min(10),
   tags: z.array(z.string().min(1)).min(1).refine(
-    tags => tags.every(t => !RESERVED_TAG_PREFIXES.some(p => t.startsWith(p))),
-    { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*) — the action manages those' },
+    tags => tags.every(t =>
+      !RESERVED_TAG_PREFIXES.some(p => t.startsWith(p)) && !RESERVED_TAGS.some(r => t === r)),
+    { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*, repo:*) or reserved tags (created-via-code) — the action manages those' },
   ),
   maxTokens: z.number().int().positive().optional(),
   assertions: z.array(AssertionSchema).min(1),

--- a/.github/actions/evalforge-yaml-gate/src/utils/sync.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/sync.ts
@@ -1,7 +1,7 @@
 import type { LoadedScenario } from './evals';
 import type { Scenario } from './schema';
 import { toEvalForgeBody } from './evalforge-mapper';
-import type { RemoteScenario, ScenarioBody } from './evalforge';
+import { withManagedTags, type RemoteScenario, type ScenarioBody } from './evalforge';
 
 export type CreateAction = { kind: 'CREATE'; name: string; body: ScenarioBody; tags: string[] };
 export type UpdateAction = { kind: 'UPDATE'; id: string; name: string; body: ScenarioBody; tags: string[] };
@@ -34,8 +34,10 @@ export function diffSyncPlan(input: {
   base: Map<string, LoadedScenario>;
   remote: RemoteScenario[];
   draftTag: string;
+  // `owner/repo` the scenarios are authored from — stamped as a managed code-origin tag.
+  repo: string;
 }): { actions: SyncAction[]; errors: SyncError[] } {
-  const { changedHead, head, base, remote, draftTag } = input;
+  const { changedHead, head, base, remote, draftTag, repo } = input;
   const remoteByName = new Map(remote.map(r => [r.name, r]));
   const actions: SyncAction[] = [];
   const errors: SyncError[] = [];
@@ -43,7 +45,7 @@ export function diffSyncPlan(input: {
   for (const [name, ls] of changedHead) {
     const r = remoteByName.get(name);
     if (!r) {
-      actions.push({ kind: 'CREATE', name, body: toScenarioBody(ls.scenario), tags: [draftTag] });
+      actions.push({ kind: 'CREATE', name, body: toScenarioBody(ls.scenario), tags: withManagedTags([draftTag], repo) });
       continue;
     }
     const foreign = foreignDraftTags(r.tags, draftTag);
@@ -51,7 +53,7 @@ export function diffSyncPlan(input: {
       errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: ls.path });
       continue;
     }
-    actions.push({ kind: 'UPDATE', id: r.id, name, body: toScenarioBody(ls.scenario), tags: [draftTag] });
+    actions.push({ kind: 'UPDATE', id: r.id, name, body: toScenarioBody(ls.scenario), tags: withManagedTags([draftTag], repo) });
   }
 
   for (const [name, ls] of base) {

--- a/.github/actions/evalforge-yaml-gate/tests/cleanup.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/cleanup.test.ts
@@ -5,6 +5,8 @@ import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
 const TAG = 'draft:wix/skills#100';
+const REPO = 'wix/skills';
+const MANAGED = ['created-via-code', 'repo:wix/skills'];
 
 const remote = (id: string, name: string, tags: string[]): RemoteScenario => ({ id, name, tags });
 
@@ -24,6 +26,7 @@ describe('planCleanup', () => {
       [remote('id1', 'events/list-events', [TAG])],
       new Map(),                     // empty base = no pre-existing
       TAG,
+      REPO,
     );
     expect(plan).toEqual([{ kind: 'DELETE', id: 'id1', name: 'events/list-events' }]);
   });
@@ -34,13 +37,14 @@ describe('planCleanup', () => {
       [remote('id1', 'events/list-events', [TAG])],
       baseEvals,
       TAG,
+      REPO,
     );
     expect(plan).toHaveLength(1);
     expect(plan[0]).toMatchObject({
       kind: 'RESTORE',
       id: 'id1',
       name: 'events/list-events',
-      tags: ['events'],            // base YAML's tags, NOT the draft tag
+      tags: ['events', ...MANAGED], // base YAML's tags + managed code-origin tags, NOT the draft tag
     });
     // body should be the mapped EvalForge shape from the base scenario
     if (plan[0].kind === 'RESTORE') {
@@ -57,6 +61,7 @@ describe('planCleanup', () => {
       ],
       new Map(),
       TAG,
+      REPO,
     );
     expect(plan).toEqual([]);
   });
@@ -71,12 +76,13 @@ describe('planCleanup', () => {
       ],
       baseEvals,
       TAG,
+      REPO,
     );
     expect(plan.map(a => a.kind)).toEqual(['RESTORE', 'DELETE']);
     expect(plan.map(a => a.name)).toEqual(['events/list-events', 'events/new-scenario']);
   });
 
-  it('preserves base YAML tags exactly (does not include the draft tag)', () => {
+  it('restores base YAML tags plus managed tags, dropping the draft and any leftover tags', () => {
     const baseEvals = new Map([
       ['blog/post', loaded('blog/post', ['blog', 'blog-v2', 'reviewed'])],
     ]);
@@ -84,9 +90,10 @@ describe('planCleanup', () => {
       [remote('id1', 'blog/post', [TAG, 'leftover-tag'])],
       baseEvals,
       TAG,
+      REPO,
     );
     if (plan[0].kind !== 'RESTORE') throw new Error('expected RESTORE');
-    expect(plan[0].tags).toEqual(['blog', 'blog-v2', 'reviewed']);
+    expect(plan[0].tags).toEqual(['blog', 'blog-v2', 'reviewed', ...MANAGED]);
     expect(plan[0].tags).not.toContain(TAG);
     expect(plan[0].tags).not.toContain('leftover-tag');
   });

--- a/.github/actions/evalforge-yaml-gate/tests/evalforge.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/evalforge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EvalForgeClient } from '../src/utils/evalforge';
+import { EvalForgeClient, CODE_TAG, repoTagFor, managedTagsFor, withManagedTags } from '../src/utils/evalforge';
 
 const APP_ID = 'aid';
 const APP_SECRET = 'sec';
@@ -124,5 +124,35 @@ describe('EvalForgeClient — test-scenarios', () => {
     mockFetch(() => ({ status: 404, body: { error: 'not found' } }));
     const c = new EvalForgeClient(URL_BASE, APP_ID, APP_SECRET);
     await expect(c.deleteTestScenario('P', 'missing')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('managed code-origin tags', () => {
+  it('repoTagFor builds a repo:<owner>/<repo> tag', () => {
+    expect(repoTagFor('wix/skills')).toBe('repo:wix/skills');
+  });
+
+  it('managedTagsFor returns the marker tag and the repo tag', () => {
+    expect(managedTagsFor('wix/skills')).toEqual([CODE_TAG, 'repo:wix/skills']);
+  });
+
+  it('withManagedTags appends both managed tags, preserving existing order', () => {
+    expect(withManagedTags(['ecommerce'], 'wix/skills'))
+      .toEqual(['ecommerce', 'created-via-code', 'repo:wix/skills']);
+  });
+
+  it('withManagedTags is idempotent and does not duplicate existing managed tags', () => {
+    const once = withManagedTags(['ecommerce'], 'wix/skills');
+    expect(withManagedTags(once, 'wix/skills')).toEqual(once);
+  });
+
+  it('withManagedTags keeps a draft tag alongside the managed tags', () => {
+    expect(withManagedTags(['draft:wix/skills#7'], 'wix/skills'))
+      .toEqual(['draft:wix/skills#7', 'created-via-code', 'repo:wix/skills']);
+  });
+
+  it('withManagedTags fills in only the missing managed tag', () => {
+    expect(withManagedTags(['created-via-code'], 'wix/skills'))
+      .toEqual(['created-via-code', 'repo:wix/skills']);
   });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/schema.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/schema.test.ts
@@ -45,6 +45,12 @@ describe('parseScenario', () => {
   it('rejects rejected:* in tags', () => {
     expect(() => parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog, "rejected:wix/skills#1"]'))).toThrow(/rejected|reserved/i);
   });
+  it('rejects repo:* in tags (action-managed code-origin tag)', () => {
+    expect(() => parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog, "repo:wix/skills"]'))).toThrow(/repo|reserved/i);
+  });
+  it('rejects the created-via-code tag (action-managed)', () => {
+    expect(() => parseScenario(minimalYaml.replace('tags: [blog]', 'tags: [blog, "created-via-code"]'))).toThrow(/created-via-code|reserved/i);
+  });
   it('rejects empty assertions', () => {
     expect(() => parseScenario(minimalYaml.replace(/assertions:[\s\S]*$/, 'assertions: []'))).toThrow(/assertions/);
   });

--- a/.github/actions/evalforge-yaml-gate/tests/sync.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/sync.test.ts
@@ -11,6 +11,8 @@ const s = (name: string): Scenario => ({
 const r = (id: string, name: string, tags: string[] = []): RemoteScenario => ({ id, name, tags });
 
 const TAG = 'draft:wix/skills#42';
+const REPO = 'wix/skills';
+const MANAGED = ['created-via-code', 'repo:wix/skills'];
 
 const ls = (name: string) => ({ path: `${name}.yml`, scenario: s(name) });
 
@@ -22,9 +24,10 @@ describe('diffSyncPlan', () => {
       base: new Map(),
       remote: [],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.actions).toHaveLength(1);
-    expect(plan.actions[0]).toMatchObject({ kind: 'CREATE', name: 'blog/a', tags: [TAG] });
+    expect(plan.actions[0]).toMatchObject({ kind: 'CREATE', name: 'blog/a', tags: [TAG, ...MANAGED] });
     expect(plan.errors).toEqual([]);
   });
 
@@ -35,9 +38,10 @@ describe('diffSyncPlan', () => {
       base: new Map([['blog/a', ls('blog/a')]]),
       remote: [r('id-1', 'blog/a', [TAG])],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.actions).toHaveLength(1);
-    expect(plan.actions[0]).toMatchObject({ kind: 'UPDATE', id: 'id-1', name: 'blog/a', tags: [TAG] });
+    expect(plan.actions[0]).toMatchObject({ kind: 'UPDATE', id: 'id-1', name: 'blog/a', tags: [TAG, ...MANAGED] });
   });
 
   it('plans FAIL on foreign draft tag at update site', () => {
@@ -47,6 +51,7 @@ describe('diffSyncPlan', () => {
       base: new Map(),
       remote: [r('id-1', 'blog/a', ['draft:wix/skills#99'])],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.errors).toHaveLength(1);
     expect(plan.errors[0]).toMatchObject({ kind: 'FOREIGN_DRAFT', name: 'blog/a' });
@@ -60,6 +65,7 @@ describe('diffSyncPlan', () => {
       base: new Map([['blog/a', ls('blog/a')]]),
       remote: [r('id-1', 'blog/a', [TAG])],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.actions).toEqual([{ kind: 'DELETE', id: 'id-1', name: 'blog/a' }]);
   });
@@ -71,6 +77,7 @@ describe('diffSyncPlan', () => {
       base: new Map([['blog/a', ls('blog/a')]]),
       remote: [r('id-1', 'blog/a', ['blog'])],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.actions).toEqual([{ kind: 'DEFER_DELETE', id: 'id-1', name: 'blog/a' }]);
   });
@@ -82,6 +89,7 @@ describe('diffSyncPlan', () => {
       base: new Map([['blog/a', ls('blog/a')]]),
       remote: [r('id-1', 'blog/a', ['draft:wix/skills#99'])],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.errors).toHaveLength(1);
     expect(plan.errors[0]).toMatchObject({ kind: 'FOREIGN_DRAFT', name: 'blog/a' });
@@ -94,6 +102,7 @@ describe('diffSyncPlan', () => {
       base: new Map([['blog/a', ls('blog/a')]]),
       remote: [],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.actions).toEqual([]);
     expect(plan.errors).toEqual([]);
@@ -110,6 +119,7 @@ describe('diffSyncPlan', () => {
       base: new Map([['blog/a', ls('blog/a')]]),
       remote: [r('id-1', 'blog/a', [TAG])],
       draftTag: TAG,
+      repo: REPO,
     });
     expect(plan.actions).toEqual([]);
     expect(plan.errors).toEqual([]);


### PR DESCRIPTION
## Summary
Mark every EvalForge scenario the gate manages as **created via code** and record **which repo** it came from — and make those marks survive promotion.

Two action-managed tags are now stamped on every scenario the action writes:
- `created-via-code` — the scenario was authored in code (not hand-made in EvalForge)
- `repo:<owner>/<repo>` — e.g. `repo:wix/skills`, taken from the GitHub context (generic, so any repo using this action gets its own)

Unlike the `draft:<repo>#<pr>` tag (which is dropped on promotion), these persist, so a promoted scenario keeps a durable record of its code origin.

## Changes
- **evalforge.ts**: `CODE_TAG`, `REPO_PREFIX`, and `repoTagFor` / `managedTagsFor` / `withManagedTags` (order-preserving, deduped, idempotent).
- **sync.ts / gate.ts**: stamp managed tags on `CREATE` and `UPDATE` (alongside the draft tag).
- **promote.ts**: keep managed tags alongside the YAML tags when promoting.
- **cleanup.ts**: keep managed tags when restoring a pre-existing scenario.
- **schema.ts**: reserve `repo:` (prefix) and `created-via-code` (exact) so YAML authors can't set them — the action owns them.
- Rebuilt `dist/index.js`; added/updated tests (helpers, schema rejection, sync/cleanup tag output).

The draft / foreign-draft / delete-on-merge logic is unaffected — it keys on the `draft:` prefix, and the managed tags never start with `draft:`.

## Verification
- `tsc --noEmit` clean
- `vitest run` — 136 passing
- `ncc build` — dist rebuilt and contains the managed tags

## Backfill (existing scenarios)
The ~22 existing code-managed scenarios in the project were backfilled separately (out of band) with the same two tags, preserving each scenario body. This PR covers all *future* creates/updates/promotions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)