### PR TITLE
🦞 igor-claw: fix dangling doc reference in bookings image-attach step

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-bookings.md
+++ b/skills/wix-headless/references/inline-recipes/setup-bookings.md
@@ -189,7 +189,7 @@ Keep each session's event id — it's `results[].itemMetadata.id` (the events bu
 
 **Only when `imagery` is on** (`SEED.md` § "Entity images"). This is the bookings entry in the required pass-2 "attach the image to the entity" flow — the service was created text-only in STEP 3; now write the image onto it. Obtain the image per `references/IMAGE_GENERATION.md` (generate + import, or import an existing URL) → keep `file.url` and its `file.id`, then patch the service.
 
-**The image is written under `media.mainMedia` and `media.coverMedia`, each `{ "image": { "id", "url", "width", "height" } }`.** Per the Services V2 reference (`references/bookings/create-and-update-booking-services.md`): `media.mainMedia` is shown in the services list, `media.coverMedia` on the service page, and `media.items[]` is the service-page gallery. The binding field is the image **`id`** (the Wix Media file id); `url` and dimensions are descriptive. Write shape:
+**The image is written under `media.mainMedia` and `media.coverMedia`, each `{ "image": { "id", "url", "width", "height" } }`.** Per the [Services V2 reference](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-and-update-booking-services): `media.mainMedia` is shown in the services list, `media.coverMedia` on the service page, and `media.items[]` is the service-page gallery. The binding field is the image **`id`** (the Wix Media file id); `url` and dimensions are descriptive. Write shape:
 
 ```json
 {


### PR DESCRIPTION
## What's broken

`wix-headless/references/inline-recipes/setup-bookings.md` (Attach images step) cites a local file `references/bookings/create-and-update-booking-services.md` that doesn't exist anywhere in the repo. A full sweep of every `references/*.md` link in the `wix-headless` skill confirms this is the *only* dangling reference in the whole skill.

## Root cause

The guidance actually lives in the live Wix docs "skills" article at the same name (`https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-and-update-booking-services`), not in this repo. The local-path citation was presumably meant to be a link to that live doc and was never updated when it was written as a bare backtick path.

## Fix

Point the citation at the live docs URL instead of the nonexistent local path.

## Context

Found while researching a headless-feedback report about Bookings service-image attach (Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1783531962091489). The report's actual complaints — a PATCH that 200s but silently drops `media.image`/`media.mainMedia.id`, and `mainMedia.image` being a `wix:image://…` URI rather than a bare URL — are already fixed in this repo as of #563 (merged 2026-07-09, one day after the report) and in the live docs article itself. This PR only cleans up the one remaining loose end (the dangling reference) from that same section.

Opened automatically.