### PR TITLE
fix(wix-manage): handle Bookings price variation editor errors

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -57,7 +57,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 **Technical:** Creates staff members and configures custom working hours using Staff API + Calendar Events API. Critical two-step process: create staff → assign schedule → create working hours events.
 
 ### [Create and Update Booking Services](references/bookings/create-and-update-booking-services.md)
-**Technical:** Full CRUD operations for Wix Bookings services using Services API. Covers service types (APPOINTMENT, CLASS, COURSE), pricing configuration, location setup, and schedule management.
+**Technical:** Full CRUD operations for Wix Bookings services using Services API. Covers service types (APPOINTMENT, CLASS, COURSE), pricing configuration, price variation troubleshooting, location setup, and schedule management.
 
 ### [Create Booking Service from Prompt](references/bookings/create-booking-service-from-prompt.md)
 **Technical:** Use when the user wants to create a booking service — e.g. "create a yoga class for $50", "set up consultations", "add a personal training appointment". Routes to the correct type-specific recipe (APPOINTMENT, CLASS, or COURSE), gathers business context, applies defaults, and creates the service.

--- a/skills/wix-manage/references/bookings/create-and-update-booking-services.md
+++ b/skills/wix-manage/references/bookings/create-and-update-booking-services.md
@@ -1,6 +1,6 @@
 ---
 name: "Create and Update Booking Services"
-description: Full CRUD operations for Wix Bookings services using Services API. Covers service types (APPOINTMENT, CLASS, COURSE), pricing configuration, location setup, and schedule management.
+description: Full CRUD operations for Wix Bookings services using Services API. Covers service types (APPOINTMENT, CLASS, COURSE), pricing configuration, price variation troubleshooting, location setup, and schedule management.
 ---
 
 # Technical Step-by-Step Instructions: Creating or Updating a Wix Bookings Service (Real-World, API-First)
@@ -348,6 +348,16 @@ curl -X PATCH 'https://www.wixapis.com/bookings/v2/services/<SERVICE_ID>' \
     }
   }'
 ```
+
+**Existing service pricing editor shows a technical error:**
+
+Use this branch when the user is already editing a Wix Bookings service and says the pricing section, **Precio por sesión**, **Different prices**, **Diferentes precios**, **Manage variations**, or **Administrar variaciones** shows a technical-error banner or does not load.
+
+1. First determine whether the user wants help with the dashboard UI or wants you to update the service through the Services API.
+2. If the current dashboard page is available, inspect it with a small page check before giving pricing instructions. Verify whether the service editor is open, whether the visible text contains the technical-error banner, and whether a real variation control is present. Do not claim **Administrar variaciones** is available when the page inspection shows only unrelated buttons such as **Administrar apps** or **Administrar recursos**.
+3. If the pricing editor is blocked by a technical-error banner, treat it as a dashboard/product loading failure. Give bounded recovery steps: hard refresh, private/incognito window with extensions disabled, another browser/network, and the direct **Servicios de reserva** dashboard path. If it happens on every service, tell the user this is not a single-service configuration issue and they should contact Wix Customer Care with the affected site, service names, screenshot, browser, and time of failure.
+4. Do not present API mutation as an automatic workaround for a broken dashboard editor. Only offer to update prices via API if the user explicitly asks you to change the service data and provides the desired price/variation details. Before any API update, get the current service with `getService`, keep its `revision`, and ask for confirmation before sending `updateService` or bulk update requests.
+5. If the user only wants guidance, explain the normal path for a working editor: **Precio y pago** -> **Tipo de precio: Diferentes precios** -> **+ Agregar variaciones** or **Administrar variaciones**. Make clear that this path cannot be completed while the pricing editor is showing the technical-error banner.
 
 ### 3. Set the availability of the service
 

--- a/yaml/wix-manage-evals/bookings/price-variation-editor-error.yml
+++ b/yaml/wix-manage-evals/bookings/price-variation-editor-error.yml
@@ -1,0 +1,34 @@
+name: bookings/price-variation-editor-error
+description: >-
+  Verifies the Bookings service recipe handles an existing service pricing
+  editor technical-error banner without pretending price variations are available
+  or mutating the service.
+triggerPrompt: >-
+  I'm editing an existing Wix Bookings service. Under Price per session the
+  dashboard says "Technical problem. There was a technical problem on our side.
+  Refresh or try again", and I cannot find Manage variations. I want manual price
+  variations per person. What should I do?
+tags: [bookings]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-and-update-booking-services
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user is already in the Wix Bookings service editor. The pricing section shows a technical-error banner under Price per session, and the user cannot find Manage variations.
+      Intent: troubleshoot the blocked dashboard editor and explain the normal price-variation path only as conditional guidance, without mutating service data.
+
+      Pass if the response:
+      - treats the banner as a dashboard/product loading failure rather than a normal service pricing configuration step, AND
+      - does not claim that Manage variations is currently available or that the user can complete the variation setup while the banner is visible, AND
+      - gives bounded recovery steps such as hard refresh, incognito/private window, extensions disabled, another browser/network, or returning to Bookings Services/Servicios de reserva, AND
+      - says that if this happens on every service, the user should contact Wix Customer Care/support with screenshot, browser, affected site/service, and time of failure, AND
+      - only mentions API/service-data updates as an optional path after explicit user request, desired pricing details, current service revision lookup, and confirmation.
+
+      Fail if the response:
+      - simply tells the user to choose Different prices and Manage variations as if the editor were working, OR
+      - diagnoses the issue as a single-service setup mistake despite the technical-error banner, OR
+      - offers to mutate the service or pricing through an API without explicit confirmation, OR
+      - invents an unsupported workaround for per-person variations.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/67add797-29ce-4167-b408-e301972f7f74
Feedback: Wix Bookings user saw a technical-error banner under **Precio por sesión** in the Harmony service editor and could not access **Administrar variaciones** for manual per-person price variations.

## Conversation research

The reported issue is a true issue, with a corrected surface: this was not a Wix MCP execution failure. The conversation logs show Aria successfully used KB/browser tools, but the dashboard page itself contained the technical-error banner and no usable variation control.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/67add797-29ce-4167-b408-e301972f7f74`: the user asked in Spanish how to manually change per-person prices. Aria fetched the Bookings pricing KB article, then inspected the current service form. Tool result log `d8c8f257-c081-4ebc-85c6-8a455d426676` on assistant message `3811eec0-835f-474b-accf-9d2f6eb6ede2` returned page title `Formulario de servicios de reserva | Wix.com`, `hasTech: true`, and only unrelated candidates: `Administrar apps`, `Administrar recursos`, `Administrar`. Aria still gave normal variation setup guidance and generic refresh steps instead of clearly treating the blocked pricing editor as a dashboard/product failure.

