### PR TITLE
fix(wix-vibe-headless): guard addToCart against silent out-of-stock 200

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/wix-store-cart.js
+++ b/skills/wix-vibe-headless/references/storefront/wix-store-cart.js
@@ -59,8 +59,14 @@ export async function addToCart(catalogItemId, variantId, quantity = 1, { modifi
   const line = (res?.cart?.lineItems ?? []).find(
     (l) => l.catalogReference?.catalogItemId === catalogItemId && (!variantId || l.catalogReference?.options?.variantId === variantId),
   );
+  // Wix returns 200 even when stock is exhausted — guard both signals:
+  // 1. availability.status set to something other than AVAILABLE
+  // 2. quantity 0 (stock exhausted, no availability field populated)
   if (line?.availability?.status && line.availability.status !== "AVAILABLE") {
     throw new Error(`Item not available for sale (status: ${line.availability.status}). Is it in stock?`);
+  }
+  if (!line || line.quantity === 0) {
+    throw new Error("Item could not be added to the cart — it may be out of stock.");
   }
   return res?.cart;
 }


### PR DESCRIPTION
## Problem

Wix returns HTTP 200 from `/ecom/v1/carts/current/add-to-cart` even when stock is exhausted. The existing `availability.status` check caught the case where Wix sets the field to `NOT_AVAILABLE`, but not when stock runs out without populating `availability` — in that scenario the line item comes back with `quantity: 0` and no status, so `addToCart` silently returned the cart and the UI showed a false "Added" confirmation.

## Fix

Added a `quantity === 0` guard alongside the existing status check:

```js
if (line?.availability?.status && line.availability.status !== "AVAILABLE") {
  throw new Error(`Item not available for sale (status: ${line.availability.status}). Is it in stock?`);
}
if (!line || line.quantity === 0) {
  throw new Error("Item could not be added to the cart — it may be out of stock.");
}
```

Both signals now throw so the caller can surface the error instead of showing a false confirmation.

## Test plan
- [ ] Add an in-stock item → cart returns with `quantity > 0`, no throw
- [ ] Add an out-of-stock item → throws (either via `availability.status` or `quantity === 0`)
- [ ] File stays under 10k chars (6,437 chars ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)