### PR TITLE
🦞 igor-claw: clarify Catalog V1 stores scope + add missing Update Variants recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -285,5 +285,8 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Update Product Pre-Order](references/stores/update-product-pre-order.md)
 **Technical:** Manages pre-order settings for product variants using V3 Inventory API. Covers enabling/disabling pre-orders, setting messages, configuring limits, and handling trackQuantity requirements.
 
+### [Update Product Variants (Catalog V1)](references/stores/update-product-variants-catalog-v1.md)
+**Technical:** Update prices, costs, and other per-variant fields for a product using the Catalog V1 Update Variants endpoint. Use this recipe when the site's catalog version is CATALOG_V1.
+
 ### [Update Product with Options](references/stores/update-product-with-options.md)
 **Technical:** Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, variant-specific pricing, and revision-based updates to prevent conflicts.

--- a/skills/wix-manage/references/stores/create-product-catalog-v1.md
+++ b/skills/wix-manage/references/stores/create-product-catalog-v1.md
@@ -118,6 +118,7 @@ This is different from V3 which uses an array structure.
 - `productType` only supports `"physical"` via the API.
 - To add media to a product, use the separate **Add Product Media** endpoint after creation.
 - To query products on a V1 site, see [Query Products (Catalog V1)](query-products-catalog-v1.md).
+- **Required permission scope: `SCOPE.DC-STORES.MANAGE-PRODUCTS`** (Method Permissions: `WIX_STORES.MODIFY_PRODUCTS`). This is a distinct, legacy scope from `SCOPE.STORES.PRODUCT_WRITE`, which only applies to Catalog V3 write endpoints. If this call returns `403` with `"the auth identity is not allowed on this resource for this site/account"`, the caller is missing `SCOPE.DC-STORES.MANAGE-PRODUCTS` specifically — granting/re-checking `SCOPE.STORES.PRODUCT_WRITE` will not fix it. [Update Product Variants (Catalog V1)](update-product-variants-catalog-v1.md) requires the same scope.
 
 ## References
 

--- a/skills/wix-manage/references/stores/update-product-variants-catalog-v1.md
+++ b/skills/wix-manage/references/stores/update-product-variants-catalog-v1.md
@@ -1,0 +1,66 @@
+---
+name: "Update Product Variants (Catalog V1)"
+description: Update prices, costs, and other per-variant fields for a product using the Catalog V1 Update Variants endpoint. Use this recipe when the site's catalog version is CATALOG_V1.
+---
+# RECIPE: Business Recipe - Update Product Variants (Catalog V1)
+
+## STEP 1: Update Variants by Choices
+
+Use `PATCH https://www.wixapis.com/stores/v1/products/{id}/variants` to update one or more variants of a product that has `manageVariants: true`.
+
+Variants can be targeted either by their option `choices` or by `variantIds` — not both in the same variant entry.
+
+```bash
+curl -X PATCH \
+   'https://www.wixapis.com/stores/v1/products/1044e7e4-37d1-0705-c5b3-623baae212fd/variants' \
+   -H 'Content-Type: application/json' \
+   -H 'Authorization: <AUTH>' \
+   --data-binary '{
+     "variants": [
+       {
+         "choices": {
+           "Size": "S",
+           "Color": "Blue"
+         },
+         "price": 100
+       }
+     ]
+   }'
+```
+
+**Key fields (per variant entry):**
+
+| Field | Type | Notes |
+|---|---|---|
+| `choices` | object | Option name → choice value map, e.g. `{"Size": "S"}`. Use instead of `variantIds`. |
+| `variantIds` | array\<string\> | Variant GUIDs. Use instead of `choices`. |
+| `price` | number | Variant price. Range: 0–999999999.99 |
+| `cost` | number | Variant cost of goods. Range: 0–999999999.99 |
+
+## STEP 2: Update Variants by ID
+
+```bash
+curl -X PATCH \
+   'https://www.wixapis.com/stores/v1/products/1044e7e4-37d1-0705-c5b3-623baae212fd/variants' \
+   -H 'Content-Type: application/json' \
+   -H 'Authorization: <AUTH>' \
+   --data-binary '{
+     "variants": [
+       {
+         "variantIds": ["00000000-0000-0002-0005-918e4641acb0"],
+         "price": 89.99
+       }
+     ]
+   }'
+```
+
+## Important Notes
+
+- The product must have `manageVariants: true` — variants are auto-generated from `productOptions` when the product is created (see [Create Product (Catalog V1)](create-product-catalog-v1.md)).
+- **Never use `/stores/v3/` endpoints on a CATALOG_V1 site** — they return `428 Precondition Required`.
+- **Required permission scope: `SCOPE.DC-STORES.MANAGE-PRODUCTS`** (Method Permissions: `WIX_STORES.MODIFY_PRODUCTS`) — the same legacy scope required by V1 Create Product. This is **not** the same as `SCOPE.STORES.PRODUCT_WRITE`, which only applies to Catalog V3 endpoints (e.g. Bulk Update Product Variants By Filter). A `403` with `"the auth identity is not allowed on this resource for this site/account"` on this endpoint means `SCOPE.DC-STORES.MANAGE-PRODUCTS` is missing — reconnecting an OAuth/API integration does not grant a new scope; the app's registered permissions must include it.
+
+## References
+
+- [V1 Update Product Variants](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v1/catalog/update-product-variants)
+- [Catalog Versioning Overview](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-versioning/introduction)

