### PR TITLE
docs(skills): add skills/README.md as the registry root page

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,23 @@
+# Wix Skills Registry
+
+The Wix Skills Registry provides self-contained context packages — instructions, schemas, and rules that let human developers and AI agents (Claude Code, Cursor, custom LLM workflows) build, manage, and extend projects across the Wix ecosystem.
+
+> **System constraint:** all skills target the current Wix CLI framework. Do not generate legacy Corvid or Velo backend code.
+
+## Usage
+
+- **`GET /skills/{name}`** — the skill's `SKILL.md` (top-level instructions + routing), without bundled references. Lightweight.
+- **`GET /skills/{name}-full`** — every file in the skill flattened into one markdown doc (`SKILL.md` + all `references/*`, scripts, etc.). One-shot ingestion.
+- **`GET /skills/{name}/{path}`** — a single raw file from the bundle (e.g. `references/X.md`).
+- **`GET /skills/{name}.tgz`** — the whole skill as a tarball, for installing locally.
+
+### Endpoints
+
+| Endpoint | Returns | Best for |
+|---|---|---|
+| `GET /skills/{name}` | `SKILL.md` only | Routing, intent checks, on-demand reference reads |
+| `GET /skills/{name}-full` | `SKILL.md` + all `references/*` and scripts, flattened | One-shot ingestion of the whole skill |
+| `GET /skills/{name}/{path}` | Raw file at path | Targeted reads of a single reference, script, or schema |
+| `GET /skills/{name}.tgz` | Compressed archive | Downloading the skill locally |
+
+> The list of available skills below is generated live from this repository.


### PR DESCRIPTION
Adds `skills/README.md` — served as the root of the skills registry at `dev.wix.com/skills` and `dev.wix.com/skills.md`.

The registry (in `wix-private/docs`, PR #4811) serves this file as the editable **intro** and **appends the live skill list** below it, so the landing copy can be edited here without a code deploy, and the skill list never goes stale.

Pairs with wix-private/docs#4811 (auto-discovery + `/skills.md` + repo-sourced root). No effect until that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)