### PR TITLE
entry: make `npx skills` install the default (drop `wix skills add`)

### DIFF
--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -65,8 +65,6 @@ The script emits one JSON object per line:
 Install the Wix Headless skills (`CI=1` forces plain non-interactive CLI output — keep it on every Wix CLI command):
 
 ```bash
-CI=1 wix skills add
-# Fallback if 'wix skills' isn't registered for this project type:
 CI=1 npx skills@latest add wix/skills --yes
 ```
 


### PR DESCRIPTION
## What

In the cold-start entry (`skills/wix-headless/entry/skill.md`), **Phase 2 — Install the skill and hand off** listed two install commands — a primary and a fallback:

```bash
CI=1 wix skills add
# Fallback if 'wix skills' isn't registered for this project type:
CI=1 npx skills@latest add wix/skills --yes
```

This drops the primary and makes the (former) fallback the single default:

```bash
CI=1 npx skills@latest add wix/skills --yes
```

## Why

The documented primary — `CI=1 wix skills add` — **cannot run at Phase 2 at all**, so listing it first (with npx as a mere "fallback") is misleading. Traced end-to-end in a live cold-start run, for two stacked reasons:

1. **There is no global `wix` binary.** The entry's bootstrap invokes the CLI exclusively as `npx -y @wix/cli@latest` — it never installs a global `wix`. So `CI=1 wix skills add` → `command not found: wix` (exit 127).

2. **`skills` is a project-scoped `@wix/cli` subcommand — but Phase 2 runs before any project exists.** Even the npx-equivalent (`npx @wix/cli@latest skills add`) crashes with `FailedToIdentifyProgramFlow`: the `skills` command lives inside `@wix/cli`'s Astro flow tree, and `identifyProgramFlow()` requires a Wix config (`wix.config.mjs`, or legacy `wix.config.json`) in the cwd. Phase 2 installs the skill *before* scaffolding, so the directory is empty → flow resolves to `UNKNOWN` → the subcommand refuses to run. This is long-standing, intended behavior (the config gate predates the `skills` command by ~9 months), not a transient regression.

The fallback is a **different tool**: `npx skills@latest add wix/skills --yes` runs the standalone `skills` package, which fetches agent skills from the `wix/skills` repo spec and works in an empty directory. At this point in the flow it's the only viable command, so it becomes the sole default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)