### PR TITLE
🦞 igor-claw: note service.form._id all-zeros sentinel is normal in how-to-code-bookings.md

### DIFF
--- a/skills/wix-headless/references/inline-recipes/how-to-code-bookings.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-bookings.md
@@ -150,6 +150,8 @@ Docs: <https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-s
 
 The booking form is a `@wix/forms` form attached to the service at `service.form._id`. Render it **schema-driven** — never hardcode field names.
 
+**`service.form._id` can be the literal all-zeros sentinel `00000000-0000-0000-0000-000000000000`** on a default/unassigned booking form — confirmed live, this is the normal value for a fresh service, not a broken reference. `getFormSummary` still resolves fields for it; call it and trust the result regardless of the id's value.
+
 **⚠️ CRITICAL: use `getFormSummary`, NOT `getForm`.** `getForm` returns the full nested schema (`form.formFields[].inputOptions.stringOptions.componentType…`), and hand-parsing that deep shape is the #1 source of a **silently empty form** — when your guess at the nested path is wrong, the parse yields zero fields and the form renders no inputs (→ empty `formSubmission` → `createBooking` 400 `first_name must have required property`) or hangs on a "loading" state. Use the **flat** summary instead:
 
 ```js


### PR DESCRIPTION
## What's broken

`how-to-code-bookings.md`'s booking-form section documents the `getFormSummary(service.form._id)` flow but never mentions that `service.form._id` can come back as the all-zeros sentinel GUID (`00000000-0000-0000-0000-000000000000`) — which reads like a broken/unset reference.

## Root cause (reproduced live)

Querying services on a throwaway Bookings site returned `"form":{"id":"00000000-0000-0000-0000-000000000000"}` for a service with no custom form assigned — and `getFormSummary` still resolves its fields correctly for that id. It's the normal default value, not an error condition.

## Fix

One-line addition right before the `getFormSummary` guidance, clarifying the sentinel value is expected and that `getFormSummary` should still be trusted regardless.

---
Filed automatically from a research pass on reported headless friction. Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1783605340973999