### PR TITLE
wix-headless: restructure FEEDBACK.md — provenance / narrative / attribution

### DIFF
--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -34,7 +34,8 @@ Wix receives only free text, so a bare sentence is low-signal. Send a
 does not. Structure it in three layers — **provenance → narrative → attribution** — so Wix can
 triage and route without chasing you.
 
-**1. Provenance** — labelled lines, omit any that don't apply:
+**1. Provenance** — labelled lines. A starting point, not a schema: omit lines that don't apply,
+add any field or value that would help Wix understand the run:
 
 ```
 Agent / model: <e.g. Claude Code · Opus, Cursor, … / whatever you are>

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -21,6 +21,9 @@ after an explicit yes:
   end, or a workaround you had to invent. When you notice the pattern, offer: *"This tripped us up a
   few times — want me to send it to Wix as feedback?"*
 
+When you offer, invite the user to add anything in their own words — fold what they say into the
+message, quoting short phrases verbatim where they carry the point.
+
 Do **not** send on a single transient error, on the user's behalf without a yes, or more than once
 for the same issue. When unsure, ask rather than send.
 

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -26,7 +26,7 @@ for the same issue. When unsure, ask rather than send.
 
 ## Compose a useful message
 
-Wix receives only free text plus the user's id, so a bare sentence is low-signal. Send a
+Wix receives only free text, so a bare sentence is low-signal. Send a
 **summary of the whole run**, not just the last error — you have the full session context that Wix
 does not. Structure it in three layers — **provenance → narrative → attribution** — so Wix can
 triage and route without chasing you.
@@ -103,7 +103,7 @@ curl -sS -w "\nHTTP_STATUS:%{http_code}" \
 
 ## Hard rules
 
-- ✅ Send only after an explicit user yes — offering is fine, sending unprompted is not.
+- ✅ Offer proactively whenever the run warrants it; send only after an explicit user yes.
 - ✅ One submission per issue; never spam with retries or duplicates.
 - ✅ Compose a specific, factual message; confirm the wording first.
 - ❌ Never include tokens, secrets, credentials, or unnecessary personal data in the message.

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -37,7 +37,8 @@ triage and route without chasing you.
 Agent / model: <e.g. Claude Code · Opus, Cursor, … / whatever you are>
 Wix tooling used: <MCP tools, Wix CLI, REST via curl, … or other/none>
 Platform / hosting: <headless, Velo, Wix-hosted, self-hosted, …>
-Wix products: <storefront, bookings, events, blog, …>
+Wix areas / APIs: <account & site management, CMS, media, auth, … — whatever the run touched>
+Wix products: <stores, bookings, events, blog, … or none — plain API work is a valid answer>
 Project type / frontend: <managed | self-managed | stripe | other> · <Astro, Next.js, …>
 Metasite / siteId: <id> · Public clientId (app id): <id>
 Links: <any relevant URL helps — dashboard/editor, live or preview site, a docs page you read, a GitHub repo/PR, anything else useful>

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -36,8 +36,9 @@ triage and route without chasing you.
 ```
 Agent / model: <e.g. Claude Code · Opus, Cursor, … / whatever you are>
 Wix tooling used: <MCP tools, Wix CLI, REST via curl, … or other/none>
-Platform / products: <headless, Velo, … · storefront, bookings, events, …>
-Project type / frontend: <managed | self-managed | stripe | other> · <Astro | …>
+Platform / hosting: <headless, Velo, Wix-hosted, self-hosted, …>
+Wix products: <storefront, bookings, events, blog, …>
+Project type / frontend: <managed | self-managed | stripe | other> · <Astro, Next.js, …>
 Metasite / siteId: <id> · Public clientId (app id): <id>
 Links: <any relevant URL helps — dashboard/editor, live or preview site, a docs page you read, a GitHub repo/PR, anything else useful>
 Skill area(s): <recipe/file(s) involved, e.g. inline-recipes/setup-bookings.md STEP 5>

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -1,12 +1,12 @@
-# Feedback — relay the user's Wix Headless experience to Wix
+# Feedback — relay the user's building-with-Wix experience to Wix
 
