### PR TITLE
Allow nested skill docs in EvalForge gate

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35515,8 +35515,8 @@ function makeCommenter(octokit, owner, repo, prNumber) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.BASE_WORKSPACE_SUBDIR = exports.DOC_YAML_GLOB = exports.EVALS_GLOB = exports.EVALS_AREA_RE = exports.AREA_RE = exports.EVALS_RE = exports.MD_RE = exports.SKILLS_ROOT = void 0;
 exports.SKILLS_ROOT = 'skills/wix-manage/references';
-// `^skills/wix-manage/references/<area>/<basename>.md`
-exports.MD_RE = /^skills\/wix-manage\/references\/[^/]+\/[^/]+\.md$/;
+// `^skills/wix-manage/references/<area>/<nested/path>.md`
+exports.MD_RE = /^skills\/wix-manage\/references\/[^/]+\/.+\.md$/;
 // `^yaml/wix-manage-evals/<area>/<rest>.(yml|yaml)`
 exports.EVALS_RE = /^yaml\/wix-manage-evals\/[^/]+\/.+\.(ya?ml)$/;
 // Captures `<area>` from a doc path under SKILLS_ROOT.

--- a/.github/actions/evalforge-yaml-gate/src/utils/paths.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/paths.ts
@@ -1,7 +1,7 @@
 export const SKILLS_ROOT = 'skills/wix-manage/references';
 
-// `^skills/wix-manage/references/<area>/<basename>.md`
-export const MD_RE = /^skills\/wix-manage\/references\/[^/]+\/[^/]+\.md$/;
+// `^skills/wix-manage/references/<area>/<nested/path>.md`
+export const MD_RE = /^skills\/wix-manage\/references\/[^/]+\/.+\.md$/;
 
 // `^yaml/wix-manage-evals/<area>/<rest>.(yml|yaml)`
 export const EVALS_RE = /^yaml\/wix-manage-evals\/[^/]+\/.+\.(ya?ml)$/;

--- a/.github/actions/evalforge-yaml-gate/tests/github.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/github.test.ts
@@ -7,11 +7,15 @@ describe('classifyChanges', () => {
   it('separates .md and evals/*.yml', () => {
     const out = classifyChanges([
       f('skills/wix-manage/references/blog/how-to-create-blog-posts.md', 'modified'),
+      f('skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-goal-drive-cross-sells-codex-file-change.md', 'added'),
       f('yaml/wix-manage-evals/blog/create.yml', 'added'),
       f('yaml/wix-manage-evals/blog/delete.yml', 'removed'),
       f('README.md', 'modified'),
     ]);
-    expect(out.mdFiles).toHaveLength(1);
+    expect(out.mdFiles.map(file => file.filename)).toEqual([
+      'skills/wix-manage/references/blog/how-to-create-blog-posts.md',
+      'skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-goal-drive-cross-sells-codex-file-change.md',
+    ]);
     expect(out.evalsAdded).toHaveLength(1);
     expect(out.evalsRemoved).toHaveLength(1);
     expect(out.evalsModified).toHaveLength(0);


### PR DESCRIPTION
## Summary
- Allow the EvalForge YAML gate to classify nested wix-manage skill reference markdown files as gated changes
- Add classifier coverage for nested ecommerce pricing-promotions docs
- Rebuild the checked-in action bundle

## Testing
- yarn test
- yarn typecheck
- yarn build