### PR TITLE
feat(evalforge-yaml-gate): require a @wix.com PR author before eval mode

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34096,6 +34096,75 @@ else {
 
 /***/ }),
 
+/***/ 9916:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isWixAuthorEmail = isWixAuthorEmail;
+exports.getFirstCommitAuthorEmail = getFirstCommitAuthorEmail;
+exports.assertWixAuthor = assertWixAuthor;
+const core = __importStar(__nccwpck_require__(7484));
+const WIX_EMAIL_RE = /@wix\.com$/i;
+function isWixAuthorEmail(email) {
+    return typeof email === 'string' && WIX_EMAIL_RE.test(email.trim());
+}
+async function getFirstCommitAuthorEmail(octokit, owner, repo, prNumber) {
+    // listCommits returns the PR's commits oldest-first, so [0] is the first commit.
+    const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
+        owner,
+        repo,
+        pull_number: prNumber,
+        per_page: 100,
+    });
+    return commits[0]?.commit?.author?.email ?? undefined;
+}
+async function assertWixAuthor(octokit, owner, repo, prNumber) {
+    const email = await getFirstCommitAuthorEmail(octokit, owner, repo, prNumber);
+    if (!isWixAuthorEmail(email)) {
+        throw new Error(`PR author gate failed: the PR's first-commit author email (${email ?? 'unknown'}) ` +
+            `is not a @wix.com address. This gate is restricted to Wix authors.`);
+    }
+    core.info(`Author gate passed — first-commit author email: ${email}`);
+}
+
+
+/***/ }),
+
 /***/ 6157:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -35197,6 +35266,7 @@ const github = __importStar(__nccwpck_require__(3228));
 const node_path_1 = __nccwpck_require__(6760);
 const config_1 = __nccwpck_require__(7799);
 const github_1 = __nccwpck_require__(6246);
+const author_gate_1 = __nccwpck_require__(9916);
 const evals_1 = __nccwpck_require__(1686);
 const doc_url_1 = __nccwpck_require__(8515);
 const coverage_1 = __nccwpck_require__(4035);
