### PR TITLE
feat(wix-headless): add opt-in headless-experience feedback capability

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -89,6 +89,8 @@ If the credentials are absent, the Wix backend isn't reachable — **stop with a
 4. **Handoff** (`references/SDK_HANDOFF.md`) — after Setup and Seed, **emit** the integration guide: SDK bootstrap, per-capability call shapes, the **seeded IDs**, and the `@wix/*` package list.
 5. **Finalize deployment** (`<TYPE_DIR>/DEPLOYMENT.md`) — run the project-type's finalize steps.
 
+**Throughout any run** — if the user asks to send feedback to Wix, complains/gets frustrated, or the run hits substantial friction (repeated API/doc/tooling failures), you may **offer** to relay it to Wix per `references/FEEDBACK.md`. Send only after an explicit yes — never automatically.
+
 **Managed create / connect / iterate** — after Discovery, hand the whole run to the conductor:
 - **create** → **`references/managed/CREATE.md`** (scaffold → Setup → Seed → build the frontend → release).
 - **connect** → **`references/managed/CONNECT.md`** (init → Setup → Seed → wire the existing UI → release).
@@ -113,6 +115,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | Seed (create backend content) | `<SKILL_ROOT>/references/SEED.md` |
 | SDK-integration handoff (emitted, or applied by create/connect) | `<SKILL_ROOT>/references/SDK_HANDOFF.md` |
 | Image generation (opt-in; agnostic) | `<SKILL_ROOT>/references/IMAGE_GENERATION.md` |
+| Feedback — relay the user's headless-experience feedback to Wix (opt-in; user-approved) | `<SKILL_ROOT>/references/FEEDBACK.md` |
 | **Authentication** — obtain `$TOKEN`/`$SITE_ID`/`clientId` (project-type-specific) | `<TYPE_DIR>/AUTHENTICATION.md` |
 | **Deployment** — finalize the live site (project-type-specific) | `<TYPE_DIR>/DEPLOYMENT.md` |
 | Managed **create** conductor (scaffold a new project) | `<SKILL_ROOT>/references/managed/CREATE.md` |

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -26,18 +26,24 @@ for the same issue. When unsure, ask rather than send.
 
 ## Compose a useful message
 
-The channel receives only free text plus the user's id, so a bare sentence is low-signal. Compose a
-few clear sentences covering:
+The channel receives only free text plus the user's id, so a bare sentence is low-signal. Send a
+**summary of the whole run**, not just the last error — you have the full session context that Wix
+does not. Structure it as:
 
-- **What the user was doing** — the goal / capability (storefront, bookings, events, blog…).
-- **What went wrong** — the concrete friction: the endpoint or step, the HTTP status, and the error
-  message; or the doc/tooling gap and the workaround.
-- **What was expected** — and a minimal repro if there is one.
-- **Context** — `siteId`/metasite and public `clientId` when relevant, and the skill area.
+- **Run summary** — the arc of the session in a few sentences: what the user set out to build
+  (goal + capabilities: storefront, bookings, events, blog…), the project type, and how it went
+  end to end (what worked cleanly vs. what fought back).
+- **Friction points** — the heart of it. Walk the flow and list every place the skill, an API, the
+  docs, or the tooling got in the way, each with specifics: the step/endpoint, the HTTP status and
+  error message, the doc/tooling gap, and any workaround you had to invent. Include the ones you
+  recovered from — a silent retry that eventually worked is exactly the signal Wix wants.
+- **What was expected** — and a minimal repro where there is one.
+- **Context** — `siteId`/metasite and public `clientId` when relevant, and the skill area(s).
 
-Keep it tight and factual. Confirm the final wording with the user before sending. **Never include
-secrets** — no bearer tokens, refresh tokens, API keys, or credentials — and no personal data beyond
-what the feedback needs.
+Aim for a scannable few paragraphs or a short bulleted list — thorough on the friction, but distilled
+from the conversation, not a raw transcript dump. Keep it factual. Confirm the final wording with the
+user before sending. **Never include secrets** — no bearer tokens, refresh tokens, API keys, or
+credentials — and no personal data beyond what the feedback needs.
 
 ## Send it
 

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -39,9 +39,15 @@ does not. Structure it as:
   recovered from — a silent retry that eventually worked is exactly the signal Wix wants.
 - **What was expected** — and a minimal repro where there is one.
 - **Context** — `siteId`/metasite and public `clientId` when relevant, and the skill area(s).
+- **The rant** — end with a short, candid, first-person take: in your own words as the agent that
+  just did the work, say what was actually painful, confusing, or dumb about the experience. Don't
+  sanitize it into corporate neutral — be blunt about the rough edges (a doc that lied, an endpoint
+  that fails silently, a flow that took five tries). The honest, unvarnished voice is the point; it's
+  the signal a tidy bug report loses. Stay factual and specific even while ranting — no secrets, no
+  personal attacks, just the real friction told straight.
 
 Aim for a scannable few paragraphs or a short bulleted list — thorough on the friction, but distilled
