### PR TITLE
docs(wix-manage): document sort.nullsLast in analytics skill

### DIFF
--- a/skills/wix-manage/references/analytics/query-site-analytics.md
+++ b/skills/wix-manage/references/analytics/query-site-analytics.md
@@ -39,6 +39,7 @@ Always follow **List → Get → Query**. You cannot construct a valid query wit
 - **Set `interval.timezone` to the site's time zone to match the Wix dashboard.** Analytics in the Wix business manager are bucketed by the site's time zone. If `interval.timezone` is omitted it defaults to **UTC**, so day boundaries shift and your numbers won't match what the owner sees in the dashboard (and the same goes for using a different time zone). Get the site's IANA time zone from `properties.timeZone` via [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) (`GET https://www.wixapis.com/site-properties/v4/properties`) and pass it through.
 - **Field names must come from `Get Semantic Model`.** The `fields`, `filters[].field`, and `sort.fieldName` values must exactly match a `name` returned by the model schema (e.g. `traffic.sessions_count`). Do not guess field names.
 - **Field dependencies.** A field returns data only if at least one of the field names in its `dependencies` array is also included in the same query; otherwise it's **silently omitted** from results (no error). For example, a measure may only return data when a specific dimension is also requested.
+- **Sorting a nullable measure — set `sort.nullsLast: true`.** `nullsLast` defaults to `false` and only affects **descending** (`DESC`) order. If a measure can return null and you sort it `DESC`, the null rows sort *first* — so a "top N" query surfaces nulls before your real values. Set `nullsLast: true` to push nulls to the end.
 - **Result cap: 1,000 rows per query.** `results` is capped at 1,000 rows — paginate with `paging.offset` for larger datasets.
 - **Formatting is opt-in.** Set `formattingEnabled: true` to also receive a human-readable `formattedValue` per cell (e.g. `1500` → `"$1,500.00"` or `1.5K`). Raw typed values are always returned.
 - **Totals are opt-in.** Set `totalsIncluded: true` to get a `totals` row summing numeric fields across the **full (unpaginated)** result set.
@@ -137,7 +138,8 @@ curl -X POST \
   ],
   "sort": {
     "fieldName": "traffic.sessions_count",
-    "order": "DESC"
+    "order": "DESC",
+    "nullsLast": true
   },
   "paging": {
     "limit": 50,
@@ -156,7 +158,7 @@ curl -X POST \
 | `interval` | Yes | `{ start, end }` UTC ISO date-times, plus `timezone`. Range is start-inclusive, end-exclusive (`[start, end)`) — set `end` to the day after the last day you want. Set `timezone` to the site's IANA time zone (see Time zone section) so results match the Wix dashboard; defaults to UTC when omitted. |
 | `fields` | Yes | Up to 60 field `name`s from the model schema. |
 | `filters` | No | Array of `{ field, values[], condition, prefix }`. `condition` defaults to `EQUAL`, `prefix` defaults to `IS`. For `RANGE_*` conditions provide exactly 2 values. |
-| `sort` | No | `{ fieldName, order, nullsLast }`. `order` defaults to `ASC`. Field must be `sortable`. |
+| `sort` | No | `{ fieldName, order, nullsLast }`. `order` defaults to `ASC`; field must be `sortable`. `nullsLast` (default `false`) applies only to `DESC` order — set it to `true` when the sorted measure can contain nulls, otherwise nulls sort before real values. |
 | `paging` | No | `{ limit, offset }`. Defaults: `limit` 50, `offset` 0. |
 | `formattingEnabled` | No | Default `false`. Adds `formattedValue` per cell. |
 | `totalsIncluded` | No | Default `false`. Adds a `totals` row. |

--- a/yaml/wix-manage-evals/analytics/query-site-analytics-sort-nulls-last.yml
+++ b/yaml/wix-manage-evals/analytics/query-site-analytics-sort-nulls-last.yml
@@ -1,0 +1,33 @@
+name: analytics/query-site-analytics-sort-nulls-last
+description: >-
+  Verifies the agent reads the query-site-analytics skill and knows that sorting a nullable
+  measure DESC surfaces null rows first, and that sort.nullsLast must be set to true (it defaults
+  to false and only applies to descending order) to push nulls to the end.
+triggerPrompt: >-
+  I'm querying a Wix semantic model and sorting a revenue measure in descending order to get my
+  top-earning days, but the first rows returned have no revenue at all instead of my highest
+  days. My sort direction looks correct. Why is this happening and how do I fix it?
+tags: [analytics]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/analytics/skills/query-site-analytics
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user sorts a nullable revenue measure DESC in a Semantic Model API query to get top days,
+      but null/no-revenue rows come first instead of the highest values.
+      Intent: explain that nulls sort first under DESC and fix it with sort.nullsLast.
+
+      Pass ONLY if the response:
+      - identifies that null values sort BEFORE real values when ordering DESC (that's why the
+        empty rows appear first), AND
+      - tells the user to set `sort.nullsLast: true` to move nulls to the end, AND
+      - conveys that `nullsLast` defaults to `false` and/or that it applies to descending order.
+
+      Fail if the response:
+      - blames the sort direction/order value or tells them to switch to ASC, OR
+      - suggests filtering the data or post-processing instead of using `nullsLast`, OR
+      - never mentions `nullsLast`, OR
+      - is generic sorting advice not grounded in the Semantic Model API's sort options.


### PR DESCRIPTION
## What

Follow-up to #459. Documents the `sort.nullsLast` option in the Query Site Analytics skill.

`nullsLast` defaults to `false` and only affects **descending** order — so sorting a nullable measure `DESC` (e.g. a "top N" query) surfaces null rows *before* your real values unless `nullsLast: true` is set. A base agent won't reliably infer this from the raw schema.

## Changes

`skills/wix-manage/references/analytics/query-site-analytics.md`
- New sharp-edge bullet explaining the nulls-first-under-DESC behavior and the fix.
- Expanded the `sort` row in the Request fields table (default `false`, `DESC`-only).
- Set `"nullsLast": true` in the example query.

`yaml/wix-manage-evals/analytics/query-site-analytics-sort-nulls-last.yml` (new)
- Trap eval scenario: revenue measure sorted `DESC` returns empty rows first → judge requires identifying nulls-first-under-DESC and fixing with `sort.nullsLast: true`. `tool` + `llm_judge` assertions; `articleUrl` matches the canonical `/skills/query-site-analytics` doc URL.

## Notes

- Verified against the Query Semantic Model Data schema (`sort.nullsLast`: "place null values last… applies to descending order… default false").
- Read-only skill; no mutating flow.