### PR TITLE
Fix eCommerce strategy goal skill references

### DIFF
--- a/skills/wix-manage/references/ecommerce/ecom-pricing.md
+++ b/skills/wix-manage/references/ecommerce/ecom-pricing.md
@@ -29,7 +29,7 @@ Discount rules, coupon codes, sales, ribbons, bundles, tiered pricing, and the s
 
 ### Business flows — the orchestrator
 
-The single business-flow orchestrator (`recommend-ecommerce-strategy`) handles all strategic discount intents. It classifies internally (SEASONAL / UPSELL_BOOST / STOCK_MOVER / BUNDLE_AND_SAVE / ABANDONED_CART) and loads its `goal-*` / `flow-*` support files from the kept ecommerce-root siblings.
+The single business-flow orchestrator (`recommend-ecommerce-strategy`) handles all strategic discount intents. It classifies internally (SEASONAL / UPSELL_BOOST / STOCK_MOVER / BUNDLE_AND_SAVE) using embedded goal logic, then loads concrete `flow-*` and action support files only when needed.
 
 > - [Run a sale / promotion strategy](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy) — tags: `[intent:run-a-sale]` · priority 0
 > - [Boost my business / increase sales](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy) — tags: `[intent:boost-business]` · priority 0
@@ -37,11 +37,11 @@ The single business-flow orchestrator (`recommend-ecommerce-strategy`) handles a
 > - [Clearance / move slow stock](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy) — tags: `[intent:clearance]` · priority 0
 > - [Increase AOV (bundle / upsell)](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy) — tags: `[intent:increase-aov]` · priority 0
 >
-> **If the orchestrator above returns a 404** — do not stop. Classify the merchant intent directly and load the matching goal skill via `ReadFullDocsArticle`, then follow its routing chain into the flow skill:
-> - Holiday / event / date mentioned (SEASONAL — takes priority over all other signals) → [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue)
-> - "Boost sales", "increase AOV", "upsell", "spend more" (UPSELL_BOOST) → [Goal: Increase AOV](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov)
-> - "Clearance", "slow stock", "overstock", "move inventory" (STOCK_MOVER) → [Goal: Clear Inventory](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-clear-inventory)
-> - "Bundle", "cross-sell", "buy together", "more items per order" (BUNDLE_AND_SAVE) → [Goal: Drive Cross-Sells](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-drive-cross-sells)
+> **If the orchestrator above returns a 404** — retry that same orchestrator URL once. If it is still unavailable, do not call `goal-*` support URLs; classify the merchant intent directly here and load the matching concrete flow:
+> - Holiday / event / date mentioned (SEASONAL — takes priority over all other signals) → [Flow: Seasonal Promotion](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-seasonal-promotion)
+> - "Boost sales", "increase AOV", "upsell", "spend more" (UPSELL_BOOST) → [Flow: Upsell Boost](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-upsell-boost)
+> - "Clearance", "slow stock", "overstock", "move inventory" (STOCK_MOVER) → [Flow: Stock Mover](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-stock-mover)
+> - "Bundle", "cross-sell", "buy together", "more items per order" (BUNDLE_AND_SAVE) → [Flow: Bundle and Save](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-bundle-and-save)
 
 ### Info / troubleshoot / recommendation
 

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-seasonal-promotion.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-seasonal-promotion.md
@@ -1,12 +1,12 @@
 ---
 name: "Flow: Seasonal Promotion"
-description: SEASONAL sub-flow — load [Goal: Seasonal Revenue] FIRST (it owns classification and routing); this is a sub-step, NOT a direct entry from README.
+description: SEASONAL sub-flow — apply the orchestrator's Goal: Seasonal Revenue logic first; this is a sub-step, NOT a direct entry from README.
 ---
 # Flow: Seasonal Promotion
 
-> ⛔ **Routing gate — [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue) must be loaded before this flow.**
+> ⛔ **Routing gate — Goal: Seasonal Revenue logic must be applied before this flow.**
 >
