### PR TITLE
feat(wix-vibe-headless): client-only REST connector skill for all business solutions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,7 +14,8 @@
     "./skills/wix-design-system",
     "./skills/wix-app",
     "./skills/wix-manage",
-    "./skills/wix-headless"
+    "./skills/wix-headless",
+    "./skills/wix-vibe-headless"
   ],
   "mcpServers": "./.mcp.json"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -15,7 +15,8 @@
     "./skills/wix-design-system",
     "./skills/wix-app",
     "./skills/wix-manage",
-    "./skills/wix-headless"
+    "./skills/wix-headless",
+    "./skills/wix-vibe-headless"
   ],
   "logo": "assets/logo.svg"
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npx skills add wix/skills -g
 | [wix-design-system](skills/wix-design-system/SKILL.md) | Wix Design System reference      | Looking up WDS component props, examples, icons                                                                                     |
 | [wix-manage](skills/wix-manage/SKILL.md) | Wix business solution management | REST API operations for configuring and managing Wix business solutions                                                             |
 | [wix-headless](skills/wix-headless/SKILL.md) | Build a complete Wix Managed Headless site | Building a new site end-to-end from a single prompt — discovery, design, feature wiring, and preview |
+| [wix-vibe-headless](skills/wix-vibe-headless/SKILL.md) | Connect an existing front end to Wix over client-only REST | Wiring a vibe-coded / HTML / Vite app to a live Wix site (storefront, bookings, blog, events, portfolio, restaurants, CMS, pricing plans) from the browser with a public `WIX_CLIENT_ID` — no SDK, no backend |
 | [replatform](replatform/README.md) | Migrate sites from WordPress and other platforms into Wix | Migrating an exiting business from another platform into Wix. Both backend data and website. `npx skills add wix/skills/replatform` |
 
 ## Supported Agents

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: wix-vibe-headless
+description: "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vite project, a design-tool export) to a live Wix site over the site's public WIX_CLIENT_ID — the browser talks to Wix directly, no SDK, no backend, no build step. One skill covering every Wix business solution: Stores/eCommerce storefront (products, cart, checkout), Bookings (services, slots, appointments), Blog (posts, categories, tags), Events & Tickets (browse, RSVP, ticketing), Portfolio (collections, projects, galleries), Restaurants (menu, online ordering, reservations), CMS / Wix Data (list, detail, filter, forms, CRUD), and Pricing Plans (memberships, subscriptions, checkout). Each vertical ships a copy-as-is REST layer plus wiring instructions. Read-only over the owner's content — never provisions, never mocks data. Triggers: connect my Wix store/shop, build a storefront over Wix, add a cart and checkout, connect Wix Bookings, take appointments/reservations, show my Wix blog, list my Wix events, sell tickets, take RSVPs, build a portfolio from Wix Portfolio, show my restaurant menu / order online / book a table, display my Wix CMS collection, wire a contact form to Wix, sell membership/subscription plans, 'here is my WIX_CLIENT_ID', connect this app to my Wix site over REST. Use this for CLIENT-ONLY REST integration over an existing site; use `wix-headless` instead for SDK + Wix CLI builds, hosting, and one-prompt new-site creation."
+---
+
+# Wix Vibe Headless — client-only REST connectors
+
+Wire an existing front end to a live Wix site **from the browser**, over the site's public
+`WIX_CLIENT_ID`, using hand-rolled REST — **no `@wix/sdk`, no backend, no build step, no
+dependencies**. One skill, one shared transport, and a copy-as-is REST layer per Wix
+business solution. Everything is **read-only over the owner's content**: render live Wix
+data or an honest empty state — **never mock, never provision, never invent** products,
+posts, events, menus, plans, reviews, or counts.
+
+## When to use this skill
+
+- The user has (or is building) a front end — a vibe-coded app, plain HTML/JSX, a Vite/React
+  project, a design-tool export — and wants it to show **live data from their existing Wix
+  site** and complete real purchases/bookings, all from the client.
+- They hand you a **public `WIX_CLIENT_ID`** and ask to "connect this to my Wix store /
+  blog / bookings / events / …".
+- They want to replace placeholder/mock data with real Wix content, or add a cart, checkout,
+  booking, RSVP, ticketing, reservation, form, or subscribe flow over an app they already have.
+
+## When NOT to use this skill
+
+| Scenario | Use instead |
+|---|---|
+| Build a **new** Wix site end-to-end from one prompt (discovery → design → build → host) | `wix-headless` |
+| The project should use the **Wix SDK** (`@wix/sdk`) and/or the **Wix CLI**, or be **hosted on Wix** | `wix-headless` |
+| Manage/configure the site via REST (install apps, seed catalogs, set up business solutions) | `wix-manage` |
+| Build a Wix **app extension** (dashboard page, widget, backend, plugin) | `wix-app` |
+
+This skill is the deliberately **client-only, REST-only** path. It is independent from
+`wix-headless` (which is SDK + CLI + hosting) — do not mix the two in one project.
+
+## The shared model (applies to every vertical)
+
+- **Auth = one public client id.** `WIX_CLIENT_ID` is a **buyer/visitor-facing** credential —
+  it only mints anonymous visitor tokens. It is **not a secret**; hardcoding and committing it
+  is fine. The user provides it (their vibe/host platform surfaces a copyable prompt with the
+  id filled in). Paste it into `wix-client.js` in place of the `<YOUR-CLIENT-ID>` placeholder.
+- **Visitor token = identity.** `wix-client.js` mints an anonymous visitor token, persists the
+  **refresh token to `localStorage`**, and refreshes on expiry. That token IS the identity of
+  the cart / reservation / member session — **never re-mint anonymously per load** or the cart
+  silently empties.
+- **Never mock, never provision.** These scaffolds are read-only over the owner's content. The
+  owner adds products/posts/services/events/menus/plans in the **Wix dashboard**. If a
+  collection is empty, show the empty state — never fabricate data, reviews, ratings, or counts.
+- **Purchases go through Wix.** Checkout/ticketing/plan purchase always complete via the Wix
+  redirect-session / Wix-hosted form — **never hand-build a `/checkout` or purchase URL**.
+- **Fail loudly.** The helpers throw on out-of-stock, empty carts, unbookable slots, expired
+  holds, and payment-still-owed. A green path means it really worked — don't swallow the error.
+- **Beyond the snippets, look it up — never guess.** The snippets cover the common paths. For
+  anything else, extend the client with `wixApiRequest`, but confirm the exact endpoint, method,
+  and body in the official Wix API reference first: https://dev.wix.com/docs/api-reference.md
+
+## How this skill is structured
+
+`<SKILL_ROOT>` is this file's directory (strip `/SKILL.md`). Two files make up each vertical's
+runtime:
+
+1. **The shared transport** — `references/shared/wix-client.js`. **Identical for every vertical.**
+   Copy it once into the app's `src/rest/` and set `WIX_CLIENT_ID` in it.
+2. **The vertical helper** — `references/<vertical>/<helper>.js`. Copy it into the **same**
+   `src/rest/` folder (it does `import { wixApiRequest } from "./wix-client.js"`, so the two
+   files must sit side by side).
+
+Each vertical's `INSTRUCTIONS.md` is the full playbook for that solution: when to use it,
+prerequisites, the exported API, how to wire it, the hard rules, and a verification checklist.
+**Open the relevant `INSTRUCTIONS.md` before wiring** — the shapes and gotchas live there.
+
+## Routing — pick the vertical(s) from the request
+
+Load the vertical(s) the user's app needs; a project may combine several (e.g. a restaurant
+with a blog, or a store with pricing plans).
+
+| The user wants… | Vertical | Read | Helper to copy (+ `shared/wix-client.js`) |
+|---|---|---|---|
+| Online store: products, categories, cart, checkout | **storefront** | `references/storefront/INSTRUCTIONS.md` | `references/storefront/wix-store.js` |
+| Appointments: services, time slots, booking, checkout | **bookings** | `references/bookings/INSTRUCTIONS.md` | `references/bookings/wix-bookings.js` |
+| Blog/news: post feed, post pages, categories, tags | **blog** | `references/blog/INSTRUCTIONS.md` | `references/blog/wix-blog.js` |
+| Events: browse, event page, RSVP, ticketing | **events** | `references/events/INSTRUCTIONS.md` | `references/events/wix-events.js` |
+| Portfolio/showcase: collections, projects, media galleries | **portfolio** | `references/portfolio/INSTRUCTIONS.md` | `references/portfolio/wix-portfolio.js` |
+| Restaurant: menu, online ordering, table reservations | **restaurants** | `references/restaurants/INSTRUCTIONS.md` | `references/restaurants/wix-restaurants.js` |
+| CMS content: list/detail, filter/search, forms, data CRUD | **cms** | `references/cms/INSTRUCTIONS.md` | `references/cms/wix-cms.js` |
+| Plans & pricing: memberships/subscriptions, subscribe, my plans | **pricing-plans** | `references/pricing-plans/INSTRUCTIONS.md` | `references/pricing-plans/wix-pricing-plans.js` |
+
+## The run
+
+1. **Get `WIX_CLIENT_ID`.** It comes from the user (the handoff prompt from their Wix/vibe
+   platform carries it). If it's missing, ask for it before wiring — nothing works without it.
+2. **Pick the vertical(s)** from the routing table and open each one's `INSTRUCTIONS.md`.
+3. **Copy the two files per vertical** — `shared/wix-client.js` (once) + the vertical helper —
+   into the app's `src/rest/` (adjust only the import path if the app uses a different folder),
+   and set `WIX_CLIENT_ID`.
+4. **Wire the UI** to the exported helpers following the vertical's INSTRUCTIONS. Build the UI
+   however the project wants — these scaffolds ship the REST layer only, no components.
+5. **Verify** against the vertical's checklist before declaring done: token persists across
+   reload, live data renders (or a real empty state), and purchases go through the Wix redirect.
+
+> Some flows need Wix-side setup the user completes later (payments connected, the deployed
+> domain allow-listed on the OAuth client for hosted-checkout return, collection permissions).
+> Those are out of scope here — if a call fails for that reason, flag it and continue; don't
+> fall back to mock data.

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -1,0 +1,115 @@
+
+# Wix Blog Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/blog/wix-blog.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix blog reader. The browser talks to Wix directly over a
+public `WIX_CLIENT_ID`. Never mock posts; never hand-build post/category/tag URLs — always
+fetch live data through the official Blog REST endpoints and route by `slug`.
+
+## When to use
+- User wants a Wix blog/news/articles section or asks to "connect my Wix blog".
+- Replacing placeholder/mock articles with live Wix Blog posts.
+- Adding a post feed, post detail pages, category pages, or tag pages over an existing
+  Wix Blog with published posts.
+
+This skill is **read-only and visitor-facing**. It does not create, edit, publish, or
+moderate posts — the author manages all content in the Wix dashboard.
+
+## Prerequisites
+1. A Wix site with **Wix Blog installed and posts already published** (this skill does
+   NOT provision — it's read-only over published content). Draft/unpublished posts are
+   never returned.
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
+   Wix Business Manager surfaces a copyable prompt with the id filled in — see
+   the router `SKILL.md`). Paste it into `src/rest/wix-client.js` in place of the placeholder. It is
+   a visitor-facing credential (it only mints anonymous visitor tokens), **not** a secret,
+   so hardcoding/committing it is fine.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the blog's UI however the
+project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and
+only adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to
+  the id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The refresh token is
+  persisted to localStorage so the same anonymous visitor is reused across reloads; do not
+  re-mint anonymously per load.
+- `src/rest/wix-blog.js` — exports:
+  - **Posts:** `queryPosts`, `getPostBySlug`, `queryPostsByCategory`, `queryPostsByTag`, `getTotalPosts`
+  - **Categories:** `queryCategories`, `getCategoryBySlug`
+  - **Tags:** `queryTags`, `getTagBySlug`
+
+The Post, Category, and Tag shapes are documented as JSDoc comments at the top of
+`wix-blog.js`. Read them before building the UI — they describe the key fields and link to
+the full API reference for anything not shown.
+
+## How to wire it (UI is the project's choice)
+- **Post feed** — `queryPosts()` for the listing (published posts only, newest first with
+  pinned posts leading); pass `nextCursor` back as `cursor` to load the next page. Render
+  `title`, `excerpt`, `firstPublishedDate`, `minutesToRead`, and the cover image from
+  **`heroImage.url`** (see the cover-image note below). Route to the detail page by `slug`.
+- **Post detail** — `getPostBySlug(slug)` keyed off the URL slug; returns `null` on miss —
+  show a not-found state, never invent a post. It returns full content:
+  - `contentText` — the body as plain text. Split on `"\n"` to render simple paragraphs.
+  - `richContent` — the body as a Ricos rich-content document (images, embeds, formatting).
+    Render it with a Ricos renderer for a faithful post. See "Beyond the snippets" if you
+    need rich rendering; `contentText` is the zero-dependency default.
+  - Resolve `categoryIds` / `tagIds` to labels with `queryCategories()` / `queryTags()`
+    (build an id→label map) to show category/tag chips.
+- **Cover image** — use **`post.heroImage.url`** (a ready-to-use https URL) for the card
+  thumbnail and post header. The `post.media` field is metadata only
+  (`{ displayed, custom, altText }`) and carries **no URL**. When `heroImage` is absent and
+  `media.custom === false`, the cover is the first image inside `richContent` — fall back to
+  the first IMAGE node there, or show a text-only card. Never substitute a stock/placeholder image.
+- **Category page** — `queryCategories()` for a category menu (ordered by `displayPosition`;
+  hide categories with `postCount === 0` if you want); `getCategoryBySlug(slug)` for a
+  category landing page. Pass `category.id` to `queryPostsByCategory(categoryId, { limit?, cursor? })`
+  to list that category's posts; paginate exactly like `queryPosts`.
+- **Tag page** — `queryTags()` for a tag cloud/list (most-used first); `getTagBySlug(slug)`
+  for a tag landing page. Pass `tag.id` to `queryPostsByTag(tagId, { limit?, cursor? })`.
+- **Empty state** — if `getTotalPosts()` is 0, show an empty state telling the user to
+  publish posts in their Wix dashboard. Never invent posts.
+
+## Hard rules (do not violate)
+- ✅ Fetch posts/categories/tags ONLY through the shipped helpers (the official Blog REST
+  endpoints). Route between screens by `slug`.
+- ❌ Never hand-build post, category, or tag URLs to fetch content. Use `getPostBySlug`,
+  `getCategoryBySlug`, `getTagBySlug`. (For an outbound link to the live Wix page, use the
+  `url` field — `url.base + url.path` — returned on the object, not a string you assemble.)
+- ❌ Never mock posts, authors, or content — render live Wix data or the empty state.
+- ❌ Never generate fake comments, likes, view counts, or ratings. This skill is read-only
+  and does not expose engagement actions; leave such UI empty or omit it.
+- ❌ Never use a placeholder/stock cover image. If `heroImage` is missing, fall back to the
+  first richContent image or a text-only card.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ Use `heroImage.url` for the cover image; `media` is metadata only (no URL).
+- The helpers fail soft on single-item lookups: `getPostBySlug` / `getCategoryBySlug` /
+  `getTagBySlug` return `null` on a miss so you can show a proper not-found state — don't
+  swallow that into a fake item.
+
+## Beyond the snippets
+The snippets cover the common blog-reader paths. If you hit a use case they don't cover
+(e.g. rendering `richContent` faithfully, full-text search/filtering, related posts,
+post metrics, members-only/pricing-plan posts, multilingual posts), extend the client
+yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and request
+body in the **official Wix API reference** first; never guess:
+- Blog API reference: https://dev.wix.com/docs/api-reference/business-solutions/blog.md
+- Query Posts (filters/sort: `categoryIds`, `tagIds`, `hashtags`, `title`, dates, `featured`):
+  https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
+- Rendering `richContent` (Ricos document format):
+  https://dev.wix.com/docs/ricos/api-reference/ricos-document
+- Each helper in `wix-blog.js` links its exact reference page inline.
+
+Keep the snippets as the default for everything they already do; reach for the API
+reference only for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (no re-mint storm; same anonymous visitor)
+- [ ] Post feed lists live published posts, newest first, and paginates via `nextCursor`
+- [ ] Post detail loads by `slug` and renders real `contentText` (or rendered `richContent`)
+- [ ] `getPostBySlug` on a bad slug shows a not-found state (no invented post)
+- [ ] Cover images come from `heroImage.url` (or richContent fallback) — no stock placeholders
+- [ ] Category and tag pages list the right posts via `queryPostsByCategory` / `queryPostsByTag`
+- [ ] Empty state shown when `getTotalPosts()` is 0
+- [ ] No mock posts, authors, comments, likes, or view counts anywhere

