### PR TITLE
fix(vibe-headless): cap booking participants by policy, not slot capacity

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -73,6 +73,14 @@ the full API reference for anything not shown.
   as `cursor` to page.
 - **Booking form** — collect the buyer's `firstName`, `lastName`, `email`, `phone`. Keep it
   minimal; richer per-service form fields live in the service's `form.id` (see "Beyond the snippets").
+- **Participant count** — cap it by the service policy, not just slot capacity. The most a single
+  booking may reserve is `service.bookingPolicy.participantsPolicy.maxParticipantsPerBooking`. Only
+  render a participant selector when that value is `> 1`, and bound its max at
+  `min(maxParticipantsPerBooking, slot.remainingCapacity)` for a class; when it is `1` (the common
+  case) show no selector and book exactly one. Never offer a fixed range like 1–4 — the slot's
+  `remainingCapacity` tells you the class's open spots, not how many one buyer may take, so relying
+  on it alone lets the buyer pick a count that `createBooking` then rejects. Pass the chosen count
+  as `createBooking`'s `totalParticipants`.
 - **Re-validate + book** — right before submitting, call
   `getAvailableSlot(serviceId, { localStartDate, localEndDate, timeZone? })` to confirm the slot
   is still open (and to pick up the staff resource). Then create + check out in one step:
@@ -94,6 +102,9 @@ the full API reference for anything not shown.
 - ✅ Send availability/booking dates as **local** `"YYYY-MM-DDThh:mm:ss"` strings plus a
   `timeZone` — do not send UTC `Z` timestamps to the slot APIs.
 - ✅ Re-validate the slot with `getAvailableSlot()` before `createBooking()` — slots get taken.
+- ✅ Cap participant count at `service.bookingPolicy.participantsPolicy.maxParticipantsPerBooking`
+  (render no selector when it is 1); never offer a fixed range and never use slot capacity as the
+  per-buyer limit — a count above the policy makes `createBooking` fail.
 - The client fails loudly on purpose: `createBooking`/`checkoutBooking` throw on an unbookable
   slot, a missing booking id, or a missing redirect URL. A green path means it's really bookable —
   don't swallow these.
@@ -124,6 +135,7 @@ only for the gap.
 - [ ] `queryServices()` renders live services; `countServices()` 0 → empty state (no mock services)
 - [ ] `listAvailableSlots()` returns real bookable slots for a chosen service and date range
 - [ ] Slot is re-validated with `getAvailableSlot()` immediately before booking
+- [ ] Participant selector capped by `maxParticipantsPerBooking` (hidden when 1) — a count above the policy is not offerable
 - [ ] `createBooking()` returns a booking with `status: "CREATED"` and a real id
 - [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL)
 - [ ] On return from checkout the booking is confirmed (status `CONFIRMED`/`PENDING`)

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
@@ -15,7 +15,12 @@ import { wixApiRequest } from "./wix-client.js";
  *   payment.fixed.price { value, currency, formattedValue },
  *   payment.options { online, inPerson, deposit, pricingPlan },
  *   schedule.id {string}, onlineBooking.enabled {boolean},
- *   category { id, name }, staffMemberIds {string[]}, locations {array}
+ *   category { id, name }, staffMemberIds {string[]}, locations {array},
+ *   bookingPolicy.participantsPolicy { enabled {boolean}, maxParticipantsPerBooking {number} }
+ *     — the MOST participants a single booking may reserve. Cap the participant selector at this
+ *     value (for a CLASS, also bound by the slot's remainingCapacity). It is commonly 1, in which
+ *     case there is no participant choice at all — book exactly 1. Sending totalParticipants above
+ *     this makes createBooking fail.
  *
  * TimeSlot (Time Slots V2, appointments):
  *   serviceId {string}, localStartDate {string}, localEndDate {string} — "YYYY-MM-DDThh:mm:ss" (no zone),


### PR DESCRIPTION
Report: a CLASS with `maxParticipantsPerBooking=1` still showed a 1–4 participant picker; booking >1 failed. The app hardcoded `[1,2,3,4]` and treated slot `remainingCapacity` (class open spots) as the per-buyer limit.

Verified live on the reporter's project (client `83dcd8c9…`): the CLASS returns `participantsPolicy: {enabled:true, maxParticipantsPerBooking:1}` to a **visitor token** — the data was available client-side, the skill just didn't surface it.

- Declares `bookingPolicy.participantsPolicy` in the Service typedef
- Booking-form wiring: render a participant selector only when the cap is >1, bound at `min(cap, slot.remainingCapacity)`, else book exactly 1
- Hard rule + checklist item

🤖 Generated with [Claude Code](https://claude.com/claude-code)