### PR TITLE
docs(wix-app): clarify auth.elevate is backend-only in Wix Data reference

### DIFF
--- a/skills/wix-app/references/data-collection/WIX_DATA.md
+++ b/skills/wix-app/references/data-collection/WIX_DATA.md
@@ -261,6 +261,16 @@ const bulkResult = await items.bulkInsert("MyCollection", [
 | `get`, `query`, `count`, `distinct` | `SCOPE.DC-DATA.READ` |
 | `insert`, `update`, `save`, `remove`, `bulkInsert`, `bulkUpdate`, `bulkRemove` | `SCOPE.DC-DATA.WRITE` |
 
+### Elevating permissions (backend only)
+
+In backend code (service plugins, events, backend APIs), wrap the `items` method with `auth.elevate` from `@wix/essentials` to run with elevated permissions:
+
+```typescript
+import { auth } from '@wix/essentials';
+const elevatedQuery = auth.elevate(items.query);
+const configResult = await elevatedQuery('MyCollection').find();
+```
+
 ## Date/Time Handling
 
 - **Date (date-only)**: Store as a string in "YYYY-MM-DD" format (as returned by `<input type="date" />`).


### PR DESCRIPTION
## What

Adds an **"Elevating permissions (backend only)"** note to the Wix Data SDK reference (`WIX_DATA.md`) showing how to wrap `items` methods with `auth.elevate` from `@wix/essentials` in backend code:

```typescript
import { auth } from '@wix/essentials';
const elevatedQuery = auth.elevate(items.query);
const configResult = await elevatedQuery('MyCollection').find();
```

## Why

Investigating **CODEAI-714**: a codegen run generated a **dashboard page** (frontend) that wrapped a Wix Data collection query in `auth.elevate()`. `auth.elevate` has no frontend runtime, so the page threw on load.

Diagnosis (codegen job logs): the agent never doc-searched and never read `DATA_COLLECTION.md` — it read `DASHBOARD_PAGE.md` → `WIX_DATA.md` (the doc the skill routes Wix Data API usage to, per `SKILL.md`) and applied the elevate pattern from its priors. `WIX_DATA.md` documented the `items` API but not the elevate-context distinction, so the model had no in-context signal that elevation is backend-only.

This puts the guidance on the doc the agent is actually routed to for Wix Data usage, making `auth.elevate` clearly scoped to backend contexts (service plugins, events, backend APIs). Frontend extensions query directly.

Ref: https://wix.atlassian.net/browse/CODEAI-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)