### PR TITLE
fix(ecom-pricing): site-wide coupon scope must omit `group` (Coupons V2 400)

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
@@ -47,10 +47,7 @@ Before creating a coupon, check for code conflicts and existing promotions on th
         "code": "SUMMER20",
         "percentOffRate": 20,
         "scope": {
-          "namespace": "stores",
-          "group": {
-            "name": "product"
-          }
+          "namespace": "stores"
         },
         "startTime": 1717200000000,
         "expirationTime": 1719792000000,
@@ -91,10 +88,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
     "code": "SPRING15",
     "percentOffRate": 15,
     "scope": {
-      "namespace": "stores",
-      "group": {
-        "name": "product"
-      }
+      "namespace": "stores"
     },
     "startTime": 1714521600000,
     "usageLimit": 200,
@@ -167,10 +161,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
     "code": "SAVE10",
     "moneyOffAmount": 10,
     "scope": {
-      "namespace": "stores",
-      "group": {
-        "name": "product"
-      }
+      "namespace": "stores"
     },
     "startTime": 1714521600000,
     "active": true
@@ -230,11 +221,15 @@ Instead of targeting a scope, you can require a minimum cart subtotal. This is a
 
 ## Scope values for Wix Stores
 
-| Scope target | `namespace` | `group.name` | `group.entityId` |
-|---|---|---|---|
-| All store products | `"stores"` | `"product"` | Omit (applies to all) |
-| Specific product | `"stores"` | `"product"` | Product UUID |
-| Specific collection | `"stores"` | `"collection"` | Collection UUID |
+> **Scope rule (READ THIS — the API enforces it strictly).** `group` is **optional**. If you want the coupon to apply to **everything** in a namespace (site-wide), **omit `group` entirely** — send `scope: { "namespace": "stores" }`. `group.name` is valid **only when paired with a `group.entityId`** (a specific product/collection UUID). Sending `group: { "name": "product" }` **without** an `entityId` is rejected with `400 — "The provided combination of scope and coupon type is invalid"` (`group=product, entityId=empty`). This applies to every namespace (`stores`, `bookings`, `pricingPlans`, `onlinePrograms`, `events`).
+
+| Scope target | `namespace` | `group` |
+|---|---|---|
+| All store products (site-wide) | `"stores"` | **Omit `group`** |
+| Specific product | `"stores"` | `{ "name": "product", "entityId": "<product UUID>" }` |
+| Specific collection | `"stores"` | `{ "name": "collection", "entityId": "<collection UUID>" }` |
+
+For other business solutions, the same rule holds — omit `group` for all-items, add `group.name` + `group.entityId` for a specific entity: `bookings` (`group.name: "service"`), `pricingPlans` (`"plan"`), `onlinePrograms` (`"program"`), `events` (`"event"` / `"ticket"`). See [Valid Scope Values](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/valid-scope-values) for the full matrix.
 
 ---
 
@@ -246,7 +241,7 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 
 | Recommendation `scope` | Coupon `scope` |
 |---|---|
-| `SITE` | `{ "namespace": "stores", "group": { "name": "product" } }` (all products, no entityId) |
+| `SITE` | `{ "namespace": "stores" }` — **omit `group`** for all products. Do NOT send `group: { "name": "product" }` without an `entityId`; the API rejects it. |
 | `CATEGORY` | `{ "namespace": "stores", "group": { "name": "collection", "entityId": "<first categoryId>" } }` |
 | `ITEMS` | `{ "namespace": "stores", "group": { "name": "product", "entityId": "<first productId>" } }` |
 
@@ -340,7 +335,9 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 
 | Error | Cause | Fix |
 |---|---|---|
