### PR TITLE
fix(wix-docs): restore the SDK portal (not deprecated)

### DIFF
--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -47,7 +47,8 @@ top-level map; the portals under it:
 
 | Portal | Start here for |
 |---|---|
-| [`api-reference.md`](https://dev.wix.com/docs/api-reference.md) | **All backend / business-solution APIs — the main one, and where SDK lives too:** each page documents **both** its REST and SDK usage (`.md?apiView=SDK` for the SDK view). |
+| [`api-reference.md`](https://dev.wix.com/docs/api-reference.md) | **All backend / business-solution APIs — the main one.** Each page documents **both** its REST and SDK usage (`.md?apiView=SDK` for the SDK view). |
+| [`sdk.md`](https://dev.wix.com/docs/sdk.md) | **SDK-only surfaces not in the API reference:** client setup (`createClient`, `OAuthStrategy`), core modules (`@wix/sdk`, `@wix/essentials`), host modules (`dashboard`/`editor`/`site`), and frontend modules (`members`, `pay`, `seo`, `storage`, `pricing-plans`, …). |
 | [`go-headless.md`](https://dev.wix.com/docs/go-headless.md) | Headless setup, auth, hosting, framework integration. |
 | [`build-apps.md`](https://dev.wix.com/docs/build-apps.md) | Building Wix apps / extensions. |
 | [`wix-cli.md`](https://dev.wix.com/docs/wix-cli.md) · [`velo.md`](https://dev.wix.com/docs/velo.md) | Wix CLI commands; Velo site-coding APIs. |

--- a/skills/wix-docs/references/EXTRACTING.md
+++ b/skills/wix-docs/references/EXTRACTING.md
@@ -46,6 +46,11 @@ dev.wix.com/docs/                                      ← append .md to any pat
 │   ├── app-management/                                install apps, OAuth, app-instance/installations
 │   ├── assets/                                        media, rich-content
 │   └── account-level/ · site/ · tools/ · articles/    domains/sites, site config, auth/query guides
+├── sdk/                                               SDK-only surfaces (not in api-reference)
+│   ├── articles/set-up-a-client                       createClient + OAuthStrategy setup
+│   ├── core-modules/                                  @wix/sdk (createClient, OAuthStrategy), essentials, realtime
+│   ├── host-modules/                                  dashboard · editor · site (build on Wix surfaces)
+│   └── frontend-modules/                              members · pay · seo · storage · pricing-plans · …
 ├── go-headless/                                       headless setup, auth, hosting, framework integration
 ├── build-apps/                                        building Wix apps / extensions
 ├── wix-cli/                                           CLI commands


### PR DESCRIPTION
Correcting an earlier over-simplification. The SDK portal (`sdk.md`) was removed on the claim that api-reference covers both REST and SDK — but that's only true for **backend/business APIs**. The **SDK-only surfaces live only in the SDK portal**:

- **Client setup** — `createClient`, `OAuthStrategy` (`sdk/articles/set-up-a-client`)
- **Core modules** — `@wix/sdk`, `@wix/essentials` (`auth.elevate`), `realtime`, `web-methods`
- **Host modules** — `dashboard`, `editor`, `site`, `workspace`
- **Frontend modules** — `members`, `pay`, `seo`, `storage`, `pricing-plans`, `location`, `mobile`

(matches Wix's own 'Unified API Reference' article: frontend-specific + SDK-only functionality stay in the SDK reference.)

Re-adds `sdk.md` to the portal table () and the ASCII tree () with correct scoping. api-reference keeps its 'REST + SDK per page' note for business APIs. Paths verified live (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)