### PR TITLE
wix-vibe-headless: prefer Wix per feature + copy helpers verbatim (don't split backends / rewrite internals)

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -49,17 +49,19 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   On success it writes the member's tokens into the *same* store the visitor token used
   (`setSessionTokens`), so **every subsequent `wixApiRequest` runs as the member** and the cart/session
   carries over. "My …" surfaces (plans, orders, bookings, registrations) light up only once logged in.
-- **⚠️ Wix is the single source of truth — do NOT use the host platform's own backend/auth for
-  Wix-backed data.** When the front end is built on a platform that ships its *own* backend (Base44
-  entities, Supabase tables, Firebase, a Next.js API, etc.), it's tempting to store Wix-related data
-  there. Don't. Anything conceptually owned by the Wix site — products, orders, members, and
-  member-generated content like likes/reviews/submissions — lives in **Wix**, reached through these
-  helpers (`wix-cms.js`, `wix-members-auth.js`, …). Concretely: **do not create a parallel host entity
-  or table for it**, **member identity is the Wix member** (`getCurrentMember()` / the Wix member
-  token — never the host's auth session or user id), and **row ownership is Wix's server-stamped
-  `_owner`** (never a hand-stored, client-supplied member id — that's spoofable, and it won't match
-  the host's session). Mixing the two backends yields split-brain data (e.g. "likes" saved to the host
-  DB that never appear in the Wix collection). One store, one identity: Wix.
+- **Prefer Wix for anything backed by the Wix site — and keep one backend + one identity per feature.**
+  The front end may live on a platform with its own backend and auth (Base44 entities, Supabase,
+  Firebase, a Next.js API, …), and using that for the app's *own* data is perfectly fine. But when a
+  feature is meant to live on the user's **Wix** site — products, orders, members, and
+  member-generated content (likes, reviews, submissions) — reach for these Wix helpers
+  (`wix-cms.js`, `wix-members-auth.js`, …) rather than the host's store. **Especially for auth:** if
+  the user wants Wix members (they gave you a `WIX_CLIENT_ID`), log them in as a **Wix member** via
+  the `members` vertical — don't substitute the host platform's own login. The thing to avoid is
+  *splitting a single feature across both* — e.g. storing "likes" in the host DB but identifying the
+  member by the Wix session (or vice-versa): the host's user id won't match the Wix member, so
+  ownership filters miss and the data never lands where the rest of the Wix content is. Per feature:
+  one backend, one identity. For Wix-backed member rows, ownership is Wix's server-stamped `_owner`
+  (not a hand-stored id).
 - **Never mock, never provision.** These scaffolds are read-only over the owner's content. The
   owner adds products/posts/services/events/menus/plans in the **Wix dashboard**. If a
   collection is empty, show the empty state — never fabricate data, reviews, ratings, or counts.

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -66,6 +66,11 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   redirect-session / Wix-hosted form — **never hand-build a `/checkout` or purchase URL**.
 - **Fail loudly.** The helpers throw on out-of-stock, empty carts, unbookable slots, expired
   holds, and payment-still-owed. A green path means it really worked — don't swallow the error.
+- **Copy the shipped helpers as-is — don't rewrite their internals.** Wire your UI to the *exported*
+  functions; don't "refactor" or reimplement the helper bodies. Several Wix request shapes are exact
+  and easy to break (the members `createRedirectSession` body is the classic trap — a rewritten
+  version returns 400 and login dies). Extend by *calling* the exports or adding a new
+  `wixApiRequest` call for a genuine gap — never by editing the shipped ones.
 - **Beyond the snippets, look it up — never guess.** The templates and the shipped
   `references/<vertical>/` helpers are the implementation — build from them first. When you hit a
   genuine gap (a field, an endpoint, or an error the snippets don't cover), extend the client with

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -49,6 +49,17 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   On success it writes the member's tokens into the *same* store the visitor token used
   (`setSessionTokens`), so **every subsequent `wixApiRequest` runs as the member** and the cart/session
   carries over. "My …" surfaces (plans, orders, bookings, registrations) light up only once logged in.
+- **⚠️ Wix is the single source of truth — do NOT use the host platform's own backend/auth for
+  Wix-backed data.** When the front end is built on a platform that ships its *own* backend (Base44
+  entities, Supabase tables, Firebase, a Next.js API, etc.), it's tempting to store Wix-related data
+  there. Don't. Anything conceptually owned by the Wix site — products, orders, members, and
+  member-generated content like likes/reviews/submissions — lives in **Wix**, reached through these
+  helpers (`wix-cms.js`, `wix-members-auth.js`, …). Concretely: **do not create a parallel host entity
+  or table for it**, **member identity is the Wix member** (`getCurrentMember()` / the Wix member
+  token — never the host's auth session or user id), and **row ownership is Wix's server-stamped
+  `_owner`** (never a hand-stored, client-supplied member id — that's spoofable, and it won't match
+  the host's session). Mixing the two backends yields split-brain data (e.g. "likes" saved to the host
+  DB that never appear in the Wix collection). One store, one identity: Wix.
 - **Never mock, never provision.** These scaffolds are read-only over the owner's content. The
   owner adds products/posts/services/events/menus/plans in the **Wix dashboard**. If a
   collection is empty, show the empty state — never fabricate data, reviews, ratings, or counts.

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -49,16 +49,20 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   On success it writes the member's tokens into the *same* store the visitor token used
   (`setSessionTokens`), so **every subsequent `wixApiRequest` runs as the member** and the cart/session
   carries over. "My …" surfaces (plans, orders, bookings, registrations) light up only once logged in.
-- **Prefer Wix for anything backed by the Wix site — keep one data store and one identity per feature.**
-  When a feature is meant to live on the user's **Wix** site — products, orders, members, and
-  member-generated content (likes, reviews, submissions) — reach for these Wix helpers
-  (`wix-cms.js`, `wix-members-auth.js`, …). **Especially for auth:** when the user wants Wix members
-  (they gave you a `WIX_CLIENT_ID`), log them in as a **Wix member** via the `members` vertical. If
-  the project also has another data or auth layer around, the thing to avoid is *splitting one
-  feature across it* — storing a row in one place but identifying the member from the Wix session (or
-  vice-versa): the ids won't match, ownership filters miss, and the data won't sit with the rest of
-  the Wix content. Per feature: one store, one identity. For Wix-backed member rows, ownership is
-  Wix's server-stamped `_owner` (not a hand-stored id).
+- **⚠️ Once you're building on Wix, keep it on Wix — auth, member data, and other business features
+  too.** If you're wiring a Wix storefront/blog/etc. over `WIX_CLIENT_ID`, prefer Wix for the *rest*
+  of the app as well, rather than reaching for a host platform's own backend or login. **Especially
+  for auth:** when the user wants members, log them in as a **Wix member** (`members` vertical) — don't
+  bolt on the host platform's auth. Likewise, member-generated content (likes, reviews, submissions,
+  "my …" lists) goes in a **Wix CMS collection** (`cms` vertical), not a host database.
+  - **The split-brain trap:** the most common failure is mixing the two — e.g. storing "likes" in the
+    host's DB while identifying the member from the Wix session (or logging in with Wix members but
+    keying data on a host user id). The two identities never match, ownership filters silently return
+    nothing (a like vanishes on refresh), and the data never sits with the rest of the Wix content.
+  - **Rule of thumb:** one store and one identity per feature. For a Wix-backed feature that's the Wix
+    member + the Wix collection, with ownership on Wix's server-stamped `_owner` (never a hand-stored
+    or host-supplied member id). Using a host backend for genuinely host-only data is fine — just
+    never straddle a single feature across both.
 - **Never mock, never provision.** These scaffolds are read-only over the owner's content. The
   owner adds products/posts/services/events/menus/plans in the **Wix dashboard**. If a
   collection is empty, show the empty state — never fabricate data, reviews, ratings, or counts.

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -49,19 +49,16 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   On success it writes the member's tokens into the *same* store the visitor token used
   (`setSessionTokens`), so **every subsequent `wixApiRequest` runs as the member** and the cart/session
   carries over. "My …" surfaces (plans, orders, bookings, registrations) light up only once logged in.
-- **Prefer Wix for anything backed by the Wix site — and keep one backend + one identity per feature.**
-  The front end may live on a platform with its own backend and auth (Base44 entities, Supabase,
-  Firebase, a Next.js API, …), and using that for the app's *own* data is perfectly fine. But when a
-  feature is meant to live on the user's **Wix** site — products, orders, members, and
+- **Prefer Wix for anything backed by the Wix site — keep one data store and one identity per feature.**
+  When a feature is meant to live on the user's **Wix** site — products, orders, members, and
   member-generated content (likes, reviews, submissions) — reach for these Wix helpers
-  (`wix-cms.js`, `wix-members-auth.js`, …) rather than the host's store. **Especially for auth:** if
-  the user wants Wix members (they gave you a `WIX_CLIENT_ID`), log them in as a **Wix member** via
-  the `members` vertical — don't substitute the host platform's own login. The thing to avoid is
-  *splitting a single feature across both* — e.g. storing "likes" in the host DB but identifying the
-  member by the Wix session (or vice-versa): the host's user id won't match the Wix member, so
-  ownership filters miss and the data never lands where the rest of the Wix content is. Per feature:
-  one backend, one identity. For Wix-backed member rows, ownership is Wix's server-stamped `_owner`
-  (not a hand-stored id).
+  (`wix-cms.js`, `wix-members-auth.js`, …). **Especially for auth:** when the user wants Wix members
+  (they gave you a `WIX_CLIENT_ID`), log them in as a **Wix member** via the `members` vertical. If
+  the project also has another data or auth layer around, the thing to avoid is *splitting one
+  feature across it* — storing a row in one place but identifying the member from the Wix session (or
+  vice-versa): the ids won't match, ownership filters miss, and the data won't sit with the rest of
+  the Wix content. Per feature: one store, one identity. For Wix-backed member rows, ownership is
+  Wix's server-stamped `_owner` (not a hand-stored id).
 - **Never mock, never provision.** These scaffolds are read-only over the owner's content. The
   owner adds products/posts/services/events/menus/plans in the **Wix dashboard**. If a
   collection is empty, show the empty state — never fabricate data, reviews, ratings, or counts.

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -122,11 +122,13 @@ remove). If you hit a use case they don't cover, make the call yourself with
   `queryDataItems(collectionId, { filter: { _owner: <memberId> } })`, and author-only
   `updateDataItem`/`removeDataItem` are enforced server-side. (This skill never provisions the
   collection — the owner creates it with those permissions in the dashboard.)
