### PR TITLE
docs(skills): link the wix/skills repo in the registry root page

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -20,4 +20,4 @@ The Wix Skills Registry provides self-contained context packages — instruction
 | `GET /skills/{name}/{path}` | Raw file at path | Targeted reads of a single reference, script, or schema |
 | `GET /skills/{name}.tgz` | Compressed archive | Downloading the skill locally |
 
-> The list of available skills below is generated live from this repository.
+> The list of available skills below is generated live from the [`wix/skills`](https://github.com/wix/skills) repository.


### PR DESCRIPTION
Small copy fix: the root page said "generated live from this repository" without linking it. Link to https://github.com/wix/skills. Served live from GitHub (no docs deploy needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)