### PR TITLE
docs(wix-manage): don't over-claim setup on inconclusive availability diagnosis

### DIFF
--- a/skills/wix-manage/references/bookings/diagnose-availability-issues.md
+++ b/skills/wix-manage/references/bookings/diagnose-availability-issues.md
@@ -33,6 +33,8 @@ Diagnosis is **endpoint-first**:
 
 - Typically the `serviceId` (optionally with a staff member's `resourceId` to scope to one provider). A `resourceId` on its own is also supported for the staff editor, where no service is in context — see [Which inputs to pass](#which-inputs-to-pass-prefer-a-service).
 
+- **Authorization:** the caller needs the `bookings:availability:v2:time_slot:diagnose_availability` permission. A plain site/owner token can come back **403 (empty body)** if that permission isn't granted to the caller — that's an auth problem, not "no cause found." Ensure the calling context carries the permission before treating a 403 as inconclusive.
+
 ---
 
 ## Step 1 — Run the diagnosis
@@ -134,7 +136,8 @@ curl -X POST 'https://www.wixapis.com/_api/service-availability/v2/time-slots/di
 |------|-------------------|-------|
 | 400 | `MISSING_ARGUMENTS` | Neither `serviceId` nor `resourceId` provided; or `deep: true` sent without a `serviceId`. |
 | 400 | `INVALID_TIME_ZONE` | `timeZone` isn't a valid IANA zone. |
-| 404 | `SERVICE_NOT_FOUND` / `RESOURCE_NOT_FOUND` | Service / staff record missing. |
+| 400 | `INVALID_SERVICE_IDS_PROVIDED` | The `serviceId` doesn't resolve to a service on the site. In practice a well-formed-but-nonexistent `serviceId` (not only a malformed one) currently surfaces here rather than as a 404 — re-check the ID. |
+| 404 | `SERVICE_NOT_FOUND` / `RESOURCE_NOT_FOUND` | Service / staff record missing. (A missing `serviceId` may instead surface as the 400 `INVALID_SERVICE_IDS_PROVIDED` above.) |
 | 404 | `NO_IMPLEMENTERS_FOUND` / `MULTIPLE_IMPLEMENTERS_FOUND` | No / multiple availability providers configured. |
 | 403 | `UNAUTHORIZED_OPERATION` | Caller lacks `bookings:availability:v2:time_slot:diagnose_availability`. |
 
@@ -217,6 +220,7 @@ Popular reasons a service shows no availability, and where each surfaces:
 
 - **`hasAvailability: false` + empty `reasons` ≠ a confirmed problem.** It means "no blocking cause detected." Always confirm with `ListAvailabilityTimeSlots`.
 - **The endpoint is ALPHA and feature-toggled.** If it returns nothing for an obviously broken service, the `diagnoseAvailabilityEndpoint` toggle may be off — fall back to Step 2.
+- **A 403 is an auth problem, not a diagnosis.** The action needs the `bookings:availability:v2:time_slot:diagnose_availability` permission; a caller without it gets a 403 with an empty body. Don't read that as "no cause found" — confirm the caller has the permission (see [Prerequisites](#prerequisites)).
 - **`deep: true` needs a `serviceId`** (resource-only + `deep` → `MISSING_ARGUMENTS`) and only refines a "no windows" result — it does nothing when windows already exist.
 - **The endpoint ignores booking policy and capacity** — those are Step 2.
 - **Resource-only diagnosis is lighter.** Passing `resourceId` without `serviceId` catches missing/empty working hours but skips the window, location, and deep checks, so it can return "inconclusive" for service-dependent problems. Valid when there's no service context (e.g. the staff editor); otherwise pair the resource with a service.

--- a/skills/wix-manage/references/bookings/diagnose-availability-issues.md
+++ b/skills/wix-manage/references/bookings/diagnose-availability-issues.md
@@ -172,7 +172,7 @@ The diagnosis is part of a conversation with a site owner. Reply in plain, frien
 - **Lead with the cause in plain English**, then give the concrete fix as the next step. One or two short sentences is usually enough.
 - **Use the owner's own terms** — "your service", "your staff", "the dates you're looking at", real location names from `resolvedLocations`.
 - **Offer to help with the fix** rather than only stating it.
-- If the result is inconclusive, say you couldn't find a setup problem and describe what you'll check next (policy/capacity) — don't imply the service is fine.
+- If the result is inconclusive (empty `reasons`), say only that you **couldn't find a blocking problem**, and describe what you'll check next (policy/capacity, or re-run against a service for a resource-only check). **Do not state or imply that anything is set up correctly** — an empty `reasons` array means "no blocker detected," *not* "working hours / locations / setup are present." In particular, on the resource-only path never say the staff "have working hours set"; the check doesn't verify that. Don't imply the service is fine.
 
 **Plain-language phrasing per cause:**
 


### PR DESCRIPTION
## Summary

Follow-up to #501. A **real end-to-end run** of the "Diagnose Bookings Availability Issues" skill (agent reads the skill, calls `DiagnoseAvailability`, writes the owner reply) surfaced a wording weakness on the **resource-only / inconclusive** path.

The endpoint returned `has_availability: false` with an **empty `reasons`** array (which the skill defines as "no blocking cause detected" — nothing more). The agent nonetheless replied *"they do appear to have working hours set"* — an over-claim the endpoint never confirmed, despite the skill's existing "don't imply the service is fine" note.

## Change
Tightens the inconclusive-result guidance in **Presenting the diagnosis**:
- Report an empty `reasons` array only as "couldn't find a blocking problem."
- Explicitly forbid stating/implying that hours, locations, or setup are present.
- Call out the resource-only path specifically: never say the staff "have working hours set" — that check doesn't verify it.

## Testing
Observed directly: three live end-to-end skill runs (broken service, healthy service, resource-only). Runs 1–2 were accurate; run 3 produced the over-claim this change prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)