### PR TITLE
wix-vibe-headless: cross-ref members from bookings/blog/restaurants/cms

### DIFF
--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -98,9 +98,11 @@ body in the **official Wix API reference** first; never guess:
   https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
 - Rendering `richContent` (Ricos document format):
   https://dev.wix.com/docs/ricos/api-reference/ricos-document
-- **Member-gated surfaces** (comments, likes, members-only posts) → the **members** vertical
-  (`references/members/INSTRUCTIONS.md`): those actions need a logged-in member, so wire custom
-  login on your own UI (email+password / Google / Facebook) before gating them.
+- **Members-only posts** → the **members** vertical (`references/members/INSTRUCTIONS.md`): once a
+  member is logged in (custom login on your own UI), the existing read helpers return the content
+  gated to members — no extra code. Note this blog helper is **read-only**: member *writes* (posting
+  a comment, liking a post) aren't included — add them as a beyond-the-snippets `wixApiRequest` call,
+  authenticated as the logged-in member.
 - Each helper in `wix-blog.js` links its exact reference page inline.
 
 Keep the snippets as the default for everything they already do; reach for the API

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -98,6 +98,9 @@ body in the **official Wix API reference** first; never guess:
   https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
 - Rendering `richContent` (Ricos document format):
   https://dev.wix.com/docs/ricos/api-reference/ricos-document
+- **Member-gated surfaces** (comments, likes, members-only posts) → the **members** vertical
+  (`references/members/INSTRUCTIONS.md`): those actions need a logged-in member, so wire custom
+  login on your own UI (email+password / Google / Facebook) before gating them.
 - Each helper in `wix-blog.js` links its exact reference page inline.
 
 Keep the snippets as the default for everything they already do; reach for the API

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -125,6 +125,9 @@ exact endpoint, method, and body in the **official Wix API reference** first (ne
 - **Add-ons:** https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/list-add-on-groups-by-service-id.md
 - **Custom booking form fields** (render `service.form.id`): Get Form Summary —
   https://dev.wix.com/docs/rest/crm/forms/form-schemas/get-form-summary.md
+- **Member login + a "my bookings" account view** → the **members** vertical
+  (`references/members/INSTRUCTIONS.md`): booking itself works anonymously, but signing a member in
+  (custom login on your own UI) lets them see their own appointments/history.
 
 Keep the snippets as the default for everything they already do; reach for the API reference
 only for the gap.

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -113,6 +113,15 @@ remove). If you hit a use case they don't cover, make the call yourself with
   Data Items — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-referenced-data-items.md
 - **Collection schema / field keys & types**: Get Data Collection —
   https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/get-data-collection.md
+- **Member-gated & user-generated content** → the **members** vertical
+  (`references/members/INSTRUCTIONS.md`). A collection whose permissions are `read: Anyone`,
+  `insert: Site Member`, `update/remove: Site Member Author` gives you the classic pattern: anyone
+  reads, only logged-in members write, and each member edits only their own. Sign the member in with
+  custom login (on your own UI), then `insertDataItem` runs as the member and Wix stamps the item's
+  `_owner` automatically — so a **"my items"** view is just
+  `queryDataItems(collectionId, { filter: { _owner: <memberId> } })`, and author-only
+  `updateDataItem`/`removeDataItem` are enforced server-side. (This skill never provisions the
+  collection — the owner creates it with those permissions in the dashboard.)
 
 Keep the snippets as the default for everything they already do; reach for the API
 reference only for the gap.

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -110,6 +110,9 @@ request body in the **official Wix API reference** first; never guess:
   https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
 - Fulfillment methods, delivery-address validation, scheduled (preorder) time slots, service fees:
   see the Online Orders section of the reference.
+- **Member login + a "my orders" account view** → the **members** vertical
+  (`references/members/INSTRUCTIONS.md`): ordering/reserving works anonymously, but signing a member
+  in (custom login on your own UI) lets them see their own order/reservation history.
 
 Keep the snippets as the default for everything they already do; reach for the API reference only
 for the gap.


### PR DESCRIPTION
## What & why

Follow-up to #591. That PR added the `members` (custom-login) vertical but only cross-referenced it from **pricing-plans** (hard login dependency) plus one-liners in **storefront** and **events** — leaving **bookings, blog, restaurants, and cms** without a pointer, even though each has a member-relevant surface. This evens it out.

## Changes (docs-only, no code/behavior change)

Same light "for the logged-in account view / gated action, use the **members** vertical" pointer added to each "Beyond the snippets" list:

- **bookings** → "my bookings" account view
- **blog** → member-gated surfaces (comments, likes, members-only posts)
- **restaurants** → "my orders" account view
- **cms** → member-gated **and user-generated** content — the `read: Anyone` / `insert: Site Member` / `update/remove: Site Member Author` pattern, noting Wix stamps `_owner` so a "my items" view is just `queryDataItems(collectionId, { filter: { _owner } })` (the pattern the canvas-gallery demo used).

pricing-plans stays the fullest treatment (it's the only vertical where login is *required*); the rest are soft — the base action works anonymously, only the account/gated view needs a member. portfolio is left alone (public showcase, no member surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)