### PR TITLE
fix(wix-vibe-headless): scope visitor-token storage key by client id

### DIFF
--- a/skills/wix-vibe-headless/references/shared/wix-client.js
+++ b/skills/wix-vibe-headless/references/shared/wix-client.js
@@ -17,7 +17,10 @@ export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
 export const WIX_API_BASE = "https://www.wixapis.com";
 const OAUTH_TOKEN_URL = `${WIX_API_BASE}/oauth2/token`;
 
-const TOKEN_STORAGE_KEY = "wix-visitor-token";
+// Scope the storage key by client id so two headless sites served from the same
+// origin (e.g. localhost:4321 across projects) don't share one visitor token —
+// which would load site A's token for site B and mix up carts/identity.
+const TOKEN_STORAGE_KEY = `wix-visitor-token-${WIX_CLIENT_ID}`;
 let tokenCache = null;
 
 function loadToken() {


### PR DESCRIPTION
## What

`wix-client.js` hardcoded `TOKEN_STORAGE_KEY = "wix-visitor-token"`. Scope it by client id:

```js
const TOKEN_STORAGE_KEY = `wix-visitor-token-${WIX_CLIENT_ID}`;
```

## Why

Every headless dev server runs on the same origin (`localhost:4321`). With one shared localStorage key, previewing a second headless project in the same browser loads the first project's visitor token — wrong client, mixed-up cart/identity. Scoping the key by `WIX_CLIENT_ID` isolates each site's token. `WIX_CLIENT_ID` is already exported just above, so it's in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)