### PR TITLE
sync(editor-react-component): Animated components

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -21,9 +21,13 @@ Recognizable signs that a project-level rule conflicts with this skill and must 
 
 Editor React components consist of the following template files (replace `<componentName>` with the actual component name in kebab-case):
 
+### `<componentName>.props.ts`
+
+Props file for the component. Holds the TypeScript props type (`type ComponentNameProps = { ... }`) and the `defaultProps` constant. Both `<componentName>.tsx` and `component.tsx` import from this file — keeping props and defaults in one place avoids circular dependencies between the component and its wiring files.
+
 ### `<componentName>.tsx`
 
-The React component file. Contains the component's UI logic, JSX structure, and TypeScript props interface.
+The React component file. Contains the component's UI logic and JSX structure.
 
 ### `<componentName>.module.css`
 
@@ -31,7 +35,7 @@ CSS Module file for the component. Contains all styles scoped to the component.
 
 ### `component.tsx`
 
-Entry point for the component. Imports the default prop values defined in `<componentName>.tsx` and wires them up so the component renders correctly when first added to the stage.
+Entry point for the component. Imports the default component export from `<componentName>.tsx` and `defaultProps` from `<componentName>.props.ts`, then wires them with `withDefaults`. Do not change this file.
 
 ### `<componentName>.generated.ts`
 

--- a/skills/wix-app/references/editor-react-component/COMPONENT-API.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-API.md
@@ -202,8 +202,8 @@ editor) or imported local assets bundled with the component.
 
 ### Default values for `Image` props
 
-Image defaults belong in the component file's exported `defaultProps`
-constant (the one consumed by `withDefaults(Component, defaultProps)` in
+Image defaults belong in the `<componentName>.props.ts` file's exported
+`defaultProps` constant (consumed by `withDefaults(Component, defaultProps)` in
 `component.tsx`). Use a Wix-hosted image from the Free-from-Wix public
 media catalog and populate **only** `uri`, `url`, and `alt` — leave
 `width`, `height`, `focalPoint`, etc. unset so the editor fills them when

--- a/skills/wix-app/references/editor-react-component/COMPONENT-CONFIGURATION.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-CONFIGURATION.md
@@ -128,14 +128,14 @@ resizeDirection: LAYOUT.RESIZE_DIRECTION.aspectRatio,
 
 ## 3. Wiring defaults into the manifest
 
-1. **Export `defaultProps` from `component.tsx`** so the extension file can import it.
+1. **Define and export `defaultProps` from `<componentName>.props.ts`** — this is the single source of truth used by both `component.tsx` and the extension file.
 2. **Import `componentUrl` from `'./component.tsx?url'`** (the wrapped component), not from `'./ComponentName.tsx?url'` (the raw component).
 3. **Wrap `editorElement` with `withEditorElementDefaults`** using the same `defaultProps`.
 
 ```ts
 import { withEditorElementDefaults } from '@wix/react-component-utils';
 import componentUrl from './component.tsx?url';
-import { defaultProps } from './component';
+import { defaultProps } from './<componentName>.props';
 
 // in the extension:
 editorElement: withEditorElementDefaults({


### PR DESCRIPTION
## Automated sync from private repo

Synced from https://github.com/wix-private/editor-react-component-creation-skills/pull/36: Rework skill to use separate file for props

### What was synced
- packages/editor-component-creation/SKILL.md -> skills/wix-app/references/EDITOR_REACT_COMPONENT.md
- packages/editor-component-creation/references/*.md -> skills/wix-app/references/editor-react-component/*.md

Auto-merged by GitHub Actions.