### PR TITLE
test: reproduce skill title slug rawdocs miss

### DIFF
--- a/skills/wix-manage/references/ecommerce/ecom-pricing.md
+++ b/skills/wix-manage/references/ecommerce/ecom-pricing.md
@@ -26,6 +26,7 @@ Discount rules, coupon codes, sales, ribbons, bundles, tiered pricing, and the s
 > - [Create discount rule (auto-apply)](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule) — tags: `[intent:create-discount-rule]` · priority 0
 > - [Add sale ribbon / new ribbon](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule) — tags: `[intent:add-ribbon]` · priority 0 · *ribbons are configured via Discount Rules; same recipe*
 > - [Schedule a future sale](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule) — tags: `[intent:schedule-sale]` · priority 0 · *uses Discount Rules with `startTime` in the future*
+> - [Linked new skill repro](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-linked-new-skill-repro) — tags: `[intent:repro-new-linked-skill]` · priority 0 · *reproduction-only link to a skill added in the same PR*
 
 ### Business flows — the orchestrator
 

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
@@ -4,6 +4,8 @@ description: "PREFERRED recipe for converting a COUPON recommendation (mechanism
 ---
 # Pricing: Create Coupon
 
+Preview test marker: existing skill content-only update.
+
 > **This skill is the single source for coupon creation.** Do NOT load `…/skills/setup-coupons` — that legacy slug pre-dates the routing tree migration and its content has been merged into this file. If the WixREADME index surfaces it, ignore it.
 
 ## Prerequisites

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
@@ -1,5 +1,5 @@
 ---
-name: "Pricing: Create Discount Rule Repro"
+name: "Pricing: Create Discount Rule"
 description: Configures automatic discount rules using the eCommerce Discount Rules API. Covers percentage and fixed-amount discounts, scope targeting (catalog-wide, specific collections, or individual products), scheduling active periods, and the find-by-name + update pattern.
 layer: config
 ---

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
@@ -1,5 +1,5 @@
 ---
-name: "Pricing: Create Discount Rule"
+name: "Pricing: Create Discount Rule Repro"
 description: Configures automatic discount rules using the eCommerce Discount Rules API. Covers percentage and fixed-amount discounts, scope targeting (catalog-wide, specific collections, or individual products), scheduling active periods, and the find-by-name + update pattern.
 layer: config
 ---

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-linked-new-skill-repro.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-linked-new-skill-repro.md
@@ -1,0 +1,12 @@
+---
+name: "Pricing: Linked New Skill Repro"
+description: Reproduction-only skill for testing whether preview-created skill URLs linked from an existing skill can be resolved by rawdocs.
+layer: config
+---
+# Pricing: Linked New Skill Repro
+
+This is a reproduction-only skill. It should not be used for merchant-facing work.
+
+The expected generated URL is:
+
+`https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-linked-new-skill-repro`

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -39,7 +39,7 @@ apiDoc:
       tags: [ecommerce]
 
     - file: ../../../skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
-      title: "Pricing: Create Discount Rule"
+      title: "Pricing: Create Discount Rule YAML Rename Repro"
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
       tags: [ecommerce]
 

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -39,7 +39,7 @@ apiDoc:
       tags: [ecommerce]
 
     - file: ../../../skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
-      title: "Pricing: Create Discount Rule"
+      title: "Pricing: Create Discount Rule Repro"
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
       tags: [ecommerce]
 

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -39,7 +39,7 @@ apiDoc:
       tags: [ecommerce]
 
     - file: ../../../skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
-      title: "Pricing: Create Discount Rule Repro"
+      title: "Pricing: Create Discount Rule"
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
       tags: [ecommerce]
 

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -43,6 +43,11 @@ apiDoc:
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
       tags: [ecommerce]
 
+    - file: ../../../skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-linked-new-skill-repro.md
+      title: "Pricing: Linked New Skill Repro"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [ecommerce]
+
     - file: ../../../skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
       title: "Pricing: Discount Not Applying"
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce


### PR DESCRIPTION
Reproduction-only PR for rawdocs PR-mode skill preview behavior.

Head commit under test: `2f4ec11efab852e504c3e08a3c7edebdc6b8dd28`.

## Four flows under test

1. New skill in PR mode
   - Adds `skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-linked-new-skill-repro.md`.
   - Registers YAML title `Pricing: Linked New Skill Repro`.
   - URL: `https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-linked-new-skill-repro`.

2. Existing skill content-only update in PR mode
   - Adds marker text to `Pricing: Create Coupon` markdown only.
   - URL: `https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon`.

3. Existing skill YAML-title rename in PR mode
   - Changes only the YAML title for `ecom-pricing-create-discount-rule.md` to `Pricing: Create Discount Rule YAML Rename Repro`.
   - URL: `https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule-yaml-rename-repro`.

4. Existing skill links/navigates to the new skill in PR mode
   - Adds a link from `Pricing & Promotions` to the new skill URL.
   - Parent URL: `https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-promotions`.

## Verification results

All requests used:
- `repo=wix/skills`
- `commitHash=2f4ec11efab852e504c3e08a3c7edebdc6b8dd28`
- rawdocs `schema=false`

Discovery:
- `get-skills-by-portal` returned 200 and listed all four target URLs.
- Request ID: `1782745564.3672710840321325`

Rawdocs results:

| Flow | Status | Request ID | Result |
| --- | ---: | --- | --- |
| New skill | 404 | `1782745566.866485735211335` | `Resource ID not found for article` |
| Existing skill content-only update | 200 | `1782745570.067147071611330` | Preview marker returned |
| Existing skill YAML-title rename, new URL | 404 | `1782745572.521148717711340` | `Resource ID not found for article` |
| Existing skill parent linking to new skill | 200 | `1782745576.136151108911336` | Parent preview content returned and contains the new skill link |

## Current conclusion

PR-mode discovery can emit URLs from preview YAML, but rawdocs article reads only work for existing resource URLs. The 404 appears when the requested article URL is new in PR mode, either because it is a brand-new skill or because an existing skill receives a new YAML-derived slug.

Existing-resource content edits do work in PR mode, and existing-resource parent articles can return preview content that links to a new skill. The failure happens when rawdocs is asked to resolve the new target URL itself.