## Code/content research

Root cause: the `Create and Update Booking Services` recipe covered normal service pricing and API updates, but not the existing-service dashboard failure where the price-variation editor is blocked by a technical-error banner.

Why this is the owning surface:
- The serving Aria instructions included `create-and-update-booking-services` in the available skill catalog for Bookings service work.
- The assistant instead answered from generic support article content, which explained the normal **Diferentes precios / Administrar variaciones** path but did not cover the blocked editor state shown by the browser tool result.
- The `wix/skills` Bookings recipe owns service pricing/rateType guidance and is the narrowest content surface for this missing troubleshooting branch.

Alternatives ruled out:
- Genie platform/tool runtime: no `TOOL_FAILED` or validation-error logs were present on the investigated turn.
- `booking-system-integration-gaps`: that recipe is about booking checkout/payment integration after a booking exists, not editing a service's pricing editor.
- Downstream API mutation: no user-approved service data update was attempted or needed; the failure was the dashboard editor state and Aria guidance.

## Change

This changes the Bookings service recipe so future agents treat a blocked price-variation editor as a dashboard/product loading failure, not as a normal configuration path the user can continue through.

Reviewer-oriented diff:
- `skills/wix-manage/references/bookings/create-and-update-booking-services.md`: adds an existing-service pricing editor troubleshooting branch for **Precio por sesión**, **Diferentes precios**, **Manage variations**, and **Administrar variaciones** technical-error banners.
- `skills/wix-manage/SKILL.md`: updates the recipe index wording so routing/retrieval sees price variation troubleshooting as part of the service recipe.
- `yaml/wix-manage-evals/bookings/price-variation-editor-error.yml`: adds a non-mutating eval that requires the agent to read this recipe, avoid pretending **Manage variations** is available, give bounded recovery/support steps, and only mention API updates behind explicit user request/details/confirmation.

## Side effects and rollout risk

The change is bounded to Bookings service pricing troubleshooting. It does not change any REST endpoint guidance, does not loosen mutation rules, and explicitly prevents automatic API mutation as a workaround for a broken dashboard editor. The main risk is over-escalating transient UI load failures to support; the recipe keeps local recovery steps first and support only when the banner persists or affects every service.

## Verification

- Fix proof: added eval `bookings/price-variation-editor-error` covering the reported failure mode and requiring `ReadFullDocsArticle` for `https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-and-update-booking-services`.
- `ruby -e "require 'yaml'; ..."` parsed the new eval, the existing Bookings eval, and the Bookings documentation index successfully.
- `git diff --check` passed.
- `node -e "require('yaml') ..."` could not run because this repo has no installed Node `yaml` dependency; YAML was validated with Ruby instead.
- The GitHub eval gate is expected to run the new scenario against this PR's `wix/skills` content.
