### PR TITLE
🦞 igor-claw: fix categories package + searchProducts response key in store recipe

### DIFF
--- a/skills/wix-headless/references/inline-recipes/how-to-code-a-store.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-a-store.md
@@ -23,7 +23,7 @@ A concise contract for writing the **frontend code** of a storefront against a C
 |---|---|---|
 | Products (list, get, search, filter) | `@wix/stores` | `productsV3` |
 | Variants (to resolve `variantId`) | `@wix/stores` | `readOnlyVariantsV3` |
-| Categories | `@wix/stores` | `categories` |
+| Categories | `@wix/categories` | `categories` |
 | Cart (add / get / checkout) | `@wix/ecom` | `currentCart` |
 | Redirect to hosted checkout | `@wix/redirects` | `redirects` |
 
@@ -52,7 +52,7 @@ A concise contract for writing the **frontend code** of a storefront against a C
 The exact field paths the storefront reads, and the **plausible-wrong sibling** each is mistaken for — the sections below reference these instead of re-describing them. All `amount`s are **strings**. These are **read** shapes; the cart-add body (under *Adding to cart*) is a separate **write** shape, and the `_id` rule applies to read **entities**, not to method-return wrappers (note `checkoutId`).
 
 ```jsonc
-// productsV3.queryProducts() / .searchProducts()  →  result.items[]
+// productsV3.queryProducts()  →  result.items[]   ⚠️ .searchProducts() is DIFFERENT — result.products[], NOT .items (see below)
 product = {
   _id,                                            // links · cart catalogItemId · variant filter   (NOT .id → empty → HTTP 500)
   slug, name, visible,                            // only visible:true is returned to a visitor token
@@ -119,11 +119,12 @@ const res = await categories.queryCategories({
 **⚠️ CRITICAL: category filtering MUST use `searchProducts`, NOT `queryProducts`.** `directCategoriesInfo.categories` is **not declared as filterable in `queryProducts`** — passing it there returns HTTP `400 "... is not declared as filterable"`, which the SDK **swallows silently**, leaving an empty category page that looks like "no products". This is the #1 way this breaks. Use Search Products:
 
 ```js
-const { items } = await productsV3.searchProducts({
+const { products } = await productsV3.searchProducts({
   filter: { 'directCategoriesInfo.categories': { $matchItems: [{ id: categoryId }] } },
 });
 ```
 
+- **⚠️ `searchProducts()` returns `{ products, pagingMetadata }` — NOT `{ items }`.** Unlike `queryProducts()` (a query-builder result that exposes `.items[]`), `searchProducts()` is a plain RPC call whose response is REST-shaped: the array is `result.products`. Destructuring `{ items }` from it (an easy copy-paste from the `queryProducts` pattern above) silently yields `items === undefined` — no error, just an empty-looking category page. Verified live against Catalog V3.
 - **`categoryId`** is the stable id from the live `categories.queryCategories()` result above (a category's `_id`) — read it from the render context, never a hardcoded seed-time id list.
 - **Method:** `searchProducts`, never `queryProducts` (the field is only filterable in search).
 - **Operator:** `$matchItems`, never `$hasSome` (the natural-looking guess returns nothing).


### PR DESCRIPTION
## What's broken

`how-to-code-a-store.md` has two verified-live bugs in its Catalog V3 category-read guidance:

1. **Module table lists the wrong package for Categories.** It says `@wix/stores`, but `@wix/stores` does not export a `categories` module — confirmed via `Object.keys(require('@wix/stores'))`, which has no `categories` key. Categories are a separate package, `@wix/categories`. The table contradicts the file's own code sample two sections later, which already (correctly) imports `categories` from `@wix/categories`.
2. **The category-filtering code sample destructures the wrong key.** `const { items } = await productsV3.searchProducts(...)` — but `searchProducts()` returns `{ products, pagingMetadata }`, not `{ items }`. Verified live via both raw REST (`POST /stores/v3/products/search`) and the `@wix/stores` SDK — both return the array under `products`. `items` comes back `undefined`, with no error, producing exactly the "category page looks empty" trap this file warns about elsewhere. (`queryProducts().find()` *does* return `.items` via a getter, which is why copying that pattern into `searchProducts` is an easy mistake.)

## Fix

- Module table: `Categories | @wix/categories | categories`.
- Code sample + cheat-sheet: destructure `products` from `searchProducts()`, with an explicit callout that `queryProducts` and `searchProducts` have different response shapes.

---
Filed automatically from a research pass on reported headless friction. Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1783605340949339