### PR TITLE
fix(wix-app): OBJECT field objectOptions requires fields array, not empty object

### DIFF
--- a/skills/wix-app/references/DATA_COLLECTION.md
+++ b/skills/wix-app/references/DATA_COLLECTION.md
@@ -80,18 +80,20 @@ export default {
 | `ARRAY_DOCUMENT`  | Array of documents               | File collections       |
 | `ANY`             | Any type                         | Most flexible          |
 
-**CRITICAL: OBJECT fields require `objectOptions`.** When using `type: "OBJECT"`, you MUST include the `objectOptions` property — the API will reject OBJECT fields without it. Use an empty object `{}` if you don't need schema validation:
+**CRITICAL: OBJECT fields require `objectOptions` with a `fields` array.** When using `type: "OBJECT"`, you MUST include `objectOptions: { fields: [] }` — the API will reject OBJECT fields without it. Use an empty `fields` array if you don't need a fixed schema (the object will still accept arbitrary JSON):
 
 ```json
 {
   "key": "settings",
   "displayName": "Settings",
   "type": "OBJECT",
-  "objectOptions": {}
+  "objectOptions": { "fields": [] }
 }
 ```
 
-For structured objects, define nested fields inside `objectOptions.fields`:
+> ⚠️ `objectOptions: {}` (without the `fields` key) is **not valid** and will cause a runtime error. Always include `fields`, even as an empty array.
+
+For structured objects with a defined schema, list the nested fields inside `objectOptions.fields`:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Fixes incorrect guidance in `DATA_COLLECTION.md` where `objectOptions: {}` was shown as valid for OBJECT-type fields
- The Wix Data Collections API rejects `objectOptions` without a `fields` key — even an empty array is required
- Updated the example to `objectOptions: { fields: [] }` and added a warning callout

## Evidence

This bug was confirmed by analyzing the `#codegen-notifications` channel: the codegen-validator subagent repeatedly encountered and fixed this exact error across 4+ runs (both INIT_CODEGEN and ITERATE_CODEGEN), adding `fields: []` to OBJECT fields in data collection schemas each time.

Example validator error message: `"OBJECT field objectOptions missing fields | Schema required nested field array | Added { fields: [] } to each OBJECT field"`

## Change

```diff
-  "objectOptions": {}
+  "objectOptions": { "fields": [] }
```

Also added a warning:
> ⚠️ `objectOptions: {}` (without the `fields` key) is **not valid** and will cause a runtime error. Always include `fields`, even as an empty array.

Made with [Cursor](https://cursor.com)