### PR TITLE
site context

### DIFF
--- a/skills/wix-manage/references/domains/domain-search-and-purchase.md
+++ b/skills/wix-manage/references/domains/domain-search-and-purchase.md
@@ -21,6 +21,10 @@ You help the user find an available domain, then collect registration details (c
 
 Domain purchase does NOT require a site. Do NOT call `ListWixSites` unless the user specifically mentions a site or asks to connect the domain to one.
 
+**Single-site context**: If the user is already operating within a specific site (e.g. they are in a site dashboard or the system prompt provides a `siteId`/`msid`), do NOT call `ListWixSites`. You already know which site they're working with — use that site context throughout the flow.
+
+**Multi-site / no site context**: Call `ListWixSites` only when no site context is available AND the user mentions connecting the domain to a site.
+
 However, after finding an available domain (Step 1), you should ask the user if they want to connect it to a Wix site. This unlocks two benefits:
 - If the user has a **premium site**, the domain can be connected to it after purchase
 - If the user has **no premium site**, they can get the domain **free for the first year** by upgrading to a premium plan (bundle deal)
@@ -139,16 +143,34 @@ Once the user picks a domain (or the original was available), proceed to Step 1b
 
 After the user has chosen a domain, ask: "Would you like to connect this domain to one of your Wix sites?"
 
-If the user says yes (or if they mentioned a site earlier), call `ListWixSites` to get their sites.
+If the user says yes, call `ListWixSites` to get their sites. If the user already mentioned a specific site by name, or if a `siteId` is already available from context, skip `ListWixSites` — you already know which site to use.
 
 The response includes each site's `id` and `name`. If the user has multiple sites, list them and ask which one they want to use.
 
 Once a site is selected, remember the `siteId` (also called `msid`) -- you'll use it in the checkout link (Step 4d).
 
 **Based on the site's plan status**, you can offer different guidance:
-- **Site has a premium plan**: "Great, after purchasing the domain you can connect it to your site."
-- **Site has no premium plan**: "I notice your site doesn't have a premium plan yet. If you upgrade to a premium plan, you can get this domain free for the first year! Want me to generate a link for the bundle deal instead?" If yes, generate: `[Get domain free with a site plan](https://manage.wix.com/premium-domains/split-page?domainName={DOMAIN_NAME})` -- this page shows the bundle option.
-- **No sites at all**: "No problem, we'll proceed with a standalone domain purchase."
+- **Site has a premium plan**: "Your domain will be automatically connected to your site after purchase."
+- **Site has no premium plan**: First, check if the chosen domain's TLD is eligible for a voucher (free domain with plan upgrade) by calling:
+  ```
+  com.wixpress.premium.domain.tlds.DomainTld/ListTlds
+  Body: { "filter": { "tlds": ["com"] } }
+  ```
+  Replace `"com"` with the actual TLD (without the dot). If the response includes `"coupons_applicable": true` for that TLD, the free domain offer applies. Also call `getIsOnSale` to check if an active premium sale is running — if so, surface it as an additional reason to upgrade now (it's a major conversion driver).
+
+  **If voucher-eligible**: Present the user with a clear two-option choice:
+
+  > 🎁 **Free domain offer**: Your site doesn't have a premium plan yet. If you upgrade, you can get this domain free for the first year!
+  >
+  > Which would you prefer?
+  > 1. **Upgrade to premium** — get the domain free for the first year *(recommended)*
+  > 2. **Purchase the domain only** — pay full price, and you won't be able to connect the domain to a site without upgrading to a Premium plan later
+
+  - If user picks **option 1**: generate and share `[Get domain free with a site plan](https://manage.wix.com/premium-domains/split-page?domainName={DOMAIN_NAME})` and end the flow — the user completes it on that page.
+  - If user picks **option 2**: proceed to Step 2 as a standalone purchase (no site attached).
+
+  **If NOT voucher-eligible**: Skip the free domain offer and proceed to Step 2 as a standalone purchase.
+- **No sites at all**: "No problem, we'll proceed with a domain only purchase."
 
 If the user says no or wants to skip, proceed without a site context.
 
@@ -411,22 +433,32 @@ This opens the checkout page with the pre-filled cart. The user only needs to co
 6. Confirm contact info -> user confirms existing info
 7. Save contact, create cart, share checkout link
 
-### Flow 4: Purchase with site connection
+### Flow 4: Purchase with site connection — site context known (no ListWixSites)
 
-1. User: "Buy mybakery.com and connect it to my site"
+1. User is in the Business Manager of "My Bakery Site" (msid: abc-123). User: "Buy mybakery.com and connect it to my site"
 2. Check availability -> available: true
-3. Ask which site -> call ListWixSites -> user picks "My Bakery Site" (msid: abc-123)
-4. Site has premium plan -> "Great, we'll connect it after purchase"
+3. Site context already known (msid: abc-123) -- skip ListWixSites
+4. Site has premium plan -> "Your domain will be automatically connected to your site after purchase."
+5. Get pricing, user picks 1 year, wants privacy, confirms contact info
+6. Save contact, create cart, share checkout link with msid: `https://manage.wix.com/cart/checkout?msid=abc-123`
+
+### Flow 4b: Purchase with site connection — no site context (call ListWixSites)
+
+1. User has no active site context. User: "Buy mybakery.com and connect it to my site"
+2. Check availability -> available: true
+3. No site context available -> ask "Which site would you like to connect it to?" -> call ListWixSites -> user picks "My Bakery Site" (msid: abc-123)
+4. Site has premium plan -> "Your domain will be automatically connected to your site after purchase."
 5. Get pricing, user picks 1 year, wants privacy, confirms contact info
 6. Save contact, create cart, share checkout link with msid: `https://manage.wix.com/cart/checkout?msid=abc-123`
 
 ### Flow 5: No premium site, suggest bundle
 
-1. User: "I want mybakery.com for my website"
+1. User is in the Business Manager of "My Bakery Site" (msid: abc-123). User: "I want mybakery.com for my website"
 2. Check availability -> available: true
-3. Call ListWixSites -> user picks "My Bakery Site" -> site has no premium plan
-4. "Your site doesn't have a premium plan. You can get this domain free for the first year by upgrading! Want the bundle deal?"
-5. User says yes -> share: [Get domain free with a site plan](https://manage.wix.com/premium-domains/split-page?domainName=mybakery.com)
+3. Site context already known (msid: abc-123) -- skip ListWixSites
+4. Site has no premium plan -> call ListTlds for `.com` -> `coupons_applicable: true` -> voucher eligible
+5. Present two-option choice: upgrade (get domain free for first year) or purchase only
+6. User picks upgrade -> share: [Get domain free with a site plan](https://manage.wix.com/premium-domains/split-page?domainName=mybakery.com)
 
 ### Flow 6: Unsupported TLD
 


### PR DESCRIPTION
## Summary
- Skip `ListWixSites` when `siteId`/`msid` is already available from context
- Add `ListTlds` voucher eligibility check before offering free domain deal for non-premium sites
- Add `getIsOnSale` call to surface active premium sales as a conversion reason
- Present structured two-option choice (upgrade vs. domain only) with clear tradeoffs
- Split Flow 4 into 4 (site context known) and 4b (no context, call ListWixSites)
- Update Flow 5 to reflect `ListTlds` check and two-option choice

Addresses changes from PR #462 (excluding per-domain pricing in suggestions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)