-> This flow is a sub-step, not a direct entry point. If you have not yet called `ReadFullDocsArticle` on [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue) in this conversation, **stop and load it now**. The goal skill owns the SEASONAL classification rule, the time-window presentation requirement, and the priority rule that gates access to this flow.
+> This flow is a sub-step, not a direct entry point. If you arrived here without first classifying through `recommend-ecommerce-strategy`, apply its embedded **SEASONAL / Goal: Seasonal Revenue** logic before continuing. Do not call `ReadFullDocsArticle` on `goal-*` support URLs; those goal docs can be unavailable and must not block this flow. The embedded goal logic owns the SEASONAL classification rule, the time-window presentation requirement, and the priority rule that gates access to this flow.
 >
 > **Before executing this flow**, also read [Create Discount Rule](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule) with `ReadFullDocsArticle` — it contains the discount-rule mechanics **and** the pre-create guardrails (conflict/stacking, margin floor, %-sanity).
 

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
@@ -1,10 +1,10 @@
 ---
 name: "Flow: Stock Mover"
-description: Stock-mover clearance sub-flow — load [Goal: Clear Inventory] FIRST (it owns the routing); this is a sub-step.
+description: Stock-mover clearance sub-flow — apply the orchestrator's Goal: Clear Inventory logic first; this is a sub-step.
 ---
 # Flow: Stock Mover Clearance
 
-> **Routing rule (READ FIRST).** This recipe is a sub-step of [Goal: Clear Inventory](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-clear-inventory). If you arrived here directly from the WixREADME index, load the goal recipe NOW before executing — it owns the velocity scoring, classification cues, and the per-recommendation presentation rules (including the **margin-floor guardrail** surfacing requirement).
+> **Routing rule (READ FIRST).** This recipe is a sub-step of the **STOCK_MOVER / Goal: Clear Inventory** logic embedded in `recommend-ecommerce-strategy`. If you arrived here directly from the WixREADME index, apply that embedded goal logic before executing. Do not call `ReadFullDocsArticle` on `goal-*` support URLs; those goal docs can be unavailable and must not block this flow. The goal logic owns the velocity scoring, classification cues, and the per-recommendation presentation rules (including the **margin-floor guardrail** surfacing requirement).
 >
 > **Then** read [Create Discount Rule](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule) with `ReadFullDocsArticle` — it contains the discount-rule mechanics **and** the pre-create guardrails (conflict/stacking, margin floor, %-sanity).
 

--- a/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
+++ b/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
@@ -26,16 +26,18 @@ references:
 
 > ⛔ **MANDATORY PRE-STEP — do this BEFORE Step 1 (before any API call).**
 >
-> Classify the merchant's request and immediately call `ReadFullDocsArticle` on the matching goal skill. Do NOT gather data first — the goal skill tells you which metrics to pull and what guardrails to apply.
+> Classify the merchant's request using the goal table below. Do NOT gather data first — the goal determines which metrics to pull and what guardrails to apply.
 >
-> | Merchant intent | Goal to load |
+> **Do not call `ReadFullDocsArticle` on `goal-*` URLs from this recipe.** The goal logic needed by this orchestrator is embedded here. Calling those support URLs can return a docs 404 and must not block the merchant flow.
+>
+> | Merchant intent | Goal to apply |
 > |---|---|
-> | Holiday / event / date mentioned | `ReadFullDocsArticle` → [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue) |
-> | "increase AOV", "spend more", "upsell", "boost sales", generic sales improvement | `ReadFullDocsArticle` → [Goal: Increase AOV](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov) |
-> | "clear inventory", "overstock", "clearance", "slow-moving" | `ReadFullDocsArticle` → [Goal: Clear Inventory](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-clear-inventory) |
-> | "bundle", "cross-sell", "buy together", "more items per order" | `ReadFullDocsArticle` → [Goal: Drive Cross-Sells](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-drive-cross-sells) |
+> | Holiday / event / date mentioned | **SEASONAL** / Goal: Seasonal Revenue |
+> | "increase AOV", "spend more", "upsell", "boost sales", generic sales improvement | **UPSELL_BOOST** / Goal: Increase AOV |
+> | "clear inventory", "overstock", "clearance", "slow-moving" | **STOCK_MOVER** / Goal: Clear Inventory |
+> | "bundle", "cross-sell", "buy together", "more items per order" | **BUNDLE_AND_SAVE** / Goal: Drive Cross-Sells |
 >
