### PR TITLE
🦞 igor-claw: add errorCode -100 to DEPLOYMENT.md transient-error list

### DIFF
--- a/skills/wix-headless/references/managed/DEPLOYMENT.md
+++ b/skills/wix-headless/references/managed/DEPLOYMENT.md
@@ -52,6 +52,6 @@ These two fixes are **Wix-hosting facts** — they apply to a connected **static
 
 ## Transient errors
 
-A release can hit transient infrastructure errors (`ECONNRESET`, `ETIMEDOUT`, `STATE_MISMATCH`, "try again shortly"). Retry the release serially up to **3×** with a short backoff. **Build failures are not retryable** — they're code bugs; fix the code, not the retry.
+A release can hit transient infrastructure errors (`ECONNRESET`, `ETIMEDOUT`, `STATE_MISMATCH`, `errorCode -100`, "try again shortly"). Retry the release serially up to **3×** with a short backoff. **Build failures are not retryable** — they're code bugs; fix the code, not the retry.
 
 That's the whole of finalize for `managed` — no `site-publisher` call, and no `oauth-app` **origin** PATCH (the origin is auto-registered). The **one** exception is the member-login callback on a non-Astro frontend above — that `allowedRedirectUris` PATCH is manual and required.


### PR DESCRIPTION
## What's broken

`wix release` hit a transient `errorCode -100` a few times in a live run (retry worked), but `managed/DEPLOYMENT.md`'s "Transient errors" section only enumerates `ECONNRESET`, `ETIMEDOUT`, `STATE_MISMATCH`, "try again shortly".

## Why it matters

The same section explicitly states build failures are **not** retryable (they're code bugs). An agent/dev hitting an unlisted `errorCode -100` has nothing to pattern-match it to the existing retry rule, and could misdiagnose it as a non-retryable build failure instead of retrying.

## Fix

One-line addition: list `errorCode -100` alongside the other transient symptoms so the retry rule triggers unambiguously.

---
Filed automatically from a research pass on reported headless friction. Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1783605340973999