### PR TITLE
docs(wix-docs): browsing is a co-equal way to find docs (not search-only)

### DIFF
--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-docs
-description: "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, or error before writing Wix code — never guess a Wix API from memory. A lookup is a short flow: find the right page, then read it. Two ways: (1) plain `curl` (zero dependencies) — a semantic search endpoint (`POST /mcp-docs-search/v1/docs/search`, natural-language `{ search_term, document_type }`) to find pages, then read any page by appending `.md` to its docs URL; and (2) the Wix MCP doc tools when your agent has them. Triggers: look up a Wix API, find the Wix endpoint/method, confirm a Wix request body or field, verify a Wix API shape, explore Wix docs, which Wix API do I call, read a Wix method schema."
+description: "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, or error before writing Wix code — never guess a Wix API from memory. A lookup is a short flow: find the right page, then read it. Two ways: (1) plain `curl` (zero dependencies) — find a page by **semantic search** (`POST /mcp-docs-search/v1/docs/search`, natural-language `{ search_term, document_type }`) **or by browsing** the docs tree as a menu from the `llms.txt` root (append `.md` to any docs path), then read the page by appending `.md` to its URL; and (2) the Wix MCP doc tools when your agent has them. Triggers: look up a Wix API, find the Wix endpoint/method, confirm a Wix request body or field, verify a Wix API shape, explore Wix docs, which Wix API do I call, read a Wix method schema."
 ---
 
 # Wix Docs — look up the Wix API/SDK documentation
@@ -17,11 +17,13 @@ or the Wix MCP doc tools if your agent has them (Lane 2).
 The docs are one tree of markdown pages: **append `.md` to any `https://dev.wix.com/docs/…` URL**
 to get that page as markdown. No SDK, no MCP.
 
-### 1. Find the page
+### 1. Find the page — search *or* browse
 