-> After loading the goal skill, continue from Step 1 below. The goal skill will instruct you to load the matching flow skill — follow those instructions too.
+> After classifying the goal, continue from Step 1 below. When you reach concrete discount mechanics, load the matching **flow** or **action** skill listed later in this recipe.
 >
 > **If COUPON mechanism in Step 4c**, also load:
 > - [Pricing: Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon)
@@ -190,25 +192,27 @@ Based on the merchant's request AND the site data, determine which domains to an
 
 ---
 
-## Step 4b: Load domain-specific goal skills
+## Step 4b: Apply domain-specific goal logic
 
-**MANDATORY — load the matching goal skill(s) now using `ReadFullDocsArticle`.** These contain detailed strategy logic, KPIs, margin tiers, campaign window calculations, and guardrails that you MUST follow.
+**MANDATORY — apply the matching goal logic now.** These goals determine detailed strategy logic, KPIs, margin tiers, campaign window calculations, and guardrails that you MUST follow.
+
+**Do not call `ReadFullDocsArticle` for `goal-*` support articles.** Use the embedded goal logic in this section. Only use `ReadFullDocsArticle` for concrete flow/action references such as `flow-upsell-boost`, `flow-bundle-and-save`, `flow-stock-mover`, `flow-seasonal-promotion`, `pricing-create-discount-rule`, and shipping setup references.
 
 **For DISCOUNTS domain — classify the discount goal and load it:**
 
-| Discount goal | Trigger | Load this skill |
+| Discount goal | Trigger | Flow/action reference to load when needed |
 |---|---|---|
-| SEASONAL | Holiday/event/date mentioned | [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue) |
-| UPSELL_BOOST | "increase AOV", "spend more", "upsell" | [Goal: Increase AOV](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov) |
-| STOCK_MOVER | "clear inventory", "overstock", "clearance" | [Goal: Clear Inventory](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-clear-inventory) |
-| BUNDLE_AND_SAVE | "bundle", "cross-sell", "buy together" | [Goal: Drive Cross-Sells](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-drive-cross-sells) |
+| SEASONAL | Holiday/event/date mentioned | [Flow: Seasonal Promotion](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-seasonal-promotion) |
+| UPSELL_BOOST | "increase AOV", "spend more", "upsell" | [Flow: Upsell Boost](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-upsell-boost) |
+| STOCK_MOVER | "clear inventory", "overstock", "clearance" | [Flow: Stock Mover](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-stock-mover) |
+| BUNDLE_AND_SAVE | "bundle", "cross-sell", "buy together" | [Flow: Bundle and Save](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-bundle-and-save) |
 | Generic (no clear goal) | "boost sales", ambiguous | Default to SEASONAL if holiday nearby, else UPSELL_BOOST |
 
-**For SHIPPING domain — load the same goal as discounts.** Shipping flows (free shipping threshold, rate optimization) serve the same business goals as discount flows. Load the matching discount goal above — it now includes shipping flow references.
+**For SHIPPING domain — use the same goal classification as discounts.** Shipping flows (free shipping threshold, rate optimization) serve the same business goals as discount flows.
 
-**The goal skill will instruct you to load flow and guardrail skills** — follow those instructions. This chain provides the detailed execution logic you need for high-quality recommendations.
+**Load the concrete flow and guardrail skills only after data gathering identifies the relevant action.** This chain provides the detailed execution logic you need for high-quality recommendations.
 
-**Do NOT skip this step.** The goal/flow/guardrail skills contain critical constraints (margin tiers, campaign windows, conflict checks) that prevent bad recommendations.
+**Do NOT skip this step.** The goal logic and flow/guardrail skills contain critical constraints (margin tiers, campaign windows, conflict checks) that prevent bad recommendations.
 
 ---
 

--- a/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
+++ b/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
@@ -7,19 +7,19 @@ references:
     path: ecommerce/api-recommendation-tracking.md
     load: false
   - name: "Goal: Increase AOV"
-    path: ecommerce/goal-increase-aov.md
+    path: ecommerce/pricing-promotions/ecom-pricing-goal-increase-aov.md
     load: false
   - name: "Goal: Clear Inventory"
-    path: ecommerce/goal-clear-inventory.md
+    path: ecommerce/pricing-promotions/ecom-pricing-goal-clear-inventory.md
     load: false
   - name: "Goal: Seasonal Revenue"
