### PR TITLE
fix(wix-manage): country support + ToS link fix for Wix Payments connect

### DIFF
--- a/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
+++ b/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
@@ -14,8 +14,15 @@ Before connecting Wix Payments, collect and confirm:
 2. First name
 3. Last name
 4. Product/service description (minimum meaningful business description)
+5. The site's country — if not already known, get it from `properties.locale.country` via `GET https://www.wixapis.com/site-properties/v4/properties`
 
-## Step 2: Connect Wix Payments account
+## Step 2: Check country support
+
+Wix Payments self-serve connect is currently supported for these countries: `US, CA, GB, ES, AT, BE, FI, DE, IT, NL, PT, CH, LT`.
+
+If the site's country is not on this list, stop here — do not call connect. Tell the user self-serve connect isn't available yet for their country, and point them to the dashboard instead (Settings → Accept Payments).
+
+## Step 3: Connect Wix Payments account
 
 Call:
 
@@ -27,12 +34,13 @@ Call:
     "firstName": "<USER_FIRST_NAME>",
     "lastName": "<USER_LAST_NAME>",
     "tosAccepted": true,
-    "productDescription": "<PRODUCT_DESCRIPTION>"
+    "productDescription": "<PRODUCT_DESCRIPTION>",
+    "country": "<COUNTRY_CODE verified in Step 2>"
   }
 }
 ```
 
-## Step 3: Handle common setup blockers
+## Step 4: Handle common setup blockers
 
 ### Location-related failure
 
@@ -43,15 +51,30 @@ If setup fails due to location details, update the business location and retry:
 
 ### Already connected
 
-If the API returns an "already connected" style response, skip reconnect and continue with onboarding checks.
+If the account is already connected, the API returns `HTTP 500` with a body like:
 
-## Step 4: Complete dashboard onboarding
+```json
+{
+  "message": "payments already connected",
+  "details": { "applicationError": { "code": "INTERNAL_ERROR" } }
+}
+```
+
+Match on the `message` text, not on the `code` alone — `INTERNAL_ERROR` is a generic code reused for unrelated failures too. On this match, skip reconnect and continue with onboarding checks.
+
+### Unsupported country
+
+If `account.country` isn't one of the countries listed in Step 2, expect an `INVALID_ARGUMENT`-style `HTTP 400` error. Step 2's own check should make hitting this rare — don't retry the call with a different country value; tell the user the same thing Step 2 would have.
+
+## Step 5: Complete dashboard onboarding
 
 Connecting the account is not always the final step. To receive payments, the site owner may still need to complete Wix Payments onboarding in the site dashboard.
+
+Connecting Wix Payments and being able to accept real checkout payments are two separate gates: the site may also need a premium eCommerce plan (Settings → Plans). Mention this even after a successful connect.
 
 ## Important Notes
 
 1. Never invent or assume user identity/business details.
-2. Always obtain explicit user consent before calling connect.
+2. Always obtain explicit user consent before calling connect — this creates a real Wix Payments account and records a legally-binding Terms of Service acceptance under the name provided.
 3. Use the exact accepted values provided by the user.
 4. Verify readiness by testing a real payment flow (for example, create payment link) after setup.

--- a/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
+++ b/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
@@ -10,7 +10,7 @@ This recipe covers the setup flow needed before creating payment links or collec
 
 Before connecting Wix Payments, collect and confirm:
 
-1. Terms acceptance: https://www.wix.com/about/terms-of-payments
+1. Terms acceptance: https://support.wix.com/en/article/wix-payments-terms-of-service
 2. First name
 3. Last name
 4. Product/service description (minimum meaningful business description)
@@ -19,7 +19,7 @@ Before connecting Wix Payments, collect and confirm:
 
 Call:
 
-- `POST https://www.wixapis.com/payments/v1/wix-payments-account/connect`
+- `POST https://www.wixapis.com/payments/mcp/v1/wix-payments-account/connect`
 
 ```json
 {

--- a/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
+++ b/skills/wix-manage/references/get-paid/how-to-setup-wix-payments.md
@@ -26,7 +26,7 @@ If the site's country is not on this list, stop here — do not call connect. Te
 
 Call:
 
-- `POST https://www.wixapis.com/payments/mcp/v1/wix-payments-account/connect`
+- `POST https://www.wixapis.com/payments/v1/wix-payments-account/connect`
 
 ```json
 {

--- a/yaml/wix-manage-evals/get-paid/how-to-setup-wix-payments.yml
+++ b/yaml/wix-manage-evals/get-paid/how-to-setup-wix-payments.yml
@@ -15,10 +15,10 @@ assertions:
 
       Pass if the response:
       - asks for (or confirms it has) the site owner's first name, last name, a product/service description, and terms-of-service acceptance before calling connect, AND
-      - if it states the connect endpoint, uses `POST https://www.wixapis.com/payments/mcp/v1/wix-payments-account/connect` (not `/payments/v1/wix-payments-account/connect`), AND
+      - if it states the connect endpoint, uses `POST https://www.wixapis.com/payments/v1/wix-payments-account/connect`, AND
       - obtains or explicitly asks for the user's consent before making the mutating connect call.
 
       Fail if the response:
       - fabricates the user's name/business details instead of asking, OR
