### PR TITLE
fix(vibe-headless): QA-found correctness fixes across verticals

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -12,10 +12,11 @@ Builds a real, client-only Wix Bookings front end. The browser talks to Wix dire
 public `WIX_CLIENT_ID`. Never mock services or slots; never hand-build a `/checkout` URL —
 always create the booking through the API and complete it via the eCom checkout + redirect-session.
 
-This skill ships the single-service booking flow for **all service types**: browse services → pick a
-service → pick an available slot → enter details → book → hosted checkout. Appointments and
-classes/courses differ only in the availability call (`listAvailableSlots` vs `listEventTimeSlots`);
-`listSlotsForService` routes by `service.type`, and `createBooking` handles either slot.
+This skill ships the single-service booking flow for **APPOINTMENT and CLASS** services: browse
+services → pick a service → pick an available slot → enter details → book → hosted checkout.
+Appointments and classes differ only in the availability call (`listAvailableSlots` vs
+`listEventTimeSlots`); `listSlotsForService` routes by `service.type`, and `createBooking` handles
+either slot. **COURSE (whole-course enrollment) is not covered** — see "Beyond the snippets".
 
 ## When to use
 - User wants a Wix Bookings appointment site or asks to "connect Wix Bookings".
@@ -58,8 +59,8 @@ the full API reference for anything not shown.
 - **Service list** — `queryServices()` for the listing (visitor-visible services only). Render
   `name`, `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price
   from `payment.fixed.price.formattedValue` (already includes the currency). Pass the returned
-  `nextOffset` back as `offset` to load the next page. Books **all service types** —
-  APPOINTMENT, CLASS, and COURSE (see the slot picker below).
+  `nextOffset` back as `offset` to load the next page. Books **APPOINTMENT and CLASS** services
+  (see the slot picker below); COURSE is whole-course enrollment and out of scope.
 - **Service detail** — `getService(serviceId)` keyed off the URL/route; returns null on miss —
   show a not-found state, never invent a service. Render `description`, price, and `locations`.
 - **Slot picker** — use **`listSlotsForService(service, { fromLocalDate, toLocalDate, timeZone? })`**:
@@ -98,13 +99,15 @@ the full API reference for anything not shown.
   don't swallow these.
 
 ## Beyond the snippets
-The snippets cover appointments **and** classes/courses (the slot picker routes by `service.type`).
+The snippets cover **APPOINTMENT and CLASS** bookings (the slot picker routes by `service.type`).
 For anything beyond that, extend the client: add a new helper on `wixApiRequest`, looking up the
 exact endpoint, method, and body in the **official Wix API reference** first (never guess):
 - Official Wix API reference: https://dev.wix.com/docs/api-reference.md
 - Single-service booking flow (the full picture): https://dev.wix.com/docs/api-reference/business-solutions/bookings/flow-single-service-booking.md
-- **Courses — enrollment/capacity nuance:** a course is booked per-session like a class
-  (`listEventTimeSlots` + `createBooking`), but whole-course capacity is computed from bookings —
+- **Courses are NOT covered — a course is enrolled as a *whole*, not booked per session.**
+  `listEventTimeSlots` returns **no** per-session slots for a COURSE (verified — empty even for admin),
+  so the slot-picker flow doesn't apply. Enrolling in a course uses a course-specific flow (whole-course
+  capacity computed from bookings) that these snippets don't implement —
   https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-reader-v2/query-extended-bookings.md
 - **Service variants / participants** (duration- or person-based pricing):
   https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/service-options-and-variants/get-service-options-and-variants-by-service-id.md

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -12,9 +12,10 @@ Builds a real, client-only Wix Bookings front end. The browser talks to Wix dire
 public `WIX_CLIENT_ID`. Never mock services or slots; never hand-build a `/checkout` URL —
 always create the booking through the API and complete it via the eCom checkout + redirect-session.
 
-This skill ships the **single-service appointment** flow: browse services → pick a service →
-pick an available time slot → enter details → book → hosted checkout. Classes and courses use
-different availability calls and are covered under "Beyond the snippets".
+This skill ships the single-service booking flow for **all service types**: browse services → pick a
+service → pick an available slot → enter details → book → hosted checkout. Appointments and
+classes/courses differ only in the availability call (`listAvailableSlots` vs `listEventTimeSlots`);
+`listSlotsForService` routes by `service.type`, and `createBooking` handles either slot.
 
 ## When to use
 - User wants a Wix Bookings appointment site or asks to "connect Wix Bookings".
@@ -57,14 +58,17 @@ the full API reference for anything not shown.
 - **Service list** — `queryServices()` for the listing (visitor-visible services only). Render
   `name`, `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price
   from `payment.fixed.price.formattedValue` (already includes the currency). Pass the returned