-A tiny, optional capability: send the **user's** feedback about the Wix Headless *building
-experience* to Wix. It posts to Wix's internal `#headless-user-feedback` channel, attributed to the
-authenticated user. Use it to close the loop when the skill itself, the APIs, the docs, or the
-tooling got in the user's way — the signal is how Wix improves the headless flow.
+A tiny, optional capability: send the **user's** feedback about the experience of *building with
+Wix* to Wix, attributed to the authenticated user. Use it to close the loop when the skill itself,
+the APIs, the docs, or the tooling got in the user's way — the signal is how Wix improves the
+building flow.
 
-This is **not** support, and not for the user's own site content. It is meta-feedback about *using
-Wix Headless*.
+This is **not** support, and not for the user's own site content. It is meta-feedback about
+*building with Wix*.
 
 ## When to offer it (user-approved only — never auto-send)
 
@@ -19,14 +19,14 @@ after an explicit yes:
   broken", "the docs are wrong", "why is this so hard"). Acknowledge, then offer to pass it on.
 - **The run hit substantial friction** — repeated API failures, wrong/missing docs, a tooling dead
   end, or a workaround you had to invent. When you notice the pattern, offer: *"This tripped us up a
-  few times — want me to send it to Wix as headless feedback?"*
+  few times — want me to send it to Wix as feedback?"*
 
 Do **not** send on a single transient error, on the user's behalf without a yes, or more than once
 for the same issue. When unsure, ask rather than send.
 
 ## Compose a useful message
 
-The channel receives only free text plus the user's id, so a bare sentence is low-signal. Send a
+Wix receives only free text plus the user's id, so a bare sentence is low-signal. Send a
 **summary of the whole run**, not just the last error — you have the full session context that Wix
 does not. Structure it in three layers — **provenance → narrative → attribution** — so Wix can
 triage and route without chasing you.
@@ -48,6 +48,10 @@ Other ids: <service / product / checkout / etc. ids created this run, as relevan
 
 - **User intent + run summary** — what the user set out to build and the arc of the session in a
   few sentences: what worked cleanly vs. what fought back.
+- **Conversation & agent flow** — a condensed play-by-play of how the session actually unfolded:
+  the key user ↔ agent exchanges, and your own path through them — tool calls made, responses
+  received, decisions taken and course-corrections. Distilled, not a transcript dump — enough for
+  Wix to replay the flow.
 - **Friction points** — the heart of it. Walk the flow and list every place something got in the
   way, each with specifics: the step/endpoint, the HTTP status and error message, the gap, the
   workaround you had to invent, and what you expected instead (minimal repro where there is one).
@@ -101,7 +105,7 @@ curl -sS -w "\nHTTP_STATUS:%{http_code}" \
 ## Hard rules
 
 - ✅ Send only after an explicit user yes — offering is fine, sending unprompted is not.
-- ✅ One submission per issue; never spam the channel with retries or duplicates.
+- ✅ One submission per issue; never spam with retries or duplicates.
 - ✅ Compose a specific, factual message; confirm the wording first.
 - ❌ Never include tokens, secrets, credentials, or unnecessary personal data in the message.
-- ❌ Never use this for the user's site content or as a support channel — it's headless-experience feedback.
+- ❌ Never use this for the user's site content or as a support channel — it's feedback about the experience of building with Wix.

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -28,33 +28,43 @@ for the same issue. When unsure, ask rather than send.
 
 The channel receives only free text plus the user's id, so a bare sentence is low-signal. Send a
 **summary of the whole run**, not just the last error — you have the full session context that Wix
-does not. Lead with a details header so Wix can triage without chasing you, then the narrative.
+does not. Structure it in three layers — **provenance → narrative → attribution** — so Wix can
+triage and route without chasing you.
 
-**Start with an identifiers block** — labelled lines, omit any that don't apply:
+**1. Provenance** — labelled lines, omit any that don't apply:
 
 ```
-Metasite / siteId: <id>
-Public clientId (app id): <id>
-Site links: <dashboard/editor URL> · <live or preview URL if released>
-Project type / frontend: <managed | self-managed | stripe> · <Astro | …>
+Agent / model: <e.g. Claude Code · Opus, Cursor, … / whatever you are>
+Wix tooling used: <MCP tools, Wix CLI, REST via curl, … or other/none>
+Platform / products: <headless, Velo, … · storefront, bookings, events, …>
+Project type / frontend: <managed | self-managed | stripe | other> · <Astro | …>
+Metasite / siteId: <id> · Public clientId (app id): <id>
+Links: <any relevant URL helps — dashboard/editor, live or preview site, a docs page you read, a GitHub repo/PR, anything else useful>
 Skill area(s): <recipe/file(s) involved, e.g. inline-recipes/setup-bookings.md STEP 5>
 Other ids: <service / product / checkout / etc. ids created this run, as relevant>
 ```
 
