### PR TITLE
wix-headless-v2: item-page SEO guidance for blog, store, bookings, events

### DIFF
--- a/skills/wix-headless-v2/references/astro.md
+++ b/skills/wix-headless-v2/references/astro.md
@@ -69,7 +69,17 @@ Prefer the documented `wix …` / `npm run dev\|build\|release` forms (the scaff
 
 This is for *custom* vars only. Because there's no client on managed-Astro, app code doesn't read `WIX_CLIENT_ID` at all (that's the v1 `import.meta.env.WIX_CLIENT_ID` pattern — drop it; it was the manual-client path).
 
-## 6 — Caveats (the gaps the docs don't mention)
+## 6 — SEO: let owners manage tags on item pages
+
+Main pages (home, listings, about) get their SEO tags **automatically** on managed-Astro — nothing to write. **Item pages** — any parameterized detail route (`/blog/[...slug]`, a product / service / event detail, an optional category/collection route) — do **not**: they need code so the tags a site owner edits in the dashboard reach the live `<head>`. Wire this on **every managed site that renders item/detail routes** — it's what lets owners control each item's `<title>`/description/OG/canonical without touching code, and it registers the route for the sitemap + dashboard SEO editor. Skipping it leaves detail pages with a generic fallback title the owner can't fix.
+
+| Page | What it settles |
+|---|---|
+| <https://dev.wix.com/docs/go-headless/wix-managed-headless/seo/add-seo-support-to-item-pages.md> | **The item-page SEO contract.** The three steps every detail route needs — export `wixMetadata` (route registration), call `loadSEOTagsServiceConfig(...)`, render `<SEO.Tags>` — plus the deps (`@wix/seo` + `@wix/essentials ≥ 1.0.10`), the `WIX_APPS` sourcing rule (reference it directly in the export), per-page-type values, and how to verify. Read it before writing any `[slug]` / `[...slug]` detail page. |
+
+The **per-vertical values** — which `WIX_APPS.*PageMetadata` accessor + `seoTags.ItemType.*` to pass — live in each capability's `inline-recipes/how-to-code-*.md` (blog, store, bookings, events each name theirs).
+
+## 7 — Caveats (the gaps the docs don't mention)
 
 The heart of the file: tribal knowledge the docs won't surface. These are **guidance the model must follow when it writes the frontend** — not things this skill writes for it.
 

--- a/skills/wix-headless-v2/references/inline-recipes/how-to-code-a-blog.md
+++ b/skills/wix-headless-v2/references/inline-recipes/how-to-code-a-blog.md
@@ -84,16 +84,19 @@ const post = items[0];
 if (!post) { /* 404 → redirect to /blog */ }
 ```
 
-**Astro page routing — `wixMetadata` is required.** A blog-post detail page (`src/pages/blog/[...slug].astro`) must export `wixMetadata` so the Wix platform recognizes it as a blog-post page (routing + SEO):
+**Astro page routing + SEO (Wix-managed) — `wixMetadata` is required.** A blog-post detail page (`src/pages/blog/[...slug].astro`) is a Wix **item page**: its `<title>`/description/OG/canonical come from what the owner sets in the dashboard. Wire it per the canonical guide — **[Add SEO Support to Item Pages](https://dev.wix.com/docs/go-headless/wix-managed-headless/seo/add-seo-support-to-item-pages.md)** — which covers all three steps: export `wixMetadata` (registers the route → sitemap + dashboard SEO editor), call `loadSEOTagsServiceConfig(...)`, and render `<SEO.Tags>` (from `@wix/seo`; deps + `@wix/essentials ≥ 1.0.10` are in the guide's "Before you begin"). Source `wixMetadata` from `WIX_APPS`, referenced **directly** inside the export (it's evaluated in module scope):
 
 ```js
+import { WIX_APPS } from "@wix/essentials";
+import { seoTags } from "@wix/seo";           // → itemType: seoTags.ItemType.BLOG_POST
+
 export const wixMetadata = {
-  appDefId: "14bcded7-0066-7c35-14d7-466cb3f09103",
-  pageIdentifier: "wix.blog.sub_pages.post",
-  identifiers: { slug: "BLOG.POST.SLUG" },
+  appDefId: WIX_APPS.blogs.id,
+  pageIdentifier: WIX_APPS.blogs.postPageMetadata.pageIdentifier,
+  identifiers: { slug: WIX_APPS.blogs.postPageMetadata.identifiers.slug },
 };
 ```
-Use the `[...slug]` **rest** param (not `[slug]`), and `Astro.params` directly — Wix headless projects run `output: "server"` (SSR), so there's no `getStaticPaths()`.
+Use the `[...slug]` **rest** param (not `[slug]`), and `Astro.params` directly — Wix headless projects run `output: "server"` (SSR), so there's no `getStaticPaths()`. **If you add a blog category route** (e.g. `/category/[slug]`), wire it the same way with `WIX_APPS.blogs.categoryPageMetadata` + `seoTags.ItemType.BLOG_CATEGORY`. ⚠️ As of testing, dashboard SEO *overrides* for blog **categories** aren't honored by the resolver (it returns label-derived defaults) — the route still registers and gets valid default tags; this is a Wix-side gap, not a wiring bug.
 
 ### Rendering the post body (Ricos rich content)
 

--- a/skills/wix-headless-v2/references/inline-recipes/how-to-code-a-store.md
+++ b/skills/wix-headless-v2/references/inline-recipes/how-to-code-a-store.md
@@ -213,6 +213,18 @@ function imgSrc(mediaMain, w = 600, h = 600) {
 
 Don't print the raw node object. A product description is rich text (`description.nodes`). Render the rich-text nodes, or use `plainDescription` for a plain string. Printing the raw node object dumps literal `<p>…</p>` into the page.
 
+### SEO on item pages (Astro, Wix-managed)
+
+A **product detail** page is a Wix **item page**: its `<title>`/description/OG/canonical come from what the owner sets in the dashboard. On the Astro (Wix-managed) frontend, wire it per the canonical guide — **[Add SEO Support to Item Pages](https://dev.wix.com/docs/go-headless/wix-managed-headless/seo/add-seo-support-to-item-pages.md)** — which covers the three steps: export `wixMetadata` (registers the route → sitemap + dashboard SEO editor), call `loadSEOTagsServiceConfig(...)`, and render `<SEO.Tags>` (from `@wix/seo`; deps + `@wix/essentials ≥ 1.0.10` are in the guide's "Before you begin").
+
+For a product page use:
+- **`wixMetadata`** from `WIX_APPS.checkoutAndOrders.productPageMetadata` — referenced **directly** in the export (module scope). ⚠️ It's `WIX_APPS.checkoutAndOrders`, **not** `WIX_APPS.stores` (`stores.id` is the catalog id for `catalogReference`, a different value). The `identifiers` key is your route param; the token is `…productPageMetadata.identifiers.handle`.
+- **`itemType`**: `seoTags.ItemType.STORES_PRODUCT`.
+
+**If you build a dedicated category route** (e.g. `/category/[slug]` or `/search/[collection]`), wire it the same way with `WIX_APPS.checkoutAndOrders.categoryPageMetadata` + `seoTags.ItemType.STORES_CATEGORY`. (A category rendered only as a query-string *filter* on the products listing is a main page — it gets its SEO from automatic injection, no `wixMetadata` needed.)
+
+Optional: render a `Product` schema.org JSON-LD `<script>` from the fetched product for rich results (see the guide's structured-data step).
+
 ---
 
 ## Conclusion

--- a/skills/wix-headless-v2/references/inline-recipes/how-to-code-bookings.md
+++ b/skills/wix-headless-v2/references/inline-recipes/how-to-code-bookings.md
@@ -249,6 +249,16 @@ if (checkoutRequired) {
 - **Image**: `service.media.mainMedia.image.url` (already an absolute URL in V2 reads). An already-`https://` URL goes straight into `<img src>`.
 - **Mount slots + form + book in a `client:only="react"` island** (Astro) — availability is timezone/session-specific. SSR only the read pages (catalog/detail) for SEO.
 
+### SEO on item pages (Astro, Wix-managed)
+
+A **service detail** page is a Wix **item page**: its `<title>`/description/OG/canonical come from what the owner sets in the dashboard. On the Astro (Wix-managed) frontend, wire it per the canonical guide — **[Add SEO Support to Item Pages](https://dev.wix.com/docs/go-headless/wix-managed-headless/seo/add-seo-support-to-item-pages.md)** — which covers the three steps: export `wixMetadata` (registers the route → sitemap + dashboard SEO editor), call `loadSEOTagsServiceConfig(...)`, and render `<SEO.Tags>` (from `@wix/seo`; deps + `@wix/essentials ≥ 1.0.10` are in the guide's "Before you begin").
+
+For a service page use:
+- **`wixMetadata`** from `WIX_APPS.bookings.servicePageMetadata` — referenced **directly** in the export (module scope). Route param `slug` → `identifiers.slug`.
+- **`itemType`**: `seoTags.ItemType.BOOKINGS_SERVICE`.
+
+Run `loadSEOTagsServiceConfig` in the same `Promise.all` as the service read, with `.catch(() => null)`, so a SEO hiccup falls back to the layout's default title instead of failing the page. Optional: render a `Service` schema.org JSON-LD `<script>` from the fetched service (see the guide's structured-data step).
+
 ### Out of scope
 Waitlist, on-site manage/cancel, payment/deposit breakdown, multi-service packages, and COURSE bookings. Waitlist and manage/cancel have **no headless source of truth** — don't invent them on the anonymous-token layer; post-booking self-service is the Wix-hosted flow / member area.
 

--- a/skills/wix-headless-v2/references/inline-recipes/how-to-code-events.md
+++ b/skills/wix-headless-v2/references/inline-recipes/how-to-code-events.md
@@ -171,6 +171,16 @@ Doc: <https://dev.wix.com/docs/api-reference/business-solutions/events/registrat
 - **Price**: `tier.price.value` (string) + `tier.price.currency` (the event's stored currency — format from it, don't assume USD).
 - **Mount the ticket picker / RSVP form in a `client:only="react"` island** (Astro) — they run visitor-session SDK calls and redirect. **SSR only the read pages** (listing/detail) for SEO.
 
+### SEO on item pages (Astro, Wix-managed)
+
+An **event detail** page is a Wix **item page**: its `<title>`/description/OG/canonical come from what the owner sets in the dashboard. On the Astro (Wix-managed) frontend, wire it per the canonical guide — **[Add SEO Support to Item Pages](https://dev.wix.com/docs/go-headless/wix-managed-headless/seo/add-seo-support-to-item-pages.md)** — which covers the three steps: export `wixMetadata` (registers the route → sitemap + dashboard SEO editor), call `loadSEOTagsServiceConfig(...)`, and render `<SEO.Tags>` (from `@wix/seo`; deps + `@wix/essentials ≥ 1.0.10` are in the guide's "Before you begin").
+
+For an event page use:
+- **`wixMetadata`** from `WIX_APPS.events.eventPageMetadata` — referenced **directly** in the export (module scope). Route param `slug` → `identifiers.slug`.
+- **`itemType`**: `seoTags.ItemType.EVENTS_PAGE`.
+
+Fold `loadSEOTagsServiceConfig` into the same `Promise.all` as the ambient `getEventBySlug` read, with `.catch(() => null)` (it needs only the slug — still a visitor-safe ambient call), so a SEO hiccup falls back to the layout's default title. Optional: render an `Event` schema.org JSON-LD `<script>` from the fetched event (see the guide's structured-data step).
+
 ### Out of scope
 Assigned seating / seat maps (display + reserve flat ticket definitions only); coupons & gift cards at checkout (Wix's hosted checkout handles those — don't build a discount UI); on-site order management / cancel / refund (handled by the hosted flow + the buyer's email); manual `orders.checkout` inline payment (use the hosted redirect).
 


### PR DESCRIPTION
## What

Adds canonical **item-page SEO** guidance to the four `wix-headless-v2` vertical recipes (blog, store, bookings, events). Small, prose-only change (4 files) that fits v2's recipe idiom — it **links out** to the canonical Wix guide for the wiring and only carries the per-vertical values.

Targets `wix-headless-new` (not `main`) so the branch owner reviews/merges on their terms.

## Per recipe

Each gets a concise **"SEO on item pages (Astro, Wix-managed)"** block that:
- names the item page and notes its tags come from the site owner's dashboard;
- points to the canonical guide — `go-headless/wix-managed-headless/seo/add-seo-support-to-item-pages` — for the three-step wiring (`wixMetadata` → `loadSEOTagsServiceConfig` → `<SEO.Tags>`) and defers deps (`@wix/seo`, `@wix/essentials ≥ 1.0.10`) to its "Before you begin";
- gives the vertical's exact `WIX_APPS.*PageMetadata` accessor + `seoTags.ItemType.*`.

| Recipe | accessor | itemType |
|---|---|---|
| blog | `blogs.postPageMetadata` (+ `categoryPageMetadata`) | `BLOG_POST` / `BLOG_CATEGORY` |
| store | `checkoutAndOrders.productPageMetadata` (+ `categoryPageMetadata`) | `STORES_PRODUCT` / `STORES_CATEGORY` |
| bookings | `bookings.servicePageMetadata` | `BOOKINGS_SERVICE` |
| events | `events.eventPageMetadata` | `EVENTS_PAGE` |

## Design decisions

- **Category routes** are framed as *optional* ("if you add a `/category` route, wire it this way") — v2 doesn't mandate a dedicated category route, and a query-string category *filter* on a listing is a main page (auto-injected, no `wixMetadata`).
- **Blog**: upgraded the existing hardcoded `wixMetadata` block to `WIX_APPS` + the guide link.
- **Scoped to the Astro/Wix-managed path only** — `@wix/seo`'s resolver is Astro-managed; non-astro/self-managed SEO is out of scope here.
- The Stores `WIX_APPS.checkoutAndOrders`-not-`stores` gotcha is called out.

## Caveats
- Carries one verified ⚠️: dashboard SEO **overrides for blog categories** aren't honored by the resolver (returns label defaults) — route still registers + gets default tags; a Wix backend gap, not a wiring bug. Other verticals' override resolution not independently verified.
- Prose-only; not build-tested. Grounded in the working reference sites (`roaming-notebook`, `bean-bliss`, `poets-table`) and the equivalent change in the current skill (#503).