### PR TITLE
wix-headless: add two wiring-discipline rules for the custom flow

### DIFF
--- a/skills/wix-headless/references/custom/INSTRUCTIONS.md
+++ b/skills/wix-headless/references/custom/INSTRUCTIONS.md
@@ -74,10 +74,12 @@ The conductor interleaves these; the business track (steps 3–5) runs frontend-
 ## Wiring discipline (applies to every `custom/<cap>/WIRING.md`)
 
 - **Additive only.** Never restructure the user's layout or CSS. Swap the *data source* behind a region; inject new components self-contained. For a persistence swap, change only the load/save functions — leave the component tree and styling untouched.
+- **Render the real backend data, not the design's mock.** A brought-in region's *shown* data — lists, options, availability — is placeholder; wire the read so it renders live Wix data, not just the write/submit action. Everything the user can see and select must map to something real.
 - **Style from the design's tokens.** Read the site's CSS custom properties (`:root { --… }`) and reuse them verbatim in any injected component so it looks designed-in.
 - **Inline `appId` literally** from `wix.config.json` as the `OAuthStrategy` `clientId`. No env vars at runtime.
 - **The wiring *mechanic* is framework-keyed** (CDN `<script>` for `none`, bundled `import` + source edit for `own`) — the Build layer's concern, not fixed here (see § "The technical spine"). The per-capability guides describe the SDK *call shapes* (framework-blind); the Build cell decides the injection form. (For `none`: one `<script type="module">` per capability, or a shared client bootstrap + per-region render calls.)
 - **Guard every SDK call** in try/catch. On a read error, leave the original sample markup visible; the injected component degrades gracefully if the backend is unreachable.
+- **Resolve UI state to real Wix ids before writing, and never silently drop what doesn't map.** A brought-in UI keys its state by client-only ids/composites that aren't Wix ids (e.g. a cart row keyed `productId + "::" + option`); map to the real id before you write. A `.filter(Boolean)` that quietly discards unmatched entries makes them vanish from the order/submission with no error — surface the mismatch instead.
 
 ## Scope — deferred (tell the user plainly when relevant)
 


### PR DESCRIPTION
## What

Adds two cross-capability rules to the shared **Wiring discipline** list in `skills/wix-headless/references/custom/INSTRUCTIONS.md` (which applies to every `custom/<cap>/WIRING.md`):

- **Render the real backend data, not the design's mock** — a brought-in region's *shown* data (lists, options, availability) is placeholder; wire the read so it renders live Wix data, not just the write/submit action.
- **Resolve UI state to real Wix ids before writing, and never silently drop what doesn't map** — a brought-in UI keys its state by client-only ids/composites that aren't Wix ids (e.g. a cart row keyed `productId + "::" + option`). A `.filter(Boolean)` that discards unmatched entries makes them vanish from the order/submission with no error.

## Why

These two gotchas previously lived only in the top-level `skill.md` (served from the `wix-headless-dev` repo). They're general wiring principles, not bootstrap-skill content, so they belong here in the reference skills where the wiring agents will actually read them. The companion PR removes them from `skill.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)