### PR TITLE
wix-headless: FEEDBACK.md must mint a user-scoped token, not --site

### DIFF
--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -53,13 +53,16 @@ credentials — and no personal data beyond what the feedback needs.
 
 ## Send it
 
-Reuse the authenticated session's bearer — the same `$TOKEN` minted per the project type's
-`<TYPE_DIR>/AUTHENTICATION.md` (for `managed`, `npx @wix/cli@latest token --site "$SITE_ID"`). This
-call is **not** site-scoped: send only the bearer, **no `wix-site-id` header**. If no token is in
-hand yet (e.g. feedback comes up before any site exists), ensure an authenticated CLI session first
-(`AUTHENTICATION.md` §1), then mint a token.
+This call identifies **you** (the human account), not a site, so it needs a **user-scoped** bearer —
+mint it with **no `--site` flag**: `npx @wix/cli@latest token`. Do **not** reuse the
+`token --site "$SITE_ID"` bearer that `AUTHENTICATION.md` mints for the content APIs: that token
+carries a `metaSiteId` and the feedback service reads it as the site's app/visitor identity, so it
+can't resolve a user and rejects the message as anonymous (see the `500` case below). Send **only the
+bearer**, **no `wix-site-id` header**. If the CLI isn't logged in yet (e.g. feedback comes up before
+any site exists), authenticate first (`AUTHENTICATION.md` §1), then run `token` (no `--site`).
 
 ```bash
+TOKEN=$(npx @wix/cli@latest token)   # NO --site: user-scoped, or the send is rejected as anonymous
 curl -sS -w "\nHTTP_STATUS:%{http_code}" \
   -X POST "https://www.wixapis.com/mcp-serverless/v1/headless-feedback" \
   -H "Authorization: Bearer $TOKEN" \
@@ -68,9 +71,12 @@ curl -sS -w "\nHTTP_STATUS:%{http_code}" \
 ```
 
 - **Success = `HTTP_STATUS:200`** with an empty body `{}`. Tell the user it was sent.
+- **`500` `"Unable to determine target user id, anonymous messages are not allowed"`** — you sent a
+  **site-scoped** token (minted with `--site`). Re-mint **without** `--site`
+  (`npx @wix/cli@latest token`) and retry once.
 - **`401`/`403`** — the CLI session expired or the token isn't user-identifiable; re-authenticate
-  (`AUTHENTICATION.md` §1), re-mint, retry once. If it still fails, surface the response and stop —
-  do not loop.
+  (`AUTHENTICATION.md` §1), re-mint (no `--site`), retry once. If it still fails, surface the response
+  and stop — do not loop.
 
 ## Hard rules
 


### PR DESCRIPTION
## Problem

`references/FEEDBACK.md` (the opt-in "relay headless feedback to Wix" capability added in #551) tells the agent to send using the **content-API bearer** — `npx @wix/cli@latest token --site "$SITE_ID"`. That token is **site-scoped**: it carries a `metaSiteId`, so the `mcp-serverless/v1/headless-feedback` service reads it as the site's app/visitor identity, can't resolve a human user, and rejects the message:

```
HTTP 500  {"message":"Unable to determine target user id, anonymous messages are not allowed","errorCode":-100}
```

The doc was also internally inconsistent — it said *"this call is **not** site-scoped"* while instructing the site-scoped mint.

## Fix

- **Mint a user-scoped bearer** with **no `--site` flag** (`npx @wix/cli@latest token`) — pure account context (no `metaSiteId`), resolves to the logged-in user.
- Inline the token mint in the curl example with a `# NO --site` note.
- Add the `500 "Unable to determine target user id"` case to error handling → re-mint without `--site`, retry once.

## Verification (live)

Reproduced by resuming a completed managed run (a Bookings/Astro spa build) and asking it to send headless feedback:

- With `token --site "$SITE_ID"` → **500 anonymous**, twice (agent correctly stopped per the no-loop rule).
- With `token` (no `--site`) → **HTTP 200 `{}`**, message delivered to `#headless-user-feedback`.

Token-claim diff confirmed the cause: both tokens carry the account (`uid`/`loginAccountId`), but only the `--site` one adds `metaSiteId`; its presence is what flips the service into site/visitor-identity mode.

## Note (follow-up, not in this PR)

The same resumed run surfaced a separate bug worth a follow-up: `inline-recipes/how-to-code-bookings.md` states `service.media.mainMedia.image` is a bare absolute URL string, but SDK reads return a `wix:image://…` URI that must be resolved with `media.getImageUrl()` — rendering it directly ships broken images. Happy to send that as its own PR once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