-from the conversation, not a raw transcript dump. Keep it factual. Confirm the final wording with the
+from the conversation, not a raw transcript dump. Keep it grounded in specifics. Confirm the final wording with the
 user before sending. **Never include secrets** — no bearer tokens, refresh tokens, API keys, or
 credentials — and no personal data beyond what the feedback needs.
 

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -1,0 +1,69 @@
+# Feedback — relay the user's Wix Headless experience to Wix
+
+A tiny, optional capability: send the **user's** feedback about the Wix Headless *building
+experience* to Wix. It posts to Wix's internal `#headless-user-feedback` channel, attributed to the
+authenticated user. Use it to close the loop when the skill itself, the APIs, the docs, or the
+tooling got in the user's way — the signal is how Wix improves the headless flow.
+
+This is **not** support, and not for the user's own site content. It is meta-feedback about *using
+Wix Headless*.
+
+## When to offer it (user-approved only — never auto-send)
+
+Sending is always the user's call. Offer once, in plain prose, in any of these situations; send only
+after an explicit yes:
+
+- The user **explicitly asks** to send feedback / report something to Wix ("tell Wix that…", "report
+  this", "send feedback"). Then just confirm the wording and send.
+- The user **complains, is frustrated, or reports a Wix bug** in the course of the work ("this API is
+  broken", "the docs are wrong", "why is this so hard"). Acknowledge, then offer to pass it on.
+- **The run hit substantial friction** — repeated API failures, wrong/missing docs, a tooling dead
+  end, or a workaround you had to invent. When you notice the pattern, offer: *"This tripped us up a
+  few times — want me to send it to Wix as headless feedback?"*
+
+Do **not** send on a single transient error, on the user's behalf without a yes, or more than once
+for the same issue. When unsure, ask rather than send.
+
+## Compose a useful message
+
+The channel receives only free text plus the user's id, so a bare sentence is low-signal. Compose a
+few clear sentences covering:
+
+- **What the user was doing** — the goal / capability (storefront, bookings, events, blog…).
+- **What went wrong** — the concrete friction: the endpoint or step, the HTTP status, and the error
+  message; or the doc/tooling gap and the workaround.
+- **What was expected** — and a minimal repro if there is one.
+- **Context** — `siteId`/metasite and public `clientId` when relevant, and the skill area.
+
+Keep it tight and factual. Confirm the final wording with the user before sending. **Never include
+secrets** — no bearer tokens, refresh tokens, API keys, or credentials — and no personal data beyond
+what the feedback needs.
+
+## Send it
+
+Reuse the authenticated session's bearer — the same `$TOKEN` minted per the project type's
+`<TYPE_DIR>/AUTHENTICATION.md` (for `managed`, `npx @wix/cli@latest token --site "$SITE_ID"`). This
+call is **not** site-scoped: send only the bearer, **no `wix-site-id` header**. If no token is in
+hand yet (e.g. feedback comes up before any site exists), ensure an authenticated CLI session first
+(`AUTHENTICATION.md` §1), then mint a token.
+
+```bash
+curl -sS -w "\nHTTP_STATUS:%{http_code}" \
+  -X POST "https://www.wixapis.com/mcp-serverless/v1/headless-feedback" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"<composed feedback>"}'
+```
+
+- **Success = `HTTP_STATUS:200`** with an empty body `{}`. Tell the user it was sent.
+- **`401`/`403`** — the CLI session expired or the token isn't user-identifiable; re-authenticate
+  (`AUTHENTICATION.md` §1), re-mint, retry once. If it still fails, surface the response and stop —
+  do not loop.
+
+## Hard rules
+
+- ✅ Send only after an explicit user yes — offering is fine, sending unprompted is not.
+- ✅ One submission per issue; never spam the channel with retries or duplicates.
+- ✅ Compose a specific, factual message; confirm the wording first.
+- ❌ Never include tokens, secrets, credentials, or unnecessary personal data in the message.
+- ❌ Never use this for the user's site content or as a support channel — it's headless-experience feedback.


### PR DESCRIPTION
Adds `references/FEEDBACK.md` — an opt-in way for the headless coding agent to relay the **user's feedback about the Wix Headless building experience** to Wix via `POST /mcp-serverless/v1/headless-feedback` (lands in `#headless-user-feedback`, attributed to the authenticated user).

**Design decisions (per discussion):**
- **Lives inside wix-headless** — that's where an authenticated *user* bearer exists. Vibe-headless is client-only (visitor token, no user identity), so it can't attribute feedback and is out of scope.
- **User-approved only** — the agent may *offer* when the user asks/complains/is frustrated, or when the run hit substantial friction (repeated API/doc/tooling failures); it never sends without an explicit yes, and never duplicates.
- **Token** — reuses the session's CLI-minted bearer (`$TOKEN` from `<TYPE_DIR>/AUTHENTICATION.md`). The call is **not** site-scoped, so no `wix-site-id` header. Success = `200 {}`.
- **Guardrails** — compose a specific factual message; never include tokens/secrets/PII; not a support channel; not for the user's own site content.

**Not live-tested** — the endpoint posts to a real Slack channel, so I didn't fire a test to avoid noise. The one unverified assumption is that the CLI site-scoped bearer resolves a `userId` for this endpoint; if it needs a non-site user token, the recovery ladder re-auths. Happy to do one controlled test post if you want it verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)