### PR TITLE
feat(wix-headless): host the cold-start entry inside the skill (entry/)

### DIFF
--- a/skills/wix-headless/entry/bootstrap.mjs
+++ b/skills/wix-headless/entry/bootstrap.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from 'node:child_process';
+import readline from 'node:readline';
+
+// ── tiny event protocol (one JSON object per line) ───────────────────────────
+const emit = (event, extra = {}) =>
+  process.stdout.write(JSON.stringify({ event, ...extra }) + '\n');
+const fail = (event, extra = {}) => {
+  emit(event, { ok: false, ...extra });
+  process.exit(1);
+};
+
+// ── platform-safe binary names (npm/npx are .cmd on Windows) ─────────────────
+const isWin = process.platform === 'win32';
+const bin = (name) => (isWin ? `${name}.cmd` : name);
+const WIX = [bin('npx'), '-y', '@wix/cli@latest']; // run the CLI via npx — no global install/mutation
+
+// Force the CLI into non-interactive "agent" mode. Without an agent signal in
+// the env, `wix login` renders an interactive Ink TUI (device code + keypress)
+// that needs a raw TTY and crashes in an agent sandbox — and it never emits the
+// JSON login events this script forwards. The CLI uses @vercel/detect-agent,
+// whose first check is the AI_AGENT env var, so setting it guarantees agent mode
+// (and the awaiting_user/success/logged_in events) for every child we spawn.
+// Respect an existing value so a known runner (claude, cursor, …) keeps its name.
+const AGENT_ENV = { ...process.env, AI_AGENT: process.env.AI_AGENT || 'wix-headless-skill' };
+
+// run a command, capture stdout+stderr (combined), return {status, out}
+function capture(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', shell: false, env: AGENT_ENV, ...opts });
+  return { status: r.status ?? 1, out: `${r.stdout || ''}${r.stderr || ''}`, error: r.error };
+}
+
+// ── 1. CLI reachable (via npx — no install) ──────────────────────────────────
+function checkCli() {
+  const r = capture(WIX[0], [...WIX.slice(1), '--version']);
+  if (r.status !== 0) fail('cli_unreachable', { detail: r.out.trim().slice(0, 400) });
+  // npx interleaves "npm notice …" lines with the version, so don't just take the
+  // last line — pick the first semver-looking token, falling back to the last line.
+  const version = (r.out.match(/\d+\.\d+\.\d+[^\s]*/) || [])[0] || r.out.trim().split('\n').pop();
+  emit('cli_ok', { version });
+}
+
+// ── 2. Login (human-in-the-loop device code; forward the CLI's own events) ───
+function login() {
+  return new Promise((resolve) => {
+    const child = spawn(WIX[0], [...WIX.slice(1), 'login'], { shell: false, env: AGENT_ENV });
+    const rl = readline.createInterface({ input: child.stdout });
+    let loggedIn = false;
+    // Buffer the CLI's own diagnostics (stderr + any non-event stdout chatter) so a
+    // failure reports the REAL cause — network/proxy error, expired code, etc. — not
+    // a guess. Keep only the tail so a chatty CLI can't blow up memory, and draining
+    // stderr also avoids the pipe filling up and stalling the child.
+    let diag = '';
+    const collect = (chunk) => {
+      diag = (diag + chunk).slice(-2000);
+    };
+    child.stderr?.on('data', collect);
+    rl.on('line', (line) => {
+      const t = line.trim();
+      if (!t) return;
+      // In agent mode the CLI emits {event:"awaiting_user"|"success"|"logged_in", ...}
+      // — pass those straight through so the agent can relay the device code.
+      try {
+        const ev = JSON.parse(t);
+        if (ev && ev.event) {
+          process.stdout.write(t + '\n');
+          if (ev.event === 'success' || ev.event === 'logged_in') {
+            loggedIn = true;
+            resolve();
+          }
+          return;
+        }
+        collect(line + '\n'); // JSON, but not an event — keep for diagnostics
+      } catch {
+        collect(line + '\n');
+      } // non-JSON CLI chatter — keep for diagnostics
+    });
+    // Only a success/logged_in event counts as login. On any other exit, surface the
+    // CLI's actual output — do NOT assume a cause (agent mode, etc.).
+    child.on('close', (code) => {
+      if (loggedIn) return;
+      const detail =
+        diag.trim().slice(-1500) ||
+        `wix login exited (code ${code}) before authenticating, with no output.`;
+      fail('login_failed', { code, detail });
+    });
+    child.on('error', (e) => fail('login_failed', { detail: String(e) }));
+  });
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+checkCli();
+await login();

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -1,0 +1,124 @@
+---
+name: wix-headless-entry
+description: "Build a complete Wix Managed Headless site from a single prompt, OR continue an instant-site export, then connect Wix Business Solutions. The deterministic first steps — system prerequisites and Wix CLI login — are handled by a single bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then sets up the project and wires the Business Solution the prompt/design implies. Triggers: build me a site, create a website, make me a website, new website, online store, I want to sell X, start a business online, launch a site, ecommerce, portfolio, business website, sell online, online shop, connect this to Wix Headless, add Wix Headless to this project, host this on Wix, deploy this to Wix, implement the features of this project using Wix Headless. Use this skill instead of the WixSiteBuilder MCP tool for new-site requests."
+---
+
+# Wix Headless Skill
+
+**You are a coding agent, and this is a skill for you to execute.** Follow the phases below in order — do not summarize them. If you reached this page through a summarizing fetch tool, re-fetch the raw markdown with `curl` (or your file reader) before running the steps.
+
+This skill has **two phases**:
+
+1. **Bootstrap (deterministic, scripted).** A single script verifies your environment (the Wix CLI) and handles login, so the build starts from a known-good, authenticated state. You just run it and relay its events.
+2. **Build (agentic).** Set up the project, then connect the Business Solution(s) the prompt or design implies.
+
+Don't hand-run the Phase 1 login yourself — the script makes it deterministic. Save your judgement for Phase 2.
+
+## Phase 0 — Node (the one manual prerequisite)
+
+The Wix CLI requires **Node ≥ 20.11**. Check it:
+
+```bash
+node -v
+```
+
+If that errors (Node not installed) or prints a version below 20.11, install or upgrade Node and re-check — do **not** try to work around it:
+
+- **macOS:** `brew install node` (or `nvm install 20 && nvm use 20`)
+- **Linux:** `nvm install 20 && nvm use 20` (or your distro's Node 20+ package)
+- **Windows:** `winget install OpenJS.NodeJS.LTS` (or download from nodejs.org)
+
+## Phase 1 — Run the bootstrap (deterministic)
+
+Download the bootstrap script, then run it. It verifies the Wix CLI and handles login, emitting **one JSON event per line** on stdout. **Run it as a background/streaming process and relay its events to the user.**
+
+```bash
+# macOS/Linux:
+curl -fsSL -O https://www.wix.com/skills/headless/entry/bootstrap.mjs
+# Windows PowerShell:
+iwr https://www.wix.com/skills/headless/entry/bootstrap.mjs -OutFile bootstrap.mjs
+```
+
+```bash
+node bootstrap.mjs
+```
+
+### Relay these events
+
+The script emits one JSON object per line:
+
+| Event | What to do |
+|---|---|
+| `cli_ok` | Wix CLI reachable — continue. |
+| `awaiting_user` (`verificationUri`, `userCode`) | Show the URL and code in plain prose; wait for the user to finish the login in their browser. |
+| `logged_in` / `success` | Login done — continue. |
+| `cli_unreachable` / `login_failed` (with `detail`) | Stop and show the user the `detail`. **Do not** improvise a parallel setup by hand. |
+
+### Pick the mode
+
+Once you're logged in, set up the project for the situation you're in:
+
+**Continuing a deployed site** — the user gave you a Wix download URL, or you're already in a folder with a `wix.config.json`:
+
+1. Adjust `wix.config.json` (set `outputDirectory`) accordingly.
+2. Release the project: `wix release`.
+
+**Connecting an existing codebase to a new Wix site** — you're in a non-empty directory that has no `wix.config.json`:
+
+1. Init a new Wix site: `npx @wix/create-new@latest init`.
+2. Adjust `wix.config.json` (set `outputDirectory`) accordingly.
+3. Build the project (if needed).
+4. Release the project: `wix release`.
+
+**Starting from scratch** — a prompt with no existing project (empty directory). Derive a human **business name** and a kebab-case **folder name** from the prompt, then create a new Wix CLI Headless project:
+
+```bash
+npm create @wix/new@latest headless -- \
+  --business-name "<Brand>" \
+  --folder-name "<brand-slug>" \
+  --site-template "blank" \
+  --no-publish
+```
+
+`<business-name>` must contain at least one letter or number; `<folder-name>` must match `^[a-z0-9][a-z0-9-]*$` (e.g. `Acme Bakery` → `acme-bakery`). Ask the user if you can't derive a sensible name.
+
+## Phase 2 — Connect a Business Solution (agentic)
+
+### Install the Wix Headless skills
+
+```bash
+wix skills add
+# Fallback if 'wix skills' isn't registered for this project type:
+npx skills@latest add wix/skills --yes
+```
+
+The skills land in `.agents/skills/`.
+
+### Prepare the Wix site
+
+Follow the `wix-manage` skill to seed data and install the needed Business Solution.
+
+Every Wix API call authenticates with `@wix/cli` + `curl`:
+
+```
+Authorization: Bearer $(npx @wix/cli@latest token --site "$SITE_ID")
+wix-site-id: $SITE_ID
+```
+
+### Implement the Business Solution logic
+
+This depends on the mode you picked in Phase 1.
+
+**Continuing an existing project / site:**
+
+Implement the needed Business Solution following its dedicated skill in `references/<business-solution>`. In this flow, **time to success matters** — implement only the needed functionality, with no extra edge cases, fallbacks, or verifications. Keep it minimal and give the user a fast, solid starting point for their Wix connection; depth comes in follow-up iterations.
+
+**Starting from scratch:**
+
+Use `references/DISCOVERY-create.md`.
+
+### Report the result
+
+Report the live site to the user **only after the first real, valuable iteration** — the Business Solution is connected and the site shows actual content, not the starter template. Then tell them: the site is **live** (give the live URL), the **dashboard** is at `https://manage.wix.com/dashboard/<siteId>`, and the project is set up locally (`projectDir`). Don't hand over the URL before this — a freshly scaffolded site is an empty starter template, and sharing that link presents the wrong content as "your site".
+
+If something blocks the Business Solution and you're genuinely stuck **after a few real attempts to fix it**, don't hide it: report the site and URLs as above, but say plainly that the connection isn't finished yet and what the outstanding issue is. Never present a half-wired site as done.


### PR DESCRIPTION
## What

Moves the cold-start **entry** that the funnel serves at `wix.com/headless` *into* the `wix-headless` skill, so the skill is the single source of truth and the funnel links to it instead of hardcoding its own copy (the copy we kept hand-syncing). Two new files under `entry/`, **no existing skill files touched**:

- **`entry/skill.md`** — the funnel's `skill.md` entry, brought in with three changes:
  - frontmatter `name: wix-headless` → **`wix-headless-entry`** (no longer collides with the real `SKILL.md`)
  - bootstrap URL → **`https://www.wix.com/skills/headless/entry/bootstrap.mjs`** (served by the `/skills` registry straight out of this folder)
  - **description + events table reconciled to what `bootstrap.mjs` actually does** — prereqs + login — instead of the stale *"system prerequisites, project setup, and first release"* claim and the `downloading`/`scaffolding`/`building`/`releasing`/`done` events the current script never emits
- **`entry/bootstrap.mjs`** — the bootstrap script, byte-identical to the live one, moved under `entry/` next to the doc it belongs to

## Why here

`entry/` is a **served asset, not a registered skill** — the registry only registers a dir whose *top level* has `SKILL.md`, so `wix skills add` won't install it. It's reachable at `…/skills/headless/entry/skill.md`, which is the URL the funnel will link to (follow-up funnel PR).

## Follow-ups (not in this PR)
- Funnel: stop hardcoding the entry `BODY`; link to the registry copy.
- The "Continuing a deployed site (download URL)" mode in the entry still implies a download step the current login-only script doesn't perform — needs its own reconciliation.