--- a/yaml/wix-manage-evals/stores/create-product-catalog-v1-scope-diagnosis.yml
+++ b/yaml/wix-manage-evals/stores/create-product-catalog-v1-scope-diagnosis.yml
@@ -1,0 +1,33 @@
+name: stores/create-product-catalog-v1-scope-diagnosis
+description: >-
+  Verifies the agent reads the Create Product (Catalog V1) skill doc when
+  creating a product on a Catalog V1 site, and correctly names the required
+  OAuth permission scope when diagnosing a 403 error instead of confusing it
+  with the unrelated Catalog V3 scope.
+triggerPrompt: >-
+  My Wix site still uses the older Stores Catalog V1. I called
+  POST stores/v1/products to create a product and got a 403 error saying
+  "the auth identity is not allowed on this resource for this site/account".
+  What permission scope do I actually need for this call?
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/create-product-catalog-v1
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user describes a 403 "the auth identity is not allowed on this resource for this
+      site/account" error on POST stores/v1/products (Catalog V1) and asks what permission
+      scope is needed to fix it.
+      Intent: identify the correct OAuth/API permission scope required for Catalog V1 product
+      writes — SCOPE.DC-STORES.MANAGE-PRODUCTS — which is a distinct, legacy scope from
+      SCOPE.STORES.PRODUCT_WRITE (that scope only gates Catalog V3 endpoints).
+
+      Pass if the response names SCOPE.DC-STORES.MANAGE-PRODUCTS (or the WIX_STORES.MODIFY_PRODUCTS
+      permission) as the scope required for this V1 endpoint, and does not claim
+      SCOPE.STORES.PRODUCT_WRITE is the fix.
+
+      Fail if the response recommends SCOPE.STORES.PRODUCT_WRITE as the fix, doesn't name a
+      specific scope, or fabricates an unrelated scope name.

--- a/yaml/wix-manage-evals/stores/update-product-variants-catalog-v1.yml
+++ b/yaml/wix-manage-evals/stores/update-product-variants-catalog-v1.yml
@@ -1,0 +1,31 @@
+name: stores/update-product-variants-catalog-v1
+description: >-
+  Verifies the agent reads the Update Product Variants (Catalog V1) skill doc
+  when asked to update a variant's price on a Catalog V1 site, and uses the
+  correct V1 endpoint and request shape rather than a Catalog V3 one.
+triggerPrompt: >-
+  My Wix store is still on the older Stores Catalog V1. How do I update the
+  price of a specific product variant (for example the "Size: S" variant) via
+  the API?
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-variants-catalog-v1
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asks how to update a specific product variant's price on a Wix store that uses
+      Stores Catalog V1.
+      Intent: use the Catalog V1 Update Variants endpoint
+      (PATCH https://www.wixapis.com/stores/v1/products/{id}/variants) with the
+      choices/variantIds + price request shape.
+
+      Pass if the response references the V1 PATCH .../stores/v1/products/{id}/variants endpoint
+      (or names it "Update Variants"/"UpdateProductVariants") and shows targeting a variant via
+      `choices` (e.g. {"Size": "S"}) or `variantIds`, setting a `price` field.
+
+      Fail if the response recommends a Catalog V3 endpoint (e.g. stores/v3/products,
+      products-with-inventory, or bulk/products/update-variants-by-filter) for this V1 site, or
+      fabricates an unrelated API.

--- a/yaml/wix-manage/stores/documentation.yaml
+++ b/yaml/wix-manage/stores/documentation.yaml
@@ -30,6 +30,10 @@ apiDoc:
       title: Update Product Pre-Order (Catalog V3)
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
       tags: [stores]
+    - file: ../../../skills/wix-manage/references/stores/update-product-variants-catalog-v1.md
+      title: Update Product Variants (Catalog V1)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [stores]
     - file: ../../../skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
       title: Setup Online Store (Catalog V3)
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores


### PR DESCRIPTION
## Summary
- Reported feedback: user hit persistent `403 Forbidden` ("the auth identity is not allowed on this resource for this site/account") on `CreateProduct` (`stores/v1/products`) and `UpdateProductVariants` on a Catalog V1 site, and assumed the missing scope was `SCOPE.STORES.PRODUCT_WRITE`. Disconnect/reconnect of the Wix MCP connector did not help.
- Per the official method docs, both V1 endpoints actually require **`SCOPE.DC-STORES.MANAGE-PRODUCTS`** — a distinct, legacy scope from `SCOPE.STORES.PRODUCT_WRITE`, which only applies to Catalog **V3** write endpoints. Reconnecting the OAuth connector can't fix this: the scope comes from the app's registered Dev Center permissions, not anything the user/session controls.
- `create-product-catalog-v1.md` had no mention of required scopes at all, and there was no recipe at all for `Update Product Variants (Catalog V1)` — so an agent working this issue via the skill index had nothing pointing it at the right scope name, which is exactly how the misdiagnosis in the report happened.

## Changes
- `skills/wix-manage/references/stores/create-product-catalog-v1.md`: added an explicit note on the required `SCOPE.DC-STORES.MANAGE-PRODUCTS` scope and the V1/V3 scope-name mismatch.
- `skills/wix-manage/references/stores/update-product-variants-catalog-v1.md`: new recipe (didn't exist before) covering `PATCH /stores/v1/products/{id}/variants`, including the same scope note.
- Registered the new recipe in `skills/wix-manage/SKILL.md` and `yaml/wix-manage/stores/documentation.yaml`, following the existing registration pattern used by the other V1/V3 stores recipes.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1783770746605679
Opened automatically in response to that feedback thread.

(Supersedes wix-private/igor-tools#1448, closed — the recipe content moved to this repo.)

## Test plan
- [ ] `skills/wix-manage/SKILL.md` surfaces "Update Product Variants (Catalog V1)" under the Stores section
- [ ] `yaml/wix-manage/stores/documentation.yaml` entry resolves correctly for the EvalForge YAML gate