### PR TITLE
fix(query-sites): correct pagination schema and add server-side premi…

### DIFF
--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -1,7 +1,8 @@
----
-name: "Query Sites"
-description: Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
----
+| name        | Query Sites                                                                                                                |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| description | Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation. |
+
+
 # Query Sites
 
 This recipe demonstrates how to list and query all sites associated with a Wix account.
@@ -9,117 +10,147 @@ This recipe demonstrates how to list and query all sites associated with a Wix a
 ## Prerequisites
 
 - Account-level API access
-- Authorization for site listing permissions
+- - Authorization for site listing permissions
+ 
+- ## Required APIs
 
-## Required APIs
+- - **Query Sites API**: [REST](https://dev.wix.com/docs/api-reference/account-level/sites/sites/query-sites)
+ 
+  - ---
 
-- **Query Sites API**: [REST](https://dev.wix.com/docs/api-reference/account-level/sites/sites/query-sites)
 
----
+  ## Query All Sites
 
-## Query All Sites
+  **Endpoint**: `POST https://www.wixapis.com/site-list/v2/sites/query`
 
-**Endpoint**: `POST https://www.wixapis.com/site-list/v2/sites/query`
+  **Request Body**:
 
-**Request Body**:
-```json
-{
-  "query": {
-    "cursorPaging": {
-      "limit": 50
-    }
-  }
-}
-```
-
-**Request**:
-```bash
-curl -X POST \
-  'https://www.wixapis.com/site-list/v2/sites/query' \
-  -H 'Authorization: <AUTH>' \
-  -H 'Content-Type: application/json' \
-  -d '{
+  ```json
+  {
     "query": {
       "cursorPaging": {
         "limit": 50
       }
     }
-  }'
-```
-
----
-
-## Response Structure
-
-```json
-{
-  "sites": [
-    {
-      "id": "site-id-123",
-      "name": "My Website",
-      "displayName": "My Website",
-      "siteUrl": "https://username.wixsite.com/mywebsite",
-      "published": true,
-      "createdDate": "2024-01-15T10:30:00Z",
-      "updatedDate": "2024-06-20T14:45:00Z"
-    }
-  ],
-  "pagingMetadata": {
-    "count": 50,
-    "cursors": {
-      "next": "cursor-for-next-page"
-    },
-    "hasNext": true
   }
-}
-```
+  ```
 
----
+  ### Filter for Premium Sites Only
 
-## Pagination
+  Pass a `filter` to let the server do the work — do not filter client-side:
 
-For accounts with many sites, use cursor-based pagination:
-
-**First Request**:
-```json
-{
-  "query": {
-    "cursorPaging": {
-      "limit": 50
+  ```json
+  {
+    "query": {
+      "cursorPaging": { "limit": 50 },
+      "filter": { "premium": true }
     }
   }
-}
-```
+  ```
 
-**Next Page** (using cursor from response):
-```json
-{
-  "query": {
-    "cursorPaging": {
-      "limit": 50,
-      "cursor": "<cursor-from-previous-response>"
-    }
-  }
-}
-```
+  ---
 
-Continue until `hasNext` is `false`.
 
----
+  ## Response Structure
 
-## Common Use Cases
+  > ⚠️ Pagination metadata is under `metadata`, **not** `pagingMetadata`.
+  > > The cursor lives at `metadata.cursors.next` (also available at `cursorPaging.cursor`).
+  > >
+  > > ```json
+  > > {
+  > >   "sites": [
+  > >     {
+  > >       "id": "site-id-123",
+  > >       "name": "My Website",
+  > >       "displayName": "My Website",
+  > >       "siteUrl": "https://username.wixsite.com/mywebsite",
+  > >       "published": true,
+  > >       "createdDate": "2024-01-15T10:30:00Z",
+  > >       "updatedDate": "2024-06-20T14:45:00Z"
+  > >     }
+  > >   ],
+  > >   "metadata": {
+  > >     "count": 50,
+  > >     "cursors": {
+  > >       "next": "cursor-for-next-page"
+  > >     },
+  > >     "hasNext": true
+  > >   },
+  > >   "cursorPaging": {
+  > >     "cursor": "cursor-for-next-page"
+  > >   }
+  > > }
+  > > ```
+  > >
+  > > ---
+  > 
+  > ## Pagination
+  >
+  > For accounts with many sites, use cursor-based pagination.
+  > Always read `metadata.hasNext` and `metadata.cursors.next` — **not** `pagingMetadata`.
+  >
+  > **First Request**:
+  >
+  > ```json
+  > {
+  >   "query": {
+  >     "cursorPaging": { "limit": 50 }
+  >   }
+  > }
+  > ```
+  >
+  > **Next Page** (using cursor from response):
+  >
+  > ```json
+  > {
+  >   "query": {
+  >     "cursorPaging": {
+  >       "limit": 50,
+  >       "cursor": "<metadata.cursors.next from previous response>"
+  >     }
+  >   }
+  > }
+  > ```
+  >
+  > Continue until `metadata.hasNext` is `false`.
+  >
+  > **Pseudocode**:
+  >
+  > ```js
+  > let cursor = null;
+  > do {
+  >   const res = await querySites({ cursor, limit: 50, filter: { premium: true } });
+  >   // process res.sites ...
+  >   cursor = res.metadata?.cursors?.next ?? null;
+  > } while (res.metadata?.hasNext);
+  > ```
+  >
+  > ---
+  
+  ## Common Use Cases
 
-### List All Sites
-Retrieve all sites without filtering - useful for account dashboards or site selection interfaces.
+  ### List All Sites
 
-### Find a Specific Site
-After querying, filter results by name or ID to locate a specific site.
+  Retrieve all sites without filtering — useful for account dashboards or site selection interfaces.
+  Paginate until `metadata.hasNext` is `false`.
 
----
+  ### List Premium Sites
 
-## Next Steps
+  Use the server-side `filter: { "premium": true }` in the request body.
+  Do **not** fetch all pages and filter client-side — the filter is supported server-side and is more efficient.
 
-After finding a site:
-- Use the site ID for site-level API calls
-- Create new sites using [Create Site from Template](create-site-from-template.md)
-- Manage site settings and content
+  ### Find a Specific Site
+
+  After querying, match by `name` or `id` from the returned `sites` array.
+
+  ---
+
+
+  ## Next Steps
+
+  After finding a site:
+
+  - Use the site ID for site-level API calls
+  - - Create new sites using [Create Site from Template](https://github.com/wix/skills/blob/main/skills/wix-manage/references/sites/create-site-from-template.md)
+    - - Manage site settings and content
+      - 


### PR DESCRIPTION
…um filter

Three bugs caused agents to miss premium sites on accounts with >50 sites:

- Bug #1: Response schema showed `pagingMetadata.cursors.next` but API returns `metadata.cursors.next`. Cursor was always undefined, pagination never advanced past page 1.
- Bug #2: No server-side premium filter documented. Agents filtered client-side on an always-incomplete dataset.
- Bug #3: `hasNext` path was `pagingMetadata.hasNext` but API returns `metadata.hasNext`. Loop always stopped after page 1.

Fixes: corrected response schema to `metadata`, added `filter: { premium: true }` server-side example, added pagination pseudocode with correct paths, added warning callout.