-  **⚠️ Put this in Wix, not the host platform's backend.** If your front end is on Base44 /
-  Supabase / Firebase / etc., do **not** store member-generated content (likes, reviews, submissions)
-  in a host entity/table — it belongs in a Wix collection via these helpers, keyed on the Wix member's
-  server-stamped `_owner`. Do **not** filter by a host `created_by`/user id or a hand-stored member
-  id (it won't match the Wix member session, and it's spoofable). One store, one identity: Wix.
+  **Prefer Wix for member-generated content, and don't split one feature across two backends.** If
+  your front end is on Base44 / Supabase / Firebase / etc., using the host DB for its own app data is
+  fine — but content that belongs to the Wix site (likes, reviews, submissions) is best kept in a Wix
+  collection via these helpers, keyed on the Wix member's server-stamped `_owner`. What breaks is a
+  *split* feature — storing the row in a host table while identifying the member by the Wix session
+  (or filtering by a host `created_by`/user id): the two ids won't match, so ownership filters miss.
+  Keep a given feature's data and identity on one side; for Wix-backed rows that's `_owner`.
 
 Keep the snippets as the default for everything they already do; reach for the API
 reference only for the gap.

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -122,13 +122,12 @@ remove). If you hit a use case they don't cover, make the call yourself with
   `queryDataItems(collectionId, { filter: { _owner: <memberId> } })`, and author-only
   `updateDataItem`/`removeDataItem` are enforced server-side. (This skill never provisions the
   collection — the owner creates it with those permissions in the dashboard.)
