### PR TITLE
fix(vibe-headless): make PDP guidance data-driven for heterogeneous catalogs

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -92,6 +92,10 @@ reference for anything not shown.
 - ❌ Never generate fake reviews, ratings, or testimonials. Empty review UI only.
 - ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
 - ✅ `lineItemId` for cart mutations is `cart.lineItems[].id`, not `catalogItemId`.
+- ✅ On the PDP, render a control for **every** `product.options` entry **and** every `product.modifiers`
+  entry — never only variants. Keep Add-to-cart disabled until a variant resolves and every
+  `modifier.mandatory === true` has a value; a mandatory modifier with no rendered control makes the
+  product unbuyable (add-to-cart returns 200 with empty `lineItems`).
 - ✅ Pass `addToCart`'s `variantId` (`variantsInfo.variants[].id`) for products with variants; omit for products without.
 - ✅ Pass `modifierChoices` (`{ [modifier.key]: choiceKey }`) for TEXT_CHOICES modifiers; pass `customTextFields`
   (`{ [modifier.freeTextSettings.key]: userInput }`) for FREE_TEXT modifiers. Include mandatory modifiers.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -55,16 +55,24 @@ reference for anything not shown.
   `actualPriceRange.minValue.formattedAmount` (already includes the currency symbol) — no
   manual formatting needed.
 - **PDP** — `getProductBySlug(slug)` keyed off the URL slug; returns null on miss — show
-  a not-found state, never invent a product. Render a selector for **every** buyer choice the
-  product carries, not just variants: one control per `product.options` (variant choices) **and**
-  one per `product.modifiers` (TEXT_CHOICES → choice buttons/select; FREE_TEXT → a text input).
-  Skipping modifiers is a common miss — a product with a **mandatory** modifier (e.g. "gift wrap?")
-  whose control isn't rendered can never be added: the buyer can't satisfy the requirement, so
-  `add-to-cart` returns 200 with an **empty** `lineItems` and the add silently no-ops.
-- **Gate the Add-to-cart button** — keep it disabled until every required choice is made: a
-  variant resolves from the selected options, and every `modifier.mandatory === true` has a value.
-  Then pass those selections to `addToCart` (see Cart below). Never call `addToCart` with a
-  required selection missing.
+  a not-found state, never invent a product. **Drive the whole PDP from the returned product
+  object at runtime — build it generically, not around the one product you happened to inspect.**
+  A catalog is heterogeneous: some products have `options`, some have `modifiers` (mandatory or
+  optional), some track inventory, some none of these. Render a selector for **every** entry the
+  product actually carries: one control per `product.options` (variant choices) **and** one per
+  `product.modifiers` (TEXT_CHOICES → choice buttons/select; FREE_TEXT → a text input); render
+  neither when the arrays are empty. Skipping modifiers is a common miss — a product with a
+  **mandatory** modifier (e.g. "gift wrap?") whose control isn't rendered can never be added: the
+  buyer can't satisfy the requirement, so `add-to-cart` returns 200 with an **empty** `lineItems`
+  and the add silently no-ops.
+- **Gate the Add-to-cart button** — disable it only until the requirements the product *actually
+  has* are met, computed from the product object (never assume every product has options or
+  modifiers): if `product.options` is non-empty, a variant must resolve from the selections; every
+  `modifier.mandatory === true` must have a value. A product with no options and no mandatory
+  modifiers is immediately addable — don't leave the button stuck. Optional modifiers never block.
+  If stock data is present (`variant.inventoryStatus.inStock` / `product.inventory.availabilityStatus`),
+  reflect it (disable/label sold-out); a product with inventory tracking off simply stays addable.
+  Then pass the selections to `addToCart` (see Cart below); never call it with a required selection missing.
 - **Categories** — `queryCategories()` for a category menu; `getCategoryBySlug(slug)` for
   a category landing page. Pass `category.id` to `queryProductsByCategory(categoryId, { limit?, cursor? })`
   to list only the products in that category; paginate exactly like `queryProducts`.


### PR DESCRIPTION
Follow-up to #546/#547. The agent can't know a catalog's shape in advance, so the PDP must be driven by the runtime product object — not the one sample product it inspected. Fixes two gaps: (1) gating "until a variant resolves" deadlocks products with no options; (2) no warning against hardcoding the PDP to one product's shape. Now: render exactly what each product carries (options/modifiers/neither), gate only on requirements the product actually has, reflect stock when present, and stay addable when inventory tracking is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)