### PR TITLE
fix(wix-auth): add links to docs and manage in device-flow

### DIFF
--- a/skills/wix-auth/references/device-flow.md
+++ b/skills/wix-auth/references/device-flow.md
@@ -132,3 +132,9 @@ Authorization: Bearer {siteToken}
 ```
 
 Returns `{ contacts: […] }`.
+
+---
+
+For the full Wix REST API reference — endpoints, request/response shapes, and field details — see [https://www.wix.com/skills/docs](https://www.wix.com/skills/docs).
+
+For REST API recipes covering common management operations (stores, bookings, contacts, CMS, and more) — see [https://www.wix.com/skills/manage](https://www.wix.com/skills/manage).


### PR DESCRIPTION
Adds the missing links to wix.com/skills/docs and wix.com/skills/manage at the bottom of device-flow.md.