### PR TITLE
fix(vibe-headless): document event.description as Ricos rich content, not a string

### DIFF
--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -56,7 +56,13 @@ the key fields and link to the full API reference for anything not shown.
   `title`, `mainImage.url`, `dateAndTimeSettings.formatted.dateAndTime`, `location.name`, and
   `shortDescription`. Use `offset`/`nextOffset` from the result to page. Link each card by `slug`.
 - **Event detail** — `getEventBySlug(slug)`; returns null on miss — show a not-found state, never
-  invent an event. Branch the registration UI on `event.registration.type`:
+  invent an event.
+  - **Description fields:** `event.shortDescription` is a **plain string** (safe teaser). The full
+    `event.description` is **Ricos rich content** — an object shaped `{ nodes: [...] }`, **not a string**.
+    Render it with a Ricos viewer (`@wix/ricos`) or walk `nodes` to extract text; **never** call string
+    methods (`.split`/`.slice`/`.substring`) on it — that crashes the page. When you only need text, use
+    `shortDescription`.
+  - Branch the registration UI on `event.registration.type`:
   - `"RSVP"` → render the RSVP form (fields from `event.form.controls`).
   - `"TICKETING"` → render the ticket picker.
   - `"EXTERNAL"` → link out to `event.registration.external.url`.

--- a/skills/wix-vibe-headless/references/events/wix-events-browse.js
+++ b/skills/wix-vibe-headless/references/events/wix-events-browse.js
@@ -8,7 +8,12 @@ import { wixApiRequest } from "./wix-client.js";
  *
  *   id {string}, title {string}, slug {string},
  *   status {string} — "UPCOMING"|"STARTED"|"ENDED"|"CANCELED"|"DRAFT" (only UPCOMING/STARTED are live),
- *   shortDescription {string} — teaser text (DETAILS fieldset),
+ *   shortDescription {string} — PLAIN-TEXT teaser, safe to render directly (DETAILS fieldset),
+ *   description {object} — RICH CONTENT (Ricos), shape { nodes: [...] } — NOT a string (TEXTS fieldset,
+ *     returned by getEventBySlug). Render it with a Ricos viewer (@wix/ricos) or walk `nodes` to extract
+ *     text; NEVER call string methods (.split/.slice/.substring/.trim) on it — that crashes the page.
+ *     For a plain-string teaser use shortDescription instead.
+ *   detailedDescription {string} — legacy plain/HTML description (TEXTS fieldset); prefer description/shortDescription,
  *   mainImage {object} — { id, url, width, height, altText } (DETAILS fieldset),
  *   dateAndTimeSettings {object}:
  *     startDate, endDate {string} — ISO-8601; absent when dateAndTimeTbd is true,


### PR DESCRIPTION
## Problem (from user feedback)

> I created an event, and at first the app did not navigate to the event description correctly. The reason was that Base treated `event.description` as a plain string and generated code that called `.split()` on it. In practice, the Events API returns the description as a rich-content object, so this caused a frontend crash. I checked both the Events skill instructions and the attached Events helper, and I don't see a clear mention that description is rich content or an object.

## Root cause

The vibe events helper/instructions documented only `shortDescription` and mentioned "description" in prose (e.g. "full detail-page fields (description, …)") **without its shape**. `getEventBySlug` requests the `TEXTS` fieldset, which populates `event.description` — so agents saw the field, inferred `string`, and called `.split()` → crash.

## Ground truth (verified against the live Events V3 spec)

- `shortDescription` → `StringValue` → **plain string** (teaser)
- `description` → **object with `nodes[]`** → **Ricos rich content** (returned by `TEXTS`)
- `detailedDescription` → separate legacy field

## Fix (wix-vibe-headless only)

- `skills/wix-vibe-headless/references/events/wix-events-browse.js` — field docblock now documents `description` (Ricos `{ nodes: [] }`), clarifies `shortDescription` is plain text, notes `detailedDescription`.
- `skills/wix-vibe-headless/references/events/INSTRUCTIONS.md` — "Event detail" wiring now calls out description rendering (Ricos viewer / walk nodes; use `shortDescription` for plain text; never string-method it).