-**Then the body:**
+**2. Narrative:**
 
-- **Run summary** — the arc of the session in a few sentences: what the user set out to build
-  (goal + capabilities: storefront, bookings, events, blog…) and how it went end to end (what
-  worked cleanly vs. what fought back).
-- **Friction points** — the heart of it. Walk the flow and list every place the skill, an API, the
-  docs, or the tooling got in the way, each with specifics: the step/endpoint, the HTTP status and
-  error message, the doc/tooling gap, and any workaround you had to invent. Include the ones you
-  recovered from — a silent retry that eventually worked is exactly the signal Wix wants.
-- **What was expected** — and a minimal repro where there is one.
-- **Bottom line** — one or two sentences naming the single most important problem and its impact or
-  severity (e.g. "a documented PATCH returns 200 but silently drops the field, so a photo-forward
-  site nearly shipped with no images"). Be direct and candid about how bad it was — but keep a
-  **professional register**: a concise engineering assessment, not a persona, jokes, or theatrics.
+- **User intent + run summary** — what the user set out to build and the arc of the session in a
+  few sentences: what worked cleanly vs. what fought back.
+- **Friction points** — the heart of it. Walk the flow and list every place something got in the
+  way, each with specifics: the step/endpoint, the HTTP status and error message, the gap, the
+  workaround you had to invent, and what you expected instead (minimal repro where there is one).
+  Include the ones you recovered from — a silent retry that eventually worked is exactly the
+  signal Wix wants.
+
+**3. Attribution** — for each significant friction point, your best diagnosis of where the fault
+lives, tagged with one of: **API behavior** (does the wrong thing) · **API schema** (shape/types
+wrong or misleading) · **API reference docs** · **docs articles / examples** (missing, wrong, or no
+working example) · **Wix harness** (CLI, MCP tools, auth flow…) · **this skill's recipes** ·
+**other / unsure** — plus whether you *confirmed* it or are *assuming*. Don't force a tag; a wrong
+route is worse than "unsure".
+
+**Bottom line** — one or two sentences naming the single most important problem and its impact.
+Lead with what was worst and don't soften it, bury it under what worked, or hedge diplomatically —
+but keep a **professional register**: a concise engineering assessment, not a persona, jokes, or
+theatrics.
 
 Write it as a scannable few paragraphs or a short bulleted list — thorough on the friction, distilled
 from the conversation rather than a raw transcript dump, and professional throughout. Confirm the

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -21,8 +21,8 @@ after an explicit yes:
   end, or a workaround you had to invent. When you notice the pattern, offer: *"This tripped us up a
   few times — want me to send it to Wix as feedback?"*
 
-When you offer, invite the user to add anything in their own words — fold what they say into the
-message, quoting short phrases verbatim where they carry the point.
+When you offer, invite the user to add anything in their own words — whatever they give you goes
+into the message verbatim, in its own "In the user's words" section.
 
 Do **not** send on a single transient error, on the user's behalf without a yes, or more than once
 for the same issue. When unsure, ask rather than send.
@@ -51,6 +51,8 @@ Other ids: <service / product / checkout / etc. ids created this run, as relevan
 
 **2. Narrative:**
 
+- **In the user's words** — anything the user added when you offered, quoted verbatim (redact
+  secrets only). Skip the section if they added nothing.
 - **User intent + run summary** — what the user set out to build and the arc of the session in a
   few sentences: what worked cleanly vs. what fought back.
 - **Conversation & agent flow** — a condensed play-by-play of how the session actually unfolded:

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -77,16 +77,16 @@ tokens, API keys, or credentials — and no personal data beyond what the feedba
 
 ## Send it
 