-    path: ecommerce/goal-seasonal-revenue.md
+    path: ecommerce/pricing-promotions/ecom-pricing-goal-seasonal-revenue.md
     load: false
   - name: "Goal: Drive Cross-Sells"
-    path: ecommerce/goal-drive-cross-sells.md
+    path: ecommerce/pricing-promotions/ecom-pricing-goal-drive-cross-sells.md
     load: false
   - name: "Setup: Coupons"
-    path: ecommerce/setup-coupons.md
+    path: ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
     load: false
 ---
 # Recommend: eCommerce Strategy

--- a/yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml
+++ b/yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml
@@ -6,10 +6,13 @@ assertions:
   - tool: ReadFullDocsArticle
     params:
       articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov
   - type: llm_judge
     minScore: 7
     maxTokens: 2048
     prompt: |
-      Pass if the response (a) loads the recommend-ecommerce-strategy orchestrator, (b) classifies the request into one of the 4 supported discount goals (SEASONAL / UPSELL_BOOST / STOCK_MOVER / BUNDLE_AND_SAVE) and/or activates the SHIPPING domain, (c) generates concrete recommendations the merchant can approve (each with a clear action and reasoning grounded in site data — AOV, orders, country, currency, etc.), and (d) references or loads api-recommendation-tracking and persists the recommendations via BatchCreate before presenting them.
-      Fail if the response activates an ABANDONED_CART domain (it was removed from the orchestrator in the routing-tree migration), invents discount goals outside the 4 supported ones, returns generic advice without any concrete action / data citation, or skips the tracking lifecycle entirely.
+      Pass if the response (a) loads the recommend-ecommerce-strategy orchestrator, (b) follows the orchestrator's mandatory pre-step by loading the Goal: Increase AOV follow-up article for this generic sales-improvement request, (c) classifies the request into one of the 4 supported discount goals (SEASONAL / UPSELL_BOOST / STOCK_MOVER / BUNDLE_AND_SAVE) and/or activates the SHIPPING domain, (d) generates concrete recommendations the merchant can approve (each with a clear action and reasoning grounded in site data — AOV, orders, country, currency, etc.), and (e) references or loads api-recommendation-tracking and persists the recommendations via BatchCreate before presenting them.
+      Fail if the response activates an ABANDONED_CART domain (it was removed from the orchestrator in the routing-tree migration), invents discount goals outside the 4 supported ones, returns generic advice without any concrete action / data citation, skips the Goal: Increase AOV follow-up article, or skips the tracking lifecycle entirely.
       Topic-completeness across all 4 discount goals AND shipping is NOT required to pass — judge the orchestrator load + classification + concrete-actions + tracking, not the breadth.

--- a/yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml
+++ b/yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml
@@ -6,13 +6,10 @@ assertions:
   - tool: ReadFullDocsArticle
     params:
       articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy
-  - tool: ReadFullDocsArticle
-    params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov
   - type: llm_judge
     minScore: 7
     maxTokens: 2048
     prompt: |
-      Pass if the response (a) loads the recommend-ecommerce-strategy orchestrator, (b) follows the orchestrator's mandatory pre-step by loading the Goal: Increase AOV follow-up article for this generic sales-improvement request, (c) classifies the request into one of the 4 supported discount goals (SEASONAL / UPSELL_BOOST / STOCK_MOVER / BUNDLE_AND_SAVE) and/or activates the SHIPPING domain, (d) generates concrete recommendations the merchant can approve (each with a clear action and reasoning grounded in site data — AOV, orders, country, currency, etc.), and (e) references or loads api-recommendation-tracking and persists the recommendations via BatchCreate before presenting them.
-      Fail if the response activates an ABANDONED_CART domain (it was removed from the orchestrator in the routing-tree migration), invents discount goals outside the 4 supported ones, returns generic advice without any concrete action / data citation, skips the Goal: Increase AOV follow-up article, or skips the tracking lifecycle entirely.
+      Pass if the response (a) loads the recommend-ecommerce-strategy orchestrator, (b) follows the orchestrator's mandatory pre-step by classifying this generic sales-improvement request as UPSELL_BOOST / Increase AOV or an appropriate cross-domain sales goal using the embedded goal logic, (c) does not block or apologize because a goal-* docs article could not be loaded, (d) generates concrete recommendations the merchant can approve (each with a clear action and reasoning grounded in site data — AOV, orders, country, currency, etc.), and (e) references or loads api-recommendation-tracking and persists the recommendations via BatchCreate before presenting them.
+      Fail if the response activates an ABANDONED_CART domain (it was removed from the orchestrator in the routing-tree migration), invents discount goals outside the 4 supported ones, returns generic advice without any concrete action / data citation, reports an internal goal-skill/docs loading blocker, or skips the tracking lifecycle entirely.
       Topic-completeness across all 4 discount goals AND shipping is NOT required to pass — judge the orchestrator load + classification + concrete-actions + tracking, not the breadth.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/7495a0c3-9606-4b5c-9464-61b4c6e91e07, https://wix-bo.com/ai-assistant/conversations/3b68c885-b598-44d0-8a30-cd31f8c8f7eb