--- a/skills/wix-vibe-headless/references/blog/wix-blog.js
+++ b/skills/wix-vibe-headless/references/blog/wix-blog.js
@@ -1,0 +1,262 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Blog Post — key fields for building a blog reader.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/post-object.md
+ *
+ *   id                         {string}   Post GUID.
+ *   title                      {string}   Post title.
+ *   excerpt                    {string}   Short summary (≤500 chars). Auto-extracted from the
+ *                                         content if the author didn't set one. Use for cards.
+ *   slug                       {string}   URL slug for routing (pass to getPostBySlug).
+ *   firstPublishedDate         {string}   ISO date — when first published. Default sort key (DESC).
+ *   lastPublishedDate          {string}   ISO date — when last updated.
+ *   pinned                     {boolean}  Pinned posts sort to the top of the feed.
+ *   featured                   {boolean}  Whether the author flagged the post as featured.
+ *   minutesToRead              {number}   Estimated reading time (auto-calculated).
+ *   categoryIds                {string[]} Category GUIDs. Resolve labels via queryCategories.
+ *   tagIds                     {string[]} Tag GUIDs. Resolve labels via queryTags.
+ *   hashtags                   {string[]} Inline hashtags used in the post.
+ *   heroImage                  {object}   Cover image — THE field with an actual image URL:
+ *                                         { id, url, height, width, altText, filename }.
+ *                                         `url` is a ready-to-use https image URL. Use it as the
+ *                                         card thumbnail / post header image. May be absent.
+ *   media                      {object}   Cover-media METADATA only — { displayed, custom, altText }.
+ *                                         NOTE: this field carries NO image URL. When media.custom
+ *                                         is false the cover is the first image inside richContent.
+ *                                         For a thumbnail use heroImage.url (above); fall back to the
+ *                                         first IMAGE node in richContent if heroImage is missing.
+ *   contentText                {string}   Full post body as PLAIN TEXT. Returned only when the
+ *                                         CONTENT_TEXT fieldset is requested (getPostBySlug does).
+ *                                         Newlines separate paragraphs — split on "\n" to render.
+ *   richContent                {object}   Full post body as a Ricos rich-content document
+ *                                         ({ nodes, metadata, documentStyle }). Returned only when
+ *                                         the RICH_CONTENT fieldset is requested (getPostBySlug does).
+ *                                         Render with a Ricos renderer for images/embeds/formatting.
+ *                                         Ricos document reference: https://dev.wix.com/docs/ricos/api-reference/ricos-document
+ *   url                        {object}   Live post URL on the Wix site — { base, path }. Returned
+ *                                         only when the URL fieldset is requested. Build the full
+ *                                         link as `url.base + url.path`. Use for canonical/share links.
+ *   seoData                    {object}   SEO tags/settings. Returned only with the SEO fieldset.
+ *   memberId                   {string}   GUID of the post author (a site member).
+ *   language                   {string}   IETF BCP 47 language code (e.g. "en").
+ *
+ * Available fieldsets (pass in `fieldsets` to enrich the response):
+ *   "URL" | "CONTENT_TEXT" | "RICH_CONTENT" | "METRICS" | "SEO" | "CONTACT_ID" | "REFERENCE_ID"
+ */
+
+/**
+ * Wix Blog Category — key fields for a category menu / landing page.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/category-object.md
+ *
+ *   id               {string}   Category GUID. Pass to queryPostsByCategory.
+ *   label            {string}   Display name shown in the category menu.
+ *   slug             {string}   URL slug for routing (pass to getCategoryBySlug).
+ *   description      {string}   Optional category description (≤500 chars).
+ *   postCount        {number}   Number of posts in the category. Use to hide empty categories.
+ *   displayPosition  {number}   Menu order (ascending). -1 means "show at the end".
+ *   coverImage       {object}   { id, url, height, width, altText, filename } — may be absent.
+ *   url              {object}   { base, path } — live category page URL. Only with the URL fieldset.
+ */
+
+/**
+ * Wix Blog Tag — key fields for a tag chip / tag landing page.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/tag-object.md
+ *
+ *   id                  {string}   Tag GUID. Pass to queryPostsByTag.
+ *   label               {string}   Tag display label.
+ *   slug                {string}   URL slug for routing (pass to getTagBySlug).
+ *   publishedPostCount  {number}   Number of published posts with this tag.
+ *   url                 {object}   { base, path } — live tag page URL. Only with the URL fieldset.
+ */
+
+const POST_LIST_FIELDSETS = ["URL"];
+const POST_FULL_FIELDSETS = ["URL", "CONTENT_TEXT", "RICH_CONTENT"];
+
+/**
+ * Query published posts (one page), newest first (pinned posts lead).
+ * Pass `nextCursor` from a previous call back as `cursor` to load the next page.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ posts: object[], nextCursor: string|null }>}
+ */
+export async function queryPosts({ limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/v3/posts/query", {
+    method: "POST",
+    body: {
+      fieldsets: POST_LIST_FIELDSETS,
+      query: {
+        cursorPaging: cursor ? { limit, cursor } : { limit },
+        sort: [{ fieldName: "firstPublishedDate", order: "DESC" }],
+      },
+    },
+  });
+  return {
+    posts: res?.posts ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Fetch one post by its URL slug, with full content (contentText + richContent + url).
+ * Returns null if no post matches the slug — show a not-found state, never invent a post.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/get-post-by-slug.md
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getPostBySlug(slug) {
+  try {
+    const res = await wixApiRequest(`/v3/posts/slugs/${encodeURIComponent(slug)}`, {
+      method: "GET",
+      query: { fieldsets: POST_FULL_FIELDSETS },
+    });
+    return res?.post ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Query published posts in a given category (one page), newest first.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
+ * @param {string} categoryId  Category GUID (`category.id` from queryCategories / getCategoryBySlug).
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ posts: object[], nextCursor: string|null }>}
+ */
+export async function queryPostsByCategory(categoryId, { limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/v3/posts/query", {
+    method: "POST",
+    body: {
+      fieldsets: POST_LIST_FIELDSETS,
+      query: {
+        ...(cursor ? {} : { filter: { categoryIds: { $hasSome: [categoryId] } } }),
+        cursorPaging: cursor ? { limit, cursor } : { limit },
+        sort: [{ fieldName: "firstPublishedDate", order: "DESC" }],
+      },
+    },
+  });
+  return {
+    posts: res?.posts ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Query published posts with a given tag (one page), newest first.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
+ * @param {string} tagId  Tag GUID (`tag.id` from queryTags / getTagBySlug).
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ posts: object[], nextCursor: string|null }>}
+ */
+export async function queryPostsByTag(tagId, { limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/v3/posts/query", {
+    method: "POST",
+    body: {
+      fieldsets: POST_LIST_FIELDSETS,
+      query: {
+        ...(cursor ? {} : { filter: { tagIds: { $hasSome: [tagId] } } }),
+        cursorPaging: cursor ? { limit, cursor } : { limit },
+        sort: [{ fieldName: "firstPublishedDate", order: "DESC" }],
+      },
+    },
+  });
+  return {
+    posts: res?.posts ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Total number of published posts. Used for empty-state logic (0 → prompt the user to add
+ * posts in their Wix dashboard). Never invent posts.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/get-total-posts.md
+ * @returns {Promise<number>}
+ */
+export async function getTotalPosts() {
+  const res = await wixApiRequest("/blog/v2/stats/posts/total", { method: "GET" });
+  return res?.total ?? 0;
+}
+
+/**
+ * Query blog categories (one page), ordered by menu display position.
+ * Categories use offset paging (max 100 per page); most blogs have well under 100.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/query-categories.md
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ categories: object[], total: number }>}
+ */
+export async function queryCategories({ limit = 100, offset = 0 } = {}) {
+  const res = await wixApiRequest("/blog/v3/categories/query", {
+    method: "POST",
+    body: {
+      fieldsets: ["URL"],
+      query: {
+        paging: { limit, offset },
+        sort: [{ fieldName: "displayPosition", order: "ASC" }],
+      },
+    },
+  });
+  return {
+    categories: res?.categories ?? [],
+    total: res?.pagingMetadata?.total ?? (res?.categories?.length ?? 0),
+  };
+}
+
+/**
+ * Get one category by its URL slug. Returns null if not found.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/get-category-by-slug.md
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getCategoryBySlug(slug) {
+  try {
+    const res = await wixApiRequest(`/blog/v3/categories/slugs/${encodeURIComponent(slug)}`, {
+      method: "GET",
+      query: { fieldsets: ["URL"] },
+    });
+    return res?.category ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Query blog tags (one page), most-used first.
+ * Tags use offset paging (max 100 per page).
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/query-tags.md
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ tags: object[], total: number }>}
+ */
+export async function queryTags({ limit = 100, offset = 0 } = {}) {
+  const res = await wixApiRequest("/v3/tags/query", {
+    method: "POST",
+    body: {
+      fieldsets: ["URL"],
+      query: {
+        paging: { limit, offset },
+        sort: [{ fieldName: "publishedPostCount", order: "DESC" }],
+      },
+    },
+  });
+  return {
+    tags: res?.tags ?? [],
+    total: res?.pagingMetadata?.total ?? (res?.tags?.length ?? 0),
+  };
+}
+
+/**
+ * Get one tag by its URL slug. Returns null if not found.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/get-tag-by-slug.md
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getTagBySlug(slug) {
+  try {
+    const res = await wixApiRequest(`/v3/tags/slugs/${encodeURIComponent(slug)}`, {
+      method: "GET",
+      query: { fieldsets: ["URL"] },
+    });
+    return res?.tag ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -1,0 +1,119 @@
+
+# Wix Bookings Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/bookings/wix-bookings.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix Bookings front end. The browser talks to Wix directly over a
+public `WIX_CLIENT_ID`. Never mock services or slots; never hand-build a `/checkout` URL —
+always create the booking through the API and complete it via the eCom checkout + redirect-session.
+
+This skill ships the **single-service appointment** flow: browse services → pick a service →
+pick an available time slot → enter details → book → hosted checkout. Classes and courses use
+different availability calls and are covered under "Beyond the snippets".
+
+## When to use
+- User wants a Wix Bookings appointment site or asks to "connect Wix Bookings".
+- Replacing placeholder/mock services or fake calendars with live Wix data.
+- Adding service listings, a slot picker, booking creation, or checkout over an existing
+  Wix Bookings setup.
+
+## Prerequisites
+1. A Wix site with **Wix Bookings installed and at least one appointment service created**
+   (this skill does NOT provision — it's read-only over services). Staff/resources and a
+   booking policy should be configured so slots are bookable.
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Paste
+   it into `src/rest/wix-client.js` in place of the placeholder. It is a buyer-facing credential
+   (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/committing it is fine.
+3. The site must **accept payments** for paid services, and the deployed app domain must be
+   allow-listed on the OAuth client for Wix-hosted checkout to return. These are **separate Wix
+   setup flows the user completes later** — out of this skill's scope. If checkout return fails
+   before that setup is done, that's expected; flag it and continue.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the booking UI however the
+project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
+adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
+  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token IS
+  the booking visitor identity; it is persisted to localStorage. Do not re-mint anonymously per
+  load.
+- `src/rest/wix-bookings.js` — exports:
+  - **Services:** `queryServices`, `getService`, `countServices`
+  - **Availability:** `listAvailableSlots`, `getAvailableSlot`
+  - **Booking & checkout:** `createBooking`, `checkoutBooking`, `bookAndCheckout`
+  - **Media:** `mediaUrl` (resolve a service image to an absolute URL)
+
+The `Service`, `TimeSlot`, and `Booking` shapes are documented as JSDoc comments at the top of
+`wix-bookings.js`. Read them before building the UI — they describe the key fields and link to
+the full API reference for anything not shown.
+
+## How to wire it (UI is the project's choice)
+- **Service list** — `queryServices()` for the listing (visitor-visible services only). Render
+  `name`, `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price
+  from `payment.fixed.price.formattedValue` (already includes the currency). Pass the returned
+  `nextOffset` back as `offset` to load the next page. This skill books **APPOINTMENT** services;
+  if you mix in CLASS/COURSE services, branch on `service.type`.
+- **Service detail** — `getService(serviceId)` keyed off the URL/route; returns null on miss —
+  show a not-found state, never invent a service. Render `description`, price, and `locations`.
+- **Slot picker** — `listAvailableSlots(serviceId, { fromLocalDate, toLocalDate, timeZone? })`.
+  Dates are **local** wall-clock strings `"YYYY-MM-DDThh:mm:ss"` (no zone), interpreted in
+  `timeZone` (defaults to the visitor's IANA zone). Only `bookable: true` slots come back. Render
+  each `slot.localStartDate`/`localEndDate`; group by day for a calendar. Pass `nextCursor` back
+  as `cursor` to page.
+- **Booking form** — collect the buyer's `firstName`, `lastName`, `email`, `phone`. Keep it
+  minimal; richer per-service form fields live in the service's `form.id` (see "Beyond the snippets").
+- **Re-validate + book** — right before submitting, call
+  `getAvailableSlot(serviceId, { localStartDate, localEndDate, timeZone? })` to confirm the slot
+  is still open (and to pick up the staff resource). Then create + check out in one step:
+  `window.location.href = (await bookAndCheckout(slot, { email, firstName, lastName, phone })).checkoutUrl;`
+  Or split it: `const booking = await createBooking(slot, contact); const url = await checkoutBooking(booking.id);`
+- **Confirmation / return** — after the buyer returns from hosted checkout, the order is placed
+  and Wix Bookings confirms the booking automatically (status becomes `CONFIRMED`, or `PENDING`
+  if the service needs manual approval). Show a confirmation screen on return.
+- **Empty state** — if `countServices()` is 0, show an empty state telling the user to add a
+  service in their Wix dashboard. Never invent services.
+
+## Hard rules (do not violate)
+- ✅ Book ONLY via `createBooking()` → `checkoutBooking()` (or `bookAndCheckout()`), then redirect
+  to the returned `fullUrl`.
+- ❌ Never hand-build a `/checkout`, booking, or calendar URL.
+- ❌ Never mock services, time slots, or availability — render live Wix data or the empty state.
+- ❌ Never invent reviews, ratings, staff, or testimonials. Empty review UI only.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ Send availability/booking dates as **local** `"YYYY-MM-DDThh:mm:ss"` strings plus a
+  `timeZone` — do not send UTC `Z` timestamps to the slot APIs.
+- ✅ Re-validate the slot with `getAvailableSlot()` before `createBooking()` — slots get taken.
+- The client fails loudly on purpose: `createBooking`/`checkoutBooking` throw on an unbookable
+  slot, a missing booking id, or a missing redirect URL. A green path means it's really bookable —
+  don't swallow these.
+
+## Beyond the snippets
+The snippets cover the appointment booking path. For the "20%" they don't cover, extend the
+client: add a new helper on `wixApiRequest`, looking up the exact endpoint, method, and body in
+the **official Wix API reference** first (never guess):
+- Official Wix API reference: https://dev.wix.com/docs/api-reference.md
+- Single-service booking flow (the full picture): https://dev.wix.com/docs/api-reference/business-solutions/bookings/flow-single-service-booking.md
+- **Classes** (group sessions): list slots with List Event Time Slots —
+  https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots.md
+- **Courses** (multi-session): capacity is computed from bookings —
+  https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-reader-v2/query-extended-bookings.md
+- **Service variants / participants** (duration- or person-based pricing):
+  https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/service-options-and-variants/get-service-options-and-variants-by-service-id.md
+- **Add-ons:** https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/list-add-on-groups-by-service-id.md
+- **Custom booking form fields** (render `service.form.id`): Get Form Summary —
+  https://dev.wix.com/docs/rest/crm/forms/form-schemas/get-form-summary.md
+
+Keep the snippets as the default for everything they already do; reach for the API reference
+only for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (same visitor identity across reloads)
+- [ ] `queryServices()` renders live services; `countServices()` 0 → empty state (no mock services)
+- [ ] `listAvailableSlots()` returns real bookable slots for a chosen service and date range
+- [ ] Slot is re-validated with `getAvailableSlot()` immediately before booking
+- [ ] `createBooking()` returns a booking with `status: "CREATED"` and a real id
+- [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL)
+- [ ] On return from checkout the booking is confirmed (status `CONFIRMED`/`PENDING`)
+- [ ] No mock services, slots, or availability anywhere

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings.js
@@ -1,0 +1,310 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Bookings business-solution app id — required inside catalogReference when
+ * creating the eCommerce checkout for a booking.
+ * https://dev.wix.com/docs/rest/articles/getting-started/wix-business-solutions.md
+ */
+const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97";
+
+/** The visitor's local IANA time zone, used as the default for availability + booking. */
+function defaultTimeZone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Wix Bookings Service (Services V2) — key fields for building a booking UI.
+ * This skill ships the APPOINTMENT flow; CLASS/COURSE are "Beyond the snippets".
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services.md
+ *
+ *   id                                   {string}  Service GUID. Pass to listAvailableSlots / getService.
+ *   type                                 {string}  "APPOINTMENT" | "CLASS" | "COURSE". This skill books APPOINTMENT.
+ *   name                                 {string}  Display name.
+ *   tagLine                              {string}  Short one-line description.
+ *   description                          {string}  Long description (may contain HTML).
+ *   hidden                               {boolean} Whether hidden from visitors. Skill queries only hidden:false.
+ *   defaultCapacity                      {number}  Max customers per booking (1 for 1:1 appointments).
+ *   media.items                          {array}   Media gallery: [{ image: { id, url, width, height, altText } }].
+ *                                                  image.url may be a bare Wix media handle (e.g. "abc.jpg") rather
+ *                                                  than an absolute URL — pass it through mediaUrl() before rendering.
+ *   payment.rateType                     {string}  "FIXED" | "CUSTOM" | "VARIED" | "NO_FEE" | "SUBSCRIPTION".
+ *   payment.fixed.price                  {object}  { value, currency, formattedValue } — the price to display.
+ *   payment.options                      {object}  { online, inPerson, deposit, pricingPlan } booleans.
+ *   schedule.id                          {string}  Schedule GUID. Carried into the booking's bookedEntity.slot.
+ *   schedule.availabilityConstraints.sessionDurations {number[]} Allowed durations in minutes.
+ *   form.id                              {string}  Booking-form GUID (see "Beyond the snippets" to render it).
+ *   staffMemberIds                       {string[]} Staff resource GUIDs that provide the service.
+ *   locations                            {array}   [{ id, type, business: { id, name } }] where it's offered.
+ *   bookingPolicy.id                     {string}  Booking-policy GUID.
+ *   category                             {object}  { id, name } — group services in the UI by category.
+ *   onlineBooking.enabled                {boolean} Whether the service can be booked online.
+ */
+
+/**
+ * Wix Bookings TimeSlot (Time Slots V2, appointments) — what listAvailableSlots returns.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots.md
+ *
+ *   serviceId        {string}  Service GUID this slot belongs to.
+ *   localStartDate   {string}  Slot start, "YYYY-MM-DDThh:mm:ss" (no zone). Display + pass to createBooking.
+ *   localEndDate     {string}  Slot end, same format.
+ *   bookable         {boolean} Whether it can be booked per the service's booking policies. Skill filters bookable:true.
+ *   scheduleId       {string}  Schedule GUID — carried into the booking's bookedEntity.slot.
+ *   location         {object}  { id, name, formattedAddress, locationType: "BUSINESS"|"CUSTOM"|"CUSTOMER" }.
+ *   totalCapacity    {number}  Spots for the slot (1 for 1:1 appointments).
+ *   remainingCapacity{number}  Remaining spots — for appointments, 1 (free) or 0 (taken).
+ *   availableResources {array} [{ resourceTypeId, resources: [{ id, name }] }]. Empty by default in the LIST
+ *                              response; call getAvailableSlot() to get the staff/resource for the chosen slot.
+ *   nonBookableReasons {object} { noRemainingCapacity, violatesBookingPolicy, ... } when bookable is false.
+ */
+
+/**
+ * Wix Bookings Booking (Bookings Writer V2) — what createBooking returns.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking.md
+ *
+ *   id                {string}  Booking GUID. Pass to checkoutBooking() as the checkout catalogItemId.
+ *   status            {string}  "CREATED" right after creation (not yet on the calendar). Becomes "CONFIRMED"
+ *                               automatically once the buyer completes the hosted checkout, or "PENDING" if the
+ *                               service requires manual approval.
+ *   paymentStatus     {string}  Payment state (e.g. "UNDEFINED" / "NOT_PAID" until checkout completes).
+ *   bookedEntity.slot {object}  Echoes the booked slot (serviceId, scheduleId, startDate, endDate, timezone, ...).
+ *   contactDetails    {object}  The buyer details submitted with the booking.
+ *   totalParticipants {number}  Number of participants.
+ */
+
+/**
+ * Resolve a service image to an absolute URL. Wix media fields are sometimes a bare
+ * handle ("abc.jpg") rather than a full URL; this prefixes the Wix static host so the
+ * image renders. Absolute URLs and `wix:image://` values are returned/normalized too.
+ * @param {{ url?: string, id?: string }|string} image  A media object or a raw handle/url.
+ * @returns {string|null}
+ */
+export function mediaUrl(image) {
+  const raw = typeof image === "string" ? image : image?.url || image?.id;
+  if (!raw) return null;
+  if (raw.startsWith("http")) return raw;
+  if (raw.startsWith("wix:image://")) {
+    const stripped = raw.slice("wix:image://".length).replace(/^v1\//, "");
+    return `https://static.wixstatic.com/media/${stripped.split("#")[0].split("/")[0]}`;
+  }
+  return `https://static.wixstatic.com/media/${raw}`;
+}
+
+/**
+ * Query bookable services (one page). Returns only services visible to visitors (hidden:false).
+ * Uses offset paging (Services V2 default). Pass the next `offset` to page.
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services.md
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ services: object[], total: number, nextOffset: number|null }>}
+ */
+export async function queryServices({ limit = 100, offset = 0 } = {}) {
+  const res = await wixApiRequest("/bookings/v2/services/query", {
+    method: "POST",
+    body: {
+      query: {
+        filter: { hidden: false },
+        paging: { limit, offset },
+      },
+    },
+  });
+  const services = res?.services ?? [];
+  const total = res?.pagingMetadata?.total ?? services.length;
+  const loaded = offset + services.length;
+  return { services, total, nextOffset: loaded < total ? loaded : null };
+}
+
+/**
+ * Fetch a single service by its GUID. Returns null if not found.
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services.md
+ * @param {string} serviceId
+ * @returns {Promise<object|null>}
+ */
+export async function getService(serviceId) {
+  const res = await wixApiRequest("/bookings/v2/services/query", {
+    method: "POST",
+    body: { query: { filter: { id: serviceId }, paging: { limit: 1 } } },
+  });
+  return res?.services?.[0] ?? null;
+}
+
+/**
+ * Total number of visitor-visible services. Used for empty-state logic
+ * (0 → prompt the owner to add services in the Wix dashboard). Never invent services.
+ * @returns {Promise<number>}
+ */
+export async function countServices() {
+  const res = await wixApiRequest("/bookings/v2/services/query", {
+    method: "POST",
+    body: { query: { filter: { hidden: false }, paging: { limit: 1 } } },
+  });
+  return res?.pagingMetadata?.total ?? (res?.services?.length ?? 0);
+}
+
+/**
+ * List bookable appointment time slots for a service within a local date range.
+ * APPOINTMENT services only (the shipped flow). For classes/courses see "Beyond the snippets".
+ * Dates are LOCAL ("YYYY-MM-DDThh:mm:ss", no zone) and interpreted in `timeZone`.
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots.md
+ *
+ * @param {string} serviceId
+ * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
+ * @returns {Promise<{ slots: object[], nextCursor: string|null }>}
+ */
+export async function listAvailableSlots(serviceId, { fromLocalDate, toLocalDate, timeZone, limit = 1000, cursor } = {}) {
+  if (!cursor && (!fromLocalDate || !toLocalDate)) {
+    throw new Error("listAvailableSlots requires fromLocalDate and toLocalDate (local 'YYYY-MM-DDThh:mm:ss').");
+  }
+  const body = cursor
+    ? { cursorPaging: { limit, cursor } }
+    : {
+        serviceId,
+        bookable: true,
+        fromLocalDate,
+        toLocalDate,
+        timeZone: timeZone || defaultTimeZone(),
+        cursorPaging: { limit },
+      };
+  const res = await wixApiRequest("/_api/service-availability/v2/time-slots", { method: "POST", body });
+  return {
+    slots: res?.timeSlots ?? [],
+    nextCursor: res?.cursorPagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Re-validate a specific appointment slot right before booking, and fetch its available
+ * resources (staff). Returns the slot or null if it's gone. Always re-check before createBooking —
+ * slots can be taken between listing and booking.
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/get-availability-time-slot.md
+ *
+ * @param {string} serviceId
+ * @param {{ localStartDate: string, localEndDate: string, timeZone?: string, location?: object }} options
+ * @returns {Promise<object|null>}
+ */
+export async function getAvailableSlot(serviceId, { localStartDate, localEndDate, timeZone, location } = {}) {
+  if (!localStartDate || !localEndDate) {
+    throw new Error("getAvailableSlot requires localStartDate and localEndDate.");
+  }
+  const res = await wixApiRequest("/_api/service-availability/v2/time-slots/get", {
+    method: "POST",
+    body: {
+      serviceId,
+      localStartDate,
+      localEndDate,
+      timeZone: timeZone || defaultTimeZone(),
+      ...(location ? { location } : {}),
+    },
+  });
+  return res?.timeSlot ?? null;
+}
+
+/**
+ * Create a booking for an appointment slot. The booking starts as status "CREATED" and is
+ * NOT yet on the calendar — it is confirmed automatically after the buyer completes the
+ * hosted checkout (call checkoutBooking next). selectedPaymentOption is "ONLINE" so the
+ * eCommerce checkout drives confirmation.
+ *
+ * Pass a `slot` object from listAvailableSlots()/getAvailableSlot() (it carries serviceId,
+ * scheduleId, localStartDate, localEndDate, location, availableResources). `timeZone` defaults
+ * to the slot's location-agnostic visitor zone; pass the same zone you listed slots with.
+ *
+ * Throws on an unbookable slot or if Wix doesn't return a booking id (fail loudly — don't let
+ * the buyer continue to checkout against a dead slot).
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking.md
+ *
+ * @param {object} slot                       A TimeSlot from listAvailableSlots/getAvailableSlot.
+ * @param {{ firstName?: string, lastName?: string, email: string, phone?: string }} contactDetails
+ * @param {{ totalParticipants?: number, timeZone?: string, title?: string }} [options]
+ * @returns {Promise<object>} The created booking (status "CREATED").
+ */
+export async function createBooking(slot, contactDetails, { totalParticipants = 1, timeZone, title } = {}) {
+  if (!slot || slot.bookable === false) {
+    throw new Error("Cannot book: the selected slot is not bookable. Re-check availability and pick another time.");
+  }
+  if (!slot.serviceId || !slot.scheduleId || !slot.localStartDate || !slot.localEndDate) {
+    throw new Error("Cannot book: slot is missing serviceId/scheduleId/localStartDate/localEndDate.");
+  }
+  if (!contactDetails?.email) {
+    throw new Error("Cannot book: contactDetails.email is required.");
+  }
+
+  // First available resource (staff), if the slot carries one — otherwise Wix auto-assigns.
+  const resource = slot.availableResources?.[0]?.resources?.[0];
+
+  const bookedSlot = {
+    serviceId: slot.serviceId,
+    scheduleId: slot.scheduleId,
+    startDate: slot.localStartDate,
+    endDate: slot.localEndDate,
+    timezone: timeZone || defaultTimeZone(),
+    ...(slot.location ? { location: slot.location } : {}),
+    ...(resource ? { resource: { id: resource.id, name: resource.name } } : {}),
+  };
+
+  const res = await wixApiRequest("/bookings/v2/bookings", {
+    method: "POST",
+    body: {
+      booking: {
+        bookedEntity: { slot: bookedSlot, title: title || undefined, tags: ["INDIVIDUAL"] },
+        contactDetails,
+        additionalFields: [],
+        totalParticipants,
+        selectedPaymentOption: "ONLINE",
+      },
+      participantNotification: { notifyParticipants: true },
+    },
+  });
+  const booking = res?.booking;
+  if (!booking?.id) throw new Error("Failed to create the booking (no booking id returned).");
+  return booking;
+}
+
+/**
+ * Create an eCommerce checkout for a created booking and return the hosted checkout URL.
+ * Redirect the buyer there (`window.location.href = ...`). On return, the order is placed and
+ * Wix Bookings confirms the booking automatically. Throws if no redirect URL is produced.
+ *
+ * Checkout: https://dev.wix.com/docs/rest/business-solutions/e-commerce/checkout/create-checkout.md
+ * @param {string} bookingId  `booking.id` from createBooking().
+ * @returns {Promise<string>} The full hosted-checkout URL to redirect to.
+ */
+export async function checkoutBooking(bookingId) {
+  if (!bookingId) throw new Error("checkoutBooking requires a bookingId.");
+
+  const checkoutRes = await wixApiRequest("/ecom/v1/checkouts", {
+    method: "POST",
+    body: {
+      channelType: "WEB",
+      lineItems: [
+        { quantity: 1, catalogReference: { appId: BOOKINGS_APP_ID, catalogItemId: bookingId } },
+      ],
+    },
+  });
+  const checkoutId = checkoutRes?.checkout?.id;
+  if (!checkoutId) throw new Error("Failed to create a checkout for the booking.");
+
+  const redirect = await wixApiRequest("/headless/v1/redirect-session", {
+    method: "POST",
+    body: { ecomCheckout: { checkoutId }, callbacks: { postFlowUrl: window.location.href } },
+  });
+  const url = redirect?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Failed to create the checkout redirect session.");
+  return url;
+}
+
+/**
+ * Convenience: create the booking and return the hosted-checkout URL in one call.
+ * Equivalent to createBooking() then checkoutBooking(booking.id). Throws loudly on any failure.
+ * @param {object} slot
+ * @param {{ firstName?: string, lastName?: string, email: string, phone?: string }} contactDetails
+ * @param {{ totalParticipants?: number, timeZone?: string, title?: string }} [options]
+ * @returns {Promise<{ booking: object, checkoutUrl: string }>}
+ */
+export async function bookAndCheckout(slot, contactDetails, options = {}) {
+  const booking = await createBooking(slot, contactDetails, options);
+  const checkoutUrl = await checkoutBooking(booking.id);
+  return { booking, checkoutUrl };
+}

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -1,0 +1,131 @@
+
+# Wix CMS Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/cms/wix-cms.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix CMS-backed app. The browser talks to Wix Data directly
+over a public `WIX_CLIENT_ID` to read and write items in the site's data collections.
+Never mock data; never hand-build API URLs — always go through the helpers, which call
+the official Wix Data endpoints.
+
+## When to use
+- User wants to display Wix CMS / Content Manager content (a collection of posts,
+  tutorials, recipes, team members, listings, FAQs, etc.) on a site.
+- Replacing placeholder/mock content with live Wix Data items.
+- Adding list pages, detail pages, category/tag filtering, or free-text search over an
+  existing Wix data collection.
+- Wiring a public form (contact, RSVP, review, signup) that writes a row into a collection.
+
+## Prerequisites
+1. A Wix site with **a data collection already created and populated** (this skill does
+   NOT provision collections — it reads/writes existing ones). The merchant creates
+   collections, fields, and items in the Wix dashboard (CMS / Content Manager).
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
+   Wix Business Manager surfaces a copyable prompt with the id filled in — see
+   the router `SKILL.md`). Paste it into `src/rest/wix-client.js` in place of the placeholder. It is
+   a buyer-facing credential (it only mints anonymous visitor tokens), **not** a secret,
+   so hardcoding/committing it is fine.
+3. **Collection permissions** must match what you're doing. This skill runs as an
+   anonymous visitor, so a call only works if the collection grants that action to
+   "Anyone": Read for listing content, Insert for a public form. Update/Delete are
+   almost always admin- or author-only and will fail for a visitor. The site owner sets
+   these in the Wix dashboard (CMS → collection → Permissions). This is a **separate Wix
+   setup step the user completes** — out of this skill's scope. If a read/insert fails
+   with a permission error (HTTP 403) before that's set, that's expected; flag it and
+   continue.
+4. You need each collection's **collection ID** (its name, e.g. `Tutorials`) and its
+   **field keys** (e.g. `title`, `publishDate`). Read field keys off a fetched item, or
+   from the collection schema (see "Beyond the snippets").
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the UI however the project
+wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
+adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID`
+  to the id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor
+  refresh token is persisted to localStorage; do not re-mint anonymously per load.
+- `src/rest/wix-cms.js` — exports:
+  - **Read:** `queryDataItems`, `getDataItem`, `getDataItemBy`, `countDataItems`
+  - **Write:** `insertDataItem`, `updateDataItem`, `removeDataItem`
+
+The Data Item shape, the per-collection **permissions model**, and the **filter/sort
+syntax** are documented as JSDoc comments at the top of `wix-cms.js`. Read them before
+building the UI — read helpers return the item's flat `data` payload (which always
+includes `_id`), and writes are bound by collection permissions.
+
+## How to wire it (UI is the project's choice)
+- **Content list** — `queryDataItems(collectionId, { filter?, sort?, limit?, cursor? })`
+  for the listing; render fields directly off each returned item (`item.title`, etc.).
+  Pass the returned `nextCursor` back as `cursor` to load the next page. Define
+  `filter`/`sort` on the first request only — cursor follow-ups reuse the original query.
+- **Detail page** — route by the item's `_id` and call `getDataItem(collectionId, itemId)`;
+  returns null on miss → show a not-found state, never invent an item. For human-readable
+  URLs, add a slug-like field to the collection and route via
+  `getDataItemBy(collectionId, "slug", slugFromUrl)`.
+- **Filter & search** — pass a `filter` to `queryDataItems` using the operators documented
+  in `wix-cms.js` (`$eq`, `$in`, `$gte`, `$startsWith`, `$hasSome`, `$and`/`$or`, …). For a
+  simple text search, `{ title: { $startsWith: term } }`; for richer free-text/fuzzy search
+  across fields, see "Beyond the snippets" (Search Data Items).
+- **Public form** — on submit, `insertDataItem(collectionId, { name, email, message })`
+  (field keys must match the collection). Requires the collection's Insert permission to be
+  "Anyone". Show success/failure from the resolved/thrown result; never fake a success.
+- **Edit / delete (admin/author flows)** — `updateDataItem(collectionId, itemId, data)`
+  (⚠ full replace — fetch + merge first to preserve other fields) and
+  `removeDataItem(collectionId, itemId)`. These need Update/Delete granted to the caller,
+  which visitors normally don't have — expect them to fail unless the collection is opened up.
+- **Empty state** — if `countDataItems(collectionId)` is 0, show an empty state telling
+  the user to add items in their Wix dashboard. Never invent items.
+
+## Hard rules (do not violate)
+- ✅ Read/write ONLY through the helpers in `wix-cms.js` (which call the official Wix Data
+  `/wix-data/v2/items` endpoints).
+- ❌ Never hand-build Wix Data URLs or invent endpoint paths.
+- ❌ Never mock data — render live Wix Data items or the empty state.
+- ❌ Never invent fields, reviews, ratings, or content not present in the collection.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ Use the item's `_id` as the route key and as `itemId` for get/update/remove.
+- ✅ `updateDataItem` REPLACES the whole item — fetch with `getDataItem`, merge your
+  changes, then pass the full object, or use Patch Data Item (see below) for partial edits.
+- ✅ Treat permission errors (HTTP 403) as a configuration step, not a code bug: tell the
+  user which permission to grant in the dashboard. Writes throw on failure — don't swallow
+  the error and show a fake success.
+
+## Beyond the snippets
+The snippets cover the common CMS paths (list, detail, filter, count, insert, update,
+remove). If you hit a use case they don't cover, make the call yourself with
+`wixApiRequest` — but look up the exact endpoint, HTTP method, and request body in the
+**official Wix API reference** first; never guess:
+- CMS / Data Items API reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
+- Data Items sample flows: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/sample-flows.md
+- **Partial update** (change some fields, keep the rest): Patch Data Item —
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/patch-data-item.md
+- **Upsert** (insert or update by id): Save Data Item —
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/save-data-item.md
+- **Bulk** insert/update/save/remove (many items in one call):
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
+- **Free-text / fuzzy search** across fields: Search Data Items —
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/search-data-items.md
+- **Aggregations** (counts/averages grouped by a field): Aggregate Data Items —
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/aggregate-data-items.md
+- **Distinct values** (e.g. all categories for a filter menu): Query Distinct Values —
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-distinct-values.md
+- **Referenced items** (expand a reference field beyond the inline limit): Query Referenced
+  Data Items — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-referenced-data-items.md
+- **Collection schema / field keys & types**: Get Data Collection —
+  https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/get-data-collection.md
+
+Keep the snippets as the default for everything they already do; reach for the API
+reference only for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (same anonymous visitor, no re-mint per load)
+- [ ] `queryDataItems` returns live items; pagination via `nextCursor` loads more
+- [ ] Detail page uses the item's `_id` (or a slug field via `getDataItemBy`) and shows a
+      not-found state on miss — no invented item
+- [ ] Filter/sort produce the expected subset (operators match the field types)
+- [ ] Public form `insertDataItem` succeeds only when Insert is "Anyone"; on a 403 the user
+      is told to grant the permission — no fake success
+- [ ] Update is treated as a full replace (fetch + merge), so no fields are silently dropped
+- [ ] Empty state shown when `countDataItems` is 0
+- [ ] No mock data anywhere; no hand-built Wix Data URLs

--- a/skills/wix-vibe-headless/references/cms/wix-cms.js
+++ b/skills/wix-vibe-headless/references/cms/wix-cms.js
@@ -1,0 +1,233 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix CMS (Wix Data) — thin REST helpers for reading and writing data items in a
+ * site's data collections. The direct analog of `wix-store.js`, but for the generic
+ * content layer instead of a product catalog.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * COLLECTIONS & PERMISSIONS — read this first.
+ *
+ * A collection (e.g. "Tutorials", "TeamMembers", "ContactForm") is identified by its
+ * `dataCollectionId` — the collection name the site owner set in the dashboard, NOT a
+ * GUID. You pass it to every call. Field keys (e.g. "title", "publishDate") are also
+ * set in the dashboard; read them off the items you fetch, or from the collection
+ * schema (see "Beyond the snippets" in SKILL.md).
+ *
+ * Every collection has per-role PERMISSIONS for Read / Insert / Update / Delete. This
+ * skill runs as an ANONYMOUS VISITOR, so a call only succeeds if the collection grants
+ * that action to "Anyone":
+ *   - Listing/reading public content  → Read must be "Anyone".
+ *   - A public form (contact, RSVP)    → Insert must be "Anyone".
+ *   - Update/Delete by a visitor       → rarely granted to "Anyone"; usually admin- or
+ *                                         author-only. Expect these to fail unless the
+ *                                         collection is explicitly opened up.
+ * A permission-denied call throws (HTTP 403) — that's by design, not a bug. The site
+ * owner sets permissions in the Wix dashboard (CMS → collection → Permissions). See:
+ * https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-permissions/data-permissions-object.md
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * Wix Data Item — the shape returned by every read helper here.
+ * Full reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/data-item-object.md
+ *
+ * Helpers in this file return the item's `data` payload directly (the object below),
+ * which is the flat bag of field values PLUS these read-only system fields:
+ *
+ *   _id           {string}  Item GUID. Use it as the route key for detail pages and as
+ *                           the `itemId` for getDataItem / updateDataItem / removeDataItem.
+ *   _createdDate  {string}  ISO 8601 — when the item was added. Serialized as { $date: "..." }
+ *                           in filters; returned as an ISO string in the payload.
+ *   _updatedDate  {string}  ISO 8601 — when the item was last modified.
+ *   _ownerId      {string}  GUID of the user who created the item.
+ *   ...fields                Every collection field, keyed by its field key, e.g.
+ *                           { title: "Hello", body: "...", publishDate: "2026-01-02T..." }.
+ *
+ * Field VALUE TYPES follow the collection's field types (text, number, boolean, date,
+ * URL, image/media, reference, multi-reference, array, object). Image fields hold a Wix
+ * media URL (e.g. "wix:image://..."); render via the Wix media URL or the field's
+ * resolved URL. Reference fields hold the referenced item's `_id`; pass `includeReferences`
+ * to queryDataItems to inline the full referenced item instead of just its id.
+ * Data types: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-types-in-wix-data.md
+ */
+
+/**
+ * FILTERS & SORT (Wix API Query Language) — used by queryDataItems / getDataItemBy / countDataItems.
+ * Full reference: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/data-retrieval/about-the-wix-api-query-language.md
+ *
+ *   filter  {object}  Equality is `{ field: value }`. Operators are
+ *                     `{ field: { $op: value } }`. Supported $ops:
+ *                       $eq $ne $gt $gte $lt $lte    — comparison
+ *                       $in $nin                      — value in / not in an array
+ *                       $startsWith                   — string prefix (not case-sensitive)
+ *                       $exists                       — field is present & non-null (true/false)
+ *                       $isEmpty                      — string/array empty (true/false)
+ *                       $hasSome $hasAll              — array contains some / all of the values
+ *                     Combine clauses with $and / $or / $not (arrays of filter objects).
+ *                     Dates must be `{ "$date": "2026-05-05T00:00:00.000Z" }`.
+ *                     Example: { category: "guides", views: { $gte: 100 } }
+ *   sort    {Array}   [{ fieldName: "publishDate", order: "DESC" }, ...]. order is
+ *                     "ASC" | "DESC" (default ASC). Earlier entries take precedence.
+ */
+
+/**
+ * Query one page of items from a collection.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-data-items.md
+ *
+ * Pass `nextCursor` back as `cursor` to load the next page. Define `filter`/`sort`/`fields`
+ * on the FIRST request only — on cursor follow-ups Wix reuses the original query and
+ * ignores them (so this helper omits them when a cursor is supplied).
+ *
+ * @param {string} dataCollectionId  Collection name (e.g. "Tutorials").
+ * @param {{
+ *   filter?: object,
+ *   sort?: Array<{ fieldName: string, order?: "ASC"|"DESC" }>,
+ *   limit?: number,
+ *   cursor?: string,
+ *   fields?: string[],
+ *   includeReferences?: Array<{ field: string, limit?: number }>
+ * }} [options]
+ * @returns {Promise<{ items: object[], nextCursor: string|null }>}  items are `data` payloads (each includes `_id`).
+ */
+export async function queryDataItems(dataCollectionId, { filter, sort, limit = 100, cursor, fields, includeReferences } = {}) {
+  const query = {
+    ...(cursor
+      ? {}
+      : {
+          ...(filter ? { filter } : {}),
+          ...(sort ? { sort } : {}),
+          ...(fields ? { fields } : {}),
+        }),
+    cursorPaging: cursor ? { limit, cursor } : { limit },
+  };
+  const res = await wixApiRequest("/wix-data/v2/items/query", {
+    method: "POST",
+    body: {
+      dataCollectionId,
+      query,
+      ...(includeReferences ? { includeReferences } : {}),
+    },
+  });
+  return {
+    items: (res?.dataItems ?? []).map((d) => d.data),
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Get a single item by its `_id`. Returns the `data` payload, or null if not found
+ * (or not readable by an anonymous visitor — see the permissions note up top).
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/get-data-item.md
+ *
+ * @param {string} dataCollectionId
+ * @param {string} itemId            The item's `_id`.
+ * @returns {Promise<object|null>}
+ */
+export async function getDataItem(dataCollectionId, itemId) {
+  try {
+    const res = await wixApiRequest(`/wix-data/v2/items/${encodeURIComponent(itemId)}`, {
+      method: "GET",
+      query: { dataCollectionId },
+    });
+    return res?.dataItem?.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the first item whose `fieldKey` equals `value`. Use for slug-style routing —
+ * Wix Data has no native get-by-slug, so detail pages keyed off a human-readable field
+ * (e.g. a "slug" or "handle" field) resolve through this. Returns the `data` payload or null.
+ * Built on Query Data Items: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-data-items.md
+ *
+ * @param {string} dataCollectionId
+ * @param {string} fieldKey   Field to match (e.g. "slug").
+ * @param {unknown} value     Value to match.
+ * @returns {Promise<object|null>}
+ */
+export async function getDataItemBy(dataCollectionId, fieldKey, value) {
+  const { items } = await queryDataItems(dataCollectionId, { filter: { [fieldKey]: value }, limit: 1 });
+  return items[0] ?? null;
+}
+
+/**
+ * Count items in a collection matching an optional filter. Use for empty-state logic
+ * (0 → prompt the user to add items in their Wix dashboard) and result counts.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/count-data-items.md
+ *
+ * @param {string} dataCollectionId
+ * @param {object} [filter]  Same filter syntax as queryDataItems.
+ * @returns {Promise<number>}
+ */
+export async function countDataItems(dataCollectionId, filter) {
+  const res = await wixApiRequest("/wix-data/v2/items/count", {
+    method: "POST",
+    body: { dataCollectionId, ...(filter ? { filter } : {}) },
+  });
+  return res?.totalCount ?? 0;
+}
+
+/**
+ * Insert a new item (e.g. a public form submission). The collection's Insert permission
+ * must be "Anyone" for this to succeed as a visitor. Returns the inserted `data` payload
+ * (including the assigned `_id`). Throws on failure (e.g. permission denied, validation).
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/insert-data-item.md
+ *
+ * @param {string} dataCollectionId
+ * @param {object} data   Field-keyed values, e.g. { name, email, message }. Omit `_id`
+ *                        to let Wix assign one; supply `_id` only for a custom GUID.
+ * @returns {Promise<object>}  The inserted item's `data` payload.
+ */
+export async function insertDataItem(dataCollectionId, data) {
+  const res = await wixApiRequest("/wix-data/v2/items", {
+    method: "POST",
+    body: { dataCollectionId, dataItem: { data } },
+  });
+  const inserted = res?.dataItem?.data;
+  if (!inserted) throw new Error(`Insert into "${dataCollectionId}" failed (no item returned).`);
+  return inserted;
+}
+
+/**
+ * Update (REPLACE) an existing item by `_id`. Returns the updated `data` payload. Throws
+ * if the item doesn't exist or the visitor lacks Update permission (usually admin/author only).
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/update-data-item.md
+ *
+ * ⚠ This is a FULL REPLACE: the new `data` overwrites the whole item, and any field NOT
+ * included is dropped. To change a few fields, fetch the item first (getDataItem), spread
+ * it, then pass the merged object — or use Patch Data Item for a partial change:
+ * https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/patch-data-item.md
+ *
+ * @param {string} dataCollectionId
+ * @param {string} itemId   The item's `_id`.
+ * @param {object} data     The complete new field set.
+ * @returns {Promise<object>}  The updated item's `data` payload.
+ */
+export async function updateDataItem(dataCollectionId, itemId, data) {
+  const res = await wixApiRequest(`/wix-data/v2/items/${encodeURIComponent(itemId)}`, {
+    method: "PUT",
+    body: { dataCollectionId, dataItem: { id: itemId, data: { ...data, _id: itemId } } },
+  });
+  const updated = res?.dataItem?.data;
+  if (!updated) throw new Error(`Update of "${itemId}" in "${dataCollectionId}" failed (no item returned).`);
+  return updated;
+}
+
+/**
+ * Remove an item by `_id`. Irreversible. Returns the removed `data` payload. Throws if the
+ * visitor lacks Delete permission (usually admin/author only).
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/remove-data-item.md
+ *
+ * @param {string} dataCollectionId
+ * @param {string} itemId   The item's `_id`.
+ * @returns {Promise<object|null>}  The removed item's `data` payload.
+ */
+export async function removeDataItem(dataCollectionId, itemId) {
+  const res = await wixApiRequest(`/wix-data/v2/items/${encodeURIComponent(itemId)}`, {
+    method: "DELETE",
+    query: { dataCollectionId },
+  });
+  return res?.dataItem?.data ?? null;
+}

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -1,0 +1,122 @@
+
+# Wix Events Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/events/wix-events.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix Events site. The browser talks to Wix directly over a
+public `WIX_CLIENT_ID`. Never mock events; never hand-build registration or payment URLs —
+register via the RSVP/ticketing APIs, and complete paid tickets on the official Wix-hosted
+ticket form.
+
+## When to use
+- User wants an events site over Wix Events & Tickets, or asks to "connect Wix Events".
+- Replacing placeholder/mock events with live Wix data.
+- Adding event listings, an event detail page, RSVP, or ticket purchase over existing,
+  published Wix events.
+
+## Prerequisites
+1. A Wix site with **Wix Events & Tickets installed and events already published** (this skill
+   does NOT create events — it's read-only over them). Selling **paid** tickets also needs a
+   Wix premium plan + a configured payment method; **free** events and RSVP events work without.
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Paste
+   it into `src/rest/wix-client.js` in place of the placeholder. It is a visitor-facing
+   credential (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/
+   committing it is fine.
+3. For paid tickets the buyer completes payment on the **Wix-hosted ticket form** (the redirect
+   target of `getTicketCheckoutUrl`). The deployed app domain may need to be allow-listed on the
+   OAuth client for that page to return cleanly — a **separate Wix setup the user completes
+   later**, out of this skill's scope. If the return fails before that's done, that's expected;
+   flag it and continue.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the events UI however the
+project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
+adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
+  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token is
+  persisted to localStorage and IS the identity of the visitor's ticket reservation/cart — do
+  not re-mint anonymously per load.
+- `src/rest/wix-events.js` — exports:
+  - **Browse:** `queryEvents`, `getEventBySlug`, `countUpcomingEvents`
+  - **Categories:** `queryEventCategories`, `listEventsByCategory`
+  - **RSVP:** `createRsvp`
+  - **Ticketing:** `queryTicketDefinitions`, `reserveTickets`, `getTicketCheckoutUrl`, `checkoutTickets`
+
+The `Event`, `TicketDefinition`, and `RSVP`/`Order` shapes are documented as JSDoc comments at
+the top of `wix-events.js`. Read them before building the UI — they describe the key fields and
+link to the full API reference for anything not shown.
+
+## How to wire it (UI is the project's choice)
+- **Event grid** — `queryEvents()` lists live (UPCOMING/STARTED) events, soonest first. Render
+  `title`, `mainImage.url`, `dateAndTimeSettings.formatted.dateAndTime`, `location.name`, and
+  `shortDescription`. Use `offset`/`nextOffset` from the result to page. Link each card by `slug`.
+- **Event detail** — `getEventBySlug(slug)`; returns null on miss — show a not-found state, never
+  invent an event. Branch the registration UI on `event.registration.type`:
+  - `"RSVP"` → render the RSVP form (fields from `event.form.controls`).
+  - `"TICKETING"` → render the ticket picker.
+  - `"EXTERNAL"` → link out to `event.registration.external.url`.
+  - `"NONE"` → details only, no registration.
+  Only `registration.status` values starting `OPEN_` accept new registrations; otherwise show the
+  closed state.
+- **Categories (optional)** — `queryEventCategories()` for a filter menu (`counts.assignedEventsCount`
+  per category); `listEventsByCategory(categoryId)` to list a category's events (same card fields
+  and paging as `queryEvents`).
+- **RSVP** — `createRsvp(eventId, { firstName, lastName, email, status, additionalGuestNames?, extraFields? })`.
+  `status` defaults to `"YES"`; only offer `"NO"` when `registration.rsvp.responseType` is
+  `"YES_AND_NO"`. If the event is full with a waitlist enabled, the returned RSVP comes back with
+  status `"WAITLIST"` — tell the guest. Completes fully client-side; no redirect.
+- **Ticketing** — show tickets, reserve, then complete on the hosted form:
+  1. `queryTicketDefinitions(eventId)` → render each ticket's `name`, price (`pricingMethod.fixedPrice.value`
+     + currency, or `pricingOptions`/`guestPrice`), and availability (`salesDetails.soldOut`).
+  2. `reserveTickets([{ ticketDefinitionId, quantity, guestPrice?, pricingOptionId? }])` → holds the
+     tickets; returns `{ id, expirationDate }`. Show a countdown to `expirationDate` if you like.
+  3. `window.location.href = getTicketCheckoutUrl(event, reservation.id)` → the Wix-hosted ticket
+     form collects guest details + payment and returns the buyer to the event. This is the path for
+     **all paid tickets**.
+  - **Free tickets only:** you may instead call `checkoutTickets(eventId, { reservationId, buyer, guests })`
+    to finish in-app — it returns an order with status `"FREE"`, a `ticketsPdf`, and `tickets[]`. It
+    throws for paid orders (status `INITIATED`), telling you to use the hosted form.
+- **Empty state** — if `countUpcomingEvents()` is 0, show an empty state telling the user to publish
+  events in their Wix dashboard. Never invent events.
+
+## Hard rules (do not violate)
+- ✅ Complete paid ticket purchases ONLY via `reserveTickets()` → `getTicketCheckoutUrl()` redirect
+  (the official Wix-hosted ticket form). 
+- ❌ Never hand-build registration, ticket, payment, or checkout URLs — derive the hosted form URL
+  from `event.eventPageUrl` via `getTicketCheckoutUrl`.
+- ❌ Never mock events, tickets, or guest counts — render live Wix data or the empty/closed state.
+- ❌ Never invent reviews, ratings, attendee names, or "X spots left" numbers not returned by the API.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public visitor-facing client id — safe to hardcode).
+- ✅ Branch registration UI on `event.registration.type`; respect `registration.status` (only `OPEN_*`
+  accepts registrations) and ticket `saleStatus`/`salesDetails.soldOut`.
+- ✅ Pass `guestPrice` for donation/"pay what you want" tickets and `pricingOptionId` for tiered tickets
+  to `reserveTickets`.
+- The helpers fail loudly on purpose: `reserveTickets` throws when tickets aren't actually held,
+  `createRsvp` throws on closed/full registration, `checkoutTickets` throws when payment is still owed.
+  A green path means it really worked — don't swallow these.
+
+## Beyond the snippets
+The snippets cover the common RSVP + ticketing paths. If you hit a use case they don't cover
+(coupons/`discount` at checkout, members/auth, schedule/agenda, seating maps, canceling a
+reservation, a field not in the typedefs), make the call yourself with `wixApiRequest` — but look
+up the exact endpoint, HTTP method, and request body in the **official Wix Events API reference**
+first; never guess:
+- Events API reference: https://dev.wix.com/docs/api-reference/business-solutions/events.md
+- Registration (RSVP + ticketing) overview: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/introduction.md
+- Ticketing flow (reservations → orders → tickets): https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/introduction.md
+
+Keep the snippets as the default for everything they already do; reach for the API reference only
+for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (same visitor identity for reservations)
+- [ ] Event grid renders live events; clicking a card opens the detail page by `slug`
+- [ ] Detail page branches correctly on `registration.type` (RSVP form vs. ticket picker vs. external link)
+- [ ] RSVP submit creates a real RSVP (and surfaces a `WAITLIST` result when the event is full)
+- [ ] Ticket purchase reserves tickets, then redirects via `getTicketCheckoutUrl` (no hand-built URL)
+- [ ] Paid checkout lands on the Wix-hosted ticket form; buyer returns to the event afterward
+- [ ] Closed registration / sold-out tickets show a clear state rather than a dead end
+- [ ] Empty state shown when `countUpcomingEvents()` is 0
+- [ ] No mock events, tickets, or attendee data anywhere

--- a/skills/wix-vibe-headless/references/events/wix-events.js
+++ b/skills/wix-vibe-headless/references/events/wix-events.js
@@ -1,0 +1,393 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Events V3 — key fields for building a visitor-facing events site.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/event-object.md
+ *
+ * Most fields below are only returned when you request the matching `fields`/fieldset
+ * (the helpers here already request DETAILS, REGISTRATION, URLS, and — for the detail
+ * page — TEXTS and FORM). Query events: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/query-events.md
+ *
+ *   id                              {string}   Event GUID.
+ *   title                           {string}   Event title.
+ *   slug                            {string}   URL slug for detail-page routing (kebab-case).
+ *   status                          {string}   "UPCOMING" | "STARTED" | "ENDED" | "CANCELED" | "DRAFT".
+ *                                              Only UPCOMING/STARTED are live for visitors.
+ *   shortDescription                {string}   Teaser under the title (DETAILS fieldset).
+ *   description                     {object}   Rich-content body (TEXTS fieldset). Ricos node tree — render
+ *                                              its text nodes, or show shortDescription if you don't render Ricos.
+ *   mainImage                       {object}   Hero image (DETAILS fieldset): { id, url, width, height, altText }.
+ *   dateAndTimeSettings             {object}   Schedule (always returned):
+ *     dateAndTimeTbd                {boolean}    When true, startDate/endDate are absent — show dateAndTimeTbdMessage.
+ *     startDate, endDate            {string}     ISO-8601 datetimes.
+ *     timeZoneId                    {string}     IANA tz, e.g. "America/New_York".
+ *     formatted.dateAndTime         {string}     Ready-to-render human string (e.g. "June 15, 2024, 9:00 – 11:00 AM PDT").
+ *     formatted.startDate/startTime/endDate/endTime {string} Individual formatted parts.
+ *   location                        {object}   Where (always returned):
+ *     type                          {string}     "VENUE" | "ONLINE".
+ *     name                          {string}     Venue/location name (also shown when locationTbd is true).
+ *     address                       {object}     { city, country, subdivision, postalCode, addressLine, streetAddress }.
+ *     locationTbd                   {boolean}    When true, show `name` instead of an address.
+ *   registration                    {object}   Registration config (REGISTRATION fieldset). Drives the whole flow:
+ *     type                          {string}     "RSVP" | "TICKETING" | "EXTERNAL" | "NONE".
+ *     status                        {string}     "OPEN_RSVP" | "OPEN_RSVP_WAITLIST_ONLY" | "OPEN_TICKETS" |
+ *                                                "OPEN_EXTERNAL" | "CLOSED_MANUALLY" | "CLOSED_AUTOMATICALLY" |
+ *                                                "SCHEDULED_RSVP". Only OPEN_* states accept new registrations.
+ *     rsvp                          {object}     RSVP config: { responseType, limit, waitlistEnabled, startDate, endDate }.
+ *                                                responseType "YES_AND_NO" allows a "NO" reply; otherwise YES-only.
+ *     tickets                       {object}     Ticketing config: { currency, lowestPrice:{value,currency},
+ *                                                highestPrice, soldOut, ticketLimitPerOrder, guestsAssignedSeparately }.
+ *                                                guestsAssignedSeparately === true → collect a form per ticket at checkout.
+ *     external.url                  {string}     External registration URL (type === "EXTERNAL" — link out, don't build a form).
+ *   eventPageUrl                    {object}   Live page URL parts (URLS fieldset): { base, path }.
+ *                                              Needed to build the hosted ticket-checkout redirect — see getTicketCheckoutUrl.
+ *   form                            {object}   Registration form (FORM fieldset). `form.controls[]` is the ordered field list:
+ *                                              [{ id, type, system, inputs:[{ name, label, ... }] }].
+ *                                              `system` controls are mandatory (name, email). Use control inputs' `name`
+ *                                              as the `inputName` when submitting createRsvp / checkoutTickets form values.
+ *   calendarUrls                    {object}   { google, ics } add-to-calendar links (DETAILS fieldset).
+ */
+
+/**
+ * Wix Events Ticket Definition (V3) — a ticket type for a ticketed event.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/ticket-definitions-v3/ticket-definition-object.md
+ *
+ *   id                              {string}   Ticket definition GUID — pass to reserveTickets.
+ *   eventId                         {string}   Event this ticket belongs to.
+ *   name                            {string}   Display name (e.g. "General Admission", "VIP").
+ *   description                     {string}   Short description.
+ *   hidden                          {boolean}  When true the ticket is not sellable to visitors — exclude it.
+ *   pricingMethod                   {object}   ONE-OF:
+ *     fixedPrice                    {object}     { value, currency } — same price for everyone.
+ *     guestPrice                    {object}     { value, currency } — "pay what you want" / donation; value is the minimum.
+ *                                                Pass the buyer's chosen amount as ticketInfo.guestPrice to reserveTickets.
+ *     pricingOptions.optionDetails  {array}      Tiered prices [{ optionId, name, price:{value,currency} }].
+ *                                                Pass the chosen optionId as ticketInfo.pricingOptionId to reserveTickets.
+ *     pricingType                   {string}     "STANDARD" | "DONATION".
+ *     free                          {boolean}    Whether the ticket is free.
+ *   salePeriod                      {object}   { startDate, endDate, displayNotOnSale }.
+ *   saleStatus                      {string}   "SALE_SCHEDULED" | "SALE_STARTED" | "SALE_ENDED".
+ *                                              Only SALE_STARTED is buyable now.
+ *   salesDetails                    {object}   Availability (SALES_DETAILS fieldset, requested by queryTicketDefinitions):
+ *                                              { unsoldCount, soldCount, reservedCount, soldOut }.
+ *                                              unsoldCount is null for unlimited tickets.
+ *   limitPerCheckout                {number}   Max quantity buyable per checkout.
+ */
+
+/**
+ * Wix Events RSVP / Order — what the registration calls return.
+ *   RSVP   full model: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/rsvp-v2/rsvp-object.md
+ *   Order  full model: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/orders/order-object.md
+ *
+ *   RSVP:   { id, eventId, status ("YES"|"NO"|"WAITLIST"), totalGuests, firstName, lastName, email }.
+ *           status comes back "WAITLIST" when the event is full and a waitlist is enabled.
+ *   Order:  { orderNumber, status, totalPrice:{value,currency}, ticketsQuantity, ticketsPdf, tickets[] }.
+ *           status "FREE" → confirmed, no payment needed (free tickets).
+ *           status "INITIATED" → payment still required at the Wix cashier — redirect to the hosted
+ *           ticket form (getTicketCheckoutUrl) instead of trying to settle payment client-side.
+ */
+
+const EVENTS_API = "https://www.wixapis.com";
+
+/** Fieldsets for list views (grid cards) and the single-event detail view. */
+const LIST_FIELDS = ["DETAILS", "REGISTRATION", "URLS"];
+const DETAIL_FIELDS = ["DETAILS", "TEXTS", "REGISTRATION", "URLS", "FORM"];
+
+/**
+ * Query live (UPCOMING/STARTED) events for a listing grid, one page.
+ * Sorted by start date ascending (soonest first). Uses offset paging, so the response
+ * carries `total` — use it for the empty state and "load more" math.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/query-events.md
+ *
+ * @param {{ limit?: number, offset?: number, status?: string[] }} [options]
+ * @returns {Promise<{ events: object[], total: number, offset: number, nextOffset: number|null }>}
+ */
+export async function queryEvents({ limit = 50, offset = 0, status = ["UPCOMING", "STARTED"] } = {}) {
+  const res = await wixApiRequest("/events/v3/events/query", {
+    method: "POST",
+    body: {
+      query: {
+        filter: { status: { $in: status } },
+        sort: [{ fieldName: "dateAndTimeSettings.startDate", order: "ASC" }],
+        paging: { limit, offset }, // limit MUST be > 0 — the API returns 0 results for limit 0
+      },
+      fields: LIST_FIELDS,
+    },
+  });
+  const events = res?.events ?? [];
+  const total = res?.pagingMetadata?.total ?? events.length;
+  const nextOffset = offset + events.length < total ? offset + events.length : null;
+  return { events, total, offset, nextOffset };
+}
+
+/**
+ * Fetch a single event by its URL slug, with everything the detail page needs
+ * (description, registration, page URL, and the registration form). Returns null if not found.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/get-event-by-slug.md
+ *
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getEventBySlug(slug) {
+  try {
+    const res = await wixApiRequest(`/events/v3/events/slug/${encodeURIComponent(slug)}`, {
+      method: "GET",
+      query: { fields: DETAIL_FIELDS },
+    });
+    return res?.event ?? null;
+  } catch {
+    return null; // 404 / not-found → show a not-found state, never invent an event
+  }
+}
+
+/**
+ * Total number of live events. Used for empty-state logic (0 → prompt the user to
+ * publish events in their Wix dashboard). Reads the query's pagingMetadata.total.
+ * @param {string[]} [status]
+ * @returns {Promise<number>}
+ */
+export async function countUpcomingEvents(status = ["UPCOMING", "STARTED"]) {
+  const res = await wixApiRequest("/events/v3/events/query", {
+    method: "POST",
+    body: { query: { filter: { status: { $in: status } }, paging: { limit: 1, offset: 0 } } },
+  });
+  return res?.pagingMetadata?.total ?? 0;
+}
+
+/**
+ * Query event categories for a category menu/filter. `counts.assignedEventsCount`
+ * (COUNTS fieldset) tells you how many events are in each category.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/categories/query-categories.md
+ *
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ categories: object[], total: number }>}
+ */
+export async function queryEventCategories({ limit = 100, offset = 0 } = {}) {
+  const res = await wixApiRequest("/events/v1/categories/query", {
+    method: "POST",
+    body: { query: { paging: { limit, offset } }, fieldset: ["COUNTS"] },
+  });
+  return {
+    categories: res?.categories ?? [],
+    total: res?.metaData?.total ?? (res?.categories?.length ?? 0),
+  };
+}
+
+/**
+ * List live events assigned to a category, one page. Same card fields as queryEvents.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/list-events-by-category.md
+ *
+ * @param {string} categoryId  Category GUID from queryEventCategories.
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ events: object[], total: number, offset: number, nextOffset: number|null }>}
+ */
+export async function listEventsByCategory(categoryId, { limit = 50, offset = 0 } = {}) {
+  const res = await wixApiRequest(`/events/v3/events/category/${encodeURIComponent(categoryId)}`, {
+    method: "GET",
+    query: {
+      fields: LIST_FIELDS,
+      "paging.limit": String(limit),
+      "paging.offset": String(offset),
+    },
+  });
+  const events = res?.events ?? [];
+  const total = res?.pagingMetadata?.total ?? events.length;
+  const nextOffset = offset + events.length < total ? offset + events.length : null;
+  return { events, total, offset, nextOffset };
+}
+
+/**
+ * Submit an RSVP for an RSVP-type event (registration.type === "RSVP").
+ * Completes fully client-side — no payment, no redirect.
+ *
+ * `status` defaults to "YES". Only pass "NO" when the event's
+ * `registration.rsvp.responseType` is "YES_AND_NO". If the event is full and a waitlist
+ * is enabled, Wix returns the created RSVP with status "WAITLIST" — surface that to the guest.
+ *
+ * For extra guests on one RSVP, pass `additionalGuestNames` (one name per extra guest).
+ * Any custom form fields the event defines (see `event.form.controls`) go in `extraFields`,
+ * keyed by the control input's `name`.
+ *
+ * Throws on closed/started-not-yet registration, guest-limit/RSVP-limit exceeded, an email
+ * already registered, or an invalid form — so a green path means the guest is really registered.
+ * Error codes: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/rsvp-v2/create-rsvp.md
+ *
+ * @param {string} eventId
+ * @param {{ firstName: string, lastName: string, email: string, status?: "YES"|"NO",
+ *           additionalGuestNames?: string[], extraFields?: Record<string,string|string[]> }} guest
+ * @returns {Promise<object>} The created RSVP.
+ */
+export async function createRsvp(eventId, { firstName, lastName, email, status = "YES", additionalGuestNames = [], extraFields = {} } = {}) {
+  if (!firstName || !lastName || !email) throw new Error("createRsvp requires firstName, lastName, and email.");
+
+  const inputValues = [
+    { inputName: "firstName", value: firstName },
+    { inputName: "lastName", value: lastName },
+    { inputName: "email", value: email },
+  ];
+  if (additionalGuestNames.length) {
+    inputValues.push({ inputName: "additionalGuests", value: String(additionalGuestNames.length) });
+    inputValues.push({ inputName: "guestNames", values: additionalGuestNames });
+  }
+  for (const [inputName, value] of Object.entries(extraFields)) {
+    inputValues.push(Array.isArray(value) ? { inputName, values: value } : { inputName, value });
+  }
+
+  const res = await wixApiRequest("/events/v2/rsvps", {
+    method: "POST",
+    body: {
+      rsvp: {
+        eventId,
+        firstName,
+        lastName,
+        email,
+        status,
+        form: { inputValues },
+        additionalGuestDetails: { guestCount: additionalGuestNames.length, guestNames: additionalGuestNames },
+      },
+    },
+  });
+  return res?.rsvp;
+}
+
+/**
+ * Query the buyable ticket definitions for a ticketed event (with availability).
+ * Filters out hidden tickets; pass `includeSoldOut: false` to also drop sold-out ones.
+ * Request includes the SALES_DETAILS fieldset so `salesDetails.soldOut`/`unsoldCount` are populated.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/ticket-definitions-v3/query-ticket-definitions.md
+ *
+ * @param {string} eventId
+ * @param {{ includeSoldOut?: boolean }} [options]
+ * @returns {Promise<object[]>} Ticket definitions (see the TicketDefinition typedef above).
+ */
+export async function queryTicketDefinitions(eventId, { includeSoldOut = true } = {}) {
+  const res = await wixApiRequest("/events/v3/ticket-definitions/query", {
+    method: "POST",
+    body: {
+      query: { filter: { eventId, hidden: false } },
+      fields: ["SALES_DETAILS"],
+    },
+  });
+  let defs = res?.ticketDefinitions ?? [];
+  if (!includeSoldOut) defs = defs.filter((d) => !d.salesDetails?.soldOut);
+  return defs;
+}
+
+/**
+ * Reserve tickets for a limited time (the event's reservation window, typically 5–30 min)
+ * while the buyer completes checkout. Reserving deducts from inventory so two buyers can't
+ * grab the same tickets. The returned reservation has status "PENDING" and an `expirationDate`.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/ticket-reservations/create-ticket-reservation.md
+ *
+ * Pass one entry per ticket type. For each:
+ *   - ticketDefinitionId  (required) and quantity (required).
+ *   - guestPrice          for "pay what you want"/donation tickets (pricingMethod.guestPrice) — the chosen amount as a string.
+ *   - pricingOptionId     for tiered tickets (pricingMethod.pricingOptions) — the chosen option's optionId.
+ *
+ * Throws if the reservation doesn't come back PENDING (e.g. tickets unavailable) so the
+ * buyer can't proceed to checkout with nothing actually held.
+ *
+ * @param {Array<{ ticketDefinitionId: string, quantity: number, guestPrice?: string, pricingOptionId?: string }>} tickets
+ * @returns {Promise<object>} The created reservation (id, expirationDate, tickets[], status).
+ */
+export async function reserveTickets(tickets) {
+  if (!Array.isArray(tickets) || !tickets.length) throw new Error("reserveTickets requires at least one ticket line.");
+
+  const lines = tickets.map(({ ticketDefinitionId, quantity, guestPrice, pricingOptionId }) => {
+    if (!ticketDefinitionId || !quantity) throw new Error("Each ticket line needs a ticketDefinitionId and quantity.");
+    const ticketInfo = {};
+    if (guestPrice !== undefined) ticketInfo.guestPrice = String(guestPrice);
+    if (pricingOptionId) ticketInfo.pricingOptionId = pricingOptionId;
+    const line = { ticketDefinitionId, quantity };
+    if (Object.keys(ticketInfo).length) line.ticketInfo = ticketInfo;
+    return line;
+  });
+
+  const res = await wixApiRequest("/events/v1/ticket-reservations", {
+    method: "POST",
+    body: { ticketReservation: { tickets: lines } },
+  });
+  const reservation = res?.ticketReservation;
+  if (!reservation?.id || reservation.status !== "PENDING") {
+    throw new Error(`Could not reserve tickets (status: ${reservation?.status ?? "unknown"}). They may be sold out.`);
+  }
+  return reservation;
+}
+
+/**
+ * Build the URL of the Wix-hosted ticket form for a reservation. THIS is the official,
+ * complete way to finish a ticketed purchase: the buyer fills in guest details and pays
+ * on Wix's PCI-compliant page, then lands back on the event. Use it for all paid tickets
+ * (and it works for free tickets too). Redirect with `window.location.href = url`.
+ *
+ * The path format is documented on the Checkout page:
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/orders/checkout.md
+ *   {eventPageUrl.base}{eventPageUrl.path}/ticket-form?reservationId={reservationId}
+ *
+ * `event` must have been fetched with the URLS fieldset (getEventBySlug already does this),
+ * so `event.eventPageUrl.base` and `.path` are present. Throws if they're missing.
+ *
+ * @param {object} event          Event from getEventBySlug (needs eventPageUrl).
+ * @param {string} reservationId  From reserveTickets.
+ * @returns {string} Absolute hosted ticket-form URL.
+ */
+export function getTicketCheckoutUrl(event, reservationId) {
+  const base = event?.eventPageUrl?.base;
+  const path = event?.eventPageUrl?.path;
+  if (!base || !path) throw new Error("Event is missing eventPageUrl — fetch it with getEventBySlug (URLS fieldset).");
+  if (!reservationId) throw new Error("getTicketCheckoutUrl requires a reservationId from reserveTickets.");
+  return `${base}${path}/ticket-form?reservationId=${encodeURIComponent(reservationId)}`;
+}
+
+/**
+ * Check out a reservation via REST — creates the order and assigns guests. Use this to
+ * complete FREE ticket orders entirely in-app (no payment, no redirect): the response order
+ * comes back with status "FREE", a `ticketsPdf`, and generated `tickets[]`.
+ *
+ * For PAID tickets this returns an order with status "INITIATED" (payment still owed at the
+ * Wix cashier) — this helper throws in that case and tells you to redirect to
+ * getTicketCheckoutUrl instead, which handles payment. Don't try to settle payment yourself.
+ * https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/orders/checkout.md
+ *
+ * Provide one `guests[]` entry per ticket (each is a { inputValues } form response). When the
+ * event has `registration.tickets.guestsAssignedSeparately`, every ticket needs its own guest
+ * form; otherwise one guest (the buyer) is enough. `buyer` is the order contact.
+ *
+ * @param {string} eventId
+ * @param {{ reservationId: string,
+ *           buyer?: { firstName: string, lastName: string, email: string },
+ *           guests: Array<{ firstName: string, lastName: string, email: string, extraFields?: Record<string,string|string[]> }> }} details
+ * @returns {Promise<object>} The created order (orderNumber, status, ticketsPdf, tickets[]).
+ */
+export async function checkoutTickets(eventId, { reservationId, buyer, guests } = {}) {
+  if (!eventId || !reservationId) throw new Error("checkoutTickets requires eventId and reservationId.");
+  if (!Array.isArray(guests) || !guests.length) throw new Error("checkoutTickets requires at least one guest.");
+
+  const toForm = ({ firstName, lastName, email, extraFields = {} }) => {
+    const inputValues = [
+      { inputName: "firstName", value: firstName },
+      { inputName: "lastName", value: lastName },
+      { inputName: "email", value: email },
+    ];
+    for (const [inputName, value] of Object.entries(extraFields)) {
+      inputValues.push(Array.isArray(value) ? { inputName, values: value } : { inputName, value });
+    }
+    return { form: { inputValues } };
+  };
+
+  const body = { reservationId, guests: guests.map(toForm) };
+  if (buyer) body.buyer = buyer;
+
+  const res = await wixApiRequest(`/events/v1/events/${encodeURIComponent(eventId)}/tickets/checkout`, {
+    method: "POST",
+    body,
+  });
+  const order = res?.order;
+  const status = order?.status;
+  if (status === "INITIATED" || status === "PENDING") {
+    throw new Error(
+      `Order ${order?.orderNumber ?? ""} needs payment (status: ${status}). Redirect the buyer to getTicketCheckoutUrl(event, reservationId) to pay on the hosted ticket form.`,
+    );
+  }
+  return order;
+}

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -1,0 +1,104 @@
+
+# Wix Portfolio Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/portfolio/wix-portfolio.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix portfolio showcase. The browser talks to Wix directly over a
+public `WIX_CLIENT_ID`. Portfolio is **read-only**: never mock projects, never invent media,
+and always render live Wix data (or an honest empty state). The content tree is
+**Collection → Project → Project Item (image/video)**.
+
+## When to use
+- User wants a Wix portfolio / showcase site or asks to "connect Wix Portfolio".
+- Replacing placeholder/mock galleries with live Wix Portfolio data.
+- Adding a collections gallery, project grids, or a project detail page (media gallery +
+  details/links) over an existing Wix Portfolio.
+
+## Prerequisites
+1. A Wix site with **Wix Portfolio installed and content already added** — at least one
+   collection with projects, and projects with items (this skill does NOT provision; it is
+   read-only over the content).
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`).
+   Paste it into `src/rest/wix-client.js` in place of the placeholder. It is a visitor-facing
+   credential (it only mints anonymous visitor tokens), **not** a secret, so
+   hardcoding/committing it is fine.
+3. If the read calls return `403`/`428` before content is published, the Portfolio app or its
+   content may not be live yet. That is a **Wix dashboard setup step the owner completes** —
+   out of this skill's scope. Flag it and continue; don't fall back to mock data.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the portfolio's UI however the
+project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
+adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
+  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token is
+  persisted to localStorage; do not re-mint anonymously per load.
+- `src/rest/wix-portfolio.js` — exports:
+  - **Collections:** `queryCollections`, `getCollectionBySlug`, `countCollections`
+  - **Projects:** `queryProjects`, `queryProjectsByCollection`, `getProjectBySlug`, `getProject`
+  - **Project items (media):** `listProjectItems`
+
+The Collection, Project, and Project Item shapes are documented as JSDoc comments at the top of
+`wix-portfolio.js`. Read them before building the UI — they describe the key fields (cover
+image/video, media resolutions, details rows) and link to the full API reference.
+
+## How to wire it (UI is the project's choice)
+- **Collections gallery (home)** — `queryCollections()` for the listing (visible collections
+  only, in dashboard order); pass `nextCursor` back as `cursor` to load the next page. Render
+  `collection.title`, `collection.description`, and `collection.coverImage.imageInfo.url`. Link
+  each card to a collection page keyed on `collection.slug`.
+- **Collection page** — `getCollectionBySlug(slug)` for the header (returns null on miss — show
+  a not-found state, never invent one). Then `queryProjectsByCollection(collection.id, { limit?, cursor? })`
+  for its project grid; paginate exactly like `queryCollections`.
+- **All-work gallery (optional)** — `queryProjects()` to list every visible project across
+  collections (newest-first); paginate the same way.
+- **Project grid card** — render `project.title` and the cover: use `project.coverImage.imageInfo.url`
+  when present, else the `project.coverVideo.videoInfo.posters[0]` / first
+  `coverVideo.videoInfo.resolutions[]` entry. Link each card to a project page keyed on `project.slug`.
+- **Project detail page** — `getProjectBySlug(slug)` for the header (title, description, and the
+  `details[]` rows: each has a `label` plus either `text` or `link: { text, url, target }`).
+  Then `listProjectItems(project.id)` for the media gallery — render IMAGE items from
+  `image.imageInfo.url` and VIDEO items from the first `video.videoInfo.resolutions[]` entry
+  (with `video.videoInfo.posters[0]` as the poster). Honor each item's optional `link`.
+  - If you already hold a project id (not a slug), use `getProject(projectId)` instead.
+- **Empty state** — if `countCollections()` is 0, show an empty state telling the user to add
+  collections and projects in their Wix dashboard. Never invent projects or media.
+
+## Hard rules (do not violate)
+- ✅ Render only live Wix Portfolio data — collections, projects, and items as returned.
+- ❌ Never mock projects, collections, or media — render live data or the empty state.
+- ❌ Never hand-build Wix Media URLs or page permalinks — use the `url`/`imageInfo.url`/
+  `videoInfo.resolutions[].url` fields Wix returns.
+- ❌ Never invent project details, captions, dates, or testimonials. Show only what the API returns.
+- ❌ Never show `hidden: true` collections or projects to visitors (the helpers already filter
+  `hidden` out — don't add them back).
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ Route on `slug` (`getCollectionBySlug` / `getProjectBySlug`); fall back to `getProject(id)`
+  only when you hold a GUID.
+- The helpers fail soft on read: single fetches return `null` on a miss so you render a
+  not-found/empty state rather than a crash — surface that state, don't paper over it with fake data.
+
+## Beyond the snippets
+The snippets cover the common portfolio paths. If you hit a use case they don't cover (e.g.
+collection SEO tags, project watermark settings, portfolio-wide settings, or filtering by a
+field not shown), make the call yourself with `wixApiRequest` — but look up the exact endpoint,
+HTTP method, and request body in the **official Wix API reference** first; never guess:
+- Wix Portfolio API reference: https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
+- Portfolio Settings (logo, layout, options): https://dev.wix.com/docs/api-reference/business-solutions/portfolio/portfolio-settings/get-portfolio-settings.md
+- API query language (filters, sort, paging): https://dev.wix.com/docs/rest/articles/getting-started/api-query-language.md
+
+Keep the snippets as the default for everything they already do; reach for the API reference
+only for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (no re-mint storm; reads stay fast)
+- [ ] Collections gallery renders live collections with cover images, in dashboard order
+- [ ] Clicking a collection lists its projects via `queryProjectsByCollection`
+- [ ] Project page renders the project's media gallery from `listProjectItems` (images AND videos)
+- [ ] Project `details[]` rows render (text rows and link rows both)
+- [ ] Slug routing works; an unknown slug shows a not-found state (no invented project)
+- [ ] Hidden collections/projects never appear
+- [ ] Empty state shown when `countCollections()` is 0
+- [ ] No mock projects, collections, or media anywhere

--- a/skills/wix-vibe-headless/references/portfolio/wix-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/wix-portfolio.js
@@ -1,0 +1,249 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Portfolio is a read-only showcase. The model is a 3-level tree:
+ *   Collection (a gallery / grouping)  →  Project (a single piece of work)  →  Project Item (one image or video).
+ * A project can belong to several collections (`project.collectionIds`). The merchant
+ * manages all content in the Wix dashboard — this client only reads it.
+ *
+ * Hidden entities (`hidden: true` on collections/projects) are editor-only and must NOT be
+ * shown to visitors. Every list helper here filters `hidden` out for you.
+ */
+
+/**
+ * Wix Portfolio Collection — key fields for a collections gallery.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/collection-object.md
+ *
+ *   id                              {string}   Collection GUID.
+ *   title                           {string}   Display title.
+ *   description                     {string}   Description (plain text).
+ *   slug                            {string}   URL slug for routing.
+ *   hidden                          {boolean}  Editor-only when true — never show to visitors.
+ *   sortOrder                       {number}   Display order index (ascending).
+ *   coverImage.imageInfo            {object}   Cover image: { id, url, height, width, altText, filename }.
+ *   coverImage.focalPoint           {object}   { x, y } focal point for cropping.
+ *   url                             {object}   { relativePath, url } — only when includePageUrl=true.
+ *   createdDate / updatedDate       {string}   ISO date-time.
+ *
+ * NOTE: `coverImage.imageInfo.url` is a Wix Media URL. It may be a static
+ * `https://static.wixstatic.com/...` URL (render directly) or a `wix:image://` URI for some
+ * legacy assets — prefer `imageInfo.url` and render it as-is when it starts with "http".
+ */
+
+/**
+ * Wix Portfolio Project — key fields for a project grid + project page header.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/project-object.md
+ *
+ *   id                              {string}   Project GUID.
+ *   title                           {string}   Display title.
+ *   description                     {string}   Description (plain text).
+ *   slug                            {string}   URL slug for routing.
+ *   hidden                          {boolean}  Editor-only when true — never show to visitors.
+ *   collectionIds                   {string[]} GUIDs of the collections this project belongs to.
+ *   details                         {array}    Labeled metadata rows. Each entry is ONE-OF text|link:
+ *                                              [{
+ *                                                label,                 // row label, e.g. "Client", "Year"
+ *                                                text,                  // present for plain-text details
+ *                                                link: { text, url, target }  // present for link details ('_blank' | '_self')
+ *                                              }]
+ *   coverImage.imageInfo            {object}   Cover image (ONE-OF with coverVideo):
+ *                                              { id, url, height, width, altText, filename }.
+ *   coverVideo.videoInfo            {object}   Cover video (ONE-OF with coverImage):
+ *                                              { id, url, filename, posters: [Image],
+ *                                                resolutions: [{ url, height, width, format, quality, filename }] }.
+ *   url                             {object}   { relativePath, url } — only when includePageUrl=true.
+ *   createdDate / updatedDate       {string}   ISO date-time.
+ *
+ * A project carries only its cover here. The full media gallery lives in its Project Items —
+ * fetch them with listProjectItems(project.id).
+ */
+
+/**
+ * Wix Portfolio Project Item — one media tile inside a project (image or video).
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/project-items/project-item-object.md
+ *
+ *   id                              {string}   Project item GUID.
+ *   projectId                       {string}   Parent project GUID.
+ *   sortOrder                       {number}   Display order index (ascending).
+ *   title                           {string}   Item title (may be empty).
+ *   description                     {string}   Item description (may be empty).
+ *   type                            {string}   "IMAGE" | "VIDEO" | "UNDEFINED".
+ *   image.imageInfo                 {object}   Present when type === "IMAGE":
+ *                                              { id, url, height, width, altText, filename } (+ focalPoint).
+ *   video.videoInfo                 {object}   Present when type === "VIDEO":
+ *                                              { id, url, filename, posters: [Image],
+ *                                                resolutions: [{ url, height, width, format, quality, filename }] }.
+ *   link                            {object}   Optional click-through: { text, url, target } ('_blank' | '_self').
+ *   createdDate / updatedDate       {string}   ISO date-time.
+ *
+ * Render IMAGE items from image.imageInfo.url; render VIDEO items from the first
+ * video.videoInfo.resolutions[] entry (highest quality first) with a poster from
+ * video.videoInfo.posters[0].
+ */
+
+const COLLECTIONS_QUERY_URL = "/portfolio/v1/collections/query";
+const PROJECTS_QUERY_URL = "/portfolio/v1/projects/query";
+
+/**
+ * Query visible portfolio collections (one page), sorted by their dashboard order.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/query-collections.md
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ collections: object[], nextCursor: string|null }>}
+ */
+export async function queryCollections({ limit = 100, cursor } = {}) {
+  const res = await wixApiRequest(COLLECTIONS_QUERY_URL, {
+    method: "POST",
+    body: {
+      includePageUrl: true,
+      query: cursor
+        ? { cursorPaging: { limit, cursor } }
+        : {
+            filter: { hidden: false },
+            sort: [{ fieldName: "sortOrder", order: "ASC" }],
+            cursorPaging: { limit },
+          },
+    },
+  });
+  return {
+    collections: res?.collections ?? [],
+    nextCursor: res?.metadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Get a single visible collection by its URL slug. Returns null if not found / hidden.
+ * Portfolio has no get-by-slug endpoint, so this queries with a slug filter.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/query-collections.md
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getCollectionBySlug(slug) {
+  const res = await wixApiRequest(COLLECTIONS_QUERY_URL, {
+    method: "POST",
+    body: {
+      includePageUrl: true,
+      query: { filter: { slug, hidden: false }, cursorPaging: { limit: 1 } },
+    },
+  });
+  return res?.collections?.[0] ?? null;
+}
+
+/**
+ * Total number of visible collections. Used for empty-state logic
+ * (0 → prompt the user to add collections in their Wix dashboard).
+ * @returns {Promise<number>}
+ */
+export async function countCollections() {
+  const res = await wixApiRequest(COLLECTIONS_QUERY_URL, {
+    method: "POST",
+    body: { query: { filter: { hidden: false }, cursorPaging: { limit: 100 } } },
+  });
+  return res?.metadata?.total ?? (res?.collections?.length ?? 0);
+}
+
+/**
+ * Query visible projects (one page), sorted newest-first. Use for an "all work" gallery.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/query-projects.md
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ projects: object[], nextCursor: string|null }>}
+ */
+export async function queryProjects({ limit = 100, cursor } = {}) {
+  const res = await wixApiRequest(PROJECTS_QUERY_URL, {
+    method: "POST",
+    body: {
+      includePageUrl: true,
+      query: cursor
+        ? { cursorPaging: { limit, cursor } }
+        : {
+            filter: { hidden: false },
+            sort: [{ fieldName: "createdDate", order: "DESC" }],
+            cursorPaging: { limit },
+          },
+    },
+  });
+  return {
+    projects: res?.projects ?? [],
+    nextCursor: res?.metadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Query the visible projects that belong to a collection (one page), in dashboard order.
+ * Filters on `collectionIds` with `$hasSome`.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/query-projects.md
+ * @param {string} collectionId  `collection.id` from queryCollections / getCollectionBySlug.
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ projects: object[], nextCursor: string|null }>}
+ */
+export async function queryProjectsByCollection(collectionId, { limit = 100, cursor } = {}) {
+  const res = await wixApiRequest(PROJECTS_QUERY_URL, {
+    method: "POST",
+    body: {
+      includePageUrl: true,
+      query: cursor
+        ? { cursorPaging: { limit, cursor } }
+        : {
+            filter: { hidden: false, collectionIds: { $hasSome: [collectionId] } },
+            cursorPaging: { limit },
+          },
+    },
+  });
+  return {
+    projects: res?.projects ?? [],
+    nextCursor: res?.metadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Get a single visible project by its URL slug. Returns null if not found / hidden.
+ * Portfolio has no get-by-slug endpoint, so this queries with a slug filter.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/query-projects.md
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getProjectBySlug(slug) {
+  const res = await wixApiRequest(PROJECTS_QUERY_URL, {
+    method: "POST",
+    body: {
+      includePageUrl: true,
+      query: { filter: { slug, hidden: false }, cursorPaging: { limit: 1 } },
+    },
+  });
+  return res?.projects?.[0] ?? null;
+}
+
+/**
+ * Get a single project by its GUID. Returns null if not found.
+ * Use when you already hold a project id (e.g. from a list) rather than a slug.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/get-project.md
+ * @param {string} projectId
+ * @returns {Promise<object|null>}
+ */
+export async function getProject(projectId) {
+  try {
+    const res = await wixApiRequest(`/portfolio/v1/projects/${encodeURIComponent(projectId)}`, {
+      method: "GET",
+      query: { includePageUrl: "true" },
+    });
+    return res?.project ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all media items (images/videos) of a project, in dashboard order.
+ * This is the project's gallery — call it on the project detail screen.
+ * https://dev.wix.com/docs/api-reference/business-solutions/portfolio/project-items/list-project-items.md
+ * @param {string} projectId  `project.id`.
+ * @param {{ limit?: number, offset?: number }} [options]  Project items use offset paging, not cursors.
+ * @returns {Promise<{ items: object[], total: number }>}
+ */
+export async function listProjectItems(projectId, { limit = 100, offset = 0 } = {}) {
+  const res = await wixApiRequest(`/portfolio/v1/projectItems/${encodeURIComponent(projectId)}/items`, {
+    method: "GET",
+    query: { "paging.limit": String(limit), "paging.offset": String(offset) },
+  });
+  const items = (res?.items ?? []).slice().sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+  return { items, total: res?.metadata?.total ?? items.length };
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -1,0 +1,117 @@
+
+# Wix Pricing Plans Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/pricing-plans/wix-pricing-plans.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix pricing-plans / membership front end. The browser talks to Wix
+directly over a public `WIX_CLIENT_ID`. Never mock plans; never hand-build a `/checkout` or
+purchase URL — purchasing always goes through the Wix-hosted **redirect-session** (which also
+handles member login and payment).
+
+## When to use
+- User wants a "Plans & Pricing", membership, or subscription page on a Wix site.
+- User asks to "connect Wix pricing plans" or sell memberships / subscriptions / paid plans.
+- Replacing placeholder/mock plans with live Wix data.
+- Adding a plan detail page, a buy/subscribe button, or a "my plans" area over existing plans.
+
+## Prerequisites
+1. A Wix site with **Pricing Plans installed and at least one plan created** (this skill does
+   NOT provision — it's read-only over the plans the merchant added in the dashboard).
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Paste
+   it into `src/rest/wix-client.js` in place of the placeholder. It is a buyer-facing credential
+   (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/committing it is fine.
+3. **Purchasing a plan is members-only and uses Wix-hosted checkout.** The hosted flow handles
+   member login/signup + the order form + payment, then returns to your site. The deployed app
+   domain must be allow-listed on the OAuth client for that return to work — this is a **separate
+   Wix setup flow the user completes later**, out of this skill's scope. If the return fails
+   before that setup is done, that's expected; flag it and continue.
+4. To actually charge for paid plans, the site needs a payment method connected and (where
+   applicable) tax/business-address configured in the Wix dashboard. Free plans work without this.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the page's UI however the project
+wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only adjust
+import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
+  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token is
+  persisted to localStorage; after a hosted checkout the same identity returns as a logged-in
+  member. Do not re-mint anonymously per load.
+- `src/rest/wix-pricing-plans.js` — exports:
+  - **Plans:** `queryPlans`, `getPlanById`, `getPlanBySlug`
+  - **Purchase:** `checkout`
+  - **Member:** `getMyPlanOrders`
+
+The Plan and Order shapes are documented as JSDoc comments at the top of `wix-pricing-plans.js`.
+Read them before building the UI — pricing has several models (recurring subscription,
+single-payment-for-duration, single-payment-unlimited, free, plus free trials) and the JSDoc
+shows exactly how to read price, cycle, and trial for display.
+
+## How to wire it (UI is the project's choice)
+- **Plans grid** — `queryPlans()` for the listing (PUBLIC plans only); pass `nextCursor` back as
+  `cursor` to load the next page. For each plan render `name`, `description`, `perks[].description`
+  as feature bullets, and the price from `pricingVariants[0]` (see the JSDoc "Reading the price"
+  notes: `pricingStrategies[0].flatRate.amount` + plan `currency`, plus `billingCycle` for
+  recurring and `freeTrialDays` for trials). Show a "Subscribe"/"Buy" button only when
+  `plan.buyable` is true.
+- **Plan detail** — `getPlanBySlug(slug)` keyed off the URL slug (or `getPlanById(id)`); returns
+  null on miss — show a not-found state, never invent a plan. Render perks, the full price/billing
+  summary, free-trial note, and `termsAndConditions` if present.
+- **Purchase** — `window.location.href = await checkout(planId, { thankYouPageUrl })`. This
+  redirects to Wix-hosted checkout, which logs the member in (or signs them up), collects the
+  order form, and takes payment. On success Wix returns to `thankYouPageUrl` with a
+  `?planOrderId=<GUID>` query param (and `wixMemberLoggedIn`); on abandon/interrupt it returns to
+  `postFlowUrl` (defaults to the current page). Never create the order or build the URL yourself.
+- **My plans / confirmation** — `getMyPlanOrders()` for the logged-in member's purchases; filter
+  with `{ orderStatuses: ["ACTIVE"] }` for current memberships. After returning from checkout,
+  re-fetch (e.g. on mount + `visibilitychange`, or when `planOrderId` is in the URL) to show the
+  new order. Returns `[]` for anonymous visitors — show a "log in to see your plans" state.
+- **Empty state** — if `queryPlans()` returns no plans, show an empty state telling the user to
+  create plans in their Wix dashboard. Never invent plans.
+
+## Hard rules (do not violate)
+- ✅ Purchase ONLY via `checkout()` (`/headless/v1/redirect-session` with `paidPlansCheckout`),
+  then redirect to `redirectSession.fullUrl`.
+- ❌ Never hand-build a checkout, purchase, or `/plans-checkout` URL; never call create-order
+  directly from the client to "skip" the hosted flow.
+- ❌ Never mock plans — render live Wix data or the empty state.
+- ❌ Never invent perks, prices, trials, testimonials, or member counts. Render only what the
+  plan object returns; empty perks → no feature list.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ Treat plan objects as display-only — never compute the final charge; Wix settles price, tax,
+  proration, and schedule during hosted checkout.
+- ✅ Show the buy button only when `plan.buyable` is true; otherwise the plan is merchant-assigned.
+- The engine fails loudly on purpose: `checkout()` throws if it can't create the redirect session.
+  A green path means it really reached Wix-hosted checkout — don't swallow these.
+
+## Beyond the snippets
+The snippets cover the common plans paths. If you hit a use case they don't cover, make the call
+yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and request body in
+the **official Wix API reference** first; never guess:
+- Pricing Plans API reference: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans.md
+- Orders (cancel / pause / resume a member's order, price preview): https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/orders.md
+- Headless redirect session (login, logout, other checkouts): https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
+
+Common genuine gaps and where to look:
+- **Cancel / pause / resume** a member's subscription → Orders API (`request-cancellation`,
+  `pause-order`, `resume-order`). Gate on `plan.buyerCanCancel`.
+- **Member login / logout** outside of a purchase → redirect session `login` / `logout` /
+  `auth` targets.
+- **Coupons / custom start date** at purchase → covered by the hosted checkout; for a fully
+  custom flow see Create Online Order in the Orders reference.
+
+Keep the snippets as the default for everything they already do; reach for the API reference only
+for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Plans list renders live data; price, billing cycle, and free trial read correctly across
+      pricing models (recurring, single-payment, free)
+- [ ] Plan detail loads by slug and shows a not-found state on a bad slug
+- [ ] Buy button shown only for `buyable` plans
+- [ ] Purchase redirects via redirect-session `fullUrl` (no hand-built URL) and reaches
+      Wix-hosted login + payment
+- [ ] On return, the new order appears via `getMyPlanOrders()` (and a "log in" state shows for
+      anonymous visitors)
+- [ ] Empty state shown when `queryPlans()` returns no plans
+- [ ] No mock plans, perks, or prices anywhere

--- a/skills/wix-vibe-headless/references/pricing-plans/wix-pricing-plans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/wix-pricing-plans.js
@@ -1,0 +1,201 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Pricing Plans V3 Plan — key fields for building a "Plans & Pricing" page.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/plan-object.md
+ *
+ *   id                                      {string}   Plan GUID. Pass to getPlanById / checkout.
+ *   name                                    {string}   Plan name shown to customers.
+ *   description                             {string}   Short explanation of what the plan offers.
+ *   slug                                    {string}   URL slug for plan-detail routing.
+ *   image                                   {object}   Plan image: { id, width, height, altText }.
+ *                                                      `id` is a WixMedia id — resolve to a URL via your media handling.
+ *   termsAndConditions                      {string}   T&C text buyers agree to at checkout (may be empty).
+ *   currency                                {string}   ISO-4217 currency code for the plan's prices (e.g. "USD").
+ *   visibility                              {string}   "PUBLIC"  — listed and buyable by anyone.
+ *                                                      "PRIVATE" — hidden; only reachable via a direct link.
+ *                                                      queryPlans returns PUBLIC plans only.
+ *   buyable                                 {boolean}  Whether a customer can purchase it themselves. When false the
+ *                                                      merchant assigns it manually in the dashboard — hide the buy button.
+ *   buyerCanCancel                          {boolean}  Whether buyers may cancel their own subscription.
+ *   perks                                   {array}    What the plan includes, for display only:
+ *                                                      [{ id, description }]   // render description as a feature bullet
+ *   pricingVariants                         {array}    Billing/pricing options. Currently exactly 1 variant per plan.
+ *     [].id                                 {string}   Pricing variant GUID.
+ *     [].name                               {string}   Variant label, e.g. "Monthly".
+ *     [].freeTrialDays                      {number}   Free days before the first charge. 0 = no trial. Recurring plans only.
+ *     [].promotion                          {string}   Optional promo message to show with the price.
+ *     [].pricingStrategies[].flatRate.amount {string}  The price as a decimal string, e.g. "9.99" (no currency symbol —
+ *                                                      pair it with the plan-level `currency`). "0" / "0.00" = free plan.
+ *     [].billingTerms.billingCycle          {object}   Length of one cycle: { period: "DAY"|"WEEK"|"MONTH"|"YEAR", count }.
+ *                                                      Present for recurring (subscription) plans; omitted for single-payment plans.
+ *     [].billingTerms.startType             {string}   "ON_PURCHASE" | "CUSTOM" (buyer picks a start date).
+ *     [].billingTerms.endType               {string}   "UNTIL_CANCELLED" — recurs until canceled.
+ *                                                      "CYCLES_COMPLETED" — ends after a fixed number of cycles
+ *                                                        (count in billingTerms.cyclesCompletedDetails.billingCycleCount).
+ *     [].fees                               {array}    Extra fees: [{ id, name, priceType:"FIXED_AMOUNT",
+ *                                                      fixedAmountOptions.amount, appliedAt:"FIRST_PAYMENT" }].
+ *
+ * Reading the price for display, per variant `v = plan.pricingVariants[0]`:
+ *   - amount   = v.pricingStrategies[0].flatRate.amount     (decimal string; "0" means free)
+ *   - currency = plan.currency
+ *   - recurring? = Boolean(v.billingTerms?.billingCycle)
+ *       → e.g. `${currency} ${amount} / ${cycle.count} ${cycle.period.toLowerCase()}`
+ *   - one-time? = no billingCycle → single payment (for a duration, or unlimited/lifetime)
+ *   - trial = v.freeTrialDays > 0 → "Includes a {n}-day free trial"
+ * The plan object is display-only. Never compute or fake a final charge — the real price, tax,
+ * proration, and schedule are settled by Wix during the hosted checkout (see `checkout`).
+ */
+
+/**
+ * Wix Pricing Plans Order (a member's purchase/subscription) — key fields for a "My plans" screen.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/orders/order-object.md
+ *
+ *   id                                      {string}  Order GUID.
+ *   planId                                  {string}  GUID of the purchased plan.
+ *   planName                                {string}  Plan name captured at purchase time.
+ *   planDescription                         {string}  Plan description captured at purchase time.
+ *   status                                  {string}  "DRAFT" (payment not processed) | "PENDING" (starts in the future) |
+ *                                                     "ACTIVE" (usable now) | "PAUSED" | "ENDED" | "CANCELED".
+ *   lastPaymentStatus                       {string}  "PAID" | "REFUNDED" | "FAILED" | "UNPAID" | "PENDING" |
+ *                                                     "NOT_APPLICABLE" (free plan / free trial).
+ *   startDate                               {string}  ISO date-time the plan starts.
+ *   endDate                                 {string}  ISO date-time it ends. Omitted for until-canceled plans still ACTIVE.
+ *   freeTrialDays                           {number}  Free-trial length for this order, if any (recurring plans).
+ *   currentCycle                            {object}  { index, startedDate, endedDate }. index is 0 during a free trial,
+ *                                                     1+ otherwise. Omitted if CANCELED/ENDED or not yet started.
+ *   pricing                                 {object}  Settled pricing model + amounts (see Order Object reference):
+ *                                                     one of subscription / singlePaymentForDuration / singlePaymentUnlimited,
+ *                                                     plus prices[].price { subtotal, tax, discount, total, currency }.
+ *   autoRenewCanceled                       {boolean} True if the subscription won't renew at the next payment date.
+ */
+
+const REDIRECT_SESSION_URL = "/headless/v1/redirect-session";
+
+/**
+ * Query public, listable pricing plans (one page).
+ * Returns only PUBLIC plans (the ones meant for the Plans & Pricing page). Some plans may have
+ * `buyable: false` (merchant-assigned only) — keep them for display but hide the buy button.
+ *
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/query-plans.md
+ *
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ plans: object[], nextCursor: string|null }>}
+ */
+export async function queryPlans({ limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/pricing-plans/v3/plans/query", {
+    method: "POST",
+    body: {
+      query: {
+        ...(cursor ? {} : { filter: { visibility: "PUBLIC" } }),
+        cursorPaging: cursor ? { limit, cursor } : { limit },
+      },
+    },
+  });
+  return {
+    plans: res?.plans ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Fetch a single plan by its GUID. Returns null if not found.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/get-plan.md
+ *
+ * @param {string} planId  Plan GUID (`plan.id`).
+ * @returns {Promise<object|null>}
+ */
+export async function getPlanById(planId) {
+  try {
+    const res = await wixApiRequest(`/pricing-plans/v3/plans/${encodeURIComponent(planId)}`, {
+      method: "GET",
+    });
+    return res?.plan ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch a single PUBLIC plan by its URL slug. Returns null if not found.
+ * There is no get-by-slug endpoint, so this queries with a slug filter and returns the first match.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/query-plans.md
+ *
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getPlanBySlug(slug) {
+  const res = await wixApiRequest("/pricing-plans/v3/plans/query", {
+    method: "POST",
+    body: {
+      query: {
+        filter: { visibility: "PUBLIC", slug },
+        cursorPaging: { limit: 1 },
+      },
+    },
+  });
+  return res?.plans?.[0] ?? null;
+}
+
+/**
+ * Start a purchase for a plan and return the Wix-hosted checkout URL.
+ *
+ * Pricing Plans purchases are MEMBERS-ONLY: the hosted flow handles member login (or signup),
+ * the order form, and payment, then returns the visitor to your site. Redirect the browser to the
+ * returned URL — do NOT create the order yourself; Wix settles price, tax, and the subscription.
+ *
+ * On return:
+ *   - postFlowUrl is hit when the flow completes, is abandoned, or is interrupted.
+ *   - thankYouPageUrl (if given) is hit only on success, with a `?planOrderId=<GUID>` query param.
+ *   - Both callbacks also carry `wixMemberLoggedIn` (true if a member logged in during the flow).
+ * After a successful purchase the visitor is a logged-in member — call getMyPlanOrders() to confirm.
+ *
+ * Reference: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
+ *
+ * @param {string} planId  Plan GUID (`plan.id`). Must be a buyable plan.
+ * @param {{ thankYouPageUrl?: string, postFlowUrl?: string }} [options]
+ * @returns {Promise<string>} The hosted checkout URL to redirect to.
+ */
+export async function checkout(planId, { thankYouPageUrl, postFlowUrl } = {}) {
+  if (!planId) throw new Error("Cannot check out: a planId is required.");
+  const callbacks = { postFlowUrl: postFlowUrl ?? window.location.href };
+  if (thankYouPageUrl) callbacks.thankYouPageUrl = thankYouPageUrl;
+
+  const redirect = await wixApiRequest(REDIRECT_SESSION_URL, {
+    method: "POST",
+    body: { paidPlansCheckout: { planId }, callbacks },
+  });
+  const url = redirect?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Failed to create the pricing-plan checkout redirect session.");
+  return url;
+}
+
+/**
+ * List the currently logged-in member's own plan orders (their purchases / subscriptions).
+ * Use for a "My plans" screen and to confirm a purchase after returning from checkout.
+ *
+ * Requires a MEMBER identity. For an anonymous visitor (not logged in) Wix returns no member
+ * context — this resolves to `[]` rather than throwing, so the UI can show a "log in to see your
+ * plans" state. Up to 50 orders are returned per call.
+ *
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/orders/member-orders-service-list-orders.md
+ *
+ * @param {{ orderStatuses?: string[], limit?: number, offset?: number }} [options]
+ *        orderStatuses: filter, e.g. ["ACTIVE"] | ["ACTIVE","PENDING","PAUSED"].
+ * @returns {Promise<object[]>} The member's orders (empty array if none / not a member).
+ */
+export async function getMyPlanOrders({ orderStatuses, limit, offset } = {}) {
+  try {
+    const res = await wixApiRequest("/pricing-plans/v2/member/orders", {
+      method: "GET",
+      query: {
+        orderStatuses,
+        limit: limit !== undefined ? String(limit) : undefined,
+        offset: offset !== undefined ? String(offset) : undefined,
+      },
+    });
+    return res?.orders ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -1,0 +1,119 @@
+
+# Wix Restaurants Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/restaurants/wix-restaurants.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix restaurant experience. The browser talks to Wix directly over a
+public `WIX_CLIENT_ID`. Never mock the menu; never hand-build `/checkout` or reservation URLs —
+always go through the official cart + redirect-session and the reservations hold/reserve flow.
+
+## When to use
+- User wants a Wix restaurant site, an online food-ordering page, or a table-reservation page.
+- User asks to "connect Wix Restaurants" or replace placeholder menu/ordering/booking UI with live data.
+- Adding a menu, cart + checkout, or reservations over an existing Wix Restaurants setup.
+
+## Prerequisites
+1. A Wix site with the **Wix Restaurants Menus** app installed and **menu content already added**
+   (this skill is read-only over the menu — it does NOT create menus/items).
+2. For **online ordering**: at least one online-ordering **Operation** configured (Wix Restaurants
+   Orders). For **reservations**: the **Table Reservations** app installed with at least one location
+   and online reservations enabled. If a flow's backing app/config isn't set up, that flow returns
+   empty — flag it and continue; don't fabricate data.
+3. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (see the router `SKILL.md`).
+   Paste it into `src/rest/wix-client.js` in place of the placeholder. It is a buyer-facing
+   credential (it only mints anonymous visitor tokens), **not** a secret — hardcoding/committing
+   it is fine.
+4. The deployed app domain must be allow-listed on the OAuth client for Wix-hosted checkout to
+   return. This is a **separate Wix setup flow the user completes later** — out of this skill's
+   scope. If checkout return fails before that setup is done, that's expected; flag it and continue.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the restaurant UI however the
+project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
+adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the id
+  from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token IS the
+  cart identity; it is persisted to localStorage. Do not re-mint anonymously per load or the cart
+  silently empties.
+- `src/rest/wix-restaurants.js` — exports, grouped by flow:
+  - **Menu (read-only):** `getFullMenu` (the assembled tree — start here), `listMenus`,
+    `listSections`, `listItems`, `listVariants`, `listModifierGroups`, `listModifiers`, `listLabels`
+  - **Online ordering:** `listOperations`, `getDefaultOperation`, `addItemToCart`,
+    `getCurrentCart`, `updateCartItemQuantity`, `removeFromCart`, `checkout`
+  - **Reservations:** `listReservationLocations`, `getTimeSlots`, `createHeldReservation`,
+    `reserveReservation`
+
+The Menu, Item, ModifierGroup, Operation, Cart, ReservationLocation, TimeSlot, and Reservation
+shapes are documented as JSDoc at the top of `wix-restaurants.js`. Read them before building the
+UI — they describe the key fields and link to the full reference for anything not shown.
+
+## How to wire it (UI is the project's choice)
+- **Menu page** — call `getFullMenu()` once. It returns `{ menus: [{ ...menu, sections: [{ ...section,
+  items: [assembledItem] }] }] }`, already ordered by `sectionIds` / `itemIds`. Render each item's
+  `name`, `description`, `image`, `labels` (`name` + `icon`), and `featured` flag. For price, show
+  `item.price` (single) or the `item.variants[]` (each `{ name, price }`). **Restaurants prices are
+  plain decimal strings with NO currency symbol** — format with the site's currency in the UI.
+- **Item detail** — render `item.modifierGroups[]`: each group's `name`, its `rule`
+  (`required`, `minSelections`, `maxSelections`), and `modifiers[]` (`name`, `additionalCharge`,
+  `preSelected`, `inStock`). If `orderSettings.acceptSpecialRequests`, offer a free-text field.
+- **Online ordering** — resolve an operation with `getDefaultOperation()` (or let the user pick from
+  `listOperations()`); if it's `null`, show an "ordering unavailable" state. Add a dish with
+  `addItemToCart(item.id, { operationId, menuId, sectionId, quantity })` — `menuId`/`sectionId` are
+  the menu and section the item was shown under. Read the cart back with `getCurrentCart()`; mutate
+  with `updateCartItemQuantity(lineItemId, qty)` / `removeFromCart(lineItemId)` using
+  `cart.lineItems[].id` (not the item id).
+- **Checkout** — `window.location.href = await checkout()`. After the visitor returns, the order is
+  placed and the cart is empty — re-fetch with `getCurrentCart()` on return (e.g. on mount +
+  `visibilitychange`) to clear the UI.
+- **Reservations** — `listReservationLocations()` for the picker (use `location` details for the
+  label; if a location's `configuration.onlineReservations.onlineReservationsEnabled` is false, hide
+  it). Then `getTimeSlots(locationId, dateISO, partySize)` — render `availableTimeSlots` (already
+  filtered to `AVAILABLE`). On slot pick, `createHeldReservation(locationId, slot.startDate,
+  partySize)` → keep the returned `id` + `revision`. Collect the visitor's details, then
+  `reserveReservation(id, revision, { firstName, phone, lastName?, email? })`. A `RESERVED` status is
+  confirmed; `REQUESTED` means the location requires manual approval — tell the user it's pending.
+- **Empty state** — if `getFullMenu()` returns no menus, show an empty state telling the user to add
+  a menu in their Wix dashboard. Never invent menu items.
+
+## Hard rules (do not violate)
+- ✅ Order ONLY through the cart: `addItemToCart()` → `checkout()` (`create-checkout` →
+  `/headless/v1/redirect-session` `fullUrl`), then redirect.
+- ❌ Never hand-build `/checkout`, ordering, or reservation URLs.
+- ❌ Never mock menus, items, prices, operations, locations, or time slots — render live Wix data or
+  the empty state.
+- ❌ Never generate fake reviews, ratings, or testimonials. Empty review UI only.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ `addItemToCart` requires `operationId`, `menuId`, and `sectionId` — it throws if any is missing.
+- ✅ `lineItemId` for cart mutations is `cart.lineItems[].id`, not the item id.
+- ✅ Reservations: offer only `AVAILABLE` slots; a HELD reservation expires in 10 minutes — pass the
+  `revision` from the hold into `reserveReservation`, and restart the flow if it expired.
+- ✅ Reservee `firstName` + `phone` (E.164, e.g. `+15551234567`) are mandatory to confirm.
+- The engine fails loudly on purpose: `addItemToCart`/`checkout` throw on out-of-stock or empty
+  carts; reservation helpers throw on unavailable slots or expired holds. A green path means it is
+  really orderable/bookable — don't swallow these.
+
+## Beyond the snippets
+The snippets cover the common menu / ordering / reservation paths. For the "20%" they don't cover,
+make the call yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and
+request body in the **official Wix API reference** first; never guess:
+- Restaurants API reference: https://dev.wix.com/docs/api-reference/business-solutions/restaurants.md
+- Selecting a specific **price variant** or applying **modifier up-charges** on the cart line: the
+  restaurants `catalogReference.options` shape for these is not documented for client add-to-cart.
+  The menu UI still displays them; confirm the shape before wiring them into `addItemToCart`:
+  https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
+- Fulfillment methods, delivery-address validation, scheduled (preorder) time slots, service fees:
+  see the Online Orders section of the reference.
+
+Keep the snippets as the default for everything they already do; reach for the API reference only
+for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (cart survives reload, same visitor)
+- [ ] `getFullMenu()` renders real sections/items with prices, variants, modifiers, and labels
+- [ ] Empty state shown when there are no menus (never invented items)
+- [ ] Add to cart works with a real `operationId`/`menuId`/`sectionId`; out-of-stock items throw
+- [ ] Quantity update / remove reflect in `getCurrentCart()`
+- [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL); cart re-fetched on return
+- [ ] Reservations: only `AVAILABLE` slots offered; hold → reserve produces `RESERVED`/`REQUESTED`
+- [ ] No mock data anywhere

--- a/skills/wix-vibe-headless/references/restaurants/wix-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/wix-restaurants.js
@@ -1,0 +1,577 @@
+import { wixApiRequest } from "./wix-client.js";
+
+/**
+ * Wix Restaurants Orders app id — required inside `catalogReference` when adding a
+ * restaurant menu item to the eCom cart. Constant across all sites.
+ * Reference: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
+ */
+const RESTAURANTS_ORDERS_APP_ID = "9a5d83fd-8570-482e-81ab-cfa88942ee60";
+
+/* ===========================================================================
+ * INLINED DATA MODEL (the key entities — read these before building the UI)
+ * The Restaurants menu model is hierarchical and split across several APIs:
+ *
+ *   Menu └─ Sections └─ Items ├─ Price Variants
+ *                             ├─ Modifier Groups └─ Modifiers
+ *                             └─ Labels
+ *
+ * `getFullMenu()` walks all of these and returns one assembled tree — prefer it
+ * over calling the individual list helpers unless you need a single slice.
+ * ===========================================================================*/
+
+/**
+ * Menu — top of the hierarchy. One per "menu" the restaurant publishes (e.g. Dinner, Drinks).
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/menu-object.md
+ *
+ *   id                 {string}   Menu GUID.
+ *   name               {string}   Display name.
+ *   description         {string}   Menu description.
+ *   visible            {boolean}  Whether shown to site visitors.
+ *   sectionIds         {string[]} Ordered Section GUIDs — render sections in this order.
+ *   urlQueryParam      {string}   URL slug fragment for the menu (e.g. "dinner-menu").
+ *   businessLocationId {string}   Business location this menu belongs to.
+ */
+
+/**
+ * Section — a group of items within a menu (e.g. Appetizers, Mains).
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/section-object.md
+ *
+ *   id               {string}   Section GUID.
+ *   name             {string}   Display name.
+ *   description       {string}  Section description.
+ *   image            {object}   { id, url, width, height, altText } — main section image.
+ *   additionalImages {object[]} More images.
+ *   itemIds          {string[]} Ordered Item GUIDs — render items in this order.
+ *   visible          {boolean}  Whether shown to site visitors.
+ */
+
+/**
+ * Item — a single dish/drink. Has EITHER a single `priceInfo` OR `priceVariants` (one-of).
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/item-object.md
+ *
+ *   id                          {string}   Item GUID — the `catalogItemId` for ordering.
+ *   name                        {string}   Display name.
+ *   description                 {string}   Item description.
+ *   image                       {object}   { id, url, width, height, altText } — main image.
+ *   additionalImages            {object[]} Gallery images.
+ *   priceInfo.price             {string}   Price as a DECIMAL STRING, no currency symbol (e.g. "12.50").
+ *                                          Present when the item has a single price.
+ *   priceVariants.variants      {object[]} Present when the item has multiple priced variants:
+ *                                          [{ variantId, priceInfo: { price } }]. Resolve variantId →
+ *                                          name via listVariants (getFullMenu does this for you).
+ *   labels                      {object[]} [{ id }] — resolve id → { name, icon } via listLabels.
+ *   visible                     {boolean}  Whether shown to site visitors.
+ *   featured                    {boolean}  Marked as featured / best-seller.
+ *   orderSettings.inStock       {boolean}  Whether the item can be ordered. Default true.
+ *   orderSettings.acceptSpecialRequests {boolean} Whether a free-text special request is allowed.
+ *   modifierGroups              {object[]} [{ id }] — resolve via listModifierGroups.
+ *   businessLocationIds         {string[]} Locations where the item is available.
+ *
+ *   NOTE: Restaurants prices are plain decimal strings WITHOUT a currency symbol. The site's
+ *   currency is configured in the Wix dashboard — format prices in the UI accordingly.
+ */
+
+/**
+ * PriceVariant (from listVariants): { id, name }. The price lives on the item's
+ * priceVariants.variants[].priceInfo.price; the name lives here. getFullMenu merges them.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-variants/variant-object.md
+ *
+ * ModifierGroup (from listModifierGroups): a choice group attached to an item (e.g. "Choose a side").
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifier-groups/modifier-group-object.md
+ *   id                       {string}   Modifier group GUID.
+ *   name                     {string}   Display name.
+ *   modifiers                {object[]} [{ id, preSelected, additionalChargeInfo: { additionalCharge } }]
+ *                                       Resolve id → name via listModifiers. additionalCharge is a
+ *                                       decimal string ("0" means free).
+ *   rule.required            {boolean}  Whether a selection is MANDATORY.
+ *   rule.minSelections       {number}   Minimum selections the visitor must make.
+ *   rule.maxSelections       {number}   Maximum selections allowed.
+ *
+ * Modifier (from listModifiers): { id, name, inStock }.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifiers/modifier-object.md
+ *
+ * Label (from listLabels): { id, name, icon: { url, ... } } — e.g. "Vegan", "Spicy".
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-labels/label-object.md
+ */
+
+/**
+ * Operation — defines an online-ordering context (fulfillment + scheduling). Every cart line
+ * item must reference an `operationId`. Pick the default / first enabled one for a simple flow.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/operation-object.md
+ *
+ *   id                   {string}  Operation GUID — goes into catalogReference.options.operationId.
+ *   name                 {string}  Display name.
+ *   default              {boolean} Whether this is the default operation.
+ *   onlineOrderingStatus {string}  "ENABLED" | "DISABLED" | "PAUSED_UNTIL" | UNDEFINED.
+ *   defaultFulfillmentType {string} "PICKUP" | "DELIVERY".
+ *   fulfillmentIds       {string[]} Fulfillment method GUIDs associated with the operation.
+ *   businessLocationId   {string}  Business location of this operation.
+ */
+
+/**
+ * Cart (Wix eCom) — restaurant orders use the SAME visitor cart as the storefront.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/cart/cart-object.md
+ *
+ *   id                                {string}  Cart GUID.
+ *   currency                          {string}  ISO-4217 currency code.
+ *   lineItems[].id                    {string}  Line item GUID (lineItemId) — for update/remove.
+ *   lineItems[].quantity              {number}
+ *   lineItems[].catalogReference.catalogItemId {string} The ordered item's GUID.
+ *   lineItems[].productName.original  {string}  Display name.
+ *   lineItems[].price.formattedAmount {string}  Line price with currency symbol.
+ *   lineItems[].availability.status   {string}  "AVAILABLE" | "NOT_AVAILABLE" | "PARTIALLY_AVAILABLE" | "NOT_FOUND"
+ */
+
+/**
+ * ReservationLocation — a restaurant location that accepts table reservations.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/reservation-location-object.md
+ *
+ *   id            {string}  Reservation location GUID — pass to getTimeSlots / createHeldReservation.
+ *   location      {object}  Physical location details ({ id, ... }); name/address come from the
+ *                           Business Info / Locations API. See the reference for the full shape.
+ *   configuration {object}  Online-reservation settings: onlineReservations.approval.mode
+ *                           ("AUTOMATIC" | "MANUAL" | "MANUAL_FOR_LARGE_PARTIES"),
+ *                           partySize.min/max, timeSlotInterval, businessSchedule, reservationForm
+ *                           (lastNameRequired, emailRequired, customFieldDefinitions), etc.
+ *   default       {boolean} Whether this is the business's default location.
+ *   archived      {boolean} Whether the location is archived.
+ *
+ * TimeSlot (from getTimeSlots): { startDate, duration, status, manualApproval }.
+ *   status is "AVAILABLE" | "UNAVAILABLE" | "NON_WORKING_HOURS". Offer only AVAILABLE slots.
+ *
+ * Reservation (from createHeldReservation / reserveReservation):
+ *   id, revision, status ("HELD" → "RESERVED" or "REQUESTED" after reserve), details
+ *   ({ reservationLocationId, startDate, endDate, partySize }), reservee, paymentStatus.
+ *   Full model: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservations/reservation-object.md
+ */
+
+/* ============================ MENU (read-only) ============================ */
+
+/**
+ * Internal: GET a list endpoint filtered by a set of GUIDs, chunking the ids so the
+ * query string never gets too long (each List endpoint accepts up to 500 ids per call).
+ */
+async function fetchAllByIds(path, idParamName, responseKey, ids, extraQuery = {}) {
+  const unique = [...new Set((ids ?? []).filter(Boolean))];
+  if (!unique.length) return [];
+  const out = [];
+  for (let i = 0; i < unique.length; i += 100) {
+    const chunk = unique.slice(i, i + 100);
+    const res = await wixApiRequest(path, {
+      method: "GET",
+      query: { [idParamName]: chunk, ...extraQuery },
+    });
+    out.push(...(res?.[responseKey] ?? []));
+  }
+  return out;
+}
+
+/**
+ * List menus (one page). Pass `onlyVisible: true` for visitor-facing menus.
+ * GET https://www.wixapis.com/restaurants/menus/v1/menus
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/list-menus.md
+ * @param {{ onlyVisible?: boolean, limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ menus: object[], nextCursor: string|null }>}
+ */
+export async function listMenus({ onlyVisible = true, limit = 500, cursor } = {}) {
+  const res = await wixApiRequest("/restaurants/menus/v1/menus", {
+    method: "GET",
+    query: {
+      onlyVisible: onlyVisible ? "true" : undefined,
+      "paging.limit": String(limit),
+      "paging.cursor": cursor,
+    },
+  });
+  return { menus: res?.menus ?? [], nextCursor: res?.pagingMetadata?.cursors?.next ?? null };
+}
+
+/**
+ * List sections by their GUIDs.
+ * GET https://www.wixapis.com/restaurants/menus/v1/sections
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/list-sections.md
+ * @param {string[]} sectionIds
+ * @param {{ onlyVisible?: boolean }} [options]
+ * @returns {Promise<object[]>}
+ */
+export async function listSections(sectionIds, { onlyVisible = true } = {}) {
+  return fetchAllByIds("/restaurants/menus/v1/sections", "sectionIds", "sections", sectionIds, {
+    onlyVisible: onlyVisible ? "true" : undefined,
+  });
+}
+
+/**
+ * List items by their GUIDs.
+ * GET https://www.wixapis.com/restaurants/menus/v1/items
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/list-items.md
+ * @param {string[]} itemIds
+ * @param {{ onlyVisible?: boolean }} [options]
+ * @returns {Promise<object[]>}
+ */
+export async function listItems(itemIds, { onlyVisible = true } = {}) {
+  return fetchAllByIds("/restaurants/menus/v1/items", "itemIds", "items", itemIds, {
+    onlyVisible: onlyVisible ? "true" : undefined,
+  });
+}
+
+/**
+ * List price variants by their GUIDs (resolves variantId → name).
+ * GET https://www.wixapis.com/restaurants/menus/v1/variants
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-variants/list-variants.md
+ * @param {string[]} variantIds
+ * @returns {Promise<object[]>}
+ */
+export async function listVariants(variantIds) {
+  return fetchAllByIds("/restaurants/menus/v1/variants", "variantIds", "variants", variantIds);
+}
+
+/**
+ * List modifier groups by their GUIDs.
+ * GET https://www.wixapis.com/restaurants/menus/v1/modifier-groups
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifier-groups/list-modifier-groups.md
+ * @param {string[]} modifierGroupIds
+ * @returns {Promise<object[]>}
+ */
+export async function listModifierGroups(modifierGroupIds) {
+  return fetchAllByIds(
+    "/restaurants/menus/v1/modifier-groups",
+    "modifierGroupIds",
+    "modifierGroups",
+    modifierGroupIds,
+  );
+}
+
+/**
+ * List modifiers by their GUIDs (resolves modifierId → name + inStock).
+ * GET https://www.wixapis.com/restaurants/item-modifiers/v1/modifiers
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifiers/list-modifiers.md
+ * @param {string[]} modifierIds
+ * @returns {Promise<object[]>}
+ */
+export async function listModifiers(modifierIds) {
+  return fetchAllByIds("/restaurants/item-modifiers/v1/modifiers", "modifierIds", "modifiers", modifierIds);
+}
+
+/**
+ * List every item label on the site (the API returns all labels; filter client-side by id).
+ * GET https://www.wixapis.com/restaurants/menus/v1/labels
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-labels/list-labels.md
+ * @returns {Promise<object[]>}
+ */
+export async function listLabels() {
+  const res = await wixApiRequest("/restaurants/menus/v1/labels", { method: "GET" });
+  return res?.labels ?? [];
+}
+
+/**
+ * Retrieve the COMPLETE, assembled menu tree in a single call. Walks menus → sections →
+ * items, then enriches each item with resolved price variants, modifier groups + modifiers,
+ * and labels. This is the recommended entry point for the menu screen.
+ *
+ * Returns:
+ *   { menus: [ { ...menu, sections: [ { ...section, items: [ assembledItem ] } ] } ] }
+ * where assembledItem adds:
+ *   price          {string|null}  Single price (null when the item is variant-priced).
+ *   variants       {object[]}      [{ variantId, name, price }]
+ *   modifierGroups {object[]}      [{ id, name, rule, modifiers: [{ id, name, preSelected, additionalCharge, inStock }] }]
+ *   labels         {object[]}      [{ id, name, icon }]
+ *
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/retrieve-a-complete-menu-structure.md
+ * @param {{ onlyVisible?: boolean }} [options]
+ * @returns {Promise<{ menus: object[] }>}
+ */
+export async function getFullMenu({ onlyVisible = true } = {}) {
+  const { menus } = await listMenus({ onlyVisible });
+  if (!menus.length) return { menus: [] };
+
+  const sectionIds = menus.flatMap((m) => m.sectionIds ?? []);
+  const sections = await listSections(sectionIds, { onlyVisible });
+
+  const itemIds = sections.flatMap((s) => s.itemIds ?? []);
+  const items = await listItems(itemIds, { onlyVisible });
+
+  const variantIds = items.flatMap((i) => (i.priceVariants?.variants ?? []).map((v) => v.variantId));
+  const modifierGroupIds = items.flatMap((i) => (i.modifierGroups ?? []).map((g) => g.id));
+
+  // Leaf lookups that don't depend on each other run together.
+  const [variants, modifierGroups, labels] = await Promise.all([
+    listVariants(variantIds),
+    listModifierGroups(modifierGroupIds),
+    listLabels(),
+  ]);
+
+  const modifierIds = modifierGroups.flatMap((g) => (g.modifiers ?? []).map((m) => m.id));
+  const modifiers = await listModifiers(modifierIds);
+
+  const variantMap = new Map(variants.map((v) => [v.id, v]));
+  const groupMap = new Map(modifierGroups.map((g) => [g.id, g]));
+  const modifierMap = new Map(modifiers.map((m) => [m.id, m]));
+  const labelMap = new Map(labels.map((l) => [l.id, l]));
+
+  const assembleItem = (item) => ({
+    ...item,
+    price: item.priceInfo?.price ?? null,
+    variants: (item.priceVariants?.variants ?? []).map((v) => ({
+      variantId: v.variantId,
+      name: variantMap.get(v.variantId)?.name ?? null,
+      price: v.priceInfo?.price ?? null,
+    })),
+    modifierGroups: (item.modifierGroups ?? [])
+      .map((ref) => groupMap.get(ref.id))
+      .filter(Boolean)
+      .map((group) => ({
+        id: group.id,
+        name: group.name,
+        rule: group.rule ?? null,
+        modifiers: (group.modifiers ?? []).map((m) => ({
+          id: m.id,
+          name: modifierMap.get(m.id)?.name ?? null,
+          preSelected: m.preSelected ?? false,
+          additionalCharge: m.additionalChargeInfo?.additionalCharge ?? "0",
+          inStock: modifierMap.get(m.id)?.inStock ?? true,
+        })),
+      })),
+    labels: (item.labels ?? []).map((ref) => labelMap.get(ref.id)).filter(Boolean),
+  });
+
+  const itemMap = new Map(items.map((i) => [i.id, assembleItem(i)]));
+  const sectionMap = new Map(
+    sections.map((s) => [
+      s.id,
+      { ...s, items: (s.itemIds ?? []).map((id) => itemMap.get(id)).filter(Boolean) },
+    ]),
+  );
+
+  return {
+    menus: menus.map((m) => ({
+      ...m,
+      sections: (m.sectionIds ?? []).map((id) => sectionMap.get(id)).filter(Boolean),
+    })),
+  };
+}
+
+/* ===================== ONLINE ORDERING (cart + checkout) ================== */
+
+/**
+ * List the restaurant's online-ordering operations.
+ * GET https://www.wixapis.com/restaurants-operations/v1/operations
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/list-operations.md
+ * @returns {Promise<object[]>}
+ */
+export async function listOperations() {
+  const res = await wixApiRequest("/restaurants-operations/v1/operations", { method: "GET" });
+  return res?.operations ?? [];
+}
+
+/**
+ * Convenience: pick the operation to order through — the default, else the first ENABLED,
+ * else the first that exists. Returns null when no operation is configured (show an
+ * "ordering unavailable" state rather than inventing one).
+ * @returns {Promise<object|null>}
+ */
+export async function getDefaultOperation() {
+  const operations = await listOperations();
+  return (
+    operations.find((o) => o.default) ??
+    operations.find((o) => o.onlineOrderingStatus === "ENABLED") ??
+    operations[0] ??
+    null
+  );
+}
+
+/**
+ * Add a restaurant menu item to the visitor's current eCom cart.
+ *
+ * A restaurant line item REQUIRES `operationId` (from listOperations / getDefaultOperation),
+ * plus the `menuId` and `sectionId` the item is being ordered from. These travel in
+ * `catalogReference.options`. Throws if any is missing, or if the added line is not AVAILABLE,
+ * so a visitor can never reach checkout with an un-orderable line.
+ *
+ * Selecting a specific price variant or applying modifier up-charges on the cart line is NOT
+ * covered here — the restaurants catalogReference.options shape for those is not documented
+ * for client add-to-cart. Display variants/modifiers in the UI, and look up the exact shape
+ * in the reference before extending:
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
+ *
+ * POST https://www.wixapis.com/ecom/v1/carts/current/add-to-cart
+ * @param {string} itemId  Menu item GUID (`item.id`).
+ * @param {{ operationId: string, menuId: string, sectionId: string, onlineOrderingPageUrl?: string, quantity?: number }} opts
+ * @returns {Promise<object>} Updated cart.
+ */
+export async function addItemToCart(itemId, { operationId, menuId, sectionId, onlineOrderingPageUrl, quantity = 1 } = {}) {
+  if (!itemId) throw new Error("addItemToCart: itemId is required.");
+  if (!operationId || !menuId || !sectionId) {
+    throw new Error("addItemToCart: operationId, menuId and sectionId are all required for a restaurant line item.");
+  }
+  const options = { operationId, menuId, sectionId };
+  if (onlineOrderingPageUrl) options.onlineOrderingPageUrl = onlineOrderingPageUrl;
+
+  const res = await wixApiRequest("/ecom/v1/carts/current/add-to-cart", {
+    method: "POST",
+    body: {
+      lineItems: [{ catalogReference: { appId: RESTAURANTS_ORDERS_APP_ID, catalogItemId: itemId, options }, quantity }],
+    },
+  });
+  const line = (res?.cart?.lineItems ?? []).find((l) => l.catalogReference?.catalogItemId === itemId);
+  if (line?.availability?.status && line.availability.status !== "AVAILABLE") {
+    throw new Error(`Item not available to order (status: ${line.availability.status}).`);
+  }
+  return res?.cart;
+}
+
+/** Read the visitor's current cart. Returns null if no cart exists yet. */
+export async function getCurrentCart() {
+  try {
+    const res = await wixApiRequest("/ecom/v1/carts/current", { method: "GET" });
+    return res?.cart ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update the quantity of a cart line. `lineItemId` is `cart.lineItems[].id`, not the item id.
+ * POST https://www.wixapis.com/ecom/v1/carts/current/update-line-items-quantity
+ * @returns {Promise<object>} Updated cart.
+ */
+export async function updateCartItemQuantity(lineItemId, quantity) {
+  const res = await wixApiRequest("/ecom/v1/carts/current/update-line-items-quantity", {
+    method: "POST",
+    body: { lineItems: [{ id: lineItemId, quantity }] },
+  });
+  return res?.cart;
+}
+
+/**
+ * Remove a line from the current cart by its `cart.lineItems[].id`.
+ * POST https://www.wixapis.com/ecom/v1/carts/current/remove-line-items
+ * @returns {Promise<object>} Updated cart.
+ */
+export async function removeFromCart(lineItemId) {
+  const res = await wixApiRequest("/ecom/v1/carts/current/remove-line-items", {
+    method: "POST",
+    body: { lineItemIds: [lineItemId] },
+  });
+  return res?.cart;
+}
+
+/**
+ * Create a checkout from the current cart and return the Wix-hosted checkout URL.
+ * Throws on empty cart, unavailable lines, or a missing redirect URL. Redirect with
+ * `window.location.href = await checkout()`.
+ * https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/checkout/checkout-object.md
+ * @returns {Promise<string>}
+ */
+export async function checkout() {
+  const cart = await getCurrentCart();
+  const lines = cart?.lineItems ?? [];
+  if (!lines.length) throw new Error("Cannot check out: the cart is empty.");
+  const unavailable = lines.filter((l) => l.availability?.status && l.availability.status !== "AVAILABLE");
+  if (unavailable.length) {
+    const names = unavailable.map((l) => l.productName?.original ?? l.catalogReference?.catalogItemId).join(", ");
+    throw new Error(`Cannot check out: ${unavailable.length} item(s) not available — ${names}.`);
+  }
+
+  const checkoutRes = await wixApiRequest("/ecom/v1/carts/current/create-checkout", {
+    method: "POST",
+    body: { channelType: "WEB" },
+  });
+  const checkoutId = checkoutRes?.checkoutId;
+  if (!checkoutId) throw new Error("Failed to create checkout from the current cart.");
+
+  const redirect = await wixApiRequest("/headless/v1/redirect-session", {
+    method: "POST",
+    body: { ecomCheckout: { checkoutId }, callbacks: { postFlowUrl: window.location.href } },
+  });
+  const url = redirect?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Failed to create the checkout redirect session.");
+  return url;
+}
+
+/* ============================== RESERVATIONS ============================== */
+
+/**
+ * List the site's reservation locations (up to 100).
+ * GET https://www.wixapis.com/table-reservations/reservation-locations/v1/reservation-locations
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/list-reservation-locations.md
+ * @returns {Promise<object[]>}
+ */
+export async function listReservationLocations() {
+  const res = await wixApiRequest(
+    "/table-reservations/reservation-locations/v1/reservation-locations",
+    { method: "GET" },
+  );
+  return res?.reservationLocations ?? [];
+}
+
+/**
+ * Get reservation time slots for a location on a date, with availability for a party size.
+ * Use `slotsBefore` / `slotsAfter` to fan out around `date`. Offer only slots whose
+ * `status === "AVAILABLE"` (filter applied here).
+ * POST https://www.wixapis.com/table-reservations/reservations/v1/time-slots
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/time-slots/get-time-slots.md
+ * @param {string} reservationLocationId
+ * @param {string} date       ISO-8601 datetime (e.g. "2026-07-01T19:00:00.000Z").
+ * @param {number} partySize
+ * @param {{ slotsBefore?: number, slotsAfter?: number, duration?: number }} [options]
+ * @returns {Promise<{ timeSlots: object[], availableTimeSlots: object[] }>}
+ */
+export async function getTimeSlots(reservationLocationId, date, partySize, { slotsBefore = 4, slotsAfter = 4, duration } = {}) {
+  if (!reservationLocationId || !date || !partySize) {
+    throw new Error("getTimeSlots: reservationLocationId, date and partySize are required.");
+  }
+  const res = await wixApiRequest("/table-reservations/reservations/v1/time-slots", {
+    method: "POST",
+    body: { reservationLocationId, date, partySize, slotsBefore, slotsAfter, ...(duration ? { duration } : {}) },
+  });
+  const timeSlots = res?.timeSlots ?? [];
+  return { timeSlots, availableTimeSlots: timeSlots.filter((s) => s.status === "AVAILABLE") };
+}
+
+/**
+ * Hold a reservation for 10 minutes while the visitor fills in their details. Returns a
+ * reservation with status "HELD" — keep its `id` and `revision` for reserveReservation.
+ * POST https://www.wixapis.com/table-reservations/reservations/v1/reservations/hold
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservations/create-held-reservation.md
+ * @param {string} reservationLocationId
+ * @param {string} startDate  ISO-8601 datetime of the chosen time slot.
+ * @param {number} partySize
+ * @returns {Promise<object>} The held reservation ({ id, revision, status: "HELD", ... }).
+ */
+export async function createHeldReservation(reservationLocationId, startDate, partySize) {
+  if (!reservationLocationId || !startDate || !partySize) {
+    throw new Error("createHeldReservation: reservationLocationId, startDate and partySize are required.");
+  }
+  const res = await wixApiRequest("/table-reservations/reservations/v1/reservations/hold", {
+    method: "POST",
+    body: { reservationDetails: { reservationLocationId, startDate, partySize } },
+  });
+  const reservation = res?.reservation;
+  if (!reservation?.id) throw new Error("Failed to hold the reservation (the slot may no longer be available).");
+  return reservation;
+}
+
+/**
+ * Confirm a held reservation with the visitor's details. Moves status from "HELD" to
+ * "RESERVED" (auto-approval) or "REQUESTED" (location requires manual approval).
+ * `reservee.firstName` and `reservee.phone` (E.164, e.g. "+15551234567") are REQUIRED.
+ * Pass the `revision` returned by createHeldReservation. Holds expire after 10 minutes.
+ * POST https://www.wixapis.com/table-reservations/reservations/v1/reservations/{reservationId}/reserve
+ * https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservations/reserve-reservation.md
+ * @param {string} reservationId
+ * @param {string} revision
+ * @param {{ firstName: string, phone: string, lastName?: string, email?: string, marketingConsent?: boolean }} reservee
+ * @returns {Promise<object>} The updated reservation ({ id, status, revision, ... }).
+ */
+export async function reserveReservation(reservationId, revision, reservee) {
+  if (!reservationId || !revision) throw new Error("reserveReservation: reservationId and revision are required.");
+  if (!reservee?.firstName || !reservee?.phone) {
+    throw new Error("reserveReservation: reservee.firstName and reservee.phone are required.");
+  }
+  const res = await wixApiRequest(
+    `/table-reservations/reservations/v1/reservations/${encodeURIComponent(reservationId)}/reserve`,
+    { method: "POST", body: { revision, reservee } },
+  );
+  const reservation = res?.reservation;
+  if (!reservation?.id) throw new Error("Failed to confirm the reservation (the hold may have expired — start over).");
+  return reservation;
+}

--- a/skills/wix-vibe-headless/references/shared/wix-client.js
+++ b/skills/wix-vibe-headless/references/shared/wix-client.js
@@ -1,0 +1,130 @@
+/**
+ * REST version of the Wix headless integration — the direct analog of
+ * `storefrontApiRequest` in src/lib/shopify.ts. Plain fetch, JSON in / JSON out.
+ * No SDK, no query builder, no Velo.
+ *
+ * WIX_CLIENT_ID is the one thing to set. The client exchanges it for a visitor
+ * access token via the OAuth2 token endpoint, then sends that token on every API call.
+ */
+
+/**
+ * The public headless OAuth client id. It is a buyer-facing credential (it only mints
+ * anonymous visitor tokens), NOT a secret — so it is safe to hardcode here. Paste the
+ * value from the Wix Business Manager prompt in place of the placeholder.
+ */
+export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
+
+export const WIX_API_BASE = "https://www.wixapis.com";
+const OAUTH_TOKEN_URL = `${WIX_API_BASE}/oauth2/token`;
+
+const TOKEN_STORAGE_KEY = "wix-visitor-token";
+let tokenCache = null;
+
+function loadToken() {
+  if (tokenCache) return tokenCache;
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (raw) tokenCache = JSON.parse(raw);
+  } catch {
+    /* ignore disabled/full storage */
+  }
+  return tokenCache;
+}
+
+function saveToken(t) {
+  tokenCache = t;
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(t));
+  } catch {
+    /* ignore */
+  }
+}
+
+async function mintToken(body) {
+  const res = await fetch(OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Wix OAuth failed: ${res.status}`);
+  const data = await res.json();
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+}
+
+/**
+ * Get a visitor access token from the client id.
+ *
+ * The visitor token IS the identity of the Wix "current cart", so we persist the
+ * refresh token to localStorage and REFRESH it on expiry — re-minting a fresh
+ * `anonymous` token would create a NEW visitor and silently empty the cart on
+ * every reload / after the 4h token lifetime. Anonymous mint happens only once
+ * (or when no refresh token is stored).
+ */
+async function getAccessToken() {
+  const cached = loadToken();
+  if (cached && cached.expiresAt > Date.now() + 60_000) return cached.accessToken;
+
+  if (cached?.refreshToken) {
+    try {
+      const refreshed = await mintToken({ clientId: WIX_CLIENT_ID, grantType: "refresh_token", refreshToken: cached.refreshToken });
+      saveToken(refreshed);
+      return refreshed.accessToken;
+    } catch {
+      /* refresh failed — fall through to a fresh anonymous visitor */
+    }
+  }
+  const fresh = await mintToken({ clientId: WIX_CLIENT_ID, grantType: "anonymous" });
+  saveToken(fresh);
+  return fresh.accessToken;
+}
+
+/**
+ * Core transport — mirrors storefrontApiRequest. Adds the Authorization header,
+ * resolves the path against the Wix API base, parses JSON, surfaces errors.
+ *
+ * @param {string} path
+ * @param {{ method?: "GET"|"POST"|"PUT"|"DELETE", body?: unknown, query?: Record<string, string | undefined> }} [options]
+ */
+export async function wixApiRequest(path, options = {}) {
+  const { method = "POST", body, query } = options;
+  const token = await getAccessToken();
+
+  const url = new URL(path.startsWith("http") ? path : `${WIX_API_BASE}${path}`);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined) continue;
+      if (Array.isArray(v)) {
+        for (const item of v) url.searchParams.append(k, item);
+      } else {
+        url.searchParams.set(k, v);
+      }
+    }
+  }
+
+  const res = await fetch(url.toString(), {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token, // Wix expects the raw access token (no "Bearer " prefix)
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  if (res.status === 402) {
+    // This API requires an active plan / premium feature on the site.
+    console.warn("Wix: Payment required (402) — this API needs an active plan/premium feature.");
+    return;
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Wix API error ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return undefined;
+  return await res.json();
+}

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -1,0 +1,106 @@
+
+# Wix Storefront Skill
+
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/storefront/wix-store.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+
+Builds a real, client-only Wix storefront. The browser talks to Wix directly over a
+public `WIX_CLIENT_ID`. Never mock products; never hand-build `/checkout` URLs — always
+go through the eCom cart + redirect-session.
+
+## When to use
+- User wants a Wix eCommerce store or asks to "connect Wix".
+- Replacing placeholder/mock products with live Wix data.
+- Adding cart, checkout, categories, or product detail pages over an existing Wix Stores catalog.
+
+## Prerequisites
+1. A Wix site with **Wix Stores installed and products already added** (this skill does
+   NOT provision — it's read-only over the catalog).
+2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
+   Wix Business Manager surfaces a copyable prompt with the id filled in — see
+   the router `SKILL.md`). Paste it into `src/rest/wix-client.js` in place of the placeholder. It is a
+   buyer-facing credential (it only mints anonymous visitor tokens), **not** a secret, so
+   hardcoding/committing it is fine.
+3. The deployed app domain must be allow-listed on the OAuth client for Wix-hosted
+   checkout to return. This is a **separate Wix setup flow the user completes later** —
+   out of this skill's scope. If checkout return fails before that setup is done, that's
+   expected; flag it and continue.
+
+## The API (copy as-is; do not re-derive it)
+This skill ships only the REST layer — no UI components. Build the storefront's UI
+however the project wants; wire it to these two snippets. Copy them into the app (e.g.
+`src/api/`) and only adjust import paths:
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to
+  the id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh
+  token IS the cart identity; it is persisted to localStorage. Do not re-mint anonymously
+  per load or the cart silently empties.
+- `src/rest/wix-store.js` — exports:
+  - **Products:** `queryProducts`, `queryProductsByCategory`, `getProductBySlug`, `countProducts`
+  - **Categories:** `queryCategories`, `getCategoryBySlug`
+  - **Cart:** `addToCart`, `updateCartItemQuantity`, `removeFromCart`, `getCurrentCart`
+  - **Checkout:** `checkout`
+
+The Product and Cart shapes are documented as JSDoc comments at the top of `wix-store.js`.
+Read them before building the UI — they describe the key fields and link to the full API
+reference for anything not shown.
+
+## How to wire it (UI is the project's choice)
+- **Product grid** — `queryProducts()` for the listing (visible products only); pass
+  `nextCursor` back as `cursor` to load the next page. Render fields directly from the Wix
+  product object (see the `Product` typedef in `wix-store.js` for key fields). For price, use
+  `actualPriceRange.minValue.formattedAmount` (already includes the currency symbol) — no
+  manual formatting needed.
+- **PDP** — `getProductBySlug(slug)` keyed off the URL slug; returns null on miss — show
+  a not-found state, never invent a product.
+- **Categories** — `queryCategories()` for a category menu; `getCategoryBySlug(slug)` for
+  a category landing page. Pass `category.id` to `queryProductsByCategory(categoryId, { limit?, cursor? })`
+  to list only the products in that category; paginate exactly like `queryProducts`.
+- **Cart** — `addToCart(catalogItemId, variantId?, qty?, { modifierChoices?, customTextFields? }?)`,
+  `updateCartItemQuantity(lineItemId, qty)`, `removeFromCart(lineItemId)`.
+  - `variantId` (`variantsInfo.variants[].id` from `getProductBySlug`) — required for products with
+    options; resolve it by matching the buyer's selections to `variant.choices[].optionChoiceIds`.
+  - `modifierChoices` — `{ [modifier.key]: choiceKey }` for `TEXT_CHOICES` modifiers.
+  - `customTextFields` — `{ [modifier.freeTextSettings.key]: userInput }` for `FREE_TEXT` modifiers.
+    Mandatory modifiers must be included. See the eCommerce integration guide:
+    https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/e-commerce-integration.md
+  - Use `cart.lineItems[].id` as `lineItemId` (not `catalogItemId`) for mutations.
+  - Read the cart back with `getCurrentCart()` rather than mirroring it locally.
+- **Checkout** — `window.location.href = await checkout()`. After the buyer returns from
+  hosted checkout the order is placed and the cart is empty — re-fetch with
+  `getCurrentCart()` on return (e.g. on mount + `visibilitychange`) to clear the UI.
+- **Empty state** — if `countProducts()` is 0, show an empty state telling the user to
+  add products in their Wix dashboard. Never invent products.
+
+## Hard rules (do not violate)
+- ✅ Checkout ONLY via `checkout()` (`create-checkout` → `/headless/v1/redirect-session`
+  `fullUrl`), then redirect.
+- ❌ Never hand-build `/checkout`, cart-add, or product permalinks for purchase.
+- ❌ Never mock products — render live Wix data or the empty state.
+- ❌ Never generate fake reviews, ratings, or testimonials. Empty review UI only.
+- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
+- ✅ `lineItemId` for cart mutations is `cart.lineItems[].id`, not `catalogItemId`.
+- ✅ Pass `addToCart`'s `variantId` (`variantsInfo.variants[].id`) for products with variants; omit for products without.
+- ✅ Pass `modifierChoices` (`{ [modifier.key]: choiceKey }`) for TEXT_CHOICES modifiers; pass `customTextFields`
+  (`{ [modifier.freeTextSettings.key]: userInput }`) for FREE_TEXT modifiers. Include mandatory modifiers.
+- The engine fails loudly on purpose: `addToCart`/`checkout` throw on out-of-stock or
+  empty carts. A green path means it is really buyable — don't swallow these.
+
+## Beyond the snippets
+The snippets cover the common storefront paths. If you hit a use case they don't cover
+(e.g. coupons, members/auth, a product field not shown in the typedef), make the call
+yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and request
+body in the **official Wix API reference** first; never guess:
+- Official Wix API reference: https://dev.wix.com/docs/api-reference.md
+- eCommerce integration guide (modifiers, custom text, variants): https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/e-commerce-integration.md
+
+Keep the snippets as the default for everything they already do; reach for the API
+reference only for the gap.
+
+## Verification checklist (before declaring done)
+- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+- [ ] Visitor token persists across reload (cart survives reload, same visitor)
+- [ ] Add to cart works; out-of-stock items throw rather than add a dead line
+- [ ] Quantity update / remove reflect in `getCurrentCart()`
+- [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL)
+- [ ] Cart re-fetched on return from checkout (clears once the order is placed)
+- [ ] Empty state shown when `countProducts()` is 0
+- [ ] No mock products anywhere

--- a/skills/wix-vibe-headless/references/storefront/wix-store.js
+++ b/skills/wix-vibe-headless/references/storefront/wix-store.js
@@ -1,0 +1,342 @@
+import { wixApiRequest } from "./wix-client.js";
+
+// Stores app id — required inside catalogReference for store products.
+const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
+
+/**
+ * Wix Stores V3 Product — key fields for building a storefront.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products.md
+ *
+ *   id                                      {string}   Product GUID.
+ *   name                                    {string}   Display name.
+ *   slug                                    {string}   URL slug for PDP routing.
+ *   visible                                 {boolean}  Whether shown to site visitors.
+ *   productType                             {string}   "PHYSICAL" | "DIGITAL"
+ *   mainCategoryId                          {string}   Primary category GUID.
+ *   media.main.image                        {object}   Primary image:
+ *                                                      { id, url, height, width, altText }
+ *   media.itemsInfo.items                   {array}    All product images (gallery):
+ *                                                      [{ id, altText, image: { id, url, height, width, altText }, mediaType }]
+ *                                                      Use for image galleries / carousels on the PDP.
+ *   actualPriceRange.minValue.amount        {string}   Lowest variant price (decimal string).
+ *   actualPriceRange.minValue.formattedAmount {string} Lowest price with currency symbol (e.g. "$199.99").
+ *   actualPriceRange.maxValue.amount        {string}   Highest variant price (decimal string).
+ *   actualPriceRange.maxValue.formattedAmount {string} Highest price with currency symbol.
+ *   compareAtPriceRange.minValue.amount     {string}   Lowest original (strikethrough) price (decimal string).
+ *   compareAtPriceRange.minValue.formattedAmount {string} Lowest original price with currency symbol.
+ *   compareAtPriceRange.maxValue.amount     {string}   Highest original (strikethrough) price (decimal string).
+ *   compareAtPriceRange.maxValue.formattedAmount {string} Highest original price with currency symbol.
+ *                                                      Only present when a sale price is set. Show as
+ *                                                      strikethrough next to actualPriceRange.
+ *   inventory.availabilityStatus            {string}   "IN_STOCK" | "OUT_OF_STOCK" |
+ *                                                      "PARTIALLY_OUT_OF_STOCK"
+ *   options                                 {array}    Product options (e.g. Size, Color):
+ *                                                      [{
+ *                                                        id, name,
+ *                                                        optionRenderType: "TEXT_CHOICES" | "COLOR_CHOICES" | "SWATCH_CHOICES",
+ *                                                        choicesSettings: {
+ *                                                          choices: [{
+ *                                                            choiceId, key, name, inStock, visible,
+ *                                                            linkedMedia: [{        // images linked to this choice (may be empty)
+ *                                                              id, altText,
+ *                                                              image: { id, url, height, width, altText },
+ *                                                              mediaType
+ *                                                            }]
+ *                                                          }]
+ *                                                        }
+ *                                                      }]
+ *                                                      Use choice.linkedMedia to swap the displayed image when
+ *                                                      the buyer selects a color/swatch choice.
+ *   modifiers                               {array}    Non-variant customizations (e.g. engraving, gift wrap):
+ *                                                      [{
+ *                                                        id, name, mandatory,
+ *                                                        modifierRenderType: "TEXT_CHOICES" | "FREE_TEXT",
+ *                                                        key,                        // present for TEXT_CHOICES modifiers
+ *                                                        choicesSettings: {          // present for TEXT_CHOICES
+ *                                                          choices: [{ key, name }]
+ *                                                        },
+ *                                                        freeTextSettings: {         // present for FREE_TEXT
+ *                                                          title, key
+ *                                                        }
+ *                                                      }]
+ *   variantSummary.variantCount             {number}   Total number of variants.
+ *   plainDescription                        {string}   Product description in HTML format.
+ *   variantsInfo.variants                   {array}    Only returned by getProductBySlug, not queryProducts/queryProductsByCategory.
+ *                                                      [{
+ *                                                        id,
+ *                                                        visible,
+ *                                                        choices: [{                 // one entry per product option
+ *                                                          optionChoiceIds: { optionId, choiceId }
+ *                                                        }],
+ *                                                        price: {
+ *                                                          actualPrice: { amount, formattedAmount },
+ *                                                          compareAtPrice: { amount, formattedAmount }
+ *                                                        },
+ *                                                        media: {                    // variant-specific image (if set)
+ *                                                          id, altText,
+ *                                                          image: { id, url, height, width, altText },
+ *                                                          mediaType
+ *                                                        },
+ *                                                        inventoryStatus: { inStock, preorderEnabled }
+ *                                                      }]
+ *                                                      To resolve a buyer's option selections to a variantId:
+ *                                                      find the variant whose choices match all selected
+ *                                                      { optionId, choiceId } pairs, then pass variant.id
+ *                                                      to addToCart. Use variant.media (if present) to show
+ *                                                      a variant-specific image on the PDP.
+ */
+
+/**
+ * Wix eCom Cart — key fields for building a cart UI.
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart/get-cart.md
+ *
+ *   id                                      {string}  Cart GUID.
+ *   currency                                {string}  ISO-4217 currency code.
+ *   lineItems                               {array}
+ *     id                                    {string}  Line item GUID (lineItemId).
+ *                                                     Pass to updateCartItemQuantity / removeFromCart.
+ *     quantity                              {number}
+ *     catalogReference.catalogItemId        {string}  Product GUID.
+ *     productName.original                  {string}  Display name.
+ *     price.formattedAmount                 {string}  Price after all discounts, with currency symbol.
+ *     fullPrice.formattedAmount             {string}  Price before any discount (strikethrough price).
+ *                                                     Show alongside price when the two differ.
+ *     descriptionLines                      {array}   Human-readable selected option/modifier labels.
+ *                                                     Render these to show the buyer's choices (e.g. "Color: Red", "Size: M").
+ *                                                     [{
+ *                                                       name: { original },   // label, e.g. "Color"
+ *                                                       // ONE-OF:
+ *                                                       plainText: { original },  // for text choices / free text
+ *                                                       colorInfo: { original, code }  // for swatch choices; code is HEX/RGB
+ *                                                     }]
+ *     image.url                             {string}  Line item image URL.
+ *     availability.status                   {string}  "AVAILABLE" | "NOT_AVAILABLE" |
+ *                                                     "PARTIALLY_AVAILABLE" | "NOT_FOUND"
+ */
+
+/**
+ * Query products (one page).
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ products: object[], nextCursor: string|null }>}
+ */
+export async function queryProducts({ limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/stores/v3/products/query", {
+    method: "POST",
+    body: {
+      fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"],
+      query: {
+        ...(cursor ? {} : { filter: { visible: true } }),
+        cursorPaging: cursor ? { limit, cursor } : { limit },
+      },
+    },
+  });
+  return {
+    products: res?.products ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Fetch a product by its URL slug. Returns null if not found.
+ * Returns the full product including variantsInfo.variants (with per-variant media and choices).
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getProductBySlug(slug) {
+  const res = await wixApiRequest(`/stores/v3/products/slug/${encodeURIComponent(slug)}`, {
+    method: "GET",
+    query: { fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"] },
+  });
+  return res?.product ?? null;
+}
+
+/**
+ * Add a product to the visitor's current cart.
+ *
+ * For products with options (variants), pass the chosen `variantId` — resolve it from
+ * `product.variantsInfo.variants` (from getProductBySlug) by matching the buyer's selected
+ * option choices to `variant.choices[].optionChoiceIds`. Always include variantId when the
+ * product has variants.
+ *
+ * For products with modifiers:
+ *   - TEXT_CHOICES modifiers → pass `modifierChoices`: `{ [modifier.key]: choiceKey }`.
+ *     Example: `{ "Remove price tag": "yes" }`
+ *   - FREE_TEXT modifiers → pass `customTextFields`: `{ [modifier.freeTextSettings.key]: userInput }`.
+ *     Example: `{ "Would you like to engrave something on the box?": "For my best friend!" }`
+ *   Mandatory modifiers (modifier.mandatory === true) MUST be included.
+ *
+ * Throws on out-of-stock so the buyer can't reach checkout with an unbuyable line.
+ *
+ * Full catalogReference reference:
+ * https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/e-commerce-integration.md
+ *
+ * @param {string} catalogItemId          Product GUID (`product.id`).
+ * @param {string} [variantId]            `variantsInfo.variants[].id` — required for products with variants.
+ * @param {number} [quantity]
+ * @param {{ modifierChoices?: Record<string,string>, customTextFields?: Record<string,string> }} [extras]
+ * @returns {Promise<object>} Updated cart.
+ */
+export async function addToCart(catalogItemId, variantId, quantity = 1, { modifierChoices, customTextFields } = {}) {
+  const catalogReferenceOptions = {};
+  if (variantId) catalogReferenceOptions.variantId = variantId;
+  if (modifierChoices && Object.keys(modifierChoices).length) catalogReferenceOptions.options = modifierChoices;
+  if (customTextFields && Object.keys(customTextFields).length) catalogReferenceOptions.customTextFields = customTextFields;
+
+  const catalogReference = { appId: STORES_APP_ID, catalogItemId };
+  if (Object.keys(catalogReferenceOptions).length) catalogReference.options = catalogReferenceOptions;
+  const res = await wixApiRequest("/ecom/v1/carts/current/add-to-cart", {
+    method: "POST",
+    body: { lineItems: [{ catalogReference, quantity }] },
+  });
+  const line = (res?.cart?.lineItems ?? []).find(
+    (l) => l.catalogReference?.catalogItemId === catalogItemId && (!variantId || l.catalogReference?.options?.variantId === variantId),
+  );
+  if (line?.availability?.status && line.availability.status !== "AVAILABLE") {
+    throw new Error(`Item not available for sale (status: ${line.availability.status}). Is it in stock?`);
+  }
+  return res?.cart;
+}
+
+/** Read the visitor's current cart. Returns null if no cart exists yet. */
+export async function getCurrentCart() {
+  try {
+    const res = await wixApiRequest("/ecom/v1/carts/current", { method: "GET" });
+    return res?.cart ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a checkout from the current cart and return the hosted checkout URL.
+ * Throws on empty cart, unavailable lines, or a missing redirect URL.
+ * @returns {Promise<string>}
+ */
+export async function checkout() {
+  const cart = await getCurrentCart();
+  const lines = cart?.lineItems ?? [];
+  if (!lines.length) throw new Error("Cannot check out: the cart is empty.");
+  const unavailable = lines.filter((l) => l.availability?.status && l.availability.status !== "AVAILABLE");
+  if (unavailable.length) {
+    const names = unavailable.map((l) => l.productName?.original ?? l.catalogReference?.catalogItemId).join(", ");
+    throw new Error(`Cannot check out: ${unavailable.length} item(s) not available — ${names}.`);
+  }
+
+  const checkoutRes = await wixApiRequest("/ecom/v1/carts/current/create-checkout", {
+    method: "POST",
+    body: { channelType: "WEB" },
+  });
+  const checkoutId = checkoutRes?.checkoutId;
+  if (!checkoutId) throw new Error("Failed to create checkout from the current cart.");
+
+  const redirect = await wixApiRequest("/headless/v1/redirect-session", {
+    method: "POST",
+    body: { ecomCheckout: { checkoutId }, callbacks: { postFlowUrl: window.location.href } },
+  });
+  const url = redirect?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Failed to create the checkout redirect session.");
+  return url;
+}
+
+/**
+ * Update the quantity of a cart line.
+ * `lineItemId` is `cart.lineItems[].id`, not `catalogItemId`.
+ * Wix caps the result at remaining stock — the returned quantity may be lower than requested.
+ * @returns {Promise<object>} Updated cart.
+ */
+export async function updateCartItemQuantity(lineItemId, quantity) {
+  const res = await wixApiRequest("/ecom/v1/carts/current/update-line-items-quantity", {
+    method: "POST",
+    body: { lineItems: [{ id: lineItemId, quantity }] },
+  });
+  return res?.cart;
+}
+
+/**
+ * Remove a line from the current cart by its `cart.lineItems[].id`. Returns the updated cart.
+ * @param {string} lineItemId
+ */
+export async function removeFromCart(lineItemId) {
+  const res = await wixApiRequest("/ecom/v1/carts/current/remove-line-items", {
+    method: "POST",
+    body: { lineItemIds: [lineItemId] },
+  });
+  return res?.cart;
+}
+
+/**
+ * Query visible products belonging to a category (one page).
+ * Uses the catalog search API which supports category filtering.
+ * @param {string} categoryId  Category GUID (`category.id` from queryCategories / getCategoryBySlug).
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ products: object[], nextCursor: string|null }>}
+ */
+export async function queryProductsByCategory(categoryId, { limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/stores/v3/products/search", {
+    method: "POST",
+    body: {
+      fields: ["CURRENCY", "PLAIN_DESCRIPTION", "MEDIA_ITEMS_INFO"],
+      search: {
+        ...(cursor
+          ? { cursorPaging: { limit, cursor } }
+          : {
+              cursorPaging: { limit },
+              filter: {
+                visible: true,
+                "allCategoriesInfo.categories": { $matchItems: [{ id: categoryId }] },
+              },
+            }),
+      },
+    },
+  });
+  return {
+    products: res?.products ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Total number of visible products. Used for empty-state logic (0 → prompt user to add products).
+ * @returns {Promise<number>}
+ */
+export async function countProducts() {
+  const res = await wixApiRequest("/stores/v3/products/count", {
+    method: "POST",
+    body: { filter: { visible: true } },
+  });
+  return res?.count ?? 0;
+}
+
+/**
+ * Query Wix Stores categories (one page).
+ * @param {{ limit?: number, cursor?: string }} [options]
+ * @returns {Promise<{ categories: object[], nextCursor: string|null }>}
+ */
+export async function queryCategories({ limit = 100, cursor } = {}) {
+  const res = await wixApiRequest("/categories/v1/categories/query", {
+    method: "POST",
+    body: {
+      treeReference: { appNamespace: "@wix/stores", treeKey: null },
+      query: { cursorPaging: cursor ? { limit, cursor } : { limit } },
+    },
+  });
+  return {
+    categories: res?.categories ?? [],
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Get a single category by its URL slug. Returns null if not found.
+ * Category fields: id, name, slug, visible, description, image, itemCounter, parentCategory.id
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/get-category-by-slug.md
+ * @param {string} slug
+ * @returns {Promise<object|null>}
+ */
+export async function getCategoryBySlug(slug) {
+  const res = await wixApiRequest(`/categories/v1/categories/slug/${encodeURIComponent(slug)}`, {
+    method: "GET",
+    query: { "treeReference.appNamespace": "@wix/stores" },
+  });
+  return res?.category ?? null;
+}


### PR DESCRIPTION
## What

Adds a new skill **`wix-vibe-headless`** that consolidates the client-only REST business-solution scaffolds from [`wix-incubator/base44-connector-instructions`](https://github.com/wix-incubator/base44-connector-instructions) into **one skill with references** in this repo.

One router `SKILL.md` + a reference folder per Wix business solution. Everything from the source PRs — **all business solutions** — is included:

| Vertical | What it wires |
|---|---|
| storefront | products, categories, cart, redirect-session checkout |
| bookings | services, time slots, booking, hosted checkout |
| blog | post feed, post pages, categories, tags |
| events | browse, event page, RSVP, ticketing |
| portfolio | collections, projects, media galleries |
| restaurants | menu, online ordering, table reservations |
| cms | list/detail, filter/search, public forms, data CRUD |
| pricing-plans | memberships/subscriptions, checkout, my plans |

## Structure

```
skills/wix-vibe-headless/
  SKILL.md                              # router: shared model + routing table
  references/
    shared/wix-client.js                # one shared visitor-token transport (deduped)
    <vertical>/INSTRUCTIONS.md          # the vertical's full playbook
    <vertical>/<helper>.js              # copy-as-is REST helper
```

- The source repo ships a **byte-identical `wix-client.js`** in every vertical — deduped here to `references/shared/wix-client.js`. Each vertical helper is preserved **verbatim** (`node --check` clean; diff-identical to source) and still does `import { wixApiRequest } from "./wix-client.js"`, so the two files copy into the app's `src/rest/` side by side.
- Each `INSTRUCTIONS.md` is the source vertical's `SKILL.md` body verbatim (frontmatter stripped), with a source-files note prepended and the per-vertical `PROMPT.md` reference redirected to the router.

## Why a new top-level skill

This is a deliberately **client-only, dependency-free REST** integration model (browser → Wix over a public `WIX_CLIENT_ID`, no SDK, no backend, no build step) — distinct from the SDK + Wix CLI + hosting `wix-headless` skill. The router `SKILL.md` cross-links both so agents pick the right one. Per `CONTRIBUTING.md`, new top-level skills are admin-gated — flagging for reviewer sign-off.

## Registration

- Added to `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` skills arrays (Codex auto-globs `./skills/`).
- Added to the README **Available Skills** table.

## Notes

- Business solutions only — the source repo's `wix-headless-skill-creator` meta-skill (skill-authoring, not a business solution) is intentionally excluded.
- The `wix-manage` eval gate does not apply (no `skills/wix-manage/**` or `yaml/**` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)