### PR TITLE
Blog post skill: reference shared Ricos recipe + editorial loop + eval coverage

### DIFF
--- a/skills/wix-manage/references/blog/how-to-create-blog-posts.md
+++ b/skills/wix-manage/references/blog/how-to-create-blog-posts.md
@@ -13,6 +13,44 @@ description: Creates and publishes blog posts using Blog Posts API. Covers Ricos
 
 This article demonstrates how to create and immediately publish blog posts using Wix Blog REST API, including handling external images, rich content formatting, and proper media management workflow.
 
+> **Rich content (Ricos) node shapes live in a shared recipe.** A blog post's `richContent` is a Ricos document. For the full node-shape reference — headings, lists, blockquotes, dividers, tables (with cell fills), code blocks, images, inline text decorations, and the nesting rules — see **[Author Ricos Rich Content](../rich-content/author-ricos-rich-content.md)**. This recipe covers the blog-specific flow (author/member id, image import, endpoints, publish); consult the Ricos recipe for *how to build the body*.
+
+## The Authoring Loop — plan → compose → audit (before you POST)
+
+Always in this order. **Never jump straight to emitting Ricos nodes.** A flat wall of identical paragraphs is what happens when you skip planning. A blog post **inherits the site's theme, fonts, and colors — you do not design the page.** Your craft is **editorial: the structure, the depth, and the right rich-content device for each idea.** Parts 0–3 below are the mechanical steps (auth, media, endpoints); this loop governs the *quality* of what goes into `richContent`.
+
+### Phase 1 — Plan the post before any nodes
+
+Decide, in your own words, *before* composing:
+
+1. **The one takeaway.** What should the reader leave with? State it in a single sentence; every section serves it.
+2. **Audience & angle.** Who is this for, and what is the specific angle — how-to, announcement, opinion, deep-dive, listicle? This sets the tone and the depth.
+3. **Outline the sections.** List the H2 sections in order as a real arc — hook → body sections → takeaway/CTA — not a generic dump. If the user asked for a post "covering X, Y, and Z," the outline must contain a real section for **each**; never ship one section and a bullet mentioning the rest.
+4. **One device per section — and vary them.** For each section, name the rich-content device that best carries it: intro `PARAGRAPH`, `BULLETED_LIST`/`ORDERED_LIST` for steps or criteria, a `TABLE` for comparisons, a `BLOCKQUOTE` for a key quote, an `IMAGE` + caption to break up long stretches, a `CODE_BLOCK` for snippets. **A post where every section is just heading + one paragraph is the generic failure.**
+5. **Title & imagery.** Choose a specific, non-generic title (this becomes the post's `title` field). Decide whether a cover image and/or in-body images earn their place.
+
+Write this outline down (section → device) and commit to it before building.
+
+### Phase 2 — Compose with real substance
+
+**Rich-content devices are not a substitute for content.** The recurring failure is beautiful structure wrapped around one-line paragraphs.
+
+- Body paragraphs are **2–4 full sentences (~40–80 words)**. A section is a heading + intro + one or two real paragraphs (or a paragraph + a list) — never a single sentence as the entire section body. One-liners are fine only for captions, labels, or list items.
+- Rough content budgets — match what the user asked for: short post ≈ **300–500 words**; standard how-to / listicle ≈ **600–1000 words** across 4+ H2 sections; deep-dive ≈ **1200+ words**.
+- **Use 2–3 different devices across the post**, not the same heading+paragraph block repeated. If you catch yourself emitting an identical "heading + one paragraph" for every section, stop and apply the devices you committed to in Phase 1.
+- Build the body's node tree per **[Author Ricos Rich Content](../rich-content/author-ricos-rich-content.md)**; the shape examples there use one-line placeholder text — copy their **structure**, never their content density.
+
+### Phase 3 — Self-audit before you POST
+
+Quick checks, all decidable from the JSON (the Ricos recipe's self-audit covers node validity; these are the blog-level ones):
+
+1. **Heading hierarchy** — the post title lives in the `draftPost.title` field, **not** as a body H1; in-body section headers start at `level: 2` and nest logically.
+2. **Images** use an **imported Wix Media `id`** (Part 1), never a raw external URL; `width`, `height`, and a meaningful `altText` are set.
+3. **Content depth** — no stub sections; every section the brief named is present at the Phase-2 depth.
+4. **Ricos validity** — run the node self-audit from the [Author Ricos Rich Content](../rich-content/author-ricos-rich-content.md) recipe (bare-string `type`, TEXT wrapped in PARAGRAPH/HEADING, complete list/table nesting, no `\n` inside `textData.text`).
+
+Then execute Parts 0–3 below to create and publish.
+
 ### Part 0: Get an Author/Member ID (Required for 3rd-Party Apps)
 
 **IMPORTANT**: When calling the Blog API as a 3rd-party app (not as the site owner), `draftPost.memberId` is **required**. The API will reject requests with "Missing post owner information" if omitted.
@@ -67,21 +105,7 @@ You have two endpoints:
        "draftPost": {
          "title": "My Blog Post",
          "memberId": "author-member-id",
-         "richContent": {
-           "nodes": [
-             {
-               "type": "PARAGRAPH",
-               "nodes": [{
-                 "type": "TEXT",
-                 "textData": {
-                   "text": "This is a paragraph with some content.",
-                   "decorations": []
-                 }
-               }],
-               "paragraphData": {}
-             }
-           ]
-         },
+         "richContent": { /* Ricos JSON — see Author Ricos Rich Content */ },
          "media": {
            "wixMedia": {
              "image": { "id": "mediaId" }
@@ -155,99 +179,9 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
    - `/blog/v3/draft-posts/bulk-create` ✗
    - The correct path is `/blog/v3/bulk/draft-posts/create` (note: `bulk` is a path segment between `v3` and `draft-posts`, not a suffix on `draft-posts`).
 
-2. Structure rich content using Ricos JSON format. Reference [Ricos documentation](https://dev.wix.com/docs/api-reference/assets/rich-content/ricos-documents/introduction) for complete node structure. Common node types:
-   - `PARAGRAPH` for text content
-   - `HEADING` for section headers
-   - `IMAGE` for embedded images (requires Wix Media ID)
-   - `ORDERED_LIST` and `BULLETED_LIST` for lists
-   - `BLOCKQUOTE` for quoted text
-   - `LIST_ITEM` for individual list items
+2. Build the `richContent` node tree per **[Author Ricos Rich Content](../rich-content/author-ricos-rich-content.md)** — that recipe is the authoritative reference for every node shape (paragraphs, headings, lists, blockquotes, dividers, tables, code blocks, images), inline text decorations, and the nesting rules. Do not reinvent node shapes here.
 
-   **CRITICAL**: All TEXT nodes MUST be wrapped in PARAGRAPH nodes within their parent containers.
-
-   **Correct Ricos structure example:**
-
-   ```json
-   {
-     "nodes": [
-       {
-         "type": "PARAGRAPH",
-         "nodes": [
-           {
-             "type": "TEXT",
-             "textData": {
-               "text": "This is a paragraph with some content.",
-               "decorations": []
-             }
-           }
-         ],
-         "paragraphData": {}
-       }
-     ]
-   }
-   ```
-
-   **Correct BLOCKQUOTE structure:**
-
-   ```json
-   {
-     "type": "BLOCKQUOTE",
-     "nodes": [
-       {
-         "type": "PARAGRAPH",
-         "nodes": [
-           {
-             "type": "TEXT",
-             "textData": { "text": "Quote text here", "decorations": [] }
-           }
-         ],
-         "paragraphData": {}
-       }
-     ],
-     "blockquoteData": { "indentation": 1 }
-   }
-   ```
-
-   **Correct LIST_ITEM structure:**
-
-   ```json
-   {
-     "type": "LIST_ITEM",
-     "nodes": [
-       {
-         "type": "PARAGRAPH",
-         "nodes": [
-           {
-             "type": "TEXT",
-             "textData": { "text": "List item text", "decorations": [] }
-           }
-         ],
-         "paragraphData": {}
-       }
-     ]
-   }
-   ```
-
-3. For embedded images in rich content, use IMAGE nodes with Wix Media IDs:
-
-   ```json
-   {
-     "type": "IMAGE",
-     "nodes": [],
-     "imageData": {
-       "containerData": {
-         "width": { "size": "CONTENT" },
-         "alignment": "CENTER"
-       },
-       "image": {
-         "src": { "id": "mediaId" },
-         "width": 900,
-         "height": 600
-       },
-       "altText": "Descriptive alt text"
-     }
-   }
-   ```
+3. For embedded images, use an `IMAGE` node whose `image.src.id` is the **imported Wix Media `id`** from Part 1 (never a raw external URL); the full IMAGE node shape lives in the Ricos recipe.
 
 4. Set `publish: true` to immediately publish the post rather than saving as draft.
 
@@ -273,17 +207,8 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 - Include `fieldsets: ['URL']` to get post URLs in the response
 - Handle image import failures gracefully - continue without images if import fails
 - Provide meaningful `displayName` values during image import for better organization
-- Use appropriate Ricos node types (PARAGRAPH, HEADING, LIST, etc.) for semantic content structure
 - Consider batching image imports when creating multiple posts with many images
-
-### CRITICAL RICOS JSON STRUCTURE RULES:
-
-- **NEVER place TEXT nodes directly in BLOCKQUOTE, LIST_ITEM, or other container nodes**
-- **ALL TEXT nodes MUST be wrapped in PARAGRAPH nodes within their parent containers**
-- **BLOCKQUOTE nodes must contain PARAGRAPH nodes, which contain TEXT nodes**
-- **LIST_ITEM nodes must contain PARAGRAPH nodes, which contain TEXT nodes**
-- **Failure to follow proper nesting will result in parsing errors: "Expected a paragraph node but found TEXT"**
-- **Always validate Ricos structure before sending to ensure TEXT nodes are properly nested**
+- For Ricos node shapes, nesting rules, and the pre-send validation, follow [Author Ricos Rich Content](../rich-content/author-ricos-rich-content.md) — do not duplicate those rules here
 
 ### Troubleshooting
 
@@ -291,5 +216,5 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 | ------------------------------------------ | --------------------------- | ------------------------------------------------------------------- |
 | "Missing post owner information"           | `memberId` not provided     | Add `draftPost.memberId` - see Part 0 for how to get one            |
 | "memberIds ... do not exist"               | Invalid member ID           | Query members first using List Members API to get valid IDs         |
-| "Expected a paragraph node but found TEXT" | Invalid Ricos structure     | Wrap TEXT nodes in PARAGRAPH nodes (see structure rules above)      |
+| "Expected a paragraph node but found TEXT" | Invalid Ricos structure     | Fix node nesting per [Author Ricos Rich Content](../rich-content/author-ricos-rich-content.md) |
 | Image not displaying                       | Using external URL directly | Import image via Media Manager first, then use the returned file ID |

--- a/yaml/wix-manage-evals/blog/blog-post-rich-content.yml
+++ b/yaml/wix-manage-evals/blog/blog-post-rich-content.yml
@@ -1,0 +1,26 @@
+name: blog/blog-post-rich-content
+description: Verifies the agent handles the blog-specific create-and-publish flow — 3rd-party memberId, importing an external cover image to Media Manager before use, the bulk draft-posts envelope, and publish — when creating Wix blog posts. Ricos node-shape correctness is covered by the rich-content evals.
+triggerPrompt: I'm building a 3rd-party app. Using the Wix REST API, how do I create and immediately publish two blog posts on a site, where each post has a cover image supplied as an external image URL? Give the exact endpoints and request bodies.
+tags: [blog]
+maxTokens: 300000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user is a 3rd-party app asking how to create and publish TWO Wix blog posts via REST, each with a cover image given as an external URL. Judge whether the response gets the blog-specific flow right (NOT whether the Ricos body is elaborate — that is out of scope here).
+
+      Pass if the response:
+      - states that `memberId` (post owner) is REQUIRED for a 3rd-party app and shows how to obtain one (e.g. List Members), AND
+      - imports each external image to the Media Manager first (Import File / `POST /site-media/v1/files/import`) and uses the returned media id in the post — never a raw external URL, AND
+      - uses the BULK create endpoint `POST /blog/v3/bulk/draft-posts/create` with the FLAT shape (each item in `draftPosts` is the post object directly, NOT wrapped in a `draftPost` field), AND
+      - sets `publish: true` to publish immediately.
+
+      Fail if the response:
+      - omits the `memberId` requirement for 3rd-party apps, OR
+      - puts the external image URL straight into the post without importing it to Media Manager first, OR
+      - uses a wrong bulk path (e.g. `/blog/v3/draft-posts/bulk`) or wraps each bulk item in a `draftPost` field, OR
+      - does not publish the posts.

--- a/yaml/wix-manage-evals/blog/blog-post-ricos-completeness.yml
+++ b/yaml/wix-manage-evals/blog/blog-post-ricos-completeness.yml
@@ -1,0 +1,34 @@
+name: blog/blog-post-ricos-completeness
+description: Verifies that a blog post body built via the How to Create Blog Posts recipe exercises the full Ricos device set — headings, a filled-header table, a divider, an ordered list, inline text decorations (bold + link), and a code block — each correctly nested, with the title kept out of the body and section headings starting at level 2.
+triggerPrompt: |
+  Using the Wix REST API, I want to create and immediately publish one blog post on my site: a developer tutorial titled "Getting Started with the Acme Webhooks API". The post should open with a short intro, then a "Plan limits" section comparing the Free and Pro tiers (requests per minute and event retention) in a small table with a highlighted header row, a "Setup" section showing the install command `npm install @acme/webhooks` as a code snippet, a "Send your first webhook" section with the steps as a numbered list, and — separated from the rest by a horizontal divider line — a closing "Next steps" section whose text includes the words "API reference" as a bold hyperlink to https://example.com/docs. Give the exact endpoint and the full request body, including the complete richContent JSON.
+tags: [blog]
+# Reads two full docs articles (blog recipe + Ricos recipe) and composes a six-device
+# richContent body — needs more headroom than the flow-focused blog eval (a 300k run
+# came in at ~305k).
+maxTokens: 400000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/assets/rich-content/skills/author-ricos-rich-content
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked for the full request to create and publish one Wix blog post (a developer tutorial) whose body needs six rich-content devices. Inspect the `richContent` JSON in the response and judge device completeness and nesting (the create/publish flow only needs to be plausible: a Blog draft-posts create endpoint with the body under `draftPost` and `publish: true`).
+
+      The six devices, each with its correct shape:
+      1. HEADING nodes for the sections, each with `headingData.level`; section headings start at `level: 2` and the post title lives in `draftPost.title`, NOT as an H1 in the body.
+      2. A TABLE nested TABLE → TABLE_ROW → TABLE_CELL → PARAGRAPH → TEXT (no TEXT directly in a cell), with the header-row fill set via `tableCellData.cellStyle.backgroundColor`.
+      3. A DIVIDER node with `dividerData` and no children, placed before the closing section.
+      4. An ORDERED_LIST for the steps, nested LIST → LIST_ITEM → PARAGRAPH → TEXT with `orderedListData`.
+      5. Inline decorations: the "API reference" words are their own TEXT run carrying BOTH a BOLD decoration (`{ "type": "BOLD", "fontWeightValue": 700 }`) and a LINK decoration with `linkData.link.url` = https://example.com/docs, with the surrounding words as separate plain runs.
+      6. A CODE_BLOCK whose children are TEXT nodes containing the install command, with `codeBlockData`.
+
+      Score 9-10: all six devices present and correctly shaped as above; every `type` is a bare string; no `\n` inside `textData.text`; title not duplicated as a body heading; `publish: true` set.
+      Score 6-8: all six devices present and correctly nested, but one or two minor field details are off (e.g. `orderedListData` or `tableData.dimensions` omitted, divider placed elsewhere, heading levels jump).
+      Score 3-5: one device missing entirely (e.g. divider or code block dropped, or the table replaced by paragraphs), OR a structural nesting error (TEXT directly inside a LIST_ITEM or TABLE_CELL, bold+link not both on the "API reference" run), OR the title repeated as a body H1.
+      Score 0-2: two or more devices missing, the body is mostly plain paragraphs, or no richContent JSON is produced.


### PR DESCRIPTION
## What

Improves the **How to Create Blog Posts** skill (`skills/wix-manage/references/blog/how-to-create-blog-posts.md`) and adds the eval coverage the skill-eval gate requires.

### 1. Delegate Ricos node shapes to the shared recipe
The blog recipe no longer embeds its own copy of Ricos node shapes. Node shapes, nesting rules, inline text decorations, and pre-send validation now live solely in the shared **[Author Ricos Rich Content](https://dev.wix.com/docs/api-reference/assets/rich-content/skills/author-ricos-rich-content)** recipe (extracted in #488), and the blog recipe links to it. This removes the duplicated PARAGRAPH/BLOCKQUOTE/LIST_ITEM/IMAGE examples, the "CRITICAL RICOS JSON STRUCTURE RULES" block, and the redundant node-type notes — making the shared recipe the single source of truth.

### 2. Editorial authoring loop
Keeps a blog-appropriate quality framework so agents stop emitting flat, thin posts:
- **Phase 1 — plan** the post (takeaway, angle, section outline, one rich-content device per section) before emitting nodes.
- **Phase 2 — compose** with real substance (word budgets, device variety, no thin scaffolding).
- **Phase 3 — self-audit** the blog-level concerns (title in `draftPost.title` not a body H1, imported media ids + alt text, content depth), delegating Ricos node validity to the shared recipe's self-audit.

The blog recipe now focuses on the blog-specific flow — author/member id (Part 0), image import to Media Manager (Part 1), endpoints and the single-vs-bulk body shape (Part 2), categories/tags (Part 3), and `publish: true`.

### 3. Eval coverage
Adds two scenarios under `yaml/wix-manage-evals/blog/`:
- **`blog-post-rich-content.yml`** — the end-to-end blog flow (import cover images, resolve memberId, bulk-create + publish) with the correct flat body shape.
- **`blog-post-ricos-completeness.yml`** — a six-device body (headings, filled-header table, divider, ordered list, bold+link inline run, code block), asserting the agent reads both the blog and Ricos recipes and nests every device correctly.

## Why

The blog recipe previously carried a partial, duplicated copy of Ricos node-shape guidance and lacked editorial-quality direction. Now that the shared Author Ricos Rich Content recipe owns node shapes, the blog recipe should reference it (one source of truth, no drift) and concentrate on the blog-specific flow plus editorial discipline.

## Test plan
- [ ] skill-eval workflow passes for both `blog-post-rich-content` and `blog-post-ricos-completeness`.