-      - calls or states the connect endpoint as `/payments/v1/wix-payments-account/connect` (the stale, incorrect path), OR
+      - calls or states the connect endpoint with a different path (e.g. `/payments/mcp/v1/wix-payments-account/connect`), OR
       - connects without any indication of explicit user consent.

--- a/yaml/wix-manage-evals/get-paid/how-to-setup-wix-payments.yml
+++ b/yaml/wix-manage-evals/get-paid/how-to-setup-wix-payments.yml
@@ -1,0 +1,24 @@
+name: get-paid/how-to-setup-wix-payments
+description: Verifies the agent reads the how-to-setup-wix-payments skill and connects a Wix Payments account against the correct endpoint after collecting the required inputs and explicit consent.
+triggerPrompt: I want to start accepting payments on my Wix site. Can you connect Wix Payments for me?
+tags: [get-paid]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/how-to-setup-wix-payments
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request: "I want to start accepting payments on my Wix site. Can you connect Wix Payments for me?"
+      Intent: connect a Wix Payments account for the site using the how-to-setup-wix-payments skill.
+
+      Pass if the response:
+      - asks for (or confirms it has) the site owner's first name, last name, a product/service description, and terms-of-service acceptance before calling connect, AND
+      - if it states the connect endpoint, uses `POST https://www.wixapis.com/payments/mcp/v1/wix-payments-account/connect` (not `/payments/v1/wix-payments-account/connect`), AND
+      - obtains or explicitly asks for the user's consent before making the mutating connect call.
+
+      Fail if the response:
+      - fabricates the user's name/business details instead of asking, OR
+      - calls or states the connect endpoint as `/payments/v1/wix-payments-account/connect` (the stale, incorrect path), OR
+      - connects without any indication of explicit user consent.


### PR DESCRIPTION
The recipe's linked ToS page (`www.wix.com/about/terms-of-payments`) was stale; swapped for the confirmed-live support article. Also adds country support: collect the site's country, check it against the connect endpoint's supported-country list before calling, and pass `account.country` in the request. Documents the confirmed "already connected" error shape (match on `message`, not the generic `INTERNAL_ERROR` code) and the expected unsupported-country shape, plus a note that connecting payments and accepting real checkout payments are two separate gates (premium eCommerce plan). Added the required eval scenario for get-paid coverage.

(Earlier revisions of this PR also changed the connect endpoint to `/payments/mcp/v1/...`, based on a mistaken belief that `/payments/v1/...` 404s on the live gateway. That was wrong — `/payments/v1/wix-payments-account/connect` is the correct, canonical path per dev.wix.com's own docs and the SDK's routing config, confirmed via live MCP calls. Reverted; this PR no longer touches the endpoint.)
