### PR TITLE
fix(vibe-headless): render product modifiers on the PDP, not just variants

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -55,7 +55,16 @@ reference for anything not shown.
   `actualPriceRange.minValue.formattedAmount` (already includes the currency symbol) — no
   manual formatting needed.
 - **PDP** — `getProductBySlug(slug)` keyed off the URL slug; returns null on miss — show
-  a not-found state, never invent a product.
+  a not-found state, never invent a product. Render a selector for **every** buyer choice the
+  product carries, not just variants: one control per `product.options` (variant choices) **and**
+  one per `product.modifiers` (TEXT_CHOICES → choice buttons/select; FREE_TEXT → a text input).
+  Skipping modifiers is a common miss — a product with a **mandatory** modifier (e.g. "gift wrap?")
+  whose control isn't rendered can never be added: the buyer can't satisfy the requirement, so
+  `add-to-cart` returns 200 with an **empty** `lineItems` and the add silently no-ops.
+- **Gate the Add-to-cart button** — keep it disabled until every required choice is made: a
+  variant resolves from the selected options, and every `modifier.mandatory === true` has a value.
+  Then pass those selections to `addToCart` (see Cart below). Never call `addToCart` with a
+  required selection missing.
 - **Categories** — `queryCategories()` for a category menu; `getCategoryBySlug(slug)` for
   a category landing page. Pass `category.id` to `queryProductsByCategory(categoryId, { limit?, cursor? })`
   to list only the products in that category; paginate exactly like `queryProducts`.
@@ -103,6 +112,9 @@ reference only for the gap.
 ## Verification checklist (before declaring done)
 - [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
 - [ ] Visitor token persists across reload (cart survives reload, same visitor)
+- [ ] Every product choice renders on the PDP — variant options **and** modifiers (mandatory ones included)
+- [ ] Add-to-cart button stays disabled until all required choices are made (variant + mandatory modifiers)
+- [ ] A product with a mandatory modifier adds successfully (its selection is sent, cart line appears)
 - [ ] Add to cart works; out-of-stock items throw rather than add a dead line
 - [ ] Quantity update / remove reflect in `getCurrentCart()`
 - [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL)

--- a/skills/wix-vibe-headless/references/storefront/wix-store-cart.js
+++ b/skills/wix-vibe-headless/references/storefront/wix-store-cart.js
@@ -59,14 +59,21 @@ export async function addToCart(catalogItemId, variantId, quantity = 1, { modifi
   const line = (res?.cart?.lineItems ?? []).find(
     (l) => l.catalogReference?.catalogItemId === catalogItemId && (!variantId || l.catalogReference?.options?.variantId === variantId),
   );
-  // Wix returns 200 even when stock is exhausted — guard both signals:
+  // Wix returns 200 even when the line is silently rejected — guard both signals:
   // 1. availability.status set to something other than AVAILABLE
-  // 2. quantity 0 (stock exhausted, no availability field populated)
+  // 2. no matching line at all (quantity 0 / line absent)
   if (line?.availability?.status && line.availability.status !== "AVAILABLE") {
     throw new Error(`Item not available for sale (status: ${line.availability.status}). Is it in stock?`);
   }
   if (!line || line.quantity === 0) {
-    throw new Error("Item could not be added to the cart — it may be out of stock.");
+    // A missing line usually means a required selection wasn't sent — a mandatory modifier
+    // (pass modifierChoices/customTextFields) or the variantId for a product with options —
+    // not necessarily out of stock. Verify every required choice is included in this call.
+    throw new Error(
+      "Item could not be added to the cart. Check that every required selection was sent: " +
+        "the variantId for a product with options, and all mandatory modifiers " +
+        "(modifierChoices for TEXT_CHOICES, customTextFields for FREE_TEXT). It may also be out of stock.",
+    );
   }
   return res?.cart;
 }


### PR DESCRIPTION
## What

QA reproduced a real user report: a Wix Stores product with a **mandatory modifier** (e.g. "wrap it as a gift?") could never be added to the cart. The generated storefront rendered variant options (size) but **not** `product.modifiers`, so the buyer couldn't satisfy the mandatory modifier. `add-to-cart` then returned **200 with an empty `lineItems`** and the add silently no-opped — the buyer just saw "item can't be added."

## Root cause (verified live, not theorized)

Against the reporter's live site:
- Product is in-stock, variant resolves correctly, catalogReference shape is correct.
- Adding the variant **without** the modifier → `lineItems: 0` (silent drop).
- Adding the **same** variant **with** the modifier populated (`catalogReference.options.options = { "wrap it as a gift?": "yes" }`) → `lineItems: 1`. ✅
- The identical helper adds fine on a store whose products have no mandatory modifiers.

So the REST layer was already correct — `addToCart` already accepts `modifierChoices`/`customTextFields`. The gap was **UI-wiring guidance**: the PDP step never told the agent to render modifier controls or gate the button, so agents build variant selectors and skip modifiers.

## Changes

- **PDP wiring** — render a control per `product.options` **and** per `product.modifiers` (TEXT_CHOICES → choices, FREE_TEXT → text input); call out the silent empty-`lineItems` failure mode.
- **Gate Add-to-cart** — disabled until every required choice is made (variant + `modifier.mandatory`).
- **Cart helper error** — the empty-line throw no longer blames "out of stock" alone; it names the more common cause (a missing required selection), which is what misled the reporter.
- **Verification checklist** — mandatory-modifier rendering + gating + a successful add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)