-| `"When scope or minimumSubtotal is not used - only FreeShipping coupon is allowed"` | Coupon sent without `scope` or `minimumSubtotal` | Add `scope: { "namespace": "stores", "group": { "name": "product" } }` for site-wide, or set `minimumSubtotal` |
+| `"The provided combination of scope and coupon type is invalid"` (`group=product, entityId=empty`) | `group.name` was sent without a `group.entityId` — most often when trying to target the whole site | For site-wide, **omit `group`**: `scope: { "namespace": "stores" }`. Only include `group` when you also have a `group.entityId` (specific product/collection). |
+| `"When scope or minimumSubtotal is not used - only FreeShipping coupon is allowed"` | Coupon sent without `scope` or `minimumSubtotal` | Add `scope: { "namespace": "stores" }` for site-wide, or set `minimumSubtotal` |
+| `"Updating coupons: field mask is missing"` (on `PATCH /v2/coupons/{id}`) | Update Coupon requires a field mask listing the fields you changed | Send a `fieldMask` alongside `specification`, e.g. `"fieldMask": { "paths": ["scope", "name"] }` |
 | Duplicate code | Another coupon uses the same code | Generate a different code |
 | Invalid startTime | Value too low (must be epoch ms, not seconds) | Multiply by 1000 if in seconds |
 | Both scope and minimumSubtotal set | These are oneOf — cannot use both | Choose scope OR minimumSubtotal |

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
@@ -263,7 +263,7 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 |---|---|
 | `minSubTotal > 0` | Use `minimumSubtotal` instead of `scope` (they are oneOf — cannot use both) |
 | `minItemQuantity > 0` | **Not natively supported by Coupons API**. Mention in the coupon name (e.g., "Buy 3+, use code BUNDLE15") but the API cannot enforce item quantity. |
-| `startDate` | Convert to UNIX epoch milliseconds: `Date.parse("2026-06-01") → 1748736000000`. Set as `startTime`. |
+| `startDate` | Convert to UNIX epoch milliseconds: `Date.parse("2026-06-01") → 1780272000000`. Set as `startTime`. |
 | `endDate` | Convert to UNIX epoch milliseconds. Set as `expirationTime`. |
 
 ### Code generation
@@ -309,8 +309,8 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
         "entityId": "electronics-collection-uuid"
       }
     },
-    "startTime": 1748736000000,
-    "expirationTime": 1751328000000,
+    "startTime": 1780272000000,
+    "expirationTime": 1782777600000,
     "usageLimit": 100,
     "limitPerCustomer": 1,
     "active": true

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon.yml
@@ -39,9 +39,11 @@ assertions:
       Pass if ALL of these are true:
         1. The agent loaded the `pricing-create-coupon` recipe (NOT the legacy `setup-coupons` slug).
         2. The create payload correctly maps recommendation fields: `percentOffRate: 20`, `code: "TECH20"`, `usageLimit: 100`, `limitPerCustomer: 1`, and `expirationTime` in UNIX milliseconds for 2026-06-30 (value ~1782777600000, ending in three zeros).
-        3. It applied the recommendation's `scope: "SITE"` — no category filter.
+        3. For the `scope: "SITE"` recommendation, the coupon `scope` is exactly `{ "namespace": "stores" }` with NO `group` object — i.e. the coupon was created successfully and applies to all products with no category filter.
 
       Fail if ANY of these are true:
         - The agent used the legacy `setup-coupons` slug or its content.
         - `expirationTime` was sent in seconds (ten-digit integer) instead of milliseconds.
         - The agent ignored the recommendation fields and invented its own coupon parameters.
+        - The `scope` contains a `group` object with `name: "product"` (or any `group.name`) WITHOUT a `group.entityId`. This is the exact combination the Coupons V2 API rejects with `400 — "The provided combination of scope and coupon type is invalid"`, so a site-wide coupon built this way fails. A site-wide scope MUST omit `group`.
+        - The create call returned an error / the coupon was not created.


### PR DESCRIPTION
The pricing-create-coupon recipe told the agent to build a site-wide stores coupon with `scope: { namespace: "stores", group: { name: "product" } }` — a group with no entityId. The Coupons V2 API rejects exactly that combination (400 "The provided combination of scope and coupon type is invalid"; group=product, entityId=empty), so every site-wide coupon create following the recipe failed. Correct site-wide scope omits `group`: `{ namespace: "stores" }`.

- Fix the 3 site-wide scope examples (Step 1 response, Step 2 %-off, Step 3 $-off)
- Rewrite the "Scope values" table + add an explicit group-requires-entityId rule
- Fix the SITE recommendation-mapping row and the Error Handling site-wide fix
- Add error rows for the invalid scope/type 400 and the UpdateCoupon field-mask 400
- Strengthen the covering eval judge to fail on group-without-entityId site-wide scope