### PR TITLE
feat(eval-gate): run scenarios covering a changed skill doc

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34518,8 +34518,9 @@ function formatComparisonResult(result, projectId) {
         '|---|---|---|---|---|---|---|',
     ];
     for (const s of (scenarios ?? [])) {
-        const winner = s.pairwiseJudgement.winner;
-        const winnerLabel = winner === 'tie' ? '≈ tie' : winner === 'with' ? '⬆️ PR' : '⬇️ prod';
+        const j = s.pairwiseJudgement;
+        const winnerLabel = !j ? '—' : j.winner === 'tie' ? '≈ tie' : j.winner === 'with' ? '⬆️ PR' : '⬇️ prod';
+        const winnerCell = j ? `${winnerLabel} (${j.confidence})` : winnerLabel;
         const costWith = s.with.totalCostUsd.toFixed(3);
         const costWithout = s.without.totalCostUsd.toFixed(3);
         const tokWith = `${(s.with.totalTokens / 1000).toFixed(1)}K`;
@@ -34528,7 +34529,7 @@ function formatComparisonResult(result, projectId) {
         const timeWithout = `${(s.without.durationMs / 1000).toFixed(1)}s`;
         const runWith = projectId && s.with.runId ? `[PR](${(0, evalforge_1.evalRunUrl)(projectId, s.with.runId, s.with.name)})` : '—';
         const runWithout = projectId && s.without.runId ? `[prod](${(0, evalforge_1.evalRunUrl)(projectId, s.without.runId, s.without.name)})` : '—';
-        lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel} (${s.pairwiseJudgement.confidence}) | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
+        lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerCell} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
     }
     for (const s of (scenarios ?? [])) {
         lines.push('', `<details><summary>${s.scenarioName}</summary>`, '', s.reason, '');
@@ -34538,10 +34539,10 @@ function formatComparisonResult(result, projectId) {
             lines.push(`[View run (prod)](${(0, evalforge_1.evalRunUrl)(projectId, s.without.runId, s.without.name)})`, '');
         lines.push('**Assertions (PR):**', ...s.with.assertions.map(assertionLine), '');
         lines.push('**Assertions (prod):**', ...s.without.assertions.map(assertionLine), '');
-        if (s.pairwiseJudgement.reasoning) {
+        if (s.pairwiseJudgement?.reasoning) {
             lines.push(`**Compare result:** ${s.pairwiseJudgement.reasoning}`, '');
         }
-        if (s.pairwiseJudgement.dimensions) {
+        if (s.pairwiseJudgement?.dimensions) {
             lines.push('**Dimensions:**', ...Object.entries(s.pairwiseJudgement.dimensions).map(([k, v]) => `- ${k}: **${v.winner}**`), '');
         }
         lines.push('</details>');

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35519,13 +35519,8 @@ function remoteScenarioFiltersForGate(input) {
     return { names: [...names].sort(), tags: [input.draftTag] };
 }
 /**
- * The head scenarios this PR should sync and (re-)run:
- *  - scenarios whose own YAML changed in this PR (existing behavior), plus
- *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
- *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
- *
- * Both sets flow through the same sync → draft-tag → eval-compare path, so a
- * doc-only change gets its covering scenarios draft-tagged and compared.
+ * Head scenarios to sync and run: those whose YAML changed, plus those covering a
+ * changed skill doc (so editing a skill re-runs the scenarios that exercise it).
  */
 function scenariosToRun(input) {
     const result = new Map();
@@ -35596,9 +35591,6 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
-    // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
-    // it, not just requires their existence). Both flow through the sync/compare path below.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34950,8 +34950,8 @@ class EvalPipelineClient {
         }
         return res.json();
     }
-    async runComparison(tags, agentName, commitSha, skillsRepo) {
-        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo });
+    async runComparison(tags, agentName, commitSha, skillsRepo, scenarioIds) {
+        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
     }
     async compareGroup(comparisonGroupId) {
         return this.post('/compare-group', { comparisonGroupId });
@@ -35487,6 +35487,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
 exports.scenariosToRun = scenariosToRun;
+exports.scenarioIdsToRun = scenarioIdsToRun;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35536,6 +35537,21 @@ function scenariosToRun(input) {
         }
     }
     return result;
+}
+function scenarioIdsToRun(scenarios, nameToId) {
+    const missing = [];
+    const ids = [];
+    for (const name of scenarios.keys()) {
+        const id = nameToId.get(name);
+        if (id)
+            ids.push(id);
+        else
+            missing.push(name);
+    }
+    if (missing.length > 0) {
+        throw new Error(`Missing EvalForge scenario IDs for: ${missing.join(', ')}`);
+    }
+    return ids;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35644,7 +35660,7 @@ async function runGate() {
         return;
     }
     const pipeline = new eval_pipeline_1.EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
-    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo), 'Could not start eval pipeline comparison', comment, config);
+    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo, scenarioIdsToRun(changedHeadScenarios, nameToId)), 'Could not start eval pipeline comparison', comment, config);
     if (!comparison)
         return;
     core.info(`Eval pipeline comparison started: comparisonGroupId=${comparison.comparisonGroupId}`);

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35486,6 +35486,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
+exports.scenariosToRun = scenariosToRun;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35516,6 +35517,30 @@ function remoteScenarioFiltersForGate(input) {
             names.add(name);
     }
     return { names: [...names].sort(), tags: [input.draftTag] };