-  `nextOffset` back as `offset` to load the next page. This skill books **APPOINTMENT** services;
-  if you mix in CLASS/COURSE services, branch on `service.type`.
+  `nextOffset` back as `offset` to load the next page. Books **all service types** —
+  APPOINTMENT, CLASS, and COURSE (see the slot picker below).
 - **Service detail** — `getService(serviceId)` keyed off the URL/route; returns null on miss —
   show a not-found state, never invent a service. Render `description`, price, and `locations`.
-- **Slot picker** — `listAvailableSlots(serviceId, { fromLocalDate, toLocalDate, timeZone? })`.
-  Dates are **local** wall-clock strings `"YYYY-MM-DDThh:mm:ss"` (no zone), interpreted in
-  `timeZone` (defaults to the visitor's IANA zone). Only `bookable: true` slots come back. Render
-  each `slot.localStartDate`/`localEndDate`; group by day for a calendar. Pass `nextCursor` back
+- **Slot picker** — use **`listSlotsForService(service, { fromLocalDate, toLocalDate, timeZone? })`**:
+  it routes by `service.type` — APPOINTMENT → `listAvailableSlots` (staff working hours), CLASS/COURSE
+  → `listEventTimeSlots` (scheduled sessions). Both return the same slot shape. (Call the specific
+  function directly if you already know the type.) Dates are **local** wall-clock strings
+  `"YYYY-MM-DDThh:mm:ss"` (no zone), interpreted in `timeZone` (defaults to the visitor's IANA zone).
+  Only `bookable: true` slots come back. Render each `slot.localStartDate`/`localEndDate`; group by
+  day for a calendar. Pass `nextCursor` back
   as `cursor` to page.
 - **Booking form** — collect the buyer's `firstName`, `lastName`, `email`, `phone`. Keep it
   minimal; richer per-service form fields live in the service's `form.id` (see "Beyond the snippets").
@@ -94,14 +98,13 @@ the full API reference for anything not shown.
   don't swallow these.
 
 ## Beyond the snippets
-The snippets cover the appointment booking path. For the "20%" they don't cover, extend the
-client: add a new helper on `wixApiRequest`, looking up the exact endpoint, method, and body in
-the **official Wix API reference** first (never guess):
+The snippets cover appointments **and** classes/courses (the slot picker routes by `service.type`).
+For anything beyond that, extend the client: add a new helper on `wixApiRequest`, looking up the
+exact endpoint, method, and body in the **official Wix API reference** first (never guess):
 - Official Wix API reference: https://dev.wix.com/docs/api-reference.md
 - Single-service booking flow (the full picture): https://dev.wix.com/docs/api-reference/business-solutions/bookings/flow-single-service-booking.md
-- **Classes** (group sessions): list slots with List Event Time Slots —
-  https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots.md
-- **Courses** (multi-session): capacity is computed from bookings —
+- **Courses — enrollment/capacity nuance:** a course is booked per-session like a class
+  (`listEventTimeSlots` + `createBooking`), but whole-course capacity is computed from bookings —
   https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-reader-v2/query-extended-bookings.md
 - **Service variants / participants** (duration- or person-based pricing):
   https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/service-options-and-variants/get-service-options-and-variants-by-service-id.md

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings-checkout.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings-checkout.js
@@ -53,13 +53,26 @@ export async function createBooking(slot, contactDetails, { totalParticipants = 
 
   const resource = slot.availableResources?.[0]?.resources?.[0];
 
+  // The availability slot's location uses the SERVICE location enum (e.g. "BUSINESS"), but the
+  // createBooking endpoint expects the BOOKING location enum [UNDEFINED, OWNER_BUSINESS,
+  // OWNER_CUSTOM, CUSTOM]. Passing slot.location straight through 400s
+  // ("slot.location.locationType enum must be in [...]"). Remap before sending.
+  const bookingLocation = (() => {
+    const loc = slot.location;
+    if (!loc) return null;
+    const valid = ["UNDEFINED", "OWNER_BUSINESS", "OWNER_CUSTOM", "CUSTOM"];
+    const map = { BUSINESS: "OWNER_BUSINESS", CUSTOM: "CUSTOM", CUSTOMER: "CUSTOM" };
+    const locationType = map[loc.locationType] || (valid.includes(loc.locationType) ? loc.locationType : "OWNER_BUSINESS");
+    return { ...loc, locationType };
+  })();
+
   const bookedSlot = {
     serviceId: slot.serviceId,
     scheduleId: slot.scheduleId,
     startDate: slot.localStartDate,
     endDate: slot.localEndDate,
     timezone: timeZone || defaultTimeZone(),
-    ...(slot.location ? { location: slot.location } : {}),
+    ...(bookingLocation ? { location: bookingLocation } : {}),
     ...(resource ? { resource: { id: resource.id, name: resource.name } } : {}),
   };
 

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings-checkout.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings-checkout.js
@@ -26,16 +26,19 @@ function defaultTimeZone() {
 }
 
 /**
- * Create a booking for an appointment slot. The booking starts as status "CREATED" and is NOT
- * yet on the calendar — it is confirmed automatically after the buyer completes the hosted
- * checkout (call checkoutBooking next). selectedPaymentOption is "ONLINE".
+ * Create a booking for a slot. The booking starts as status "CREATED" and is NOT yet on the
+ * calendar — it is confirmed automatically after the buyer completes the hosted checkout (call
+ * checkoutBooking next). selectedPaymentOption is "ONLINE".
  *
- * Pass a slot from listAvailableSlots()/getAvailableSlot() — it carries serviceId, scheduleId,
- * localStartDate, localEndDate, location, availableResources. Always call getAvailableSlot
- * first to re-validate and get staff info. Throws on an unbookable slot or missing booking id.
+ * Works for **both** service types — it reads the discriminator off the slot:
+ *  - APPOINTMENT slot (from `listAvailableSlots`/`getAvailableSlot`) carries `scheduleId`.
+ *  - CLASS/COURSE slot (from `listEventTimeSlots`) carries `eventInfo.eventId` and no `scheduleId`;
+ *    Wix derives the session's date/resource/location from that event.
+ * For appointments, call `getAvailableSlot` first to re-validate and get staff (`availableResources`).
+ * Throws on an unbookable slot or missing booking id.
  * https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking.md
  *
- * @param {object} slot                       A TimeSlot from listAvailableSlots/getAvailableSlot.
+ * @param {object} slot                       A TimeSlot from listAvailableSlots/getAvailableSlot/listEventTimeSlots.
  * @param {{ firstName?: string, lastName?: string, email: string, phone?: string }} contactDetails
  * @param {{ totalParticipants?: number, timeZone?: string, title?: string }} [options]
  * @returns {Promise<object>} The created booking (status "CREATED").
@@ -44,8 +47,10 @@ export async function createBooking(slot, contactDetails, { totalParticipants = 
   if (!slot || slot.bookable === false) {
     throw new Error("Cannot book: the selected slot is not bookable. Re-check availability and pick another time.");
   }
-  if (!slot.serviceId || !slot.scheduleId || !slot.localStartDate || !slot.localEndDate) {
-    throw new Error("Cannot book: slot is missing serviceId/scheduleId/localStartDate/localEndDate.");
+  // A slot is bound either by scheduleId (appointment) or by eventInfo.eventId (class/course).
+  const eventId = slot.eventInfo?.eventId;
+  if (!slot.serviceId || (!slot.scheduleId && !eventId) || !slot.localStartDate || !slot.localEndDate) {
+    throw new Error("Cannot book: slot is missing serviceId, localStartDate/localEndDate, and a scheduleId (appointment) or eventInfo.eventId (class/course).");
   }
   if (!contactDetails?.email) {
     throw new Error("Cannot book: contactDetails.email is required.");
@@ -68,7 +73,8 @@ export async function createBooking(slot, contactDetails, { totalParticipants = 
 
   const bookedSlot = {
     serviceId: slot.serviceId,
-    scheduleId: slot.scheduleId,
+    // Appointment → scheduleId; class/course → eventId. Send exactly one.
+    ...(eventId ? { eventId } : { scheduleId: slot.scheduleId }),
     startDate: slot.localStartDate,
     endDate: slot.localEndDate,
     timezone: timeZone || defaultTimeZone(),

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
@@ -100,8 +100,11 @@ export async function countServices() {
 }
 
 /**
- * List bookable appointment time slots for a service within a local date range.
- * APPOINTMENT services only. Dates are LOCAL ("YYYY-MM-DDThh:mm:ss") in timeZone.
+ * List bookable time slots for an **APPOINTMENT** service within a local date range (availability
+ * comes from staff working hours). For **CLASS / COURSE** services (booked against scheduled
+ * sessions) use `listEventTimeSlots` — this endpoint returns an empty list for them, silently.
+ * If you render a mixed catalog, route by `service.type` via `listSlotsForService`.
+ * Dates are LOCAL ("YYYY-MM-DDThh:mm:ss") in timeZone.
  * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots.md
  * @param {string} serviceId
  * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
@@ -152,4 +155,54 @@ export async function getAvailableSlot(serviceId, { localStartDate, localEndDate
     },
   });
   return res?.timeSlot ?? null;
+}
+
+/**
+ * List bookable session slots for **CLASS / COURSE** services within a local date range. These
+ * services are booked against scheduled sessions (calendar events), not staff working hours, so
+ * they use a different endpoint than appointments. Each returned slot carries `eventInfo.eventId`
+ * (the session) and has **no** `scheduleId` — `createBooking` reads that `eventId`.
+ * Dates are LOCAL ("YYYY-MM-DDThh:mm:ss") in timeZone.
+ * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots.md
+ * @param {string|string[]} serviceIds  One service id or several (the endpoint takes a plural list).
+ * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
+ * @returns {Promise<{ slots: object[], nextCursor: string|null }>}
+ */
+export async function listEventTimeSlots(serviceIds, { fromLocalDate, toLocalDate, timeZone, limit = 1000, cursor } = {}) {
+  if (!cursor && (!fromLocalDate || !toLocalDate)) {
+    throw new Error("listEventTimeSlots requires fromLocalDate and toLocalDate (local 'YYYY-MM-DDThh:mm:ss').");
+  }
+  const ids = Array.isArray(serviceIds) ? serviceIds : [serviceIds];
+  const body = cursor
+    ? { cursorPaging: { limit, cursor } }
+    : {
+        serviceIds: ids,
+        bookable: true,
+        fromLocalDate,
+        toLocalDate,
+        timeZone: timeZone || defaultTimeZone(),
+        cursorPaging: { limit },
+      };
+  const res = await wixApiRequest("/_api/service-availability/v2/time-slots/event", { method: "POST", body });
+  return {
+    slots: res?.timeSlots ?? [],
+    nextCursor: res?.cursorPagingMetadata?.cursors?.next ?? null,
+  };
+}
+
+/**
+ * Type-agnostic convenience: list bookable slots for a service, routing to the right endpoint by
+ * `service.type` — APPOINTMENT → `listAvailableSlots`, CLASS/COURSE → `listEventTimeSlots`. The
+ * returned slots are shaped the same either way (`localStartDate`/`localEndDate`/`location`/
+ * `availableResources`), and each is bookable via `createBooking` regardless of type.
+ * @param {{ _id?: string, id?: string, type?: string }} service  A service from queryServices.
+ * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
+ * @returns {Promise<{ slots: object[], nextCursor: string|null }>}
+ */
+export async function listSlotsForService(service, options = {}) {
+  const serviceId = service?._id || service?.id;
+  if (!serviceId) throw new Error("listSlotsForService requires a service with an id.");
+  return service?.type === "CLASS" || service?.type === "COURSE"
+    ? listEventTimeSlots(serviceId, options)
+    : listAvailableSlots(serviceId, options);
 }

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
@@ -194,7 +194,9 @@ export async function listEventTimeSlots(serviceIds, { fromLocalDate, toLocalDat
  * Type-agnostic convenience: list bookable slots for a service, routing to the right endpoint by
  * `service.type` — APPOINTMENT → `listAvailableSlots`, CLASS/COURSE → `listEventTimeSlots`. The
  * returned slots are shaped the same either way (`localStartDate`/`localEndDate`/`location`/
- * `availableResources`), and each is bookable via `createBooking` regardless of type.
+ * `availableResources`), and each is bookable via `createBooking`.
+ * NOTE: a **COURSE** is enrolled as a whole (not per session), so it typically returns **no** slots
+ * here — the per-slot booking flow applies to APPOINTMENT and CLASS.
  * @param {{ _id?: string, id?: string, type?: string }} service  A service from queryServices.
  * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
  * @returns {Promise<{ slots: object[], nextCursor: string|null }>}

--- a/skills/wix-vibe-headless/references/events/wix-events-registration.js
+++ b/skills/wix-vibe-headless/references/events/wix-events-registration.js
@@ -41,33 +41,22 @@ import { wixApiRequest } from "./wix-client.js";
 export async function createRsvp(eventId, { firstName, lastName, email, status = "YES", additionalGuestNames = [], extraFields = {} } = {}) {
   if (!firstName || !lastName || !email) throw new Error("createRsvp requires firstName, lastName, and email.");
 
-  const inputValues = [
-    { inputName: "firstName", value: firstName },
-    { inputName: "lastName", value: lastName },
-    { inputName: "email", value: email },
-  ];
-  if (additionalGuestNames.length) {
-    inputValues.push({ inputName: "additionalGuests", value: String(additionalGuestNames.length) });
-    inputValues.push({ inputName: "guestNames", values: additionalGuestNames });
-  }
+  // The built-in fields go TOP-LEVEL on rsvp — the API rejects them inside form.inputValues
+  // (400 "rsvp.firstName must not be empty"). form.inputValues is ONLY for the event's extra
+  // custom fields; sending a built-in-only form, or additionalGuestDetails when the event has no
+  // guest fields, throws INVALID_FORM_RESPONSE ("input additionalGuests/guestNames is unexpected").
+  const rsvp = { eventId, firstName, lastName, email, status };
+
+  const inputValues = [];
   for (const [inputName, value] of Object.entries(extraFields)) {
     inputValues.push(Array.isArray(value) ? { inputName, values: value } : { inputName, value });
   }
+  if (inputValues.length) rsvp.form = { inputValues };
+  if (additionalGuestNames.length) {
+    rsvp.additionalGuestDetails = { guestCount: additionalGuestNames.length, guestNames: additionalGuestNames };
+  }
 
-  const res = await wixApiRequest("/events/v2/rsvps", {
-    method: "POST",
-    body: {
-      rsvp: {
-        eventId,
-        firstName,
-        lastName,
-        email,
-        status,
-        form: { inputValues },
-        additionalGuestDetails: { guestCount: additionalGuestNames.length, guestNames: additionalGuestNames },
-      },
-    },
-  });
+  const res = await wixApiRequest("/events/v2/rsvps", { method: "POST", body: { rsvp } });
   return res?.rsvp;
 }
 


### PR DESCRIPTION
vibe-headless correctness fixes + one capability gap, all found and verified live by the end-to-end QA run (bootstrap a real headless site per vertical → build a Base44 app on the vibe helpers → seed → verify in a browser).

## Fixes

### events — `createRsvp` body shape
Nested built-in fields in `form.inputValues` + always sent `additionalGuestDetails` → **400 `INVALID_FORM_RESPONSE`** on a standard RSVP event. Now flat top-level `rsvp:{eventId,firstName,lastName,email,status}`; `form.inputValues` only for extra custom fields; `additionalGuestDetails` only when guest names are provided. Verified: RSVP submits from the app.

### bookings — `createBooking` slot location enum
Passed the availability slot's `location` (`"BUSINESS"`, the *service* enum) straight into the booking, which needs the *booking* enum → **400 "locationType enum must be in [...]"** on every default appointment booking. Now remaps (`BUSINESS`→`OWNER_BUSINESS`). Verified: appointment books end-to-end.

## Capability added

### bookings — CLASS/COURSE availability (parity with the SDK recipe)
The pack was appointment-only; classes were "beyond the snippets" even though the wix-headless SDK recipe already covers them.
- New `listEventTimeSlots(serviceIds)` → the class/course session-slots endpoint (slots carry `eventInfo.eventId`).
- New `listSlotsForService(service)` → routes by `service.type`.
- `createBooking` reads the slot discriminator (appointment `scheduleId` vs class/course `eventInfo.eventId`); checkout unchanged.
- `listAvailableSlots` documented as APPOINTMENT-only; INSTRUCTIONS updated.
- Verified live: a **CLASS session books end-to-end from the browser**; appointments still book. (COURSE = whole-course enrollment, no per-session slots — same scope as the SDK recipe, noted in INSTRUCTIONS.)

## QA scorecard (all 8 verticals) — all ✅ in a real browser
blog · events (fix) · cms (incl. write) · portfolio · pricing-plans · restaurants (menu) · storefront (incl. cart) · bookings (appointment **and** class booking; fix + class support)

wix-headless seeding-recipe fixes from the same QA are in a separate PR (#536).