Feedback: `ReadFullDocsArticle` returned 404 for eCommerce goal skill URLs such as `goal-increase-aov`, blocking the `Recommend: eCommerce Strategy` recipe during Aria store-analysis flows.

## Conversation research

The reported issue is a true issue. In https://wix-bo.com/ai-assistant/conversations/7495a0c3-9606-4b5c-9464-61b4c6e91e07, the merchant asked `waar zie je kansen`; the assistant activated `recommend-e-commerce-strategy`, followed the recipe's mandatory pre-step, and then failed twice on `ReadFullDocsArticle` for `https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov`. The assistant message completed with severity `ERROR` and told the merchant it could not finish the data-driven analysis because the required goal documentation returned 404.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/7495a0c3-9606-4b5c-9464-61b4c6e91e07`: assistant message `6b088871-f554-476b-ae85-4fa95092d322`; `activateSkill` result log `b159b557-3844-40b2-a3b5-b958fb51a3cf`; `ReadFullDocsArticle` call logs `00bf188c-5cbc-4486-899c-c6027eec183d` and `0bdd7e83-cccd-49bb-af5e-35e9837a3d50`; `TOOL_FAILED` logs `106984c7-0b66-405a-97cd-f363021c2292` and `e6d350c0-aa9b-4c36-8a50-65c902a44ec7`, both returning `Could not fetch article content: "Resource ID not found for article (status 404)"`.
- `https://wix-bo.com/ai-assistant/conversations/3b68c885-b598-44d0-8a30-cd31f8c8f7eb`: the merchant asked `DA UMA ANALISADA NA MINHA LOJA`; the assistant activated `recommend-e-commerce-strategy` and then called `ReadFullDocsArticle` with `articleUrl=https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov`; the tool failed with the same 404 and the assistant told the merchant it lacked access because of an internal documentation issue. Evidence: assistant message `7498ba99-e253-4978-bdc7-1170b8d5ac7c`; `activateSkill` log `0346f480-2cbf-46cf-894d-8f971aad7946`; `activateSkill` result log `d29345c0-9f07-4a02-a698-d2b13a398c5f`; `ReadFullDocsArticle` call log `72138257-ddf9-4022-a127-179c10bee074`; `TOOL_FAILED` log `980f0043-365b-4500-bfcf-3bc2a4c0ffe2`.

Impact/frequency: app-log query on `com.wixpress.genie.ai-assistant-mcp-proxy-v2` for 2026-07-01 through 2026-07-08 found `ReadFullDocsArticle` 404s in 15-27 distinct requests/day. A stricter query requiring both the `goal-increase-aov` URL signature and the 404 error signature in the same request found 9-19 distinct requests/day. This is recurring production cost/user-visible blockage, not a single self-recovered turn.

## Code/content research

Root cause: `recommend-ecommerce-strategy.md` required agents to call `ReadFullDocsArticle` on `goal-*` support URLs such as `goal-increase-aov`, but those goal support pages are not independently readable by the docs tool and return 404. The same file also listed stale local frontmatter paths such as `ecommerce/goal-increase-aov.md` and `ecommerce/setup-coupons.md`, while the actual source files live under `ecommerce/pricing-promotions/ecom-pricing-*.md`.

Why this is the owning surface:
- The failing URL is emitted from `skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md`.
- The target goal docs are registered in `yaml/wix-manage/ecommerce/documentation.yaml` as files under `skills/wix-manage/references/ecommerce/pricing-promotions/`.
- This is skill content owned by `wix/skills`; the Genie runtime executed the requested `ReadFullDocsArticle` call and surfaced the upstream 404 correctly.

