### PR TITLE
docs(wix-headless): surface the connect (existing-project) mode in the cold-start entry

### DIFF
--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -12,7 +12,7 @@ This entry gets a cold environment to the point where the real skill can run, th
 1. **Bootstrap (deterministic, scripted).** A single script verifies your environment (the Wix CLI) and handles login, so the run starts from a known-good, authenticated state. You just run it and relay its events.
 2. **Hand off (agentic).** Install the skill, then open `wix-headless/SKILL.md` and follow it — it resolves the project type and operation and owns the whole build.
 
-Both entry modes take these same two phases — a **new** build from a prompt (empty CWD), or **connecting an existing project/design** (a frontend on disk, a `wix.config.json`, or a brought-in zip/URL). Nothing here branches on it: run the bootstrap, hand off, and let `wix-headless/SKILL.md` resolve *create* vs *connect*.
+These two phases are the same whether you're building **new** from a prompt (empty CWD) or **connecting an existing project/design** (a frontend on disk, a `wix.config.json`, or a brought-in zip/URL). Nothing here branches on it: run the bootstrap, hand off, and let `wix-headless/SKILL.md` resolve *create* vs *connect*.
 
 ## Phase 0 — Node (the one manual prerequisite)
 

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -12,6 +12,8 @@ This entry gets a cold environment to the point where the real skill can run, th
 1. **Bootstrap (deterministic, scripted).** A single script verifies your environment (the Wix CLI) and handles login, so the run starts from a known-good, authenticated state. You just run it and relay its events.
 2. **Hand off (agentic).** Install the skill, then open `wix-headless/SKILL.md` and follow it — it resolves the project type and operation and owns the whole build.
 
+Both entry modes take these same two phases — a **new** build from a prompt (empty CWD), or **connecting an existing project/design** (a frontend on disk, a `wix.config.json`, or a brought-in zip/URL). Nothing here branches on it: run the bootstrap, hand off, and let `wix-headless/SKILL.md` resolve *create* vs *connect*.
+
 ## Phase 0 — Node (the one manual prerequisite)
 
 The Wix CLI requires **Node ≥ 20.11**. Check it:

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -12,7 +12,13 @@ This entry gets a cold environment to the point where the real skill can run, th
 1. **Bootstrap (deterministic, scripted).** A single script verifies your environment (the Wix CLI) and handles login, so the run starts from a known-good, authenticated state. You just run it and relay its events.
 2. **Hand off (agentic).** Install the skill, then open `wix-headless/SKILL.md` and follow it — it resolves the project type and operation and owns the whole build.
 
-These two phases are the same regardless of the starting point — building **new** from a prompt (empty CWD), **connecting** a frontend/design not yet on Wix (a project on disk without `wix.config.json`, or a brought-in zip/URL), or **iterating** on a project already connected to Wix (a `.wix/` or `wix.config.json` is present). Nothing here branches on it: run the bootstrap, hand off, and let `wix-headless/SKILL.md` resolve the project type and operation.
+Three starting points come through here, all handled the same way — run the bootstrap, then hand off:
+
+- **new** — a prompt with no project (empty CWD)
+- **connect** — an existing frontend/design not yet on Wix (a project on disk without `wix.config.json`, or a brought-in zip/URL)
+- **iterate** — a project already connected to Wix (`.wix/` or `wix.config.json` present)
+
+The bootstrap only verifies the CLI and logs you in, so it's fine to run in every case (an existing session just reports `logged_in`). After it, `wix-headless/SKILL.md` resolves what to do and owns the build.
 
 ## Phase 0 — Node (the one manual prerequisite)
 

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -12,7 +12,7 @@ This entry gets a cold environment to the point where the real skill can run, th
 1. **Bootstrap (deterministic, scripted).** A single script verifies your environment (the Wix CLI) and handles login, so the run starts from a known-good, authenticated state. You just run it and relay its events.
 2. **Hand off (agentic).** Install the skill, then open `wix-headless/SKILL.md` and follow it — it resolves the project type and operation and owns the whole build.
 
-These two phases are the same whether you're building **new** from a prompt (empty CWD) or **connecting an existing project/design** (a frontend on disk, a `wix.config.json`, or a brought-in zip/URL). Nothing here branches on it: run the bootstrap, hand off, and let `wix-headless/SKILL.md` resolve *create* vs *connect*.
+These two phases are the same regardless of the starting point — building **new** from a prompt (empty CWD), **connecting** a frontend/design not yet on Wix (a project on disk without `wix.config.json`, or a brought-in zip/URL), or **iterating** on a project already connected to Wix (a `.wix/` or `wix.config.json` is present). Nothing here branches on it: run the bootstrap, hand off, and let `wix-headless/SKILL.md` resolve the project type and operation.
 
 ## Phase 0 — Node (the one manual prerequisite)
 


### PR DESCRIPTION
## What

The cold-start entry (`skills/wix-headless/entry/skill.md`) read as new-site-only after the v2 refactor (#445) moved the existing-project handling downstream. This reintroduces a short, technical note that the same two phases (bootstrap → hand off) also cover **connecting an existing project/design**, deferring the actual create-vs-connect resolution to `wix-headless/SKILL.md`.

## Why

Agents landing in a non-empty dir / with a `wix.config.json` / a brought-in design had no signal in the entry that the flow supports them. This surfaces it without duplicating the moved logic in `references/managed/CONNECT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)