### PR TITLE
docs(wix-headless): warn that @wix/site-* frontend modules don't work headless

### DIFF
--- a/skills/wix-headless/references/shared/DOCS_SEARCH.md
+++ b/skills/wix-headless/references/shared/DOCS_SEARCH.md
@@ -28,6 +28,10 @@ curl -sS 'https://dev.wix.com/docs/api-reference/business-management/app-install
 
 No auth headers required on these endpoints.
 
+## Skip `@wix/site-*` frontend modules
+
+Doc discovery surfaces `@wix/site-*` **Frontend Modules** (`@wix/site-ecom`, `@wix/site-seo`, `@wix/site-members`, …). These require Wix hosting and are **not headless-compatible** — they look right and fail silently. Use the vertical's REST recipe or the `@wix/<vertical>` SDK client via `createClient` instead (e.g. `@wix/seo`, not `@wix/site-seo`). Rule of thumb: `@wix/site-…` = site-runtime, wrong for headless; `@wix/…` without `site-` = headless-safe.
+
 > For the full doc-lookup playbook — semantic-search variants, slicing big method pages, and structured API-spec queries (`getResourceSchemaByUrl`, no MCP) — see the **`wix-docs`** skill (`<SKILL_ROOT>/../wix-docs/SKILL.md` when co-installed).
 
 ## Prefer bundled references


### PR DESCRIPTION
## What

Adds a guardrail to `wix-headless/references/shared/DOCS_SEARCH.md` warning that the `@wix/site-*` **Frontend Modules** (surfaced by SDK-scoped doc search and the `sdk.md` portal) **are not compatible with headless projects** and should not be installed/imported.

## Why

Doc discovery is exactly where an agent building a headless site gets lured into these modules. Searching for a cart-change listener lands on `@wix/site-ecom`'s `onCartChange()`/`openSideCart()`; SEO lands on `@wix/site-seo` (vs. the canonical `@wix/seo` we just migrated stores to); auth lands on `@wix/site-members`. They look perfect in the docs and **fail silently** in a headless app. The frontend-SDK portal states it outright:

> Frontend modules require Wix hosting and are not available for external hosting environments. **Important:** Frontend modules are not compatible with Wix Headless projects. For headless implementations, use the appropriate backend modules.

Nothing hardcodes `@wix/site-*` in the skill today — this is purely a discovery-time trap, so the fix lives in the docs-exploration guidance.

## The guardrail

Steers to the headless-native path:
- **Data/business logic** → the vertical's bundled REST recipe, or the `@wix/<vertical>` SDK client via `createClient` — never the `@wix/site-<vertical>` twin.
- **SEO** → `@wix/seo`, not `@wix/site-seo`.
- **Cart events/nav** → the ecom REST/SDK cart flow the templates already use, not `@wix/site-ecom`.
- Rule of thumb: `@wix/site-…` = site-runtime (wrong for headless); `@wix/…` without `site-` = headless-safe.

## Scope

**`wix-headless` only.** `wix-vibe-headless` is client-only, REST-only, and zero-dependency — its contract already forbids `@wix/sdk` and any npm package, so the `@wix/site-*` footgun is subsumed by its existing "no SDK, no dependencies" rule. No change needed there.

Not touching the shared `wix-docs` skill in this PR (a neutral annotation to its `sdk.md` row was suggested separately, since that skill also serves Velo/app contexts where these modules are valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)