Alternatives ruled out:
- Genie platform/tool orchestration: ruled out because `activateSkill`, `ReadFullDocsArticle`, and `TOOL_FAILED` logs show normal execution, not validation or routing failure.
- Downstream eCommerce API: ruled out because the failure occurs before any site API call.
- Aria assistant prompt issue: ruled out because the bad instruction is in the served `recommend-e-commerce-strategy` recipe content.

## Change

This changes the `Recommend: eCommerce Strategy` recipe so goal classification happens from embedded inline logic instead of calling broken `goal-*` support article URLs. It keeps concrete flow/action docs as `ReadFullDocsArticle` targets, because those pages are readable. It also aligns the recipe metadata with the actual registered eCommerce pricing-promotion docs and strengthens the eval so a generic sales-improvement scenario fails if the agent blocks on a goal-doc loading issue.

Reviewer-oriented diff:
- `skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md`: replace stale `ecommerce/goal-*.md` and `ecommerce/setup-coupons.md` frontmatter paths with the actual `ecommerce/pricing-promotions/ecom-pricing-*.md` files; remove instructions to call `ReadFullDocsArticle` for `goal-*` URLs; point later execution to concrete flow/action pages such as `flow-upsell-boost`.
- `skills/wix-manage/references/ecommerce/ecom-pricing.md`: update the fallback path so it does not send agents to broken `goal-*` support URLs.
- `yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml`: update the judge to require embedded goal classification and fail if the agent reports an internal goal-skill/docs loading blocker.

## Side effects and rollout risk

Risk is bounded to eCommerce pricing guidance and one existing eval. The change does not alter the recipe's public URL, site API instructions, or mutation behavior; it changes the doc-loading policy so agents stop calling known-broken `goal-*` support URLs and continue with the embedded goal logic.

Safety & ownership gate: this is not an opaque rewrite of another team's runtime output and does not patch the reachable MCP reader/enforcement point. It changes the authoring source that told the model to call unreadable `goal-*` support URLs. The behavior is observable through PR-served skill activation and the existing eval gate.

## Verification

- Fix proof: PR-served smoke test against head `e1b90bb5548d08b89370316edd1b3f943f0f31a2` confirmed `activateSkill(recommend-e-commerce-strategy)` loaded the patched frontmatter from this PR (`ecommerce/pricing-promotions/ecom-pricing-goal-increase-aov.md`) and the inline guardrail saying not to call `ReadFullDocsArticle` for `goal-*` support articles. Evidence: conversation `fc7df2f5-3674-45fb-be45-06aef56cdde6`, assistant message `e1c5d7b1-3c28-4468-8ea2-325edcdb517a`, activation log `3a986efc-bb02-4a27-abd0-7c4fb7e692d4`, result log `a30e207b-0926-429b-b466-4a37dc4b296c`. The subsequent blocker was the expected placeholder-site `CallWixSiteAPI` failure, not a `goal-*` docs article load.
- Earlier smoke testing confirmed the old `goal-increase-aov` `ReadFullDocsArticle` target still 404s, which is why the final fix avoids that call path instead of renaming it to another unreadable support URL.
- Local static check confirmed every frontmatter `path:` in `recommend-ecommerce-strategy.md` resolves to an existing file under `skills/wix-manage/references`.
- Parsed `yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml`, `yaml/wix-manage-evals/ecommerce/ecom-pricing.yml`, and `yaml/wix-manage/ecommerce/documentation.yaml` with Ruby YAML.
- Static search confirmed the orchestrator and pricing dispatcher now instruct agents not to call `goal-*` support article URLs.
- Could not run the action Vitest suites locally: `yarn test` first failed because the local Yarn install state was missing; `yarn install` in `.github/actions/evalforge-yaml-gate` and `.github/actions/skill-eval` failed during package fetch with repeated `RequestError: read ENOTCONN`.
- Current PR check status: `Check @wix/cli pinned to @latest` passed, `Skill Eval` skipped, and `EvalForge YAML Gate` failed while creating the temporary MCP version (`EvalForge POST /projects/.../capabilities/.../versions -> 404`) after printing the PR head SHA. No content/schema validation error was emitted before that infrastructure failure.
