### PR TITLE
fix(vibe-headless): blog cover image is post.media.wixMedia.image, not heroImage

### DIFF
--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -47,7 +47,7 @@ the full API reference for anything not shown.
 - **Post feed** — `queryPosts()` for the listing (published posts only, newest first with
   pinned posts leading); pass `nextCursor` back as `cursor` to load the next page. Render
   `title`, `excerpt`, `firstPublishedDate`, `minutesToRead`, and the cover image from
-  **`heroImage.url`** (see the cover-image note below). Route to the detail page by `slug`.
+  **`post.media.wixMedia.image.url`** (see the cover-image note below). Route to the detail page by `slug`.
 - **Post detail** — `getPostBySlug(slug)` keyed off the URL slug; returns `null` on miss —
   show a not-found state, never invent a post. It returns full content:
   - `contentText` — the body as plain text. Split on `"\n"` to render simple paragraphs.
@@ -56,11 +56,11 @@ the full API reference for anything not shown.
     need rich rendering; `contentText` is the zero-dependency default.
   - Resolve `categoryIds` / `tagIds` to labels with `queryCategories()` / `queryTags()`
     (build an id→label map) to show category/tag chips.
-- **Cover image** — use **`post.heroImage.url`** (a ready-to-use https URL) for the card
-  thumbnail and post header. The `post.media` field is metadata only
-  (`{ displayed, custom, altText }`) and carries **no URL**. When `heroImage` is absent and
-  `media.custom === false`, the cover is the first image inside `richContent` — fall back to
-  the first IMAGE node there, or show a text-only card. Never substitute a stock/placeholder image.
+- **Cover image** — use **`post.media.wixMedia.image.url`** (a ready-to-use https URL) for the card
+  thumbnail and post header. `media` is returned by default (including on the list query), so no extra
+  fieldset is needed. When `post.media?.wixMedia?.image` is absent, the cover is the first image inside
+  `richContent` — fall back to the first IMAGE node there, or show a text-only card. Never substitute a
+  stock/placeholder image.
 - **Category page** — `queryCategories()` for a category menu (ordered by `displayPosition`;
   hide categories with `postCount === 0` if you want); `getCategoryBySlug(slug)` for a
   category landing page. Pass `category.id` to `queryPostsByCategory(categoryId, { limit?, cursor? })`
@@ -79,10 +79,10 @@ the full API reference for anything not shown.
 - ❌ Never mock posts, authors, or content — render live Wix data or the empty state.
 - ❌ Never generate fake comments, likes, view counts, or ratings. This skill is read-only
   and does not expose engagement actions; leave such UI empty or omit it.
-- ❌ Never use a placeholder/stock cover image. If `heroImage` is missing, fall back to the
-  first richContent image or a text-only card.
+- ❌ Never use a placeholder/stock cover image. If `post.media?.wixMedia?.image` is missing, fall back
+  to the first richContent image or a text-only card.
 - ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Use `heroImage.url` for the cover image; `media` is metadata only (no URL).
+- ✅ Use `post.media.wixMedia.image.url` for the cover image.
 - The helpers fail soft on single-item lookups: `getPostBySlug` / `getCategoryBySlug` /
   `getTagBySlug` return `null` on a miss so you can show a proper not-found state — don't
   swallow that into a fake item.
@@ -109,7 +109,7 @@ reference only for the gap.
 - [ ] Post feed lists live published posts, newest first, and paginates via `nextCursor`
 - [ ] Post detail loads by `slug` and renders real `contentText` (or rendered `richContent`)
 - [ ] `getPostBySlug` on a bad slug shows a not-found state (no invented post)
-- [ ] Cover images come from `heroImage.url` (or richContent fallback) — no stock placeholders
+- [ ] Cover images come from `post.media.wixMedia.image.url` (or richContent fallback) — no stock placeholders
 - [ ] Category and tag pages list the right posts via `queryPostsByCategory` / `queryPostsByTag`
 - [ ] Empty state shown when `getTotalPosts()` is 0
 - [ ] No mock posts, authors, comments, likes, or view counts anywhere

--- a/skills/wix-vibe-headless/references/blog/wix-blog.js
+++ b/skills/wix-vibe-headless/references/blog/wix-blog.js
@@ -9,7 +9,9 @@ import { wixApiRequest } from "./wix-client.js";
  *   firstPublishedDate {string} — ISO date, default sort key DESC,
  *   pinned {boolean}, featured {boolean}, minutesToRead {number},
  *   categoryIds {string[]}, tagIds {string[]}, hashtags {string[]},
- *   heroImage {object} — { id, url, height, width, altText } — use url for card thumbnails,
+ *   media {object} — cover image at media.wixMedia.image { id, url, height, width, filename, altText? };
+ *     media.wixMedia.image.url is a ready-to-use https URL (returned by default, incl. the list query).
+ *     media.displayed / media.custom are booleans,
  *   contentText {string} — plain text body (CONTENT_TEXT fieldset; getPostBySlug requests it),
  *   richContent {object} — Ricos document (RICH_CONTENT fieldset; getPostBySlug requests it),
  *   url {object} — { base, path } live post URL (URL fieldset; build full link as base+path)


### PR DESCRIPTION
## Problem (from user feedback)

> The post was added successfully, but the image was not included.

## Root cause (verified live)

The vibe blog helper/instructions told agents to read the cover image from **`post.heroImage.url`** and explicitly claimed **`post.media` "carries no URL"** (`INSTRUCTIONS.md` hard rules). Both are wrong.

Tested against a real headless Blog V3 site (`queryPosts` + `getPostBySlug`):
- The post object has **no `heroImage` field**.
- The cover lives at **`post.media.wixMedia.image`** → `{ id, url, height, width, filename }`, where `.url` is a ready `https://static.wixstatic.com/...` URL.
- `media` is returned **by default**, including on the list query (there is no `MEDIA` fieldset — requesting one 400s).

So generated code reads `post.heroImage.url` → `undefined` → the image silently disappears. That's the reported symptom.

## Fix

- `references/blog/wix-blog.js` — field docblock now documents `media.wixMedia.image` (with a "there is NO heroImage" note) instead of `heroImage`.
- `references/blog/INSTRUCTIONS.md` — corrected every `heroImage` reference (post feed, cover-image note, hard rules, verification checklist) to `post.media.wixMedia.image.url`, and removed the false "`media` carries no URL" claim.

Note: the wix-headless recipe (`how-to-code-a-blog.md`) already had this right (`post.media?.wixMedia?.image`) — this brings the vibe helper in line.