-This call identifies **you** (the human account), not a site, so it needs a **user-scoped** bearer —
-mint it with **no `--site` flag**: `npx @wix/cli@latest token`. Do **not** reuse the
-`token --site "$SITE_ID"` bearer that `AUTHENTICATION.md` mints for the content APIs: that token
-carries a `metaSiteId` and the feedback service reads it as the site's app/visitor identity, so it
-can't resolve a user and rejects the message as anonymous (see the `500` case below). Send **only the
-bearer**, **no `wix-site-id` header**. If the CLI isn't logged in yet (e.g. feedback comes up before
-any site exists), authenticate first (`AUTHENTICATION.md` §1), then run `token` (no `--site`).
+This call identifies **you** (the human account), so it needs a **user-scoped** bearer — mint it
+with the bare command: `npx @wix/cli@latest token`. The site-scoped bearer `AUTHENTICATION.md`
+mints for the content APIs (`token --site …`) carries a `metaSiteId`, so the feedback service
+resolves it to the site's app/visitor identity and rejects the send as anonymous (the `500` case
+below). Send the bearer alone — the `Authorization` header is the only one this call needs beyond
+`Content-Type`. If the CLI isn't logged in yet (e.g. feedback comes up before any site exists),
+authenticate first (`AUTHENTICATION.md` §1), then run `token`.
 
 ```bash
-TOKEN=$(npx @wix/cli@latest token)   # NO --site: user-scoped, or the send is rejected as anonymous
+TOKEN=$(npx @wix/cli@latest token)   # bare token command → user-scoped bearer
 curl -sS -w "\nHTTP_STATUS:%{http_code}" \
   -X POST "https://www.wixapis.com/mcp-serverless/v1/headless-feedback" \
   -H "Authorization: Bearer $TOKEN" \
@@ -95,11 +95,10 @@ curl -sS -w "\nHTTP_STATUS:%{http_code}" \
 ```
 
 - **Success = `HTTP_STATUS:200`** with an empty body `{}`. Tell the user it was sent.
-- **`500` `"Unable to determine target user id, anonymous messages are not allowed"`** — you sent a
-  **site-scoped** token (minted with `--site`). Re-mint **without** `--site`
-  (`npx @wix/cli@latest token`) and retry once.
+- **`500` `"Unable to determine target user id, anonymous messages are not allowed"`** — the token
+  was site-scoped. Re-mint user-scoped (`npx @wix/cli@latest token`, bare) and retry once.
 - **`401`/`403`** — the CLI session expired or the token isn't user-identifiable; re-authenticate
-  (`AUTHENTICATION.md` §1), re-mint (no `--site`), retry once. If it still fails, surface the response
+  (`AUTHENTICATION.md` §1), re-mint user-scoped, retry once. If it still fails, surface the response
   and stop — do not loop.
 
 ## Hard rules


### PR DESCRIPTION
## What

Full rewrite of the **Compose a useful message** section of `skills/wix-headless/references/FEEDBACK.md`, restructuring the composed feedback into three explicit layers so Wix can triage and route without chasing the sender:

1. **Provenance** — extends the identifiers header with agent/model, Wix tooling used (MCP tools / CLI / REST / other), and platform/products (headless / Velo / …). Links line now invites *any* useful URL — docs pages read, live/preview site, GitHub repo/PR — not just site links.
2. **Narrative** — user intent + run arc, then friction points walked in flow order with endpoint/status/error/workaround specifics (minimal repro folded in).
3. **Attribution** (new) — per-friction-point diagnosis of where the fault lives, tagged with a fixed-but-open vocabulary: **API behavior · API schema · API reference docs · docs articles/examples · Wix harness · this skill's recipes · other/unsure**, plus a confirmed-vs-assuming hedge (\"a wrong route is worse than 'unsure'\").

**Bottom line** kept, sharpened with a candor guard: lead with the worst problem, don't soften/bury/hedge it — while keeping the existing professional-register rule (no persona, jokes, theatrics).

## Why

The previous format was site-scoped only (no signal on which agent/harness/tooling produced the run) and had no structured fault attribution, so routing to the right team (API vs. docs vs. DevRel/tooling) had to be inferred from prose.

Every example list keeps an explicit "other" escape hatch so the agent is never boxed into a closed enumeration.

Net size ≈ unchanged — the narrative section was compressed to pay for the two new layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)