@@ -35224,6 +35294,7 @@ function remoteScenarioFiltersForGate(input) {
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
     const octokit = github.getOctokit(config.githubToken);
+    await (0, author_gate_1.assertWixAuthor)(octokit, config.owner, config.repo, config.prNumber);
     const comment = (0, github_1.makeCommenter)(octokit, config.owner, config.repo, config.prNumber);
     const workspace = (0, workspace_1.workspaceRoot)();
     const draftTag = (0, evalforge_1.draftTagFor)(`${config.owner}/${config.repo}`, config.prNumber);

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34144,14 +34144,15 @@ function isWixAuthorEmail(email) {
     return typeof email === 'string' && WIX_EMAIL_RE.test(email.trim());
 }
 async function getFirstCommitAuthorEmail(octokit, owner, repo, prNumber) {
-    // listCommits returns the PR's commits oldest-first, so [0] is the first commit.
-    const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
+    // listCommits returns the PR's commits oldest-first; we only need the first,
+    // so ask for a single-item page rather than paginating the whole PR.
+    const { data } = await octokit.rest.pulls.listCommits({
         owner,
         repo,
         pull_number: prNumber,
-        per_page: 100,
+        per_page: 1,
     });
-    return commits[0]?.commit?.author?.email ?? undefined;
+    return data[0]?.commit?.author?.email ?? undefined;
 }
 async function assertWixAuthor(octokit, owner, repo, prNumber) {
     const email = await getFirstCommitAuthorEmail(octokit, owner, repo, prNumber);

--- a/.github/actions/evalforge-yaml-gate/src/utils/author-gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/author-gate.ts
@@ -15,14 +15,15 @@ export async function getFirstCommitAuthorEmail(
   repo: string,
   prNumber: number,
 ): Promise<string | undefined> {
-  // listCommits returns the PR's commits oldest-first, so [0] is the first commit.
-  const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
+  // listCommits returns the PR's commits oldest-first; we only need the first,
+  // so ask for a single-item page rather than paginating the whole PR.
+  const { data } = await octokit.rest.pulls.listCommits({
     owner,
     repo,
     pull_number: prNumber,
-    per_page: 100,
+    per_page: 1,
   });
-  return commits[0]?.commit?.author?.email ?? undefined;
+  return data[0]?.commit?.author?.email ?? undefined;
 }
 
 export async function assertWixAuthor(

--- a/.github/actions/evalforge-yaml-gate/src/utils/author-gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/author-gate.ts
@@ -1,0 +1,42 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+type Octokit = ReturnType<typeof github.getOctokit>;
+
+const WIX_EMAIL_RE = /@wix\.com$/i;
+
+export function isWixAuthorEmail(email: string | undefined | null): boolean {
+  return typeof email === 'string' && WIX_EMAIL_RE.test(email.trim());
+}
+
+export async function getFirstCommitAuthorEmail(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<string | undefined> {
+  // listCommits returns the PR's commits oldest-first, so [0] is the first commit.
+  const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
+    owner,
+    repo,
+    pull_number: prNumber,
+    per_page: 100,
+  });
+  return commits[0]?.commit?.author?.email ?? undefined;
+}
+
+export async function assertWixAuthor(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<void> {
+  const email = await getFirstCommitAuthorEmail(octokit, owner, repo, prNumber);
+  if (!isWixAuthorEmail(email)) {
+    throw new Error(
+      `PR author gate failed: the PR's first-commit author email (${email ?? 'unknown'}) ` +
+        `is not a @wix.com address. This gate is restricted to Wix authors.`,
+    );
+  }
+  core.info(`Author gate passed — first-commit author email: ${email}`);
+}

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github';
 import { posix } from 'node:path';
 import { getEvalConfig, type Config } from './config';
 import { fail, getChangedFiles, classifyChanges, makeCommenter, type ChangedFile } from './github';
+import { assertWixAuthor } from './author-gate';
 import { loadEvals, type LoadedScenario } from './evals';
 import { canonicalDocUrl } from './doc-url';
 import { computeCoverage } from './coverage';
@@ -49,6 +50,7 @@ export function remoteScenarioFiltersForGate(input: {
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
+  await assertWixAuthor(octokit, config.owner, config.repo, config.prNumber);
   const comment = makeCommenter(octokit, config.owner, config.repo, config.prNumber);
   const workspace = workspaceRoot();
   const draftTag = draftTagFor(`${config.owner}/${config.repo}`, config.prNumber);

--- a/.github/actions/evalforge-yaml-gate/tests/author-gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/author-gate.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isWixAuthorEmail, getFirstCommitAuthorEmail, assertWixAuthor } from '../src/utils/author-gate';
+
+describe('isWixAuthorEmail', () => {
+  it('accepts @wix.com addresses (case-insensitive)', () => {
+    expect(isWixAuthorEmail('orgold@wix.com')).toBe(true);
+    expect(isWixAuthorEmail('Some.Person@Wix.com')).toBe(true);
+    expect(isWixAuthorEmail('  dev@wix.com  ')).toBe(true);
+  });
+
+  it('rejects non-wix, spoofed, bot, and empty addresses', () => {
+    expect(isWixAuthorEmail('attacker@gmail.com')).toBe(false);
+    expect(isWixAuthorEmail('evil@wix.com.attacker.io')).toBe(false);
+    expect(isWixAuthorEmail('wix.com@gmail.com')).toBe(false);
+    expect(isWixAuthorEmail('123+bot@users.noreply.github.com')).toBe(false);
+    expect(isWixAuthorEmail('')).toBe(false);
+    expect(isWixAuthorEmail(undefined)).toBe(false);
+    expect(isWixAuthorEmail(null)).toBe(false);
+  });
+});
+
+type CommitStub = { commit: { author: { email: string } | null } };
+
+function fakeOctokit(commits: CommitStub[]) {
+  return {
+    rest: { pulls: { listCommits: 'listCommits' } },
+    paginate: async () => commits,
+  } as unknown as Parameters<typeof getFirstCommitAuthorEmail>[0];
+}
+
+describe('getFirstCommitAuthorEmail', () => {
+  it('returns the first (oldest) commit author email', async () => {
+    const octokit = fakeOctokit([
+      { commit: { author: { email: 'first@wix.com' } } },
+      { commit: { author: { email: 'later@gmail.com' } } },
+    ]);
+    expect(await getFirstCommitAuthorEmail(octokit, 'wix', 'skills', 1)).toBe('first@wix.com');
+  });
+
+  it('returns undefined when there are no commits', async () => {
+    expect(await getFirstCommitAuthorEmail(fakeOctokit([]), 'wix', 'skills', 1)).toBeUndefined();
+  });
+});
+
+describe('assertWixAuthor', () => {
+  it('resolves when the first commit is a @wix.com author', async () => {
+    const octokit = fakeOctokit([{ commit: { author: { email: 'dev@wix.com' } } }]);
+    await expect(assertWixAuthor(octokit, 'wix', 'skills', 1)).resolves.toBeUndefined();
+  });
+
+  it('throws when the first commit is not a @wix.com author', async () => {
+    const octokit = fakeOctokit([{ commit: { author: { email: 'outsider@gmail.com' } } }]);
+    await expect(assertWixAuthor(octokit, 'wix', 'skills', 1)).rejects.toThrow(/not a @wix\.com address/);
+  });
+
+  it('throws when the PR has no commits', async () => {
+    await expect(assertWixAuthor(fakeOctokit([]), 'wix', 'skills', 1)).rejects.toThrow(/author gate failed/i);
+  });
+});

--- a/.github/actions/evalforge-yaml-gate/tests/author-gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/author-gate.test.ts
@@ -23,17 +23,13 @@ type CommitStub = { commit: { author: { email: string } | null } };
 
 function fakeOctokit(commits: CommitStub[]) {
   return {
-    rest: { pulls: { listCommits: 'listCommits' } },
-    paginate: async () => commits,
+    rest: { pulls: { listCommits: async () => ({ data: commits }) } },
   } as unknown as Parameters<typeof getFirstCommitAuthorEmail>[0];
 }
 
 describe('getFirstCommitAuthorEmail', () => {
   it('returns the first (oldest) commit author email', async () => {
-    const octokit = fakeOctokit([
-      { commit: { author: { email: 'first@wix.com' } } },
-      { commit: { author: { email: 'later@gmail.com' } } },
-    ]);
+    const octokit = fakeOctokit([{ commit: { author: { email: 'first@wix.com' } } }]);
     expect(await getFirstCommitAuthorEmail(octokit, 'wix', 'skills', 1)).toBe('first@wix.com');
   });
 


### PR DESCRIPTION
## What
Adds an author gate to the **evalforge-yaml-gate** action: in **eval** mode it reads the PR's **first-commit author email** and **hard-fails** unless it ends in `@wix.com`.

## Why
This is a public repo, and the eval gate runs **paid EvalForge evaluations** and uses secrets on PRs. We want that expensive, secret-using path to run only for Wix authors — an explicit `@wix.com` check on top of the existing same-repo (`head.repo.full_name == github.repository`) guard.

## Behavior
- Runs at the very start of `runGate` (eval mode), before any MCP version creation / eval work.
- **Always blocking** — independent of the `blocking` input; a security gate shouldn't be downgradable to a warning.
- **eval mode only.** `promote` (on merge) and `cleanup` (on close) are post-merge/close housekeeping and are intentionally left ungated.
- Rule: the PR's **first** (oldest) commit author email, via `octokit.rest.pulls.listCommits` (`[0]`), case-insensitive `@wix.com` suffix.

## Changes
- `src/utils/author-gate.ts` (new) — `isWixAuthorEmail` (pure predicate), `getFirstCommitAuthorEmail`, `assertWixAuthor` (throws → `core.setFailed`).
- `src/utils/gate.ts` — call `assertWixAuthor(...)` right after octokit is created, before `makeCommenter`.
- `tests/author-gate.test.ts` (new) — 7 tests.
- `dist/index.js` — rebuilt with `ncc` (+71 lines, only the gate code + wiring).

## Caveats
- First-commit author isn't strictly guaranteed to be the GitHub PR opener (one could branch off another person's commit), and commit emails are set via git config — so this is a gate, not a spoof-proof identity check. Org membership would be stronger if we later want that.

## Testing
- `yarn typecheck` — clean.
- `yarn test` — **146 passed** (incl. 7 new): `isWixAuthorEmail` accepts `@wix.com`/mixed-case/whitespace and rejects gmail, suffix-spoof `evil@wix.com.attacker.io`, prefix-spoof `wix.com@gmail.com`, bot noreply, empty/null/undefined; `getFirstCommitAuthorEmail` returns the oldest commit's email; `assertWixAuthor` resolves for wix, throws for non-wix and for zero-commit PRs.
- `yarn build` — `dist` rebuilt; verified `assertWixAuthor` is bundled and invoked in `dist/index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)