-Fastest is a **semantic** search — describe what you want in natural language ("let a customer book
-an appointment"), not just keywords; hits come back ranked by relevance, each with a docs `url`.
-It has two variants — append `/markdown` for the second:
+Two ways to reach the right page — use whichever fits.
+
+**A. Semantic search.** Describe what you want in natural language ("let a customer book an
+appointment"), not just keywords; hits come back ranked by relevance, each with a docs `url`. Two
+variants — append `/markdown` for the second:
 
 | Variant | URL | Returns |
 |---|---|---|
@@ -33,24 +35,33 @@ Same JSON body: `search_term` (required, 1–500), `document_type` (`REST` defau
 (1–20, def 15), `lines_in_each_result` (1–200, def 20).
 
 ```bash
-# markdown — hand straight to the model; append nothing for JSON to parse result[].url
+# markdown — hand straight to the model; drop /markdown for JSON to parse result[].url
 curl -sS -X POST 'https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown' \
   -H 'Content-Type: application/json' \
   --data-raw '{"search_term":"create a booking","document_type":"REST","maximum_results":3}'
 ```
 
-Each hit's `url` is the page to read next. (Rather navigate by hand? Start at a menu page — see
-below. If the Wix MCP is present, its search is richer — Lane 2.)
+**B. Browse the tree from the root, like a menu.** Every docs path has a `.md` twin, so you can
+navigate the docs as a menu tree — no search needed:
+
+- **Start at the index:** `curl https://dev.wix.com/docs/llms.txt` — the top-level map of every
+  portal (API reference, SDK, Go Headless, Velo). `https://dev.wix.com/docs/api-reference.md` is the
+  authoritative root for all Wix APIs (each API page documents **both** its REST and SDK usage).
+- **Drill like a menu:** append `.md` to any path — a *section* path returns a **menu** (a list of
+  child links); a *leaf* returns the content/method page. Truncate a path to go up, extend it to go
+  down.
+- **Read the sibling articles too** — a module's menu lists intro / "About …" / sample-flow pages
+  next to the endpoints; those often explain the API better than the method page alone.
+
+If the Wix MCP is present, its search/browse tools are richer — Lane 2.
 
 ### 2. Read what you land on
 
 Appending `.md` to a URL gives one of **three kinds of page**. Know which you're looking at, and
 handle it accordingly:
 
-- **Menu page** — what a *section* path returns (truncate any URL to a parent + `.md`, e.g.
-  `…/business-solutions/bookings.md`; the root of the tree is `https://dev.wix.com/docs/llms.txt`).
-  It's a list of links to child pages and can be tens of KB — **don't read it whole; `grep` it** for
-  the child you want, then drill in:
+- **Menu page** — a *section* path (from browsing, §1B). A list of child links, often tens of KB —
+  **don't read it whole; `grep` it** for the child you want, then drill into that page:
 
   ```bash
   curl -sS 'https://dev.wix.com/docs/api-reference/business-solutions/bookings.md' | grep -i 'booking'

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -42,18 +42,31 @@ curl -sS -X POST 'https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdow
 ```
 
 **B. Browse the tree from the root, like a menu.** Every docs path has a `.md` twin, so you can
-navigate the docs as a menu tree — no search needed:
+navigate the docs as a menu tree — no search needed. `curl https://dev.wix.com/docs/llms.txt` is the
+top-level map; the portals under it:
 
-- **Start at the index:** `curl https://dev.wix.com/docs/llms.txt` — the top-level map of every
-  portal (API reference, SDK, Go Headless, Velo). `https://dev.wix.com/docs/api-reference.md` is the
-  authoritative root for all Wix APIs (each API page documents **both** its REST and SDK usage).
-- **Drill like a menu:** append `.md` to any path — a *section* path returns a **menu** (a list of
-  child links); a *leaf* returns the content/method page. Truncate a path to go up, extend it to go
-  down.
-- **Read the sibling articles too** — a module's menu lists intro / "About …" / sample-flow pages
-  next to the endpoints; those often explain the API better than the method page alone.
+| Portal | Start here for |
+|---|---|
+| [`api-reference.md`](https://dev.wix.com/docs/api-reference.md) | **All backend / business-solution APIs — the main one.** Each page documents **both** REST and SDK usage. |
+| [`sdk.md`](https://dev.wix.com/docs/sdk.md) | Frontend-only SDK modules not in the API reference (npm `@wix/<module>`). |
+| [`go-headless.md`](https://dev.wix.com/docs/go-headless.md) | Headless setup, auth, hosting, framework integration. |
+| [`build-apps.md`](https://dev.wix.com/docs/build-apps.md) | Building Wix apps / extensions. |
+| [`wix-cli.md`](https://dev.wix.com/docs/wix-cli.md) · [`velo.md`](https://dev.wix.com/docs/velo.md) | Wix CLI commands; Velo site-coding APIs. |
 
-If the Wix MCP is present, its search/browse tools are richer — Lane 2.
+**Drill like a menu** — append `.md` to any path (a *section* → a menu of child links, a *leaf* →
+the content/method page); truncate to go up, extend to go down. **Read the sibling intro / "About …"
+/ flow articles too**, not just the method page. Example — drill to the create-booking method,
+grepping each menu for the next link:
+
+```bash
+curl -sS https://dev.wix.com/docs/api-reference/business-solutions.md            | grep -i bookings   # → .../bookings.md
+curl -sS https://dev.wix.com/docs/api-reference/business-solutions/bookings.md   | grep -iE 'bookings|flow'  # → resource/flow pages
+curl -sS https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings.md | grep -i create      # → the create method leaf
+curl -sS https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking.md  # read it
+```
+
+A 2-level map of the API-reference portal (all verticals, one level down) is in
+`references/EXTRACTING.md`. If the Wix MCP is present, its search/browse tools are richer — Lane 2.
 
 ### 2. Read what you land on
 

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -47,8 +47,7 @@ top-level map; the portals under it:
 
 | Portal | Start here for |
 |---|---|
-| [`api-reference.md`](https://dev.wix.com/docs/api-reference.md) | **All backend / business-solution APIs — the main one.** Each page documents **both** REST and SDK usage. |
-| [`sdk.md`](https://dev.wix.com/docs/sdk.md) | Frontend-only SDK modules not in the API reference (npm `@wix/<module>`). |
+| [`api-reference.md`](https://dev.wix.com/docs/api-reference.md) | **All backend / business-solution APIs — the main one, and where SDK lives too:** each page documents **both** its REST and SDK usage (`.md?apiView=SDK` for the SDK view). |
 | [`go-headless.md`](https://dev.wix.com/docs/go-headless.md) | Headless setup, auth, hosting, framework integration. |
 | [`build-apps.md`](https://dev.wix.com/docs/build-apps.md) | Building Wix apps / extensions. |
 | [`wix-cli.md`](https://dev.wix.com/docs/wix-cli.md) · [`velo.md`](https://dev.wix.com/docs/velo.md) | Wix CLI commands; Velo site-coding APIs. |

--- a/skills/wix-docs/references/EXTRACTING.md
+++ b/skills/wix-docs/references/EXTRACTING.md
@@ -23,6 +23,21 @@ read it whole:
   page; `https://dev.wix.com/docs/llms-full.txt` is the full concatenated corpus (very large — grep,
   don't read).
 
+### A 2-level map to start from
+
+A partial map of the **`api-reference`** portal (the main one) — its top sections, and the Business
+Solutions verticals one level deeper. A starting point, not exhaustive; re-derive from the `.md`
+menus when in doubt.
+
+- [**API Reference**](https://dev.wix.com/docs/api-reference.md) — all backend APIs; each page = REST + SDK
+  - [**Business Solutions**](https://dev.wix.com/docs/api-reference/business-solutions.md) — [Stores](https://dev.wix.com/docs/api-reference/business-solutions/stores.md) · [eCommerce](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce.md) · [Bookings](https://dev.wix.com/docs/api-reference/business-solutions/bookings.md) · [Events](https://dev.wix.com/docs/api-reference/business-solutions/events.md) · [Blog](https://dev.wix.com/docs/api-reference/business-solutions/blog.md) · [CMS](https://dev.wix.com/docs/api-reference/business-solutions/cms.md) · [Pricing Plans](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans.md) · [Restaurants](https://dev.wix.com/docs/api-reference/business-solutions/restaurants.md) · [Portfolio](https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md) · [Gift Cards](https://dev.wix.com/docs/api-reference/business-solutions/gift-cards.md) · [Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons.md) · [Donations](https://dev.wix.com/docs/api-reference/business-solutions/donations.md)
+  - [**CRM**](https://dev.wix.com/docs/api-reference/crm.md) — contacts, members, forms, inbox, loyalty
+  - [**Business Management**](https://dev.wix.com/docs/api-reference/business-management.md) — payments, invoices, SEO, site properties, automations
+  - [**App Management**](https://dev.wix.com/docs/api-reference/app-management.md) — install apps, OAuth, app instance/installations
+  - [**Assets**](https://dev.wix.com/docs/api-reference/assets.md) — media, rich content
+  - [**Account Level**](https://dev.wix.com/docs/api-reference/account-level.md) — sites, domains
+- Other portals: [SDK](https://dev.wix.com/docs/sdk.md) · [Go Headless](https://dev.wix.com/docs/go-headless.md) · [Build Apps](https://dev.wix.com/docs/build-apps.md) · [Wix CLI](https://dev.wix.com/docs/wix-cli.md) · [Velo](https://dev.wix.com/docs/velo.md)
+
 ## Method pages — slice, don't swallow
 
 A method page is often **huge** (Create Booking's `.md` is ~144 KB / 900+ lines). It carries **both**

--- a/skills/wix-docs/references/EXTRACTING.md
+++ b/skills/wix-docs/references/EXTRACTING.md
@@ -23,20 +23,35 @@ read it whole:
   page; `https://dev.wix.com/docs/llms-full.txt` is the full concatenated corpus (very large — grep,
   don't read).
 
-### A 2-level map to start from
+### A partial map to orient from
 
-A partial map of the **`api-reference`** portal (the main one) — its top sections, and the Business
-Solutions verticals one level deeper. A starting point, not exhaustive; re-derive from the `.md`
-menus when in doubt.
+Paths under `https://dev.wix.com/docs/` — **append `.md` to any of them** to read that page.
+**This is a pruned map, not the full tree** — `…` marks where real children were left out; the
+deep leaves are cherry-picked to show how far it goes. Re-derive from the `.md` menus / `llms.txt`
+for anything not shown.
 
-- [**API Reference**](https://dev.wix.com/docs/api-reference.md) — all backend APIs; each page = REST + SDK
-  - [**Business Solutions**](https://dev.wix.com/docs/api-reference/business-solutions.md) — [Stores](https://dev.wix.com/docs/api-reference/business-solutions/stores.md) · [eCommerce](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce.md) · [Bookings](https://dev.wix.com/docs/api-reference/business-solutions/bookings.md) · [Events](https://dev.wix.com/docs/api-reference/business-solutions/events.md) · [Blog](https://dev.wix.com/docs/api-reference/business-solutions/blog.md) · [CMS](https://dev.wix.com/docs/api-reference/business-solutions/cms.md) · [Pricing Plans](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans.md) · [Restaurants](https://dev.wix.com/docs/api-reference/business-solutions/restaurants.md) · [Portfolio](https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md) · [Gift Cards](https://dev.wix.com/docs/api-reference/business-solutions/gift-cards.md) · [Coupons](https://dev.wix.com/docs/api-reference/business-solutions/coupons.md) · [Donations](https://dev.wix.com/docs/api-reference/business-solutions/donations.md)
-  - [**CRM**](https://dev.wix.com/docs/api-reference/crm.md) — contacts, members, forms, inbox, loyalty
-  - [**Business Management**](https://dev.wix.com/docs/api-reference/business-management.md) — payments, invoices, SEO, site properties, automations
-  - [**App Management**](https://dev.wix.com/docs/api-reference/app-management.md) — install apps, OAuth, app instance/installations
-  - [**Assets**](https://dev.wix.com/docs/api-reference/assets.md) — media, rich content
-  - [**Account Level**](https://dev.wix.com/docs/api-reference/account-level.md) — sites, domains
-- Other portals: [SDK](https://dev.wix.com/docs/sdk.md) · [Go Headless](https://dev.wix.com/docs/go-headless.md) · [Build Apps](https://dev.wix.com/docs/build-apps.md) · [Wix CLI](https://dev.wix.com/docs/wix-cli.md) · [Velo](https://dev.wix.com/docs/velo.md)
+```text
+dev.wix.com/docs/                                      ← append .md to any path below
+├── api-reference/                                     all backend APIs — REST + SDK on every page
+│   ├── business-solutions/
+│   │   ├── stores/                                    products, inventory, categories
+│   │   │   └── catalog-v3/products-v3/query-products  ← a method page (leaf: schema + examples)
+│   │   ├── bookings/
+│   │   │   └── bookings/bookings-writer-v2/create-booking   ← a method page (leaf)
+│   │   ├── e-commerce/                                cart, checkout, orders, discounts
+│   │   ├── cms/                                       Wix Data — data-items, collections
+│   │   ├── blog/ · events/ · pricing-plans/ · restaurants/ · portfolio/ · gift-cards/ · coupons/ · donations/ · …
+│   ├── crm/                                           contacts, members, forms, inbox, loyalty
+│   ├── business-management/                           payments, invoices, SEO, site-properties, automations
+│   ├── app-management/                                install apps, OAuth, app-instance/installations
+│   ├── assets/                                        media, rich-content
+│   └── account-level/ · site/ · tools/ · articles/    domains/sites, site config, auth/query guides
+├── go-headless/                                       headless setup, auth, hosting, framework integration
+├── build-apps/                                        building Wix apps / extensions
+├── wix-cli/                                           CLI commands
+├── velo/ · develop-websites/                          Velo site-coding APIs + guides
+└── …                                                  (full portal list: curl llms.txt)
+```
 
 ## Method pages — slice, don't swallow
 


### PR DESCRIPTION
Makes it explicit in the `wix-docs` skill that **semantic search is just one way** to find a doc page — you can equally **browse the docs tree as a menu** from the `llms.txt` root.

## Change
`SKILL.md` › "Find the page" is now two co-equal methods:
- **A. Semantic search** — `POST /mcp-docs-search/v1/docs/search` (unchanged).
- **B. Browse from the root, like a menu** — start at `llms.txt` (top-level portal map) / `api-reference.md` (authoritative root, each page = REST + SDK); drill by appending `.md` to any path (section → menu of child links, leaf → content/method page); and **read the sibling intro / "About …" / sample-flow articles**, not just the method page.

Also: trimmed the §2 menu-page bullet's duplicated browse mechanics (now owned by §1B), and updated the frontmatter description.

Inspired by the `DISCOVER.md` framing in `wix-private/memex` (llms.txt as the portal map + `.md` menu drilling + sibling articles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)