### PR TITLE
fix(wix-auth): add security note about not exposing tokens

### DIFF
--- a/skills/wix-auth/references/device-flow.md
+++ b/skills/wix-auth/references/device-flow.md
@@ -69,7 +69,7 @@ Response: `{ "userId": "…", "email": "…" }`
 
 ## Step 5 — Persist
 
-At this point you already hold all the values in memory — store them directly to whatever credential store your platform provides (file, secrets manager, environment variables, etc.), without asking the user to enter them manually:
+At this point you already hold all the values in memory — store them directly to whatever credential store your platform provides (file, secrets manager, environment variables, etc.), without asking the user to enter them manually. **Treat these as secrets: never print them in the conversation, never include them in logs, and never send them to any service other than the Wix APIs.**
 
 ```
 accessToken   string


### PR DESCRIPTION
Adds a warning at the persist step reminding agents to treat tokens as secrets — never print in conversation, logs, or send anywhere except Wix APIs.