### PR TITLE
fix(bookings): correct service-image write nesting + read resolution

### DIFF
--- a/skills/wix-headless/references/inline-recipes/how-to-code-bookings.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-bookings.md
@@ -67,7 +67,7 @@ service = {
   mainSlug: { name },                               // the URL slug   (NOT service.slug; fallback supportedSlugs[0].name)
   schedule: { id, availabilityConstraints: { sessionDurations: [60] } },  // duration = sessionDurations[0] (minutes)
   payment: { fixed: { price: { value, currency } } },                     // value is a STRING; currency is the site's
-  media: { mainMedia: { image: { url } } },         // already a URL in V2 reads
+  media: { mainMedia: { image } },                  // image is a "wix:image://…" string — resolve via media.getImageUrl()
   category: { _id },                                // the service's category
   form: { _id },                                    // the booking form (fetch via @wix/forms)
   bookingPolicy: { cancellationFeePolicy: { enabled } },  // drives the checkout-vs-place decision
@@ -249,7 +249,7 @@ if (checkoutRequired) {
 ### Rendering & mounting
 
 - **Price**: `service.payment.fixed.price.value` (string) + `.currency` (the site's stored currency — format from it, don't assume USD).
-- **Image**: `service.media.mainMedia.image` is a **bare URL string** (already absolute in V2 reads) — read it **directly**, NOT `.image.url` (the installed type is `image?: string`, so `.url` fails `tsc`). An already-`https://` URL goes straight into `<img src>`.
+- **Image**: `service.media.mainMedia.image` is a **string**, not an object (the installed type is `image?: string`, so `.image.url` fails `tsc`) — but its value is a Wix media URI like `wix:image://v1/…`, **not** an absolute URL (`.startsWith("https://")` is `false`). Putting it straight into `<img src>` ships broken images. Resolve it first: `import { media } from "@wix/sdk"`, then `media.getImageUrl(service.media.mainMedia.image).url` → `https://static.wixstatic.com/media/…`. Guard for services with no image.
 - **Mount slots + form + book in a `client:only="react"` island** (Astro) — availability is timezone/session-specific. SSR only the read pages (catalog/detail) for SEO.
 
 ### SEO on item pages (Astro, Wix-managed)

--- a/skills/wix-manage/references/bookings/create-and-update-booking-services.md
+++ b/skills/wix-manage/references/bookings/create-and-update-booking-services.md
@@ -33,7 +33,7 @@ A Bookings service defines a time based offering and includes the following cons
 - When creating an APPOINTMENT service and specifying `staffMemberIds`, ensure you are using the staff member's resourceId, not their primary staff member id.
 - Service Images - the service may have several images - `service.media.mainMedia` - presented in the services list, `service.media.coverMedia` - presented in the service page and `service.media.items` - array of images presented as a gallery in the service page for site visitors.
 - In order to add a media (image) to a service, it should first be defined in Wix Media Manager - search existing ([REST](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/search-files)) or new ([REST](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/bulk-import-file))
-- You should only set the image id (for example `item.id` -> `service.media.mainMedia.id`) there is no need to set the entire object.
+- Set only the image **id**, but nest it inside the media item's `image` object: `service.media.mainMedia.image.id` (likewise `service.media.coverMedia.image.id` and `service.media.items[].image.id`). The `id` is the binding field; `url` and dimensions are descriptive and need not be set. ⚠️ Setting the id directly on the media item (`service.media.mainMedia.id`, without the `image` wrapper) returns HTTP 200 but **silently drops** it — the image reads back empty (`image.id: ""`). Because it's a silent 200, a success status is not proof: always nest under `.image` and confirm with a re-query.
 
 ### Service Type Selection Guide
 


### PR DESCRIPTION
All three claims from a real headless feedback submission, live-validated against the Bookings Services V2 API.

**#1 — `setup-bookings.md` top-level `media.image` silent drop → already fixed** in #545 (correct `media.mainMedia`/`coverMedia` shape + silent-200 warning). No change.

**#2 — `wix-manage/.../create-and-update-booking-services.md` → fixed.** The doc said *"only set `service.media.mainMedia.id`"*. Live PATCH on a service:
| sent | HTTP | persisted |
|---|---|---|
| `mainMedia.id` (as documented) | 200 | `image.id: ""` — silently dropped |
| `mainMedia.image.id` (nested) | 200 | id persists |
The `id` binds, but must be nested under `.image` (`MediaItem` has no `id` field). Corrected nesting + added the silent-200/re-query warning.

**#3 — `wix-headless/.../how-to-code-bookings.md` → fixed.** Live SDK `queryServices()` returns `mainMedia.image` = `"wix:image://v1/…"` (a string; `startsWith("https://")` is `false`), and `media.getImageUrl(img).url` resolves it to `https://static.wixstatic.com/…`. The recipe said "bare absolute URL, read directly into `<img src>`" → broken images. Corrected to resolve via `media.getImageUrl()`, and fixed the contradicting shape sketch (`image: { url }`).

Bonus finding: REST returns `image` as an object (bare-handle `url`); the SDK returns a `wix:image://` string — a real REST/SDK divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)