### PR TITLE
feat(marketing-plan): add "Generate a Marketing Plan and Schedule Its Posts" skill

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, site-properties, ecommerce, social media."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, site-properties, ecommerce, social media, marketing plans."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -181,6 +181,13 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Payment Links for Bookings](references/get-paid/payment-links-for-bookings.md)
 **Technical:** Creates payment links for unpaid bookings using Payment Links API. Links booking IDs to payment requests with proper redirect handling.
+
+---
+
+## Marketing Plan
+
+### [Generate a Marketing Plan and Schedule Its Posts](references/marketing-plan/generate-and-publish-marketing-plan.md)
+**Technical:** Generates a site's AI social media marketing plan (a calendar of marketing activities, each with per-channel post drafts) via the Marketing Plan API, then schedules the drafts for publishing. Covers optional marketing settings (goal, channels, tone, frequency, content pillars), asynchronous generation with polling until `ACTIVE`, scheduling `DRAFT` posts (only for channels connected through the Publisher), and generating posts for additional activities. Use for "generate a marketing plan", "create a social media plan/calendar", or "schedule my plan's posts".
 
 ---
 

--- a/skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
+++ b/skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
@@ -1,0 +1,194 @@
+---
+name: "Generate a Marketing Plan and Schedule Its Posts"
+description: "End-to-end flow to generate an AI-powered social media marketing plan for a site and schedule its generated posts for publishing, using the Wix Marketing Plan API. Optionally configures marketing settings (goal, channels, tone, content pillars, frequency) first, generates the plan asynchronously, polls until it's ready, then schedules the DRAFT posts. Includes generating posts for additional activities. Use for 'generate a marketing plan', 'create a social media plan/calendar', or 'schedule my plan's posts' requests."
+---
+# RECIPE: Generate a Marketing Plan and Schedule Its Posts
+
+This recipe generates a site's AI marketing plan — a schedule of marketing activities (social campaigns, blog posts, emails) from today through the end of next month — and schedules the social posts it generates. Generation is **asynchronous and non-deterministic**: you fire it, poll until it's ready, then act on the results.
+
+Base URL for all endpoints: `https://www.wixapis.com/promote/marketing-plan-service/v1`.
+
+**Prerequisites:**
+- The site must be **published** — generation draws on the published site. This isn't validated at call time; an unpublished site yields a `FAILED` plan or an `ACTIVE` plan with no posts. Verify before generating.
+- For posts to be **scheduled/published**, the target channels must be connected through the Publisher (see the [Publish or Schedule a Social Media Post](https://dev.wix.com/docs/api-reference/business-management/marketing/social-media/skills) recipe). Drafts for unconnected channels stay as drafts.
+
+---
+
+## STEP 1 (optional): Tailor the plan with marketing settings
+
+Settings are optional — sensible defaults apply if unset. Configure them only to customize the output. Skip to STEP 2 to generate with defaults.
+
+**API Endpoint:** `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-settings`
+
+Both `marketingSettings` and `fieldMask` are **required**. `fieldMask` lists the paths to write, and **every path in `fieldMask` must be present** in `marketingSettings` (otherwise `FAILED_PRECONDITION`).
+
+```json
+{
+  "marketingSettings": {
+    "settings": {
+      "marketingPlanGoal": { "goalKey": "BOOST_SALES" },
+      "socialChannels": ["INSTAGRAM", "FACEBOOK", "TIKTOK"],
+      "marketingTools": ["SOCIAL_MARKETING"],
+      "pointOfView": "SECOND_PERSON",
+      "frequency": { "interval": "WEEK", "count": 3 },
+      "topics": { "included": ["handmade ceramics", "studio life"], "excluded": ["politics"] }
+    }
+  },
+  "fieldMask": [
+    "settings.marketingPlanGoal",
+    "settings.socialChannels",
+    "settings.marketingTools",
+    "settings.pointOfView",
+    "settings.frequency",
+    "settings.topics"
+  ]
+}
+```
+
+Key fields:
+- `marketingPlanGoal.goalKey`: `DRIVE_TRAFFIC`, `BRAND_AWARENESS`, `BOOST_SALES`, or `COLLECT_LEADS` (or use `customGoal` free text instead).
+- `socialChannels`: `FACEBOOK`, `INSTAGRAM`, `LINKEDIN`, `PINTEREST`, `GBP`, `TIKTOK`, `TWITTER`. `TWITTER` (X) is being sunset — it's no longer functional after **July 31, 2026**, so don't include it in a plan whose posts would publish on or after that date.
+- `marketingTools`: must include `SOCIAL_MARKETING` for social post drafts to be generated (also `BLOGS`, `EMAIL_MARKETING`).
+- `pointOfView`: `FIRST_PERSON`, `SECOND_PERSON`, `THIRD_PERSON`.
+- `frequency`: `{ interval: WEEK | MONTH | YEAR, count: 1–30 }`.
+- `topics.included` / `topics.excluded`: content pillars to focus on or avoid.
+
+To fetch the selectable values at runtime instead of hardcoding them, call `GET .../marketing-settings/plan-goal-options` and `GET .../marketing-settings/point-of-view-options`; `GET .../marketing-settings/defaults` returns the site's default goal, channels, and frequency.
+
+**Note:** Settings shape the plan only at generation time. If a plan already exists, changing settings requires a regenerate (STEP 2) to take effect. If you changed `topics`, use `RegenerateMarketingPlanWithKeywordResearch` (`POST .../marketing-plan/regenerate-marketing-plan-with-keyword-research`) instead.
+
+---
+
+## STEP 2: Generate the plan
+
+**API Endpoint:** `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-plan/generate-marketing-plan`
+
+No body is required:
+
+```json
+{}
+```
+
+**Expected response** — generation runs in the background:
+
+```json
+{ "status": "GENERATING" }
+```
+
+If the site already has a plan and you want to refresh it, call `POST .../marketing-plan/regenerate-marketing-plan` instead (same response shape).
+
+---
+
+## STEP 3: Poll until the plan is ready
+
+Poll this endpoint until `status` is `ACTIVE` (ready) or `FAILED`. Poll about every **5 seconds**, and stop after ~15 minutes as a safety timeout.
+
+**API Endpoint:** `GET https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-plan?timeframe.startDate=2026-07-01T00:00:00.000Z&timeframe.endDate=2026-08-31T23:59:59.999Z`
+
+`timeframe` is optional; omit it to return all activities from today onward.
+
+**Expected response when ready:**
+
+```json
+{
+  "status": "ACTIVE",
+  "marketingActivities": [
+    {
+      "marketingActivityId": "b3f9d2e1-7a4c-4d68-9f02-1c5e8a6b4d30",
+      "date": "2026-07-08T09:00:00.000Z",
+      "title": "Summer collection launch",
+      "description": "Announce the new handmade ceramic mugs summer collection with a 20% launch discount.",
+      "items": [
+        {
+          "id": "834dc801-3e5c-416a-bd14-b130a95d100e",
+          "channel": { "name": "INSTAGRAM", "accountId": "17841405822304914" },
+          "type": "POST",
+          "status": "DRAFT",
+          "instagramPost": {
+            "mediaWrapper": { "media": [ { "type": "IMAGE", "url": "https://static.wixstatic.com/media/....jpg" } ] },
+            "caption": "Summer collection just dropped! Shop the look now. #summerstyle #newarrivals"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+`PlanStatus` values: `NEVER_CREATED`, `GENERATING` (keep polling), `ACTIVE` (ready), `INACTIVE` (deactivated after long inactivity — regenerate to reactivate), `FAILED` (retry with STEP 2).
+
+Posts are generated automatically only for the **near-term** activities (how far ahead depends on the site's premium plan). Later activities have no `items` yet — see STEP 5 to generate them.
+
+---
+
+## STEP 4: Schedule the draft posts
+
+Collect the `id` of every `item` whose `status` is `DRAFT`, from the activities you want to publish, then schedule them.
+
+**API Endpoint:** `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-plan/schedule-drafts`
+
+`draftIds` are item IDs; 1–20 per call:
+
+```json
+{ "draftIds": ["834dc801-3e5c-416a-bd14-b130a95d100e"] }
+```
+
+**Expected response:** the scheduled items (`status` now `SCHEDULED`):
+
+```json
+{ "items": [ { "id": "834dc801-3e5c-416a-bd14-b130a95d100e", "status": "SCHEDULED", "channel": { "name": "INSTAGRAM" } } ] }
+```
+
+Behavior:
+- Only `DRAFT` items are scheduled; non-draft IDs are silently ignored.
+- Only drafts for channels connected through the Publisher are scheduled; drafts for unconnected channels are silently skipped and stay drafts.
+- Requires the site's plan to include the schedule-posts premium feature; otherwise the call returns `FAILED_PRECONDITION`.
+
+The scheduled posts are managed by the Publisher and appear on the site's Social Media Marketing page.
+
+---
+
+## STEP 5 (optional): Generate posts for more activities
+
+For activities that have no `items` yet, generate their posts, then schedule them.
+
+1. **Generate** — `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-plan/generate-social-posts` (1–20 activity IDs; returns `{}` immediately, async):
+
+   ```json
+   { "marketingActivityIds": ["b3f9d2e1-7a4c-4d68-9f02-1c5e8a6b4d30"] }
+   ```
+
+2. **Poll** — `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-activity-posts` with the same activity IDs until posts appear:
+
+   ```json
+   { "marketingActivityIds": ["b3f9d2e1-7a4c-4d68-9f02-1c5e8a6b4d30"] }
+   ```
+
+   Response: `{ "marketingActivities": [ { "marketingActivityId": "...", "items": [ { "id": "...", "status": "DRAFT", ... } ] } ] }`.
+
+3. **Schedule** — collect the new `DRAFT` item IDs and call `schedule-drafts` as in STEP 4.
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Plan `status: FAILED`, or `ACTIVE` with no posts | Site not published, or `SOCIAL_MARKETING` not enabled in settings | Publish the site; ensure `settings.marketingTools` includes `SOCIAL_MARKETING`, then regenerate (STEP 2) |
+| `FAILED_PRECONDITION` on Upsert Marketing Settings | A `fieldMask` path is missing from `marketingSettings` | Include every `fieldMask` path in the `marketingSettings` body |
+| `FAILED_PRECONDITION` on Schedule Drafts | Plan lacks the schedule-posts premium feature | Advise upgrading the social media marketing plan |
+| `FAILED_PRECONDITION` / `PLAN_ALREADY_GENERATING_ERROR` on Regenerate | A generation is already in progress | Wait for STEP 3 to reach `ACTIVE` or `FAILED` before regenerating |
+| Drafts remain `DRAFT` after Schedule Drafts | Their channels aren't connected through the Publisher | Connect those channels (Publisher Accounts API), then reschedule |
+| Polling never reaches `ACTIVE` | Generation stuck or very slow | Stop after ~15 minutes and retry generation |
+| `GetSocialMarketingPlan` returns `INACTIVE` with no activities | Plan auto-deactivated after long inactivity | Call generate/regenerate (STEP 2) to reactivate |
+
+## References
+
+- [Marketing Plan API introduction](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/introduction)
+- [Marketing Plan API sample flows](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/sample-flows)
+- [Generate Marketing Plan](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/marketing-plan-v1/generate-marketing-plan)
+- [Get Social Marketing Plan](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/marketing-plan-v1/get-social-marketing-plan)
+- [Schedule Drafts](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/marketing-plan-v1/schedule-drafts)
+- [Generate Social Posts](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/marketing-plan-v1/generate-social-posts)
+- [Get Marketing Activity Posts](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/marketing-plan-v1/get-marketing-activity-posts)
+- [Upsert Marketing Settings](https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/marketing-settings-v1/upsert-marketing-settings)

--- a/skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
+++ b/skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
@@ -1,6 +1,6 @@
 ---
 name: "Generate a Marketing Plan and Schedule Its Posts"
-description: "End-to-end flow to generate an AI-powered social media marketing plan for a site and schedule its generated posts for publishing, using the Wix Marketing Plan API. Optionally configures marketing settings (goal, channels, tone, content pillars, frequency) first, generates the plan asynchronously, polls until it's ready, then schedules the DRAFT posts. Includes generating posts for additional activities. Use for 'generate a marketing plan', 'create a social media plan/calendar', or 'schedule my plan's posts' requests."
+description: "End-to-end flow to generate an AI-powered social media marketing plan for a site and schedule its generated posts for publishing, using the Wix Marketing Plan API. Recommends configuring marketing settings (goal, tone, cadence, content pillars) before the first generation, generates the plan asynchronously, polls until it's ready, then schedules the DRAFT posts. Includes generating posts for additional activities. Use for 'generate a marketing plan', 'create a social media plan/calendar', or 'schedule my plan's posts' requests."
 ---
 # RECIPE: Generate a Marketing Plan and Schedule Its Posts
 
@@ -14,48 +14,58 @@ Base URL for all endpoints: `https://www.wixapis.com/promote/marketing-plan-serv
 
 ---
 
-## STEP 1 (optional): Tailor the plan with marketing settings
+## STEP 1 (recommended before your first plan): Tailor the plan with marketing settings
 
-Settings are optional — sensible defaults apply if unset. Configure them only to customize the output. Skip to STEP 2 to generate with defaults.
+For a first-time plan, configure marketing settings **before** generating (STEP 2), so the first plan reflects the brand's goal, voice, and cadence. Settings are optional — the service applies per-site defaults if you skip this — but they're read **only at generation time**, so a plan generated with defaults won't change until you regenerate. After a plan exists, changing settings requires a regenerate (STEP 2) to take effect.
 
 **API Endpoint:** `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-settings`
 
-Both `marketingSettings` and `fieldMask` are **required**. `fieldMask` lists the paths to write, and **every path in `fieldMask` must be present** in `marketingSettings` (otherwise `FAILED_PRECONDITION`).
+Both `marketingSettings` and `fieldMask` are **required**. `fieldMask` lists the paths to write, and **every path in `fieldMask` must be present** in `marketingSettings` (otherwise the call fails with `INVALID_FIELD_MASK_ERROR`).
 
 ```json
 {
   "marketingSettings": {
     "settings": {
       "marketingPlanGoal": { "goalKey": "BOOST_SALES" },
-      "socialChannels": ["INSTAGRAM", "FACEBOOK", "TIKTOK"],
       "marketingTools": ["SOCIAL_MARKETING"],
+      "topics": { "included": ["handmade ceramics", "studio life"], "excluded": ["politics"] },
+      "toneOfVoice": "warm and playful",
       "pointOfView": "SECOND_PERSON",
-      "frequency": { "interval": "WEEK", "count": 3 },
-      "topics": { "included": ["handmade ceramics", "studio life"], "excluded": ["politics"] }
+      "businessProfile": { "valueProposition": "hand-thrown stoneware for everyday rituals", "targetAudience": "design-conscious home cooks" }
+    },
+    "overrides": {
+      "socialMarketing": { "frequency": { "interval": "WEEK", "count": 3 } }
     }
   },
   "fieldMask": [
     "settings.marketingPlanGoal",
-    "settings.socialChannels",
     "settings.marketingTools",
+    "settings.topics",
+    "settings.toneOfVoice",
     "settings.pointOfView",
-    "settings.frequency",
-    "settings.topics"
+    "settings.businessProfile",
+    "overrides.socialMarketing.frequency"
   ]
 }
 ```
 
-Key fields:
-- `marketingPlanGoal.goalKey`: `DRIVE_TRAFFIC`, `BRAND_AWARENESS`, `BOOST_SALES`, or `COLLECT_LEADS` (or use `customGoal` free text instead).
-- `socialChannels`: `FACEBOOK`, `INSTAGRAM`, `LINKEDIN`, `PINTEREST`, `GBP`, `TIKTOK`, `TWITTER`. `TWITTER` (X) is being sunset — it's no longer functional after **July 31, 2026**, so don't include it in a plan whose posts would publish on or after that date.
-- `marketingTools`: must include `SOCIAL_MARKETING` for social post drafts to be generated (also `BLOGS`, `EMAIL_MARKETING`).
-- `pointOfView`: `FIRST_PERSON`, `SECOND_PERSON`, `THIRD_PERSON`.
-- `frequency`: `{ interval: WEEK | MONTH | YEAR, count: 1–30 }`.
-- `topics.included` / `topics.excluded`: content pillars to focus on or avoid.
+**What each field shapes.** Generation has two stages, and fields feed different stages:
+- **The activities** (what to post about, and when): `marketingPlanGoal` (`goalKey` ∈ `DRIVE_TRAFFIC`, `BRAND_AWARENESS`, `BOOST_SALES`, `COLLECT_LEADS`, or `customGoal` free text), `topics.included`/`topics.excluded` (content pillars), `businessProfile` (`valueProposition`, `targetAudience`, `businessGoal`), `calendar.ids` (which calendars feed the plan), and per-tool cadence `overrides.<socialMarketing|emailMarketing|blogs>.frequency` (`{ interval: WEEK | MONTH | YEAR, count: 1–30 }`).
+- **The post drafts** (captions and images): `toneOfVoice` (free text), `pointOfView` (`FIRST_PERSON`/`SECOND_PERSON`/`THIRD_PERSON`), `customContentGuidelines` (free text), `imageGuidelines` (free text), and `businessProfile.targetAudience`.
+- `marketingTools` must include `SOCIAL_MARKETING` for social post drafts to be generated (also `BLOGS`, `EMAIL_MARKETING`).
 
-To fetch the selectable values at runtime instead of hardcoding them, call `GET .../marketing-settings/plan-goal-options` and `GET .../marketing-settings/point-of-view-options`; `GET .../marketing-settings/defaults` returns the site's default goal, channels, and frequency.
+**`socialChannels` does not limit channels.** The plan generates post drafts for **all** supported channels; `settings.socialChannels` is only a hint to the caption generator, not a filter. To avoid publishing to a channel, simply don't schedule (or connect) it in STEP 4 — don't rely on `socialChannels` to exclude it. Supported channels: `FACEBOOK`, `INSTAGRAM`, `LINKEDIN`, `PINTEREST`, `GBP`, `TIKTOK`, `TWITTER` (X, sunset — no longer functional after **July 31, 2026**).
 
-**Note:** Settings shape the plan only at generation time. If a plan already exists, changing settings requires a regenerate (STEP 2) to take effect. If you changed `topics`, use `RegenerateMarketingPlanWithKeywordResearch` (`POST .../marketing-plan/regenerate-marketing-plan-with-keyword-research`) instead.
+**What you can't set here (site-derived, read-only).** Several inputs that shape the plan are **not** part of marketing settings and can't be changed through this endpoint — they come from the site, and setting them via Upsert Marketing Settings has no effect:
+- **Language / region** — from the site's Language & Region settings (`settings.language` is read-only here).
+- **Business / target locations** — from the site's SEO business-location settings (`settings.businessLocation` / `settings.targetLocations` are read-only here).
+- **Industry, SEO summary, and published site content** (products, blog posts, events) — from the published site itself.
+
+To change any of these, edit them at the site level, then (re)generate the plan (STEP 2) so it picks them up.
+
+To fetch selectable values at runtime, call `GET .../marketing-settings/plan-goal-options` (goals) and `GET .../marketing-settings/defaults` (the site's default goal, channels, and frequency); point-of-view values are the fixed enum above. (Two fields are accepted but currently ignored by generation: `settings.imageGenerationSettings` and `topics.coreTopic`.)
+
+**Note:** If you changed `topics` on an existing plan, regenerate with `RegenerateMarketingPlanWithKeywordResearch` (`POST .../marketing-plan/regenerate-marketing-plan-with-keyword-research`) so keyword research reruns.
 
 ---
 
@@ -115,7 +125,7 @@ Poll this endpoint until `status` is `ACTIVE` (ready) or `FAILED`. Poll about ev
 }
 ```
 
-`PlanStatus` values: `NEVER_CREATED`, `GENERATING` (keep polling), `ACTIVE` (ready), `INACTIVE` (deactivated after long inactivity — regenerate to reactivate), `FAILED` (retry with STEP 2).
+`PlanStatus` values: `NEVER_CREATED`, `GENERATING` (keep polling), `ACTIVE` (ready), `INACTIVE` (auto-deactivated after ~6 weeks idle — and calling this endpoint on a stale plan can itself trigger the transition; regenerate to reactivate), `FAILED` (retry with STEP 2).
 
 Posts are generated automatically only for the **near-term** activities (how far ahead depends on the site's premium plan). Later activities have no `items` yet — see STEP 5 to generate them.
 
@@ -158,6 +168,8 @@ For activities that have no `items` yet, generate their posts, then schedule the
    { "marketingActivityIds": ["b3f9d2e1-7a4c-4d68-9f02-1c5e8a6b4d30"] }
    ```
 
+   Note: this generates drafts for **all** supported channels (it ignores `socialChannels`) and doesn't re-check `SOCIAL_MARKETING` in `marketingTools`.
+
 2. **Poll** — `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-activity-posts` with the same activity IDs until posts appear:
 
    ```json
@@ -175,7 +187,8 @@ For activities that have no `items` yet, generate their posts, then schedule the
 | Symptom | Cause | Fix |
 | --- | --- | --- |
 | Plan `status: FAILED`, or `ACTIVE` with no posts | Site not published, or `SOCIAL_MARKETING` not enabled in settings | Publish the site; ensure `settings.marketingTools` includes `SOCIAL_MARKETING`, then regenerate (STEP 2) |
-| `FAILED_PRECONDITION` on Upsert Marketing Settings | A `fieldMask` path is missing from `marketingSettings` | Include every `fieldMask` path in the `marketingSettings` body |
+| `INVALID_FIELD_MASK_ERROR` on Upsert Marketing Settings | A `fieldMask` path is missing from `marketingSettings` | Include every `fieldMask` path in the `marketingSettings` body |
+| Language, region, or location "won't change" via Upsert Marketing Settings | Those fields are read-only here (site-derived) | Change them in the site's Language & Region / SEO business-location settings, then regenerate |
 | `FAILED_PRECONDITION` on Schedule Drafts | Plan lacks the schedule-posts premium feature | Advise upgrading the social media marketing plan |
 | `FAILED_PRECONDITION` / `PLAN_ALREADY_GENERATING_ERROR` on Regenerate | A generation is already in progress | Wait for STEP 3 to reach `ACTIVE` or `FAILED` before regenerating |
 | Drafts remain `DRAFT` after Schedule Drafts | Their channels aren't connected through the Publisher | Connect those channels (Publisher Accounts API), then reschedule |

--- a/skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
+++ b/skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
@@ -10,7 +10,7 @@ Base URL for all endpoints: `https://www.wixapis.com/promote/marketing-plan-serv
 
 **Prerequisites:**
 - The site must be **published** — generation draws on the published site. This isn't validated at call time; an unpublished site yields a `FAILED` plan or an `ACTIVE` plan with no posts. Verify before generating.
-- For posts to be **scheduled/published**, the target channels must be connected through the Publisher (see the [Publish or Schedule a Social Media Post](https://dev.wix.com/docs/api-reference/business-management/marketing/social-media/skills) recipe). Drafts for unconnected channels stay as drafts.
+- For posts to be **scheduled/published**, the target channels must be connected through the Publisher (see the [Create and Publish a Social Media Post](https://dev.wix.com/docs/api-reference/business-management/marketing/social-media/skills) recipe for the connect flow). Drafts for unconnected channels silently stay as drafts (STEP 4).
 
 ---
 
@@ -65,7 +65,7 @@ To change any of these, edit them at the site level, then (re)generate the plan 
 
 To fetch selectable values at runtime, call `GET .../marketing-settings/plan-goal-options` (goals) and `GET .../marketing-settings/defaults` (the site's default goal, channels, and frequency); point-of-view values are the fixed enum above. (Two fields are accepted but currently ignored by generation: `settings.imageGenerationSettings` and `topics.coreTopic`.)
 
-**Note:** If you changed `topics` on an existing plan, regenerate with `RegenerateMarketingPlanWithKeywordResearch` (`POST .../marketing-plan/regenerate-marketing-plan-with-keyword-research`) so keyword research reruns.
+**Note — settings only take effect on (re)generation.** Editing settings never changes an existing plan on its own. To apply changes to an existing plan, regenerate it (STEP 2, `regenerate-marketing-plan`). **If you changed `topics`, use `RegenerateMarketingPlanWithKeywordResearch` instead** (`POST .../marketing-plan/regenerate-marketing-plan-with-keyword-research`) so keyword research reruns for the new content pillars.
 
 ---
 
@@ -133,7 +133,7 @@ Posts are generated automatically only for the **near-term** activities (how far
 
 ## STEP 4: Schedule the draft posts
 
-Collect the `id` of every `item` whose `status` is `DRAFT`, from the activities you want to publish, then schedule them.
+Collect the `id` of every `item` whose `status` is `DRAFT` from the activities you want to publish. **Before scheduling, show the user what will be published** — each draft's caption and media (render the image inline if the surface supports it, otherwise post its URL as a clickable link) — and get their approval. The drafts are AI-generated and scheduling publishes them, so never schedule content the user hasn't reviewed.
 
 **API Endpoint:** `POST https://www.wixapis.com/promote/marketing-plan-service/v1/marketing-plan/schedule-drafts`
 
@@ -149,10 +149,10 @@ Collect the `id` of every `item` whose `status` is `DRAFT`, from the activities 
 { "items": [ { "id": "834dc801-3e5c-416a-bd14-b130a95d100e", "status": "SCHEDULED", "channel": { "name": "INSTAGRAM" } } ] }
 ```
 
-Behavior:
+**Check the response — scheduling can partially and silently succeed:**
 - Only `DRAFT` items are scheduled; non-draft IDs are silently ignored.
-- Only drafts for channels connected through the Publisher are scheduled; drafts for unconnected channels are silently skipped and stay drafts.
-- Requires the site's plan to include the schedule-posts premium feature; otherwise the call returns `FAILED_PRECONDITION`.
+- **Only drafts for Publisher-connected channels are scheduled; drafts for unconnected channels are silently skipped and stay `DRAFT` — with no error.** A `200` does not mean everything was scheduled. **Diff the returned `items` against the `draftIds` you sent:** any id not returned as `SCHEDULED` is still a draft. Tell the user which channels those drafts belong to and that the channel needs connecting — connect it via the [Create and Publish a Social Media Post](https://dev.wix.com/docs/api-reference/business-management/marketing/social-media/skills) recipe's connect flow, then reschedule those ids.
+- Requires the site's plan to include the schedule-posts premium feature; otherwise the call returns `FAILED_PRECONDITION` (advise upgrading the social media marketing plan).
 
 The scheduled posts are managed by the Publisher and appear on the site's Social Media Marketing page.
 

--- a/yaml/wix-manage-evals/marketing-plan/generate-and-publish-marketing-plan.yml
+++ b/yaml/wix-manage-evals/marketing-plan/generate-and-publish-marketing-plan.yml
@@ -1,13 +1,14 @@
 name: marketing-plan/generate-and-publish-marketing-plan
 description: >-
-  Action scenario for the "Generate a Marketing Plan and Schedule Its Posts" skill
-  on a fresh site with no marketing plan yet: the agent is asked to schedule the
-  plan's posts, and the correct behavior is to check the plan first (Get Social
-  Marketing Plan), find none (NEVER_CREATED), and explain that a plan must be
-  generated first (asynchronously), rather than fabricating posts or blindly
-  scheduling. A fresh site has no plan, so nothing can actually be scheduled.
+  Action scenario for the "Generate a Marketing Plan and Schedule Its Posts" skill:
+  the user asks to set up the plan for a French-speaking Paris audience and to boost
+  sales. The correct behavior is to set the goal via Upsert Marketing Settings (with
+  a valid fieldMask), while recognizing that language and location are site-derived
+  and read-only on marketing settings and must be changed at the site level, rather
+  than trying to set them through Upsert Marketing Settings.
 triggerPrompt: >-
-  Schedule this week's posts from my marketing plan.
+  Set up my marketing plan to promote to French-speaking customers in Paris, and
+  focus on boosting sales.
 tags: [marketing]
 siteSetup:
   mode: template
@@ -20,23 +21,30 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: |
-      The user asked to schedule this week's marketing-plan posts, on a fresh site
-      that has NO marketing plan yet (Get Social Marketing Plan returns NEVER_CREATED).
-      The only correct outcome is to detect that no plan exists and not fabricate or
-      blindly schedule anything.
+      The user asked to set up their marketing plan to (a) target a French-speaking
+      audience in Paris and (b) focus on boosting sales. Key fact: on the Marketing Plan
+      API the plan's GOAL is settable via Upsert Marketing Settings, but LANGUAGE and
+      LOCATION are site-derived and read-only on marketing settings. They cannot be
+      changed through Upsert Marketing Settings; they are changed at the site level
+      (the site's Language & Region settings, and SEO business-location settings), after
+      which the plan is regenerated.
 
       Pass if the response:
-      - checks the plan status via Get Social Marketing Plan
-        (GET /promote/marketing-plan-service/v1/marketing-plan) BEFORE scheduling, AND
-      - on finding no plan (status NEVER_CREATED, or no activities/drafts), explains a
-        plan must be generated first with Generate Marketing Plan (noting generation is
-        asynchronous and must be polled until ACTIVE), or offers to generate it, AND
-      - does NOT fabricate marketing activities, draft IDs, or posts, AND
-      - does NOT call Schedule Drafts with made-up IDs, AND
+      - sets the plan goal to BOOST_SALES via Upsert Marketing Settings
+        (POST /promote/marketing-plan-service/v1/marketing-settings) with a fieldMask in
+        which every path is also present in marketingSettings, AND
+      - correctly explains that language (French) and location (Paris) are NOT set through
+        marketing settings (they are site-derived / read-only) and directs the user to
+        change them in the site's Language & Region and SEO business-location settings,
+        then regenerate the plan, AND
+      - does NOT put language, targetLocations, or businessLocation in the Upsert Marketing
+        Settings request, and does NOT claim that call changed the plan's language or
+        location, AND
       - does not fall back to searching the REST docs instead of using the skill.
 
       Fail if the response:
-      - calls Schedule Drafts with invented IDs, OR
-      - fabricates a plan or its activities/posts, OR
-      - treats generation as synchronous, OR
-      - never checks the plan before acting.
+      - calls Upsert Marketing Settings with language / targetLocations / businessLocation,
+        or claims doing so sets them, OR
+      - omits fieldMask, or includes a fieldMask path not present in marketingSettings, OR
+      - fabricates a successful language/location change, OR
+      - never uses the skill.

--- a/yaml/wix-manage-evals/marketing-plan/generate-and-publish-marketing-plan.yml
+++ b/yaml/wix-manage-evals/marketing-plan/generate-and-publish-marketing-plan.yml
@@ -1,0 +1,42 @@
+name: marketing-plan/generate-and-publish-marketing-plan
+description: >-
+  Action scenario for the "Generate a Marketing Plan and Schedule Its Posts" skill
+  on a fresh site with no marketing plan yet: the agent is asked to schedule the
+  plan's posts, and the correct behavior is to check the plan first (Get Social
+  Marketing Plan), find none (NEVER_CREATED), and explain that a plan must be
+  generated first (asynchronously), rather than fabricating posts or blindly
+  scheduling. A fresh site has no plan, so nothing can actually be scheduled.
+triggerPrompt: >-
+  Schedule this week's posts from my marketing plan.
+tags: [marketing]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan/skills/generate-a-marketing-plan-and-schedule-its-posts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked to schedule this week's marketing-plan posts, on a fresh site
+      that has NO marketing plan yet (Get Social Marketing Plan returns NEVER_CREATED).
+      The only correct outcome is to detect that no plan exists and not fabricate or
+      blindly schedule anything.
+
+      Pass if the response:
+      - checks the plan status via Get Social Marketing Plan
+        (GET /promote/marketing-plan-service/v1/marketing-plan) BEFORE scheduling, AND
+      - on finding no plan (status NEVER_CREATED, or no activities/drafts), explains a
+        plan must be generated first with Generate Marketing Plan (noting generation is
+        asynchronous and must be polled until ACTIVE), or offers to generate it, AND
+      - does NOT fabricate marketing activities, draft IDs, or posts, AND
+      - does NOT call Schedule Drafts with made-up IDs, AND
+      - does not fall back to searching the REST docs instead of using the skill.
+
+      Fail if the response:
+      - calls Schedule Drafts with invented IDs, OR
+      - fabricates a plan or its activities/posts, OR
+      - treats generation as synchronous, OR
+      - never checks the plan before acting.

--- a/yaml/wix-manage/marketing-plan/documentation.yaml
+++ b/yaml/wix-manage/marketing-plan/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Marketing Plan Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/marketing-plan/generate-and-publish-marketing-plan.md
+      title: Generate a Marketing Plan and Schedule Its Posts
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/marketing-plan
+      tags: [marketing]


### PR DESCRIPTION
## What

Adds the second Promote wix-manage skill (after the Publisher skill #480), for the now-public **Marketing Plan API**. Four pieces:
- **Recipe:** `references/marketing-plan/generate-and-publish-marketing-plan.md`
- **`documentation.yaml`:** `docsEntry` = `.../business-management/marketing/marketing-plan`, tag `marketing`
- **SKILL.md:** index entry + routing (adds "marketing plans")
- **Coverage eval:** `yaml/wix-manage-evals/marketing-plan/...` (action scenario, `ReadFullDocsArticle` canonical-URL assertion + llm_judge)

## Flow

Optional marketing settings (goal, channels, tone, frequency, content pillars) → **Generate Marketing Plan** (async) → poll **Get Social Marketing Plan** until `ACTIVE` → collect `DRAFT` item IDs → **Schedule Drafts** → optionally **Generate Social Posts** + **Get Marketing Activity Posts** for more activities.

## Grounding

Every endpoint path, enum, gating rule, and async behavior was verified against the `marketing-plan-service` protos + service implementation (not the early draft):
- `schedule-drafts` is premium-gated (`SCHEDULE_POST` → `FAILED_PRECONDITION`); generation is **not** premium- or experiment-gated; site-published is **not** validated (warning only).
- `PlanStatus` = `NEVER_CREATED | GENERATING | ACTIVE | INACTIVE | FAILED`; `GetSocialMarketingPlan` itself can trigger the INACTIVE transition after ~6 weeks idle.
- Posts are the Publisher `Item` type; only `DRAFT` items on Publisher-connected channels are schedulable.
- `socialChannels` includes `TWITTER`, documented with the **July 31, 2026** sunset caveat (consistent with the Publisher skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)