### PR TITLE
🦞 igor-claw: fix wix-headless bootstrap.mjs Windows shell:false bug

### DIFF
--- a/skills/wix-headless/entry/bootstrap.mjs
+++ b/skills/wix-headless/entry/bootstrap.mjs
@@ -26,7 +26,7 @@ const AGENT_ENV = { ...process.env, AI_AGENT: process.env.AI_AGENT || 'wix-headl
 
 // run a command, capture stdout+stderr (combined), return {status, out}
 function capture(cmd, args, opts = {}) {
-  const r = spawnSync(cmd, args, { encoding: 'utf8', shell: false, env: AGENT_ENV, ...opts });
+  const r = spawnSync(cmd, args, { encoding: 'utf8', shell: isWin, env: AGENT_ENV, ...opts });
   return { status: r.status ?? 1, out: `${r.stdout || ''}${r.stderr || ''}`, error: r.error };
 }
 
@@ -43,7 +43,7 @@ function checkCli() {
 // ── 2. Login (human-in-the-loop device code; forward the CLI's own events) ───
 function login() {
   return new Promise((resolve) => {
-    const child = spawn(WIX[0], [...WIX.slice(1), 'login'], { shell: false, env: AGENT_ENV });
+    const child = spawn(WIX[0], [...WIX.slice(1), 'login'], { shell: isWin, env: AGENT_ENV });
     const rl = readline.createInterface({ input: child.stdout });
     let loggedIn = false;
     // Buffer the CLI's own diagnostics (stderr + any non-event stdout chatter) so a


### PR DESCRIPTION
## What's broken

`skills/wix-headless/entry/bootstrap.mjs` correctly detects Windows and renames the binary to `npx.cmd` (`bin()`, line 15), but both `spawnSync`/`spawn` calls that run it still hard-code `shell: false` (lines 29, 46).

## Root cause

On Windows, `.cmd`/`.bat` files are not native PE executables — `CreateProcess` can't launch them directly, only `cmd.exe` can. `child_process.spawn`/`spawnSync` with `shell: false` therefore fails to run `npx.cmd` (this is the well-known Node.js Windows gotcha that `cross-spawn` exists to work around). This hits on the very first thing the entry script runs — `checkCli()` (`// ── 1. CLI reachable`) — so the cold-start entry breaks immediately on native Windows shells, before login even starts.

## Fix

`shell: isWin` in both `capture()` and the `login()` spawn call. `WIX`'s args are all static/trusted (no user input interpolated), so enabling the shell only on Windows is safe and is the standard fix for this exact pattern.

---
Filed automatically from a research pass on reported headless friction. Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1783605340973999