-  **Prefer Wix for member-generated content, and don't split one feature across two backends.** If
-  your front end is on Base44 / Supabase / Firebase / etc., using the host DB for its own app data is
-  fine — but content that belongs to the Wix site (likes, reviews, submissions) is best kept in a Wix
-  collection via these helpers, keyed on the Wix member's server-stamped `_owner`. What breaks is a
-  *split* feature — storing the row in a host table while identifying the member by the Wix session
-  (or filtering by a host `created_by`/user id): the two ids won't match, so ownership filters miss.
-  Keep a given feature's data and identity on one side; for Wix-backed rows that's `_owner`.
+  **Prefer Wix for member-generated content, and keep one feature's data and identity together.**
+  Content that belongs to the Wix site (likes, reviews, submissions) is best kept in a Wix collection
+  via these helpers, keyed on the Wix member's server-stamped `_owner`. What breaks is a *split*
+  feature — the row stored in one place while the member is identified from the Wix session elsewhere
+  (or filtered by some other `created_by`/user id): the two ids won't match, so ownership filters
+  miss. Keep them on one side; for Wix-backed rows that's `_owner`.
 
 Keep the snippets as the default for everything they already do; reach for the API
 reference only for the gap.

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -122,6 +122,11 @@ remove). If you hit a use case they don't cover, make the call yourself with
   `queryDataItems(collectionId, { filter: { _owner: <memberId> } })`, and author-only
   `updateDataItem`/`removeDataItem` are enforced server-side. (This skill never provisions the
   collection — the owner creates it with those permissions in the dashboard.)
+  **⚠️ Put this in Wix, not the host platform's backend.** If your front end is on Base44 /
+  Supabase / Firebase / etc., do **not** store member-generated content (likes, reviews, submissions)
+  in a host entity/table — it belongs in a Wix collection via these helpers, keyed on the Wix member's
+  server-stamped `_owner`. Do **not** filter by a host `created_by`/user id or a hand-stored member
+  id (it won't match the Wix member session, and it's spoofable). One store, one identity: Wix.
 
 Keep the snippets as the default for everything they already do; reach for the API
 reference only for the gap.

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -80,6 +80,12 @@ Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIEN
 The full state-machine, `profile`, and error semantics are documented as JSDoc at the top of
 `wix-members-auth.js`. **Read it before wiring the UI.**
 
+> **⚠️ Copy `wix-members-auth.js` verbatim — do NOT rewrite its internals.** Wire the UI to the
+> exported functions, but leave the helper's bodies alone. The OAuth request shapes are **exact and
+> unforgiving** — the `createRedirectSession` body in particular needs the `auth.authRequest` wrapper,
+> flat PKCE fields, and `responseType`/`scope`; "simplifying" it into a spread of the input object
+> returns **400 Bad Request** and login dies. Extend by *calling* the exports, not by editing them.
+
 ## How to wire it (UI is the project's choice — the skill ships the REST layer only)
 
 ### (A) Credential form + the state machine — handle every branch (not just SUCCESS)

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -53,7 +53,7 @@ have). Don't blend their exchange calls — the helper handles each internally.
      setup**. But social **still fails on `localhost:4321`** until you add `http://localhost:4321/callback`
      to `allowedRedirectUris` — the default covers the origin, not the callback URI. (These are genuinely
      two separate fields; matching Oz's SDK `wix-headless` `managed/DEPLOYMENT.md`.)
-   - **Any non-default origin** — your deployed domain (e.g. a Base44 URL), a different localhost port —
+   - **Any non-default origin** — your deployed domain, a different localhost port —
      must be registered too: the origin (for A) and the `<origin>/callback` (for B).
    - **Symptoms:** (A) unregistered origin → login hangs, then `MemberAuthError('timeout')` + a console
      *"Failed to execute 'postMessage'… target origin … does not match"*. (B) unregistered callback →

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -148,11 +148,13 @@ create in the Business Manager (dashboard link below).
 - ✅ **One shared client.** Member login swaps the token set on `wix-client.js` — reuse the same
   transport for everything so the member identity (and their cart) carries across the app. Never mint
   a second client or re-mint anonymously after login (it drops the member).
-- ⛔ **The Wix member is the ONLY identity — don't mix in the host platform's auth.** On a platform
-  with its own auth (Base44, Supabase, Firebase, …), the logged-in user is the **Wix member** here
-  (`getCurrentMember()` / the Wix member token), *not* the host's auth session. Don't gate on the
-  host's user, and don't key Wix data on the host's `created_by`/user id — for member-owned rows use
-  Wix's server-stamped `_owner` (see the `cms` vertical). Two identities = broken ownership.
+- ✅ **For a Wix-backed feature, prefer the Wix member as the identity — don't split it with the
+  host's auth.** On a platform with its own auth (Base44, Supabase, …), using the host login for
+  host-only features is fine; but when the feature is about **Wix members** (the user gave you a
+  `WIX_CLIENT_ID`), log in and gate on the **Wix member** (`getCurrentMember()` / the Wix member
+  token) rather than substituting the host's login, and key member-owned Wix rows on `_owner` (see the
+  `cms` vertical). Don't identify one feature's user by the host session on one side and the Wix member
+  on the other — the ids won't match.
 - ❌ **Don't blend the two exchanges.** Credential login finishes via the hidden iframe; social
   finishes via `/callback`. The helper keeps them separate — don't cross-wire.
 - ❌ **Never fake a member.** No mock "logged-in" state, no invented profile, roles, or member counts.

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -148,6 +148,11 @@ create in the Business Manager (dashboard link below).
 - ✅ **One shared client.** Member login swaps the token set on `wix-client.js` — reuse the same
   transport for everything so the member identity (and their cart) carries across the app. Never mint
   a second client or re-mint anonymously after login (it drops the member).
+- ⛔ **The Wix member is the ONLY identity — don't mix in the host platform's auth.** On a platform
+  with its own auth (Base44, Supabase, Firebase, …), the logged-in user is the **Wix member** here
+  (`getCurrentMember()` / the Wix member token), *not* the host's auth session. Don't gate on the
+  host's user, and don't key Wix data on the host's `created_by`/user id — for member-owned rows use
+  Wix's server-stamped `_owner` (see the `cms` vertical). Two identities = broken ownership.
 - ❌ **Don't blend the two exchanges.** Credential login finishes via the hidden iframe; social
   finishes via `/callback`. The helper keeps them separate — don't cross-wire.
 - ❌ **Never fake a member.** No mock "logged-in" state, no invented profile, roles, or member counts.

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -148,13 +148,11 @@ create in the Business Manager (dashboard link below).
 - ✅ **One shared client.** Member login swaps the token set on `wix-client.js` — reuse the same
   transport for everything so the member identity (and their cart) carries across the app. Never mint
   a second client or re-mint anonymously after login (it drops the member).
-- ✅ **For a Wix-backed feature, prefer the Wix member as the identity — don't split it with the
-  host's auth.** On a platform with its own auth (Base44, Supabase, …), using the host login for
-  host-only features is fine; but when the feature is about **Wix members** (the user gave you a
-  `WIX_CLIENT_ID`), log in and gate on the **Wix member** (`getCurrentMember()` / the Wix member
-  token) rather than substituting the host's login, and key member-owned Wix rows on `_owner` (see the
-  `cms` vertical). Don't identify one feature's user by the host session on one side and the Wix member
-  on the other — the ids won't match.
+- ✅ **For a Wix-backed feature, use the Wix member as the identity — keep it consistent.** When the
+  feature is about **Wix members** (the user gave you a `WIX_CLIENT_ID`), log in and gate on the
+  **Wix member** (`getCurrentMember()` / the Wix member token), and key member-owned Wix rows on
+  `_owner` (see the `cms` vertical). Don't identify one feature's user from two different sessions —
+  the ids won't match.
 - ❌ **Don't blend the two exchanges.** Credential login finishes via the hidden iframe; social
   finishes via `/callback`. The helper keeps them separate — don't cross-wire.
 - ❌ **Never fake a member.** No mock "logged-in" state, no invented profile, roles, or member counts.

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -259,6 +259,12 @@ export async function logout(returnTo) {
 
 async function createRedirectSession({ authRequest }) {
   const { responseMode, sessionToken, idp, redirectUri, pkce } = authRequest;
+  // ⚠️ EXACT Wix wire shape — do NOT simplify or inline this. It is NOT the input
+  // object: the request needs the `auth.authRequest` wrapper, the PKCE fields FLAT
+  // (`codeChallenge` + `codeChallengeMethod`, not a nested `pkce` object; the
+  // `codeVerifier` is NOT sent here — it's kept for the token exchange), and
+  // `responseType`/`scope` present. Spreading the input straight onto the body →
+  // 400 Bad Request.
   const { redirectSession } = await wixApiRequest(REDIRECT_SESSION_URL, {
     body: {
       auth: {


### PR DESCRIPTION
## What & why

Two guardrails for host-platform builders consuming this skill, both from issues seen in real Base44 builds:

### 1. Prefer Wix per feature; don't split one feature across two backends/identities
A builder has its own backend + auth; the problem is **splitting a single Wix-backed feature** — storing Wix-owned data in another store while identifying the member from the Wix session (or substituting the host's login for Wix members). The ids won't match, ownership filters miss, and the data never lands with the rest of the Wix content. *(Observed: a product-"like" feature stored likes off-Wix keyed on a non-Wix user id.)*

### 2. Copy the helpers verbatim — don't rewrite their internals
A build **rewrote** the members helper's `createRedirectSession` into a spread of the input object — dropping the `auth.authRequest` wrapper, sending PKCE as a nested object instead of flat `codeChallenge`/`codeChallengeMethod`/`state`, and omitting `responseType`/`scope` → **400 Bad Request, login dead**. The Wix request shapes are exact and unforgiving.

## Changes (docs + one inline comment)

- **SKILL.md → shared model:** (a) prefer Wix for Wix-backed features (esp. auth — use Wix members), one store + one identity per feature, ownership via server-stamped `_owner`; (b) copy the shipped helpers as-is — extend by *calling* the exports, don't rewrite their bodies.
- **cms/INSTRUCTIONS.md:** keep a member-generated feature's data + identity together.
- **members/INSTRUCTIONS.md:** (a) Wix member is the identity for Wix-backed features; (b) copy `wix-members-auth.js` verbatim — the `createRedirectSession` body is exact.
- **wix-members-auth.js:** inline ⚠️ comment at the `createRedirectSession` wire body documenting the exact shape and the 400 trap.

No technology/platform names; guidance is a preference, not a prohibition. Follows #591 and #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)