### PR TITLE
wix-headless: add AI_FEATURES reference (text/chat + embeddings)

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -117,6 +117,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | Seed (create backend content) | `<SKILL_ROOT>/references/SEED.md` |
 | SDK-integration handoff (emitted, or applied by create/connect) | `<SKILL_ROOT>/references/SDK_HANDOFF.md` |
 | Image generation (opt-in; agnostic) | `<SKILL_ROOT>/references/IMAGE_GENERATION.md` |
+| AI features — text/chat + embeddings (opt-in; agnostic) | `<SKILL_ROOT>/references/AI_FEATURES.md` |
 | Feedback — relay the user's headless-experience feedback to Wix (opt-in; user-approved) | `<SKILL_ROOT>/references/FEEDBACK.md` |
 | **Authentication** — obtain `$TOKEN`/`$SITE_ID`/`clientId` (project-type-specific) | `<TYPE_DIR>/AUTHENTICATION.md` |
 | **Deployment** — finalize the live site (project-type-specific) | `<TYPE_DIR>/DEPLOYMENT.md` |
@@ -124,7 +125,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | Managed **connect** flow (wire an existing project) | `<SKILL_ROOT>/references/managed/CONNECT.md` |
 | Frontend-axis references (how a frontend wires to Wix) | `<SKILL_ROOT>/references/astro.md`, `non-astro.md` |
 
-**Start a run by opening `DISCOVERY.md`.** The flow files (`CAPABILITIES`, `DISCOVERY`, `SETUP`, `SEED`, `SDK_HANDOFF`, `IMAGE_GENERATION`) are project-type-agnostic; the per-type specifics live under `<TYPE_DIR>/` (`AUTHENTICATION.md`, `DEPLOYMENT.md`, and — managed only — `CREATE.md`/`CONNECT.md`).
+**Start a run by opening `DISCOVERY.md`.** The flow files (`CAPABILITIES`, `DISCOVERY`, `SETUP`, `SEED`, `SDK_HANDOFF`, `IMAGE_GENERATION`, `AI_FEATURES`) are project-type-agnostic; the per-type specifics live under `<TYPE_DIR>/` (`AUTHENTICATION.md`, `DEPLOYMENT.md`, and — managed only — `CREATE.md`/`CONNECT.md`).
 
 ## Where the *how* comes from
 

--- a/skills/wix-headless/references/AI_FEATURES.md
+++ b/skills/wix-headless/references/AI_FEATURES.md
@@ -173,6 +173,6 @@ without them:
 | insufficient credits / quota | Account is out of AI credits — degrade soft; tell the owner. |
 
 ## See also
-- `IMAGE_GENERATION.md` — image generation (Runware), a seed-time REST recipe using the same gateway.
+- `IMAGE_GENERATION.md` — image generation (Runware) via the same gateway.
 - Live docs: `dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis` (+ `…/set-up-the-wix-ai-sdk`).
 - Provider request/response params: OpenAI & Anthropic API references (the gateway is pass-through).

--- a/skills/wix-headless/references/AI_FEATURES.md
+++ b/skills/wix-headless/references/AI_FEATURES.md
@@ -1,0 +1,240 @@
+# AI features — text, chat & embeddings (opt-in, all project types)
+
+Add **generative-AI features** to a headless app using the **Wix AI APIs** (`www.wixapis.com`): LLM
+text/chat completions and text embeddings, through the same `$TOKEN`/`$SITE_ID` call shape as every
+other Wix call. Wix fronts the model providers (OpenAI, Anthropic) and handles auth + billing, so
+you never hold a provider key. **For image generation, see `IMAGE_GENERATION.md`** — same gateway,
+same auth, covered there; this file is text + embeddings and the rules that apply to *all* AI calls.
+
+**Opt-in, by intent** — only build AI features when the intent calls for them (a support chatbot, AI
+product descriptions, semantic search, summarization…). Like imagery, it's off by default; there's
+no fixed slot list. **Status: Developer Preview** — the API shape can change; confirm models with
+`/models` (below) rather than trusting a hardcoded list.
+
+## The one hard rule: AI runs server-side only
+
+**Every AI call must be made from server code with an authorized identity. Never from the browser.**
+This is enforced at two layers, both verified:
+
+- A **visitor / anonymous token** (the identity a headless frontend holds in the browser) gets
+  **`403 Permission denied`** from the gateway. Site **members** are visitor-class too — same denial.
+- The `@wix/ai` SDK **throws in browser environments** (*"AI calls from browser code are not
+  supported. Move your AI logic to backend code."*) and **elevates** every call to the app/owner
+  identity server-side (`auth.elevate`).
+
+So the AI call always sits **behind a server boundary** — a Wix serverless/web-method backend
+(managed), or the app's own server (self-managed/stripe). The browser calls *your* endpoint; your
+endpoint calls Wix. This boundary is also where you enforce credits/abuse controls (see **Credits &
+cost control**) — it is not optional plumbing, it is the security and billing perimeter.
+
+**Authorized identities** (what may sit on the server side):
+
+| Identity | How obtained | Works? |
+|---|---|---|
+| Wix **user** (site-scoped REST token) | managed CLI `wix token --site` — seed/build/backend | ✅ |
+| **API key** with `Invoke AI Models` scope | site-development API key (`ApiKeyStrategy`) | ✅ |
+| **App** (`AppStrategy`) with `Invoke AI Models` scope | a Wix app whose OAuth app has the `SCOPE.DATA_SCIENCE.INVOKE_AI_MODELS` permission granted in the Dev Center | ✅ |
+| App / API key **without** that scope | — | ❌ `403 Forbidden` |
+| Anonymous **visitor** / member | OAuth `grantType:anonymous`, member session | ❌ `403 Permission denied` |
+
+> A plain headless OAuth app **does not** have `Invoke AI Models` by default — it must be added to the
+> app's permissions before `AppStrategy`/`ApiKeyStrategy` can invoke models. Surface this
+> if a run 403s on a correctly-formed AI call.
+
+### Build/seed-time vs runtime — they use different identities (verified, easy to miss)
+
+- **Build/seed time** (the skill's *own* AI calls — e.g. generating product copy or images during
+  Seed, and `IMAGE_GENERATION.md`): these run under the **CLI token** (`wix token --site`), which is
+  the **Wix user (owner)** identity — the owner inherently owns the AI credits, so this **works today
+  with no extra setup**.
+- **Runtime** (AI features baked into the *deployed* site's server code): the running site does **not**
+  use the owner's CLI token — `@wix/ai` elevates to the site's **app/companion identity**, which is
+  **not granted `INVOKE_AI_MODELS` by default → `403 Forbidden` at runtime**, even though seed-time
+  worked. This is the trap: a feature that generated fine during Seed will 403 once it's serving real
+  requests.
+
+**Enabling runtime AI on a managed headless site** — grant `SCOPE.DATA_SCIENCE.INVOKE_AI_MODELS` to
+the site's app (`appId`/`clientId` from `wix.config.json`). Self-serve, as the app owner (a plain
+`wix token` developer bearer — **not** an account API key, despite the REST doc's claim):
+
+```bash
+curl -X POST 'https://www.wixapis.com/apps/v1/app-permissions/v1/app-permissions' \
+  -H "Authorization: Bearer $(npx @wix/cli@latest token)" \
+  -H 'Content-Type: application/json' \
+  -d '{"appPermission":{"appId":"<APP_ID>","permission":{"permissionId":"SCOPE.DATA_SCIENCE.INVOKE_AI_MODELS"}}}'
+```
+
+(Or click **Add** on the app's Dev Center permissions page — same API underneath.) Note the **doubled
+path** `/apps/v1/app-permissions/v1/app-permissions` (the doc's single-path "URL" is wrong), and that
+the grant takes **~60–90s to propagate** before the gateway honors it — the first calls after granting
+still `403`. Confirm with `ListAppPermissions`, then the runtime call succeeds.
+
+> This per-app grant is the current interim path. The clean platform fix (in progress with the CLI /
+> identity teams) is to add `INVOKE_AI_MODELS` to the `SCOPE.HEADLESS.MEGA` scope so every headless
+> site gets it automatically — once that lands, no per-app grant is needed.
+
+## Call shape (REST — primary)
+
+The gateway is a **transparent pass-through** to each provider: base URL is
+`https://www.wixapis.com/{provider}/v1/...` and the **request/response bodies are the provider's
+native shape** — model params, streaming, tool calls all follow the provider's own docs, not a Wix
+schema. Use the skill's universal call shape (`SETUP.md` §1) with the server-side `$TOKEN`/`$SITE_ID`:
+
+```bash
+curl -sS -X POST "https://www.wixapis.com/{provider}/v1/{path}" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "wix-site-id: $SITE_ID" \
+  -H "Content-Type: application/json" \
+  -d '<provider-native body>'
+```
+
+(`wix-site-id` is accepted-but-not-required for AI calls — the token is already site-scoped — but
+include it for consistency with every other call in the skill.)
+
+## Text & chat generation
+
+| Provider | Path | Body / docs |
+|---|---|---|
+| OpenAI | `POST /openai/v1/responses` | OpenAI **Responses API** (`{ "model", "input" }`) |
+| OpenAI | `POST /openai/v1/chat/completions` | OpenAI **Chat Completions** (`{ "model", "messages":[…] }`) |
+| Anthropic | `POST /anthropic/v1/messages` | Anthropic **Messages** (`{ "model", "max_tokens", "messages":[…] }`) |
+
+```bash
+# OpenAI chat
+curl … -X POST "https://www.wixapis.com/openai/v1/chat/completions" \
+  -d '{"model":"gpt-5-nano","messages":[{"role":"user","content":"Write a 1-line product tagline"}]}'
+
+# Anthropic messages — NOTE the required version header
+curl … -H "anthropic-version: 2023-06-01" \
+  -X POST "https://www.wixapis.com/anthropic/v1/messages" \
+  -d '{"model":"claude-haiku-4-5-20251001","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+- **Anthropic requires the `anthropic-version: 2023-06-01` header.** Omitting it → `400 anthropic-version:
+  header is required` (the public doc's curl example omits it — don't copy that).
+- **Streaming**: set `"stream": true` — the response is SSE (`data:` lines), provider-native. Only
+  useful if your server streams to the client (e.g. SSE/Response stream); a one-shot seed/build call
+  doesn't need it.
+
+## Embeddings (semantic search, similarity)
+
+```bash
+curl … -X POST "https://www.wixapis.com/openai/v1/embeddings" \
+  -d '{"model":"text-embedding-3-small","input":"The food was delicious but the waiter was rude."}'
+# → data[0].embedding : number[]  (text-embedding-3-small = 1536 dims)
+```
+
+`input` may be a string or an array of strings (batch). Store vectors in a Wix Data/CMS collection
+(or an external vector store) and compare with cosine similarity for search/recommendations.
+
+## Models — query, don't hardcode
+
+`GET /{provider}/v1/models` is the **source of truth** (Anthropic needs the version header). New
+provider models land on Wix a few days after release; some ids are **date-stamped**. Tested-current
+picks (verify with `/models`):
+
+- **OpenAI text**: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`,
+  `gpt-4.1-mini`, `gpt-4.1-nano`.
+- **OpenAI embeddings**: `text-embedding-3-small` (1536), `text-embedding-3-large`, `text-embedding-ada-002`.
+- **Anthropic**: `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-7`, `claude-sonnet-4-6`,
+  **`claude-haiku-4-5-20251001`** — the *dated* id. **`claude-haiku-4-5` (undated) → `400 Unsupported
+  model`**; use the dated id `/models` returns.
+
+## SDK path (`@wix/ai` — typed alternative, backend only)
+
+Built on the [Vercel AI SDK](https://ai-sdk.dev). Same gateway, same permission model — just typed
+and with elevation handled for you. **Backend only** (it throws in the browser).
+
+```bash
+npm install @wix/ai "ai@>=6.0.26" "zod@>=4.1.8"
+```
+
+```js
+// Wix-managed backend (Astro-on-Wix serverless / web method): auth is elevated automatically
+import { generateText } from "ai";
+import { openai } from "@wix/ai";              // or: anthropic, runware
+const { text } = await generateText({ model: openai("gpt-5.2"), prompt: "…" });
+
+// Self-managed / stripe: pass an authenticated client (needs the Invoke AI Models scope)
+import { createOpenAI } from "@wix/ai";
+import { createClient, AppStrategy } from "@wix/sdk";  // or ApiKeyStrategy
+const client = createClient({ auth: AppStrategy({ appId, appSecret, instanceId }) });
+const openai = createOpenAI({ client });
+```
+
+Methods (from `ai`): `generateText` / `streamText` (text), `embed` / `embedMany` (embeddings),
+`generateImage` (images). `@wix/ai` exports `openai`, `anthropic`, `runware` (ambient, Wix-managed)
+and `createOpenAI`, `createAnthropic`, `createRunware` (client-injected, self-managed). **Exact model
+selectors** (verified — don't guess the method names):
+
+- **Text:** `openai("gpt-5.2")` or `openai.responses(id)` / `openai.chat(id)`; `anthropic("claude-…")`.
+- **Embeddings:** `openai.embeddingModel("text-embedding-3-small")` — **not** `textEmbeddingModel` (that
+  method doesn't exist and throws). Returns `embeddings[i]` as `number[]` (1536 dims for `3-small`).
+- **Images:** `runware.image("<air-id>")`. `generateImage` returns `{ image }` with `image.base64` +
+  `image.mediaType` — build a data URL (`data:${mediaType};base64,${base64}`) or import to Wix Media.
+  In `ai` v7 the fn may be exported as `experimental_generateImage`; fall back to it if `generateImage`
+  is undefined.
+
+> **Runware via the SDK — model gotcha (verified):** `google:4@2` (Nano Banana) **fails via the SDK**
+> ("Unknown Runware API error" — the Vercel provider injects params it rejects), even though it works
+> on the raw REST proxy. Use **`bfl:5@1`** (FLUX.2 Pro) or **`runware:100@1`**. Runware is also
+> **intermittently flaky** — wrap image calls in a **retry + model fallback** (`bfl:5@1` → `runware:100@1`)
+> so a transient blip doesn't surface to the user. See `IMAGE_GENERATION.md` for the REST path.
+
+**REST vs SDK:** prefer **REST** to stay consistent with the rest of the skill's `curl` flow and for
+seed/build-time calls; reach for the **SDK** when the frontend is a JS/TS server (Astro-on-Wix, Node)
+that already uses `@wix/*` and wants typed calls + auto-elevation. **Wiring to the browser:** expose a
+**server route (or action) that returns plain JSON** and have the browser `fetch` it — the AI runs in
+that route; the browser never touches the gateway.
+
+## Credits & cost control — the gap you MUST design for
+
+**AI usage is billed to the site *owner's* account, never to the end user.** This is structural, not
+a setting:
+
+- AI credits belong to the **account's Premium plan**, shared across the whole account; monthly
+  allowance by tier, **no rollover** (free plan ≈ 30/day, 120/mo). Each call ≈ **1 credit** (varies
+  by model/size); the platform meters every call and **blocks when the account balance runs out**.
+- Because every AI call is **elevated to the owner/app identity** (that's the only identity the
+  gateway accepts), **there is no per-visitor or per-member credit pool.** A visitor who triggers an
+  AI feature spends the *owner's* credits.
+
+**Consequence:** any AI feature exposed to end-users (a public chatbot, "generate my bio", etc.) lets
+anonymous traffic **drain the owner's credits** — and gives you no built-in way to attribute or cap
+usage per end-user. The platform will not solve this for you. **The app must own a metering layer.**
+
+When AI is exposed to end-users, build these into the **server boundary** (the same endpoint that
+holds `$TOKEN`) — don't ship AI to end-users without them:
+
+1. **Gate access** — require an authenticated member (or your own key) for anything that costs
+   credits; don't wire AI to a fully-open public route by default.
+2. **Rate-limit & quota per identity** — track calls per member/session/IP in a Wix Data/CMS
+   collection; **check-and-decrement before the AI call**, reject over quota (re-check after, since
+   balance is shared — see the account-level `InsufficientCreditsError`).
+3. **Cap inputs** — bound prompt/`max_tokens`/`input` size; large requests cost more credits.
+4. **Cache / dedupe** — memoize identical prompts (product description for the same product, etc.);
+   many "AI features" are computed once at seed/build time, not per request — prefer that when the
+   content is static.
+5. **Fail soft** — on `403`/quota/`insufficient credits`, degrade gracefully (cached/canned copy),
+   never hard-error the page; surface cost transparently to the owner.
+
+> If the user wants true **per-end-user AI budgets** (e.g. "each member gets N generations/month"),
+> that is an **applicative feature to build** — a usage-ledger collection keyed by member, enforced
+> server-side — because Wix bills only the owner and offers no per-visitor pool. Call this out to the
+> user rather than implying the platform meters end-users.
+
+## Failure ladder
+
+| Symptom | Cause → fix |
+|---|---|
+| `403 Permission denied` | Called with a visitor/member token, or from the browser. **Move the call server-side** with an authorized identity. |
+| `403 Forbidden` (server identity) — esp. at **runtime** after seed-time worked | The site's app identity lacks `INVOKE_AI_MODELS`. Grant it (see "Enabling runtime AI") and wait ~60–90s for propagation. |
+| `400 anthropic-version: header is required` | Add `-H "anthropic-version: 2023-06-01"`. |
+| `400 Unsupported model` | Use the exact id from `/{provider}/v1/models` (Anthropic ids are often date-stamped, e.g. `claude-haiku-4-5-20251001`). |
+| `Unknown Runware API error` (images) | Transient, or the model rejects SDK params (`google:4@2`). Retry + fall back to `bfl:5@1` / `runware:100@1`. |
+| insufficient credits / quota | Account is out of AI credits — degrade soft; tell the owner. |
+
+## See also
+- `IMAGE_GENERATION.md` — image generation (Runware) via the same gateway/auth.
+- Live docs: `dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis` (+ `…/set-up-the-wix-ai-sdk`).
+- Provider request/response params: OpenAI & Anthropic API references (the gateway is pass-through).

--- a/skills/wix-headless/references/AI_FEATURES.md
+++ b/skills/wix-headless/references/AI_FEATURES.md
@@ -1,10 +1,9 @@
 # AI features — text, chat & embeddings (opt-in, all project types)
 
-Add **generative-AI features** to a headless app using the **Wix AI APIs** (`www.wixapis.com`): LLM
-text/chat completions and text embeddings, through the same `$TOKEN`/`$SITE_ID` call shape as every
-other Wix call. Wix fronts the model providers (OpenAI, Anthropic) and handles auth + billing, so
-you never hold a provider key. **For image generation, see `IMAGE_GENERATION.md`** — same gateway,
-same auth, covered there; this file is text + embeddings and the rules that apply to *all* AI calls.
+Add **generative-AI features** to a headless app using the **Wix AI APIs**: LLM text/chat completions
+and text embeddings. Wix fronts the model providers (OpenAI, Anthropic) and handles auth + billing, so
+you never hold a provider key. **For image generation, see `IMAGE_GENERATION.md`** — same gateway, same
+rules; this file is text + embeddings and the rules that apply to *all* AI calls.
 
 **Opt-in, by intent** — only build AI features when the intent calls for them (a support chatbot, AI
 product descriptions, semantic search, summarization…). Like imagery, it's off by default; there's
@@ -13,125 +12,49 @@ no fixed slot list. **Status: Developer Preview** — the API shape can change; 
 
 ## The one hard rule: AI runs server-side only
 
-**Every AI call must be made from server code with an authorized identity. Never from the browser.**
-This is enforced at two layers, both verified:
+**Every AI call must be made from server code. Never from the browser.**
 
-- A **visitor / anonymous token** (the identity a headless frontend holds in the browser) gets
-  **`403 Permission denied`** from the gateway. Site **members** are visitor-class too — same denial.
-- The `@wix/ai` SDK **throws in browser environments** (*"AI calls from browser code are not
-  supported. Move your AI logic to backend code."*) and **elevates** every call to the app/owner
-  identity server-side (`auth.elevate`).
+- A **visitor / member** identity (what a headless frontend holds in the browser) is **rejected** by
+  the gateway.
+- The `@wix/ai` SDK **throws in browser environments** (*"AI calls from browser code are not supported.
+  Move your AI logic to backend code."*).
 
 So the AI call always sits **behind a server boundary** — a Wix serverless/web-method backend
 (managed), or the app's own server (self-managed/stripe). The browser calls *your* endpoint; your
-endpoint calls Wix. This boundary is also where you enforce credits/abuse controls (see **Credits &
-cost control**) — it is not optional plumbing, it is the security and billing perimeter.
+endpoint calls Wix. That boundary is also where you enforce credits/abuse controls (see **Credits &
+cost control**) — it's the security and billing perimeter, not optional plumbing.
 
-On a **Wix-managed backend** (Astro-on-Wix serverless / web methods) the call is authenticated for
-you. On a **self-managed** backend, pass an authenticated `WixClient` (`AppStrategy` or
-`ApiKeyStrategy`) — see the SDK path below. Either way the browser only ever calls *your* server
-route; that route calls Wix.
+## Use the SDK (`@wix/ai`) — the path for app code
 
-> **Building a Wix app** (rather than a site) needs the **`Invoke AI Models`** permission on the app —
-> see [About the Wix AI APIs](https://dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis).
-
-## Call shape (REST — primary)
-
-The gateway is a **transparent pass-through** to each provider: base URL is
-`https://www.wixapis.com/{provider}/v1/...` and the **request/response bodies are the provider's
-native shape** — model params, streaming, tool calls all follow the provider's own docs, not a Wix
-schema. Use the skill's universal call shape (`SETUP.md` §1) with the server-side `$TOKEN`/`$SITE_ID`:
-
-```bash
-curl -sS -X POST "https://www.wixapis.com/{provider}/v1/{path}" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "wix-site-id: $SITE_ID" \
-  -H "Content-Type: application/json" \
-  -d '<provider-native body>'
-```
-
-(`wix-site-id` is accepted-but-not-required for AI calls — the token is already site-scoped — but
-include it for consistency with every other call in the skill.)
-
-## Text & chat generation
-
-| Provider | Path | Body / docs |
-|---|---|---|
-| OpenAI | `POST /openai/v1/responses` | OpenAI **Responses API** (`{ "model", "input" }`) |
-| OpenAI | `POST /openai/v1/chat/completions` | OpenAI **Chat Completions** (`{ "model", "messages":[…] }`) |
-| Anthropic | `POST /anthropic/v1/messages` | Anthropic **Messages** (`{ "model", "max_tokens", "messages":[…] }`) |
-
-```bash
-# OpenAI chat
-curl … -X POST "https://www.wixapis.com/openai/v1/chat/completions" \
-  -d '{"model":"gpt-5-nano","messages":[{"role":"user","content":"Write a 1-line product tagline"}]}'
-
-# Anthropic messages — NOTE the required version header
-curl … -H "anthropic-version: 2023-06-01" \
-  -X POST "https://www.wixapis.com/anthropic/v1/messages" \
-  -d '{"model":"claude-haiku-4-5-20251001","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}'
-```
-
-- **Anthropic requires the `anthropic-version: 2023-06-01` header.** Omitting it → `400 anthropic-version:
-  header is required` (the public doc's curl example omits it — don't copy that).
-- **Streaming**: set `"stream": true` — the response is SSE (`data:` lines), provider-native. Only
-  useful if your server streams to the client (e.g. SSE/Response stream); a one-shot seed/build call
-  doesn't need it.
-
-## Embeddings (semantic search, similarity)
-
-```bash
-curl … -X POST "https://www.wixapis.com/openai/v1/embeddings" \
-  -d '{"model":"text-embedding-3-small","input":"The food was delicious but the waiter was rude."}'
-# → data[0].embedding : number[]  (text-embedding-3-small = 1536 dims)
-```
-
-`input` may be a string or an array of strings (batch). Store vectors in a Wix Data/CMS collection
-(or an external vector store) and compare with cosine similarity for search/recommendations.
-
-## Models — query, don't hardcode
-
-`GET /{provider}/v1/models` is the **source of truth** (Anthropic needs the version header). New
-provider models land on Wix a few days after release; some ids are **date-stamped**. Tested-current
-picks (verify with `/models`):
-
-- **OpenAI text**: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`,
-  `gpt-4.1-mini`, `gpt-4.1-nano`.
-- **OpenAI embeddings**: `text-embedding-3-small` (1536), `text-embedding-3-large`, `text-embedding-ada-002`.
-- **Anthropic**: `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-7`, `claude-sonnet-4-6`,
-  **`claude-haiku-4-5-20251001`** — the *dated* id. **`claude-haiku-4-5` (undated) → `400 Unsupported
-  model`**; use the dated id `/models` returns.
-
-## SDK path (`@wix/ai` — typed alternative, backend only)
-
-Built on the [Vercel AI SDK](https://ai-sdk.dev). Same gateway, same permission model — just typed
-and with elevation handled for you. **Backend only** (it throws in the browser).
+For the app you build (Astro-on-Wix, Node — any JS/TS server), **use the SDK**. It's built on the
+[Vercel AI SDK](https://ai-sdk.dev) — typed, and auth is handled for you. **Backend only.**
 
 ```bash
 npm install @wix/ai "ai@>=6.0.26" "zod@>=4.1.8"
 ```
 
 ```js
-// Wix-managed backend (Astro-on-Wix serverless / web method): auth is elevated automatically
+// Wix-managed backend (Astro-on-Wix serverless / web method): auth is handled automatically.
 import { generateText } from "ai";
-import { openai } from "@wix/ai";              // or: anthropic, runware
+import { openai } from "@wix/ai";              // also: anthropic, runware
 const { text } = await generateText({ model: openai("gpt-5.2"), prompt: "…" });
-
-// Self-managed / stripe: pass an authenticated client (needs the Invoke AI Models scope)
-import { createOpenAI } from "@wix/ai";
-import { createClient, AppStrategy } from "@wix/sdk";  // or ApiKeyStrategy
-const client = createClient({ auth: AppStrategy({ appId, appSecret, instanceId }) });
-const openai = createOpenAI({ client });
 ```
 
-Methods (from `ai`): `generateText` / `streamText` (text), `embed` / `embedMany` (embeddings),
-`generateImage` (images). `@wix/ai` exports `openai`, `anthropic`, `runware` (ambient, Wix-managed)
-and `createOpenAI`, `createAnthropic`, `createRunware` (client-injected, self-managed). **Exact model
-selectors** (verified — don't guess the method names):
+```js
+// Self-managed / stripe: pass an authenticated WixClient instead.
+import { createOpenAI } from "@wix/ai";
+import { createClient, AppStrategy } from "@wix/sdk";   // or ApiKeyStrategy
+const openai = createOpenAI({ client: createClient({ auth: AppStrategy({ appId, appSecret, instanceId }) }) });
+```
+
+`@wix/ai` exports `openai`, `anthropic`, `runware` (ambient, Wix-managed) and `createOpenAI`,
+`createAnthropic`, `createRunware` (client-injected, self-managed). Methods come from `ai`:
+`generateText` / `streamText`, `embed` / `embedMany`, `generateImage`. **Exact model selectors**
+(verified — don't guess the method names):
 
 - **Text:** `openai("gpt-5.2")` or `openai.responses(id)` / `openai.chat(id)`; `anthropic("claude-…")`.
 - **Embeddings:** `openai.embeddingModel("text-embedding-3-small")` — **not** `textEmbeddingModel` (that
-  method doesn't exist and throws). Returns `embeddings[i]` as `number[]` (1536 dims for `3-small`).
+  method doesn't exist and throws). Returns a `number[]` (1536 dims for `3-small`).
 - **Images:** `runware.image("<air-id>")`. `generateImage` returns `{ image }` with `image.base64` +
   `image.mediaType` — build a data URL (`data:${mediaType};base64,${base64}`) or import to Wix Media.
   In `ai` v7 the fn may be exported as `experimental_generateImage`; fall back to it if `generateImage`
@@ -141,13 +64,67 @@ selectors** (verified — don't guess the method names):
 > ("Unknown Runware API error" — the Vercel provider injects params it rejects), even though it works
 > on the raw REST proxy. Use **`bfl:5@1`** (FLUX.2 Pro) or **`runware:100@1`**. Runware is also
 > **intermittently flaky** — wrap image calls in a **retry + model fallback** (`bfl:5@1` → `runware:100@1`)
-> so a transient blip doesn't surface to the user. See `IMAGE_GENERATION.md` for the REST path.
+> so a transient blip doesn't surface to the user.
 
-**REST vs SDK:** prefer **REST** to stay consistent with the rest of the skill's `curl` flow and for
-seed/build-time calls; reach for the **SDK** when the frontend is a JS/TS server (Astro-on-Wix, Node)
-that already uses `@wix/*` and wants typed calls + auto-elevation. **Wiring to the browser:** expose a
-**server route (or action) that returns plain JSON** and have the browser `fetch` it — the AI runs in
-that route; the browser never touches the gateway.
+**Wiring to the browser:** expose a **server route (or action) that returns plain JSON** and have the
+browser `fetch` it — the AI runs in that route; the browser never touches the gateway.
+
+## Text & chat generation
+
+```js
+import { generateText, streamText } from "ai";
+import { openai, anthropic } from "@wix/ai";
+
+const a = await generateText({ model: openai.responses("gpt-5.2"), prompt: "Invent a holiday." });
+const b = await generateText({ model: anthropic("claude-sonnet-5"), prompt: "Tell me a story." });
+// streamText(...) for token-by-token streaming to the client.
+```
+
+## Embeddings (semantic search, similarity)
+
+```js
+import { embed, embedMany } from "ai";
+import { openai } from "@wix/ai";
+const model = openai.embeddingModel("text-embedding-3-small");
+
+const { embeddings } = await embedMany({ model, values: products.map((p) => p.text) });
+const { embedding } = await embed({ model, value: query });
+// rank by cosine similarity; persist product vectors in a Wix Data collection to avoid re-embedding.
+```
+
+## Models — query, don't hardcode
+
+`GET /{provider}/v1/models` is the **source of truth**. New provider models land on Wix a few days
+after release; some ids are **date-stamped**. Tested-current picks (verify with `/models`):
+
+- **OpenAI text**: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1`,
+  `gpt-4.1-mini`, `gpt-4.1-nano`.
+- **OpenAI embeddings**: `text-embedding-3-small` (1536), `text-embedding-3-large`, `text-embedding-ada-002`.
+- **Anthropic**: `claude-opus-4-8`, `claude-sonnet-5`, `claude-opus-4-7`, `claude-sonnet-4-6`,
+  **`claude-haiku-4-5-20251001`** — the *dated* id. **`claude-haiku-4-5` (undated) → `400 Unsupported
+  model`**; use the dated id `/models` returns.
+
+## REST (provider pass-through) — for the skill's seed-time calls / non-JS callers
+
+The gateway is a **transparent pass-through**: base URL `https://www.wixapis.com/{provider}/v1/...`,
+with the **provider's native request/response bodies** (model params, streaming, tool calls per the
+provider's own docs). The **skill's own seed/build-time AI calls use this** — the universal `curl`
+shape (`SETUP.md` §1), same as `SETUP`/`SEED`/`IMAGE_GENERATION`:
+
+```bash
+curl -sS -X POST "https://www.wixapis.com/openai/v1/chat/completions" \
+  -H "Authorization: Bearer $TOKEN" -H "wix-site-id: $SITE_ID" -H "Content-Type: application/json" \
+  -d '{"model":"gpt-5-nano","messages":[{"role":"user","content":"Write a 1-line product tagline"}]}'
+```
+
+Endpoints: OpenAI `POST /openai/v1/responses` · `/chat/completions` · `/embeddings`; Anthropic
+`POST /anthropic/v1/messages`.
+
+- **Anthropic requires `-H "anthropic-version: 2023-06-01"`.** Omitting it → `400 anthropic-version:
+  header is required` (the public doc's curl example omits it — don't copy that).
+- **Streaming**: set `"stream": true` — response is SSE (`data:` lines), provider-native.
+- `wix-site-id` is accepted-but-not-required for AI calls (the token is already site-scoped) — include
+  it for consistency with every other call in the skill.
 
 ## Credits & cost control — the gap you MUST design for
 
@@ -157,16 +134,16 @@ a setting:
 - AI credits belong to the **account's Premium plan**, shared across the whole account; monthly
   allowance by tier, **no rollover** (free plan ≈ 30/day, 120/mo). Each call ≈ **1 credit** (varies
   by model/size); the platform meters every call and **blocks when the account balance runs out**.
-- Because every AI call is **elevated to the owner/app identity** (that's the only identity the
-  gateway accepts), **there is no per-visitor or per-member credit pool.** A visitor who triggers an
-  AI feature spends the *owner's* credits.
+- Because every AI call runs under the **owner/app identity** (the only identity the gateway accepts),
+  **there is no per-visitor or per-member credit pool.** A visitor who triggers an AI feature spends
+  the *owner's* credits.
 
 **Consequence:** any AI feature exposed to end-users (a public chatbot, "generate my bio", etc.) lets
 anonymous traffic **drain the owner's credits** — and gives you no built-in way to attribute or cap
 usage per end-user. The platform will not solve this for you. **The app must own a metering layer.**
 
-When AI is exposed to end-users, build these into the **server boundary** (the same endpoint that
-holds `$TOKEN`) — don't ship AI to end-users without them:
+When AI is exposed to end-users, build these into the **server boundary** — don't ship AI to end-users
+without them:
 
 1. **Gate access** — require an authenticated member (or your own key) for anything that costs
    credits; don't wire AI to a fully-open public route by default.
@@ -177,8 +154,8 @@ holds `$TOKEN`) — don't ship AI to end-users without them:
 4. **Cache / dedupe** — memoize identical prompts (product description for the same product, etc.);
    many "AI features" are computed once at seed/build time, not per request — prefer that when the
    content is static.
-5. **Fail soft** — on `403`/quota/`insufficient credits`, degrade gracefully (cached/canned copy),
-   never hard-error the page; surface cost transparently to the owner.
+5. **Fail soft** — on a rejected/quota/insufficient-credits response, degrade gracefully (cached/canned
+   copy), never hard-error the page; surface cost transparently to the owner.
 
 > If the user wants true **per-end-user AI budgets** (e.g. "each member gets N generations/month"),
 > that is an **applicative feature to build** — a usage-ledger collection keyed by member, enforced
@@ -189,14 +166,14 @@ holds `$TOKEN`) — don't ship AI to end-users without them:
 
 | Symptom | Cause → fix |
 |---|---|
-| `403 Permission denied` | Called with a visitor/member token, or from the browser. **Move the call server-side** with an authorized identity. |
+| Call rejected from the browser / with a visitor or member identity | **Move the call server-side.** AI never runs in the browser. |
 | `403 Forbidden` (server identity) | Building a Wix **app**: add the `Invoke AI Models` permission to the app (see the AI-APIs doc). |
-| `400 anthropic-version: header is required` | Add `-H "anthropic-version: 2023-06-01"`. |
+| `400 anthropic-version: header is required` | REST only — add `-H "anthropic-version: 2023-06-01"` (the SDK sets it for you). |
 | `400 Unsupported model` | Use the exact id from `/{provider}/v1/models` (Anthropic ids are often date-stamped, e.g. `claude-haiku-4-5-20251001`). |
 | `Unknown Runware API error` (images) | Transient, or the model rejects SDK params (`google:4@2`). Retry + fall back to `bfl:5@1` / `runware:100@1`. |
 | insufficient credits / quota | Account is out of AI credits — degrade soft; tell the owner. |
 
 ## See also
-- `IMAGE_GENERATION.md` — image generation (Runware) via the same gateway/auth.
+- `IMAGE_GENERATION.md` — image generation (Runware), a seed-time REST recipe using the same gateway.
 - Live docs: `dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis` (+ `…/set-up-the-wix-ai-sdk`).
 - Provider request/response params: OpenAI & Anthropic API references (the gateway is pass-through).

--- a/skills/wix-headless/references/AI_FEATURES.md
+++ b/skills/wix-headless/references/AI_FEATURES.md
@@ -27,51 +27,13 @@ So the AI call always sits **behind a server boundary** — a Wix serverless/web
 endpoint calls Wix. This boundary is also where you enforce credits/abuse controls (see **Credits &
 cost control**) — it is not optional plumbing, it is the security and billing perimeter.
 
-**Authorized identities** (what may sit on the server side):
+On a **Wix-managed backend** (Astro-on-Wix serverless / web methods) the call is authenticated for
+you. On a **self-managed** backend, pass an authenticated `WixClient` (`AppStrategy` or
+`ApiKeyStrategy`) — see the SDK path below. Either way the browser only ever calls *your* server
+route; that route calls Wix.
 
-| Identity | How obtained | Works? |
-|---|---|---|
-| Wix **user** (site-scoped REST token) | managed CLI `wix token --site` — seed/build/backend | ✅ |
-| **API key** with `Invoke AI Models` scope | site-development API key (`ApiKeyStrategy`) | ✅ |
-| **App** (`AppStrategy`) with `Invoke AI Models` scope | a Wix app whose OAuth app has the `SCOPE.DATA_SCIENCE.INVOKE_AI_MODELS` permission granted in the Dev Center | ✅ |
-| App / API key **without** that scope | — | ❌ `403 Forbidden` |
-| Anonymous **visitor** / member | OAuth `grantType:anonymous`, member session | ❌ `403 Permission denied` |
-
-> A plain headless OAuth app **does not** have `Invoke AI Models` by default — it must be added to the
-> app's permissions before `AppStrategy`/`ApiKeyStrategy` can invoke models. Surface this
-> if a run 403s on a correctly-formed AI call.
-
-### Build/seed-time vs runtime — they use different identities (verified, easy to miss)
-
-- **Build/seed time** (the skill's *own* AI calls — e.g. generating product copy or images during
-  Seed, and `IMAGE_GENERATION.md`): these run under the **CLI token** (`wix token --site`), which is
-  the **Wix user (owner)** identity — the owner inherently owns the AI credits, so this **works today
-  with no extra setup**.
-- **Runtime** (AI features baked into the *deployed* site's server code): the running site does **not**
-  use the owner's CLI token — `@wix/ai` elevates to the site's **app/companion identity**, which is
-  **not granted `INVOKE_AI_MODELS` by default → `403 Forbidden` at runtime**, even though seed-time
-  worked. This is the trap: a feature that generated fine during Seed will 403 once it's serving real
-  requests.
-
-**Enabling runtime AI on a managed headless site** — grant `SCOPE.DATA_SCIENCE.INVOKE_AI_MODELS` to
-the site's app (`appId`/`clientId` from `wix.config.json`). Self-serve, as the app owner (a plain
-`wix token` developer bearer — **not** an account API key, despite the REST doc's claim):
-
-```bash
-curl -X POST 'https://www.wixapis.com/apps/v1/app-permissions/v1/app-permissions' \
-  -H "Authorization: Bearer $(npx @wix/cli@latest token)" \
-  -H 'Content-Type: application/json' \
-  -d '{"appPermission":{"appId":"<APP_ID>","permission":{"permissionId":"SCOPE.DATA_SCIENCE.INVOKE_AI_MODELS"}}}'
-```
-
-(Or click **Add** on the app's Dev Center permissions page — same API underneath.) Note the **doubled
-path** `/apps/v1/app-permissions/v1/app-permissions` (the doc's single-path "URL" is wrong), and that
-the grant takes **~60–90s to propagate** before the gateway honors it — the first calls after granting
-still `403`. Confirm with `ListAppPermissions`, then the runtime call succeeds.
-
-> This per-app grant is the current interim path. The clean platform fix (in progress with the CLI /
-> identity teams) is to add `INVOKE_AI_MODELS` to the `SCOPE.HEADLESS.MEGA` scope so every headless
-> site gets it automatically — once that lands, no per-app grant is needed.
+> **Building a Wix app** (rather than a site) needs the **`Invoke AI Models`** permission on the app —
+> see [About the Wix AI APIs](https://dev.wix.com/docs/api-reference/articles/ai-tools/ai-apis/about-the-wix-ai-apis).
 
 ## Call shape (REST — primary)
 
@@ -210,7 +172,7 @@ holds `$TOKEN`) — don't ship AI to end-users without them:
    credits; don't wire AI to a fully-open public route by default.
 2. **Rate-limit & quota per identity** — track calls per member/session/IP in a Wix Data/CMS
    collection; **check-and-decrement before the AI call**, reject over quota (re-check after, since
-   balance is shared — see the account-level `InsufficientCreditsError`).
+   the credit balance is account-wide).
 3. **Cap inputs** — bound prompt/`max_tokens`/`input` size; large requests cost more credits.
 4. **Cache / dedupe** — memoize identical prompts (product description for the same product, etc.);
    many "AI features" are computed once at seed/build time, not per request — prefer that when the
@@ -228,7 +190,7 @@ holds `$TOKEN`) — don't ship AI to end-users without them:
 | Symptom | Cause → fix |
 |---|---|
 | `403 Permission denied` | Called with a visitor/member token, or from the browser. **Move the call server-side** with an authorized identity. |
-| `403 Forbidden` (server identity) — esp. at **runtime** after seed-time worked | The site's app identity lacks `INVOKE_AI_MODELS`. Grant it (see "Enabling runtime AI") and wait ~60–90s for propagation. |
+| `403 Forbidden` (server identity) | Building a Wix **app**: add the `Invoke AI Models` permission to the app (see the AI-APIs doc). |
 | `400 anthropic-version: header is required` | Add `-H "anthropic-version: 2023-06-01"`. |
 | `400 Unsupported model` | Use the exact id from `/{provider}/v1/models` (Anthropic ids are often date-stamped, e.g. `claude-haiku-4-5-20251001`). |
 | `Unknown Runware API error` (images) | Transient, or the model rejects SDK params (`google:4@2`). Retry + fall back to `bfl:5@1` / `runware:100@1`. |

--- a/skills/wix-headless/references/AI_FEATURES.md
+++ b/skills/wix-headless/references/AI_FEATURES.md
@@ -104,12 +104,12 @@ after release; some ids are **date-stamped**. Tested-current picks (verify with 
   **`claude-haiku-4-5-20251001`** — the *dated* id. **`claude-haiku-4-5` (undated) → `400 Unsupported
   model`**; use the dated id `/models` returns.
 
-## REST (provider pass-through) — for the skill's seed-time calls / non-JS callers
+## REST (provider pass-through) — when the SDK doesn't fit
 
-The gateway is a **transparent pass-through**: base URL `https://www.wixapis.com/{provider}/v1/...`,
-with the **provider's native request/response bodies** (model params, streaming, tool calls per the
-provider's own docs). The **skill's own seed/build-time AI calls use this** — the universal `curl`
-shape (`SETUP.md` §1), same as `SETUP`/`SEED`/`IMAGE_GENERATION`:
+Use REST if your backend **isn't JS/TS**, or when you want the **raw HTTP** API. The gateway is a
+**transparent pass-through**: base URL `https://www.wixapis.com/{provider}/v1/...` with the
+**provider's native request/response bodies** (model params, streaming, tool calls per the provider's
+own docs). Authenticate with the skill's universal call shape (`SETUP.md` §1):
 
 ```bash
 curl -sS -X POST "https://www.wixapis.com/openai/v1/chat/completions" \
@@ -152,8 +152,7 @@ without them:
    the credit balance is account-wide).
 3. **Cap inputs** — bound prompt/`max_tokens`/`input` size; large requests cost more credits.
 4. **Cache / dedupe** — memoize identical prompts (product description for the same product, etc.);
-   many "AI features" are computed once at seed/build time, not per request — prefer that when the
-   content is static.
+   static AI content is best computed **once, ahead of time** and stored, not regenerated per request.
 5. **Fail soft** — on a rejected/quota/insufficient-credits response, degrade gracefully (cached/canned
    copy), never hard-error the page; surface cost transparently to the owner.
 


### PR DESCRIPTION
Adds `references/AI_FEATURES.md` to the **wix-headless** skill — how to add generative-AI features (LLM text/chat completions + embeddings) to a headless app via the **Wix AI APIs** — and wires it into `SKILL.md` (path table + flow-files list). Images stay in `IMAGE_GENERATION.md`; this file cross-links it.

Every claim was verified end-to-end against a live managed headless site (Astro-on-Wix), not copied from docs.

## What it covers (developer-facing only)
- **Server-side-only rule** — visitor/browser calls are rejected; the `@wix/ai` SDK blocks the browser. AI must run behind a server route/action that the browser `fetch`es.
- **REST + SDK** usage — provider-native pass-through (`www.wixapis.com/{provider}/v1/...`) and the `@wix/ai` SDK (Wix-managed = auto-authenticated; self-managed = `AppStrategy`/`ApiKeyStrategy`).
- **Verified specifics** — Anthropic requires `anthropic-version: 2023-06-01`; dated model ids (`claude-haiku-4-5-20251001`); `openai.embeddingModel(...)` (not `textEmbeddingModel`); Runware `google:4@2` fails via the SDK (use `bfl:5@1`/`runware:100@1`) + retry/fallback for transient errors.
- **Credits & cost-control** — the site owner is billed for all end-user usage; there's no per-visitor pool → the app must own a metering/quota layer.

Internal platform details (scope ids, permission-grant mechanics) are intentionally excluded — that gap is being solved centrally, and it's not public info for building headless apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)