### PR TITLE
test(skills): cache-invalidation probe

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,5 +1,7 @@
 # Wix Skills Registry
 
+<!-- cache-invalidation-probe-01 -->
+
 The Wix Skills Registry provides self-contained context packages — instructions, schemas, and rules that let human developers and AI agents (Claude Code, Cursor, custom LLM workflows) build, manage, and extend projects across the Wix ecosystem.
 
 > **System constraint:** all skills target the current Wix CLI framework. Do not generate legacy Corvid or Velo backend code.


### PR DESCRIPTION
Temporary marker to verify md-resolver auto-invalidates the /skills SSR cache on a wix/skills push. Will revert. 🤖