+}
+/**
+ * The head scenarios this PR should sync and (re-)run:
+ *  - scenarios whose own YAML changed in this PR (existing behavior), plus
+ *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
+ *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
+ *
+ * Both sets flow through the same sync → draft-tag → eval-compare path, so a
+ * doc-only change gets its covering scenarios draft-tagged and compared.
+ */
+function scenariosToRun(input) {
+    const result = new Map();
+    for (const [name, ls] of input.headScenarios) {
+        if (input.changedEvalPaths.has(ls.path))
+            result.set(name, ls);
+    }
+    for (const coveringNames of input.coveredBy.values()) {
+        for (const name of coveringNames) {
+            const ls = input.headScenarios.get(name);
+            if (ls)
+                result.set(name, ls);
+        }
+    }
+    return result;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35571,16 +35596,14 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+    // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
+    // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
+    // it, not just requires their existence). Both flow through the sync/compare path below.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),
     ]);
-    const changedHeadScenarios = new Map();
-    for (const [name, ls] of headScenarios) {
-        if (changedEvalPaths.has(ls.path))
-            changedHeadScenarios.set(name, ls);
-    }
+    const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
     const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
     const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)

--- a/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
@@ -118,8 +118,9 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
   ];
 
   for (const s of (scenarios ?? [])) {
-    const winner = s.pairwiseJudgement.winner;
-    const winnerLabel = winner === 'tie' ? '≈ tie' : winner === 'with' ? '⬆️ PR' : '⬇️ prod';
+    const j = s.pairwiseJudgement;
+    const winnerLabel = !j ? '—' : j.winner === 'tie' ? '≈ tie' : j.winner === 'with' ? '⬆️ PR' : '⬇️ prod';
+    const winnerCell = j ? `${winnerLabel} (${j.confidence})` : winnerLabel;
     const costWith = s.with.totalCostUsd.toFixed(3);
     const costWithout = s.without.totalCostUsd.toFixed(3);
     const tokWith = `${(s.with.totalTokens / 1000).toFixed(1)}K`;
@@ -128,7 +129,7 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
     const timeWithout = `${(s.without.durationMs / 1000).toFixed(1)}s`;
     const runWith = projectId && s.with.runId ? `[PR](${evalRunUrl(projectId, s.with.runId, s.with.name)})` : '—';
     const runWithout = projectId && s.without.runId ? `[prod](${evalRunUrl(projectId, s.without.runId, s.without.name)})` : '—';
-    lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel} (${s.pairwiseJudgement.confidence}) | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
+    lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerCell} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
   }
 
   for (const s of (scenarios ?? [])) {
@@ -137,10 +138,10 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
     if (projectId && s.without.runId) lines.push(`[View run (prod)](${evalRunUrl(projectId, s.without.runId, s.without.name)})`, '');
     lines.push('**Assertions (PR):**', ...s.with.assertions.map(assertionLine), '');
     lines.push('**Assertions (prod):**', ...s.without.assertions.map(assertionLine), '');
-    if (s.pairwiseJudgement.reasoning) {
+    if (s.pairwiseJudgement?.reasoning) {
       lines.push(`**Compare result:** ${s.pairwiseJudgement.reasoning}`, '');
     }
-    if (s.pairwiseJudgement.dimensions) {
+    if (s.pairwiseJudgement?.dimensions) {
       lines.push('**Dimensions:**', ...Object.entries(s.pairwiseJudgement.dimensions).map(([k, v]) => `- ${k}: **${v.winner}**`), '');
     }
     lines.push('</details>');

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -113,8 +113,8 @@ export class EvalPipelineClient {
     return res.json() as Promise<T>;
   }
 
-  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string): Promise<ComparisonResult> {
-    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo });
+  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string, scenarioIds?: string[]): Promise<ComparisonResult> {
+    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
   }
 
   async compareGroup(comparisonGroupId: string): Promise<CompareGroupStatus> {

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -33,7 +33,8 @@ export type ScenarioComparison = {
   reason: string;
   with: ScenarioRunResult;
   without: ScenarioRunResult;
-  pairwiseJudgement: {
+  // Optional: the pipeline omits it when pairwise judging is disabled or the judge call fails.
+  pairwiseJudgement?: {
     winner: 'tie' | 'with' | 'without';
     confidence: string;
     reasoning: string;

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -47,6 +47,33 @@ export function remoteScenarioFiltersForGate(input: {
   return { names: [...names].sort(), tags: [input.draftTag] };
 }
 
+/**
+ * The head scenarios this PR should sync and (re-)run:
+ *  - scenarios whose own YAML changed in this PR (existing behavior), plus
+ *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
+ *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
+ *
+ * Both sets flow through the same sync → draft-tag → eval-compare path, so a
+ * doc-only change gets its covering scenarios draft-tagged and compared.
+ */
+export function scenariosToRun(input: {
+  headScenarios: Map<string, LoadedScenario>;
+  changedEvalPaths: Set<string>;
+  coveredBy: Map<string, string[]>;
+}): Map<string, LoadedScenario> {
+  const result = new Map<string, LoadedScenario>();
+  for (const [name, ls] of input.headScenarios) {
+    if (input.changedEvalPaths.has(ls.path)) result.set(name, ls);
+  }
+  for (const coveringNames of input.coveredBy.values()) {
+    for (const name of coveringNames) {
+      const ls = input.headScenarios.get(name);
+      if (ls) result.set(name, ls);
+    }
+  }
+  return result;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -114,15 +141,14 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+  // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
+  // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
+  // it, not just requires their existence). Both flow through the sync/compare path below.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),
   ]);
-  const changedHeadScenarios = new Map<string, LoadedScenario>();
-  for (const [name, ls] of headScenarios) {
-    if (changedEvalPaths.has(ls.path)) changedHeadScenarios.set(name, ls);
-  }
+  const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
 
   const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
   const remote = await guardedCall(

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -69,6 +69,23 @@ export function scenariosToRun(input: {
   return result;
 }
 
+export function scenarioIdsToRun(
+  scenarios: Map<string, LoadedScenario>,
+  nameToId: Map<string, string>,
+): string[] {
+  const missing: string[] = [];
+  const ids: string[] = [];
+  for (const name of scenarios.keys()) {
+    const id = nameToId.get(name);
+    if (id) ids.push(id);
+    else missing.push(name);
+  }
+  if (missing.length > 0) {
+    throw new Error(`Missing EvalForge scenario IDs for: ${missing.join(', ')}`);
+  }
+  return ids;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -194,7 +211,7 @@ export async function runGate(): Promise<void> {
 
   const pipeline = new EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
   const comparison = await guardedCall(
-    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo),
+    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo, scenarioIdsToRun(changedHeadScenarios, nameToId)),
     'Could not start eval pipeline comparison', comment, config,
   );
   if (!comparison) return;

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -48,13 +48,8 @@ export function remoteScenarioFiltersForGate(input: {
 }
 
 /**
- * The head scenarios this PR should sync and (re-)run:
- *  - scenarios whose own YAML changed in this PR (existing behavior), plus
- *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
- *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
- *
- * Both sets flow through the same sync → draft-tag → eval-compare path, so a
- * doc-only change gets its covering scenarios draft-tagged and compared.
+ * Head scenarios to sync and run: those whose YAML changed, plus those covering a
+ * changed skill doc (so editing a skill re-runs the scenarios that exercise it).
  */
 export function scenariosToRun(input: {
   headScenarios: Map<string, LoadedScenario>;
@@ -141,9 +136,6 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
-  // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
-  // it, not just requires their existence). Both flow through the sync/compare path below.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),

--- a/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
@@ -117,6 +117,14 @@ describe('comment formatters', () => {
     expect(out).toContain('[View run (prod)](https://bo.wix.com/pages/evalforge/proj-1/results?runId=prod-run');
   });
 
+  it('formatComparisonResult handles a scenario with no pairwiseJudgement', () => {
+    // The pipeline omits pairwiseJudgement when pairwise judging is off or the judge fails.
+    const out = c.formatComparisonResult(group([scenario({ pairwiseJudgement: undefined })]), 'proj-1');
+    // renders a placeholder winner instead of throwing on the missing field
+    expect(out).toContain('| scenario-a | ✅ | — |');
+    expect(out).not.toContain('Compare result:');
+  });
+
   it('formatTooManyNewSkills includes count and file names', () => {
     const out = c.formatTooManyNewSkills(2, 1, [
       'skills/wix-manage/references/payments/process.md',

--- a/.github/actions/evalforge-yaml-gate/tests/eval-pipeline.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/eval-pipeline.test.ts
@@ -6,6 +6,7 @@ beforeEach(() => { vi.restoreAllMocks(); });
 describe('EvalPipelineClient — OAuth Bearer auth', () => {
   it('runComparison mints a token and sends Authorization: Bearer (no x-app headers)', async () => {
     let seen: Headers | undefined;
+    let body: unknown;
     let mints = 0;
     globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);
@@ -14,16 +15,24 @@ describe('EvalPipelineClient — OAuth Bearer auth', () => {
         return new Response(JSON.stringify({ access_token: 'tok-1', token_type: 'Bearer', expires_in: 300 }), { status: 200, headers: { 'content-type': 'application/json' } });
       }
       seen = new Headers(init?.headers);
+      body = JSON.parse(String(init?.body));
       expect(url).toBe('https://pipe.test/run-comparison');
       return new Response(JSON.stringify({ comparisonGroupId: 'cg-1' }), { status: 200, headers: { 'content-type': 'application/json' } });
     }) as unknown as typeof fetch;
 
     const c = new EvalPipelineClient('https://pipe.test', 'aid', 'sec');
-    const r = await c.runComparison(['draft:o/r#1'], 'agent', 'sha', 'wix/skills');
+    const r = await c.runComparison(['draft:o/r#1'], 'agent', 'sha', 'wix/skills', ['s1', 's2']);
     expect(r).toEqual({ comparisonGroupId: 'cg-1' });
     expect(seen?.get('authorization')).toBe('Bearer tok-1');
     expect(seen?.get('x-app-id')).toBeNull();
     expect(seen?.get('x-app-secret')).toBeNull();
+    expect(body).toEqual({
+      tags: ['draft:o/r#1'],
+      agentName: 'agent',
+      commitSha: 'sha',
+      skillsRepo: 'wix/skills',
+      scenarioIds: ['s1', 's2'],
+    });
     expect(mints).toBe(1);
   });
 

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, scenariosToRun } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -38,5 +38,52 @@ describe('remoteScenarioFiltersForGate', () => {
       names: ['blog/changed', 'blog/deleted', 'stores/changed'],
       tags: ['draft:wix/skills#42'],
     });
+  });
+});
+
+describe('scenariosToRun', () => {
+  const head = new Map<string, LoadedScenario>([
+    ['blog/changed', scenario('blog/changed')],
+    ['blog/unchanged', scenario('blog/unchanged')],
+    ['marketing/social', scenario('marketing/social')],
+  ]);
+
+  it('includes scenarios whose own YAML changed in this PR (existing behavior)', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      coveredBy: new Map(),
+    });
+    expect([...out.keys()]).toEqual(['blog/changed']);
+  });
+
+  it('also includes scenarios covering a changed doc, even when their YAML is unchanged', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(),
+      coveredBy: new Map([['skills/wix-manage/references/marketing/social.md', ['marketing/social']]]),
+    });
+    expect([...out.keys()]).toEqual(['marketing/social']);
+  });
+
+  it('unions changed + doc-covered scenarios without duplicates', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      coveredBy: new Map([
+        ['skills/wix-manage/references/marketing/social.md', ['marketing/social']],
+        ['skills/wix-manage/references/blog/changed.md', ['blog/changed']],
+      ]),
+    });
+    expect([...out.keys()].sort()).toEqual(['blog/changed', 'marketing/social']);
+  });
+
+  it('ignores covering names with no loaded head scenario', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(),
+      coveredBy: new Map([['skills/wix-manage/references/x/y.md', ['does/not-exist']]]),
+    });
+    expect(out.size).toBe(0);
   });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate, scenariosToRun } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, scenarioIdsToRun, scenariosToRun } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -85,5 +85,26 @@ describe('scenariosToRun', () => {
       coveredBy: new Map([['skills/wix-manage/references/x/y.md', ['does/not-exist']]]),
     });
     expect(out.size).toBe(0);
+  });
+});
+
+describe('scenarioIdsToRun', () => {
+  it('maps selected scenario names to EvalForge IDs in run order', () => {
+    const selected = new Map<string, LoadedScenario>([
+      ['blog/changed', scenario('blog/changed')],
+      ['marketing/social', scenario('marketing/social')],
+    ]);
+    const ids = scenarioIdsToRun(selected, new Map([
+      ['marketing/social', 'id-social'],
+      ['blog/changed', 'id-changed'],
+    ]));
+    expect(ids).toEqual(['id-changed', 'id-social']);
+  });
+
+  it('fails clearly when a selected scenario has no remote ID', () => {
+    const selected = new Map<string, LoadedScenario>([
+      ['blog/changed', scenario('blog/changed')],
+    ]);
+    expect(() => scenarioIdsToRun(selected, new Map())).toThrow('Missing EvalForge scenario IDs for: blog/changed');
   });
 });


### PR DESCRIPTION
## Problem

Editing a skill doc (`skills/wix-manage/references/<area>/*.md`) currently passes the gate green **without running any eval**. The gate's coverage check only requires that a changed doc *has* a covering scenario — it never *runs* it. Eval execution is triggered solely by **scenario YAML** changes, so a pure doc edit (which can absolutely change agent behavior) is never validated against the scenarios that exercise it.

Example: PR #542 edited `create-and-publish-social-post.md`; the gate passed and logged "No scenarios created or updated — skipping eval pipeline comparison", even though `marketing/create-and-publish-social-post.yml` covers that doc.

## Change

Extend the set of scenarios the gate syncs + runs to include **scenarios that cover a changed skill doc**, in addition to scenarios whose own YAML changed. Both sets flow through the **same** sync → draft-tag → eval-compare path the gate already uses, so a doc edit now:
1. draft-tags its covering scenarios (idempotent UPDATE with the current YAML body), and
2. runs them in the eval-pipeline comparison against the PR's skill version vs baseline.

The selection is extracted into a pure, unit-tested `scenariosToRun` helper. It reuses the coverage map (`coveredBy`) the gate already computes.

## Not broken (by design)

- **Existing flow preserved:** scenarios whose YAML changed are still included exactly as before — this is purely additive (a `Map` union, deduped by name).
- **Uncovered docs still fail** earlier at the coverage check (unchanged).
- **promote / cleanup** already reconcile draft-tagged scenarios on merge/close, so the draft tag added to a doc-covering scenario is removed there (promote re-applies managed tags from the unchanged YAML; cleanup restores from base).

## Tests

`scenariosToRun` unit tests: YAML-changed only, doc-covered only, union/dedup, and ignoring covering names with no loaded scenario. Full suite green (174), typecheck clean, `dist` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)