### PR TITLE
TEST: exercise eval-gate covered-scenario run (do not merge)

### DIFF
--- a/.github/actions/evalforge-yaml-gate/action.yml
+++ b/.github/actions/evalforge-yaml-gate/action.yml
@@ -55,5 +55,5 @@ inputs:
     required: false
     default: '1'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34499,8 +34499,19 @@ function formatEvalTimeout(runId, runUrl, blocking) {
 function formatNoChanges() {
     return render('✅', 'No Gated Changes', ['Nothing under `evals/` or sibling `.md` changed.']);
 }
+function isPassedStatus(status) {
+    return status === 'passed' || status.endsWith('_PASSED');
+}
+function winnerLabel(s) {
+    const judgement = s.pairwiseJudgement;
+    if (!judgement)
+        return s.verdict ? `\`${s.verdict}\`` : '—';
+    const winner = judgement.winner;
+    const label = winner === 'tie' ? '≈ tie' : winner === 'with' ? '⬆️ PR' : '⬇️ prod';
+    return `${label} (${judgement.confidence})`;
+}
 function assertionLine(a) {
-    const icon = a.status === 'passed' ? '✅' : '❌';
+    const icon = isPassedStatus(a.status) ? '✅' : '❌';
     const score = a.score !== undefined ? ` (${a.score}/10)` : '';
     const detail = a.verdict ? `: ${a.verdict}` : a.message ? `: ${a.message}` : '';
     return `- ${icon} ${a.name}${score}${detail}`;
@@ -34518,8 +34529,6 @@ function formatComparisonResult(result, projectId) {
         '|---|---|---|---|---|---|---|',
     ];
     for (const s of (scenarios ?? [])) {
-        const winner = s.pairwiseJudgement.winner;
-        const winnerLabel = winner === 'tie' ? '≈ tie' : winner === 'with' ? '⬆️ PR' : '⬇️ prod';
         const costWith = s.with.totalCostUsd.toFixed(3);
         const costWithout = s.without.totalCostUsd.toFixed(3);
         const tokWith = `${(s.with.totalTokens / 1000).toFixed(1)}K`;
@@ -34528,7 +34537,7 @@ function formatComparisonResult(result, projectId) {
         const timeWithout = `${(s.without.durationMs / 1000).toFixed(1)}s`;
         const runWith = projectId && s.with.runId ? `[PR](${(0, evalforge_1.evalRunUrl)(projectId, s.with.runId, s.with.name)})` : '—';
         const runWithout = projectId && s.without.runId ? `[prod](${(0, evalforge_1.evalRunUrl)(projectId, s.without.runId, s.without.name)})` : '—';
-        lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel} (${s.pairwiseJudgement.confidence}) | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
+        lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel(s)} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
     }
     for (const s of (scenarios ?? [])) {
         lines.push('', `<details><summary>${s.scenarioName}</summary>`, '', s.reason, '');
@@ -34538,10 +34547,10 @@ function formatComparisonResult(result, projectId) {
             lines.push(`[View run (prod)](${(0, evalforge_1.evalRunUrl)(projectId, s.without.runId, s.without.name)})`, '');
         lines.push('**Assertions (PR):**', ...s.with.assertions.map(assertionLine), '');
         lines.push('**Assertions (prod):**', ...s.without.assertions.map(assertionLine), '');
-        if (s.pairwiseJudgement.reasoning) {
+        if (s.pairwiseJudgement?.reasoning) {
             lines.push(`**Compare result:** ${s.pairwiseJudgement.reasoning}`, '');
         }
-        if (s.pairwiseJudgement.dimensions) {
+        if (s.pairwiseJudgement?.dimensions) {
             lines.push('**Dimensions:**', ...Object.entries(s.pairwiseJudgement.dimensions).map(([k, v]) => `- ${k}: **${v.winner}**`), '');
         }
         lines.push('</details>');

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35519,13 +35519,8 @@ function remoteScenarioFiltersForGate(input) {
     return { names: [...names].sort(), tags: [input.draftTag] };
 }
 /**
- * The head scenarios this PR should sync and (re-)run:
- *  - scenarios whose own YAML changed in this PR (existing behavior), plus
- *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
- *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
- *
- * Both sets flow through the same sync → draft-tag → eval-compare path, so a
- * doc-only change gets its covering scenarios draft-tagged and compared.
+ * Head scenarios to sync and run: those whose YAML changed, plus those covering a
+ * changed skill doc (so editing a skill re-runs the scenarios that exercise it).
  */
 function scenariosToRun(input) {
     const result = new Map();
@@ -35596,9 +35591,6 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
-    // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
-    // it, not just requires their existence). Both flow through the sync/compare path below.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34950,8 +34950,8 @@ class EvalPipelineClient {
         }
         return res.json();
     }
-    async runComparison(tags, agentName, commitSha, skillsRepo) {
-        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo });
+    async runComparison(tags, agentName, commitSha, skillsRepo, scenarioIds) {
+        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
     }
     async compareGroup(comparisonGroupId) {
         return this.post('/compare-group', { comparisonGroupId });
@@ -35487,6 +35487,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
 exports.scenariosToRun = scenariosToRun;
+exports.scenarioIdsToRun = scenarioIdsToRun;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35536,6 +35537,21 @@ function scenariosToRun(input) {
         }
     }
     return result;
+}
+function scenarioIdsToRun(scenarios, nameToId) {
+    const missing = [];
+    const ids = [];
+    for (const name of scenarios.keys()) {
+        const id = nameToId.get(name);
+        if (id)
+            ids.push(id);
+        else
+            missing.push(name);
+    }
+    if (missing.length > 0) {
+        throw new Error(`Missing EvalForge scenario IDs for: ${missing.join(', ')}`);
+    }
+    return ids;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35644,7 +35660,7 @@ async function runGate() {
         return;
     }
     const pipeline = new eval_pipeline_1.EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
-    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo), 'Could not start eval pipeline comparison', comment, config);
+    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo, scenarioIdsToRun(changedHeadScenarios, nameToId)), 'Could not start eval pipeline comparison', comment, config);
     if (!comparison)
         return;
     core.info(`Eval pipeline comparison started: comparisonGroupId=${comparison.comparisonGroupId}`);

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35486,6 +35486,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
+exports.scenariosToRun = scenariosToRun;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35516,6 +35517,30 @@ function remoteScenarioFiltersForGate(input) {
             names.add(name);
     }
     return { names: [...names].sort(), tags: [input.draftTag] };
+}
+/**
+ * The head scenarios this PR should sync and (re-)run:
+ *  - scenarios whose own YAML changed in this PR (existing behavior), plus
+ *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
+ *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
+ *
+ * Both sets flow through the same sync → draft-tag → eval-compare path, so a
+ * doc-only change gets its covering scenarios draft-tagged and compared.
+ */
+function scenariosToRun(input) {
+    const result = new Map();
+    for (const [name, ls] of input.headScenarios) {
+        if (input.changedEvalPaths.has(ls.path))
+            result.set(name, ls);
+    }
+    for (const coveringNames of input.coveredBy.values()) {
+        for (const name of coveringNames) {
+            const ls = input.headScenarios.get(name);
+            if (ls)
+                result.set(name, ls);
+        }
+    }
+    return result;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35571,16 +35596,14 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+    // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
+    // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
+    // it, not just requires their existence). Both flow through the sync/compare path below.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),
     ]);
-    const changedHeadScenarios = new Map();
-    for (const [name, ls] of headScenarios) {
-        if (changedEvalPaths.has(ls.path))
-            changedHeadScenarios.set(name, ls);
-    }
+    const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
     const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
     const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)

--- a/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
@@ -97,8 +97,21 @@ export function formatNoChanges(): string {
   return render('✅', 'No Gated Changes', ['Nothing under `evals/` or sibling `.md` changed.']);
 }
 
+function isPassedStatus(status: string): boolean {
+  return status === 'passed' || status.endsWith('_PASSED');
+}
+
+function winnerLabel(s: ScenarioComparison): string {
+  const judgement = s.pairwiseJudgement;
+  if (!judgement) return s.verdict ? `\`${s.verdict}\`` : '—';
+
+  const winner = judgement.winner;
+  const label = winner === 'tie' ? '≈ tie' : winner === 'with' ? '⬆️ PR' : '⬇️ prod';
+  return `${label} (${judgement.confidence})`;
+}
+
 function assertionLine(a: { status: string; name: string; score?: number; verdict?: string; message?: string }): string {
-  const icon = a.status === 'passed' ? '✅' : '❌';
+  const icon = isPassedStatus(a.status) ? '✅' : '❌';
   const score = a.score !== undefined ? ` (${a.score}/10)` : '';
   const detail = a.verdict ? `: ${a.verdict}` : a.message ? `: ${a.message}` : '';
   return `- ${icon} ${a.name}${score}${detail}`;
@@ -118,8 +131,6 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
   ];
 
   for (const s of (scenarios ?? [])) {
-    const winner = s.pairwiseJudgement.winner;
-    const winnerLabel = winner === 'tie' ? '≈ tie' : winner === 'with' ? '⬆️ PR' : '⬇️ prod';
     const costWith = s.with.totalCostUsd.toFixed(3);
     const costWithout = s.without.totalCostUsd.toFixed(3);
     const tokWith = `${(s.with.totalTokens / 1000).toFixed(1)}K`;
@@ -128,7 +139,7 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
     const timeWithout = `${(s.without.durationMs / 1000).toFixed(1)}s`;
     const runWith = projectId && s.with.runId ? `[PR](${evalRunUrl(projectId, s.with.runId, s.with.name)})` : '—';
     const runWithout = projectId && s.without.runId ? `[prod](${evalRunUrl(projectId, s.without.runId, s.without.name)})` : '—';
-    lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel} (${s.pairwiseJudgement.confidence}) | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
+    lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel(s)} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
   }
 
   for (const s of (scenarios ?? [])) {
@@ -137,10 +148,10 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
     if (projectId && s.without.runId) lines.push(`[View run (prod)](${evalRunUrl(projectId, s.without.runId, s.without.name)})`, '');
     lines.push('**Assertions (PR):**', ...s.with.assertions.map(assertionLine), '');
     lines.push('**Assertions (prod):**', ...s.without.assertions.map(assertionLine), '');
-    if (s.pairwiseJudgement.reasoning) {
+    if (s.pairwiseJudgement?.reasoning) {
       lines.push(`**Compare result:** ${s.pairwiseJudgement.reasoning}`, '');
     }
-    if (s.pairwiseJudgement.dimensions) {
+    if (s.pairwiseJudgement?.dimensions) {
       lines.push('**Dimensions:**', ...Object.entries(s.pairwiseJudgement.dimensions).map(([k, v]) => `- ${k}: **${v.winner}**`), '');
     }
     lines.push('</details>');

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -113,8 +113,8 @@ export class EvalPipelineClient {
     return res.json() as Promise<T>;
   }
 
-  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string): Promise<ComparisonResult> {
-    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo });
+  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string, scenarioIds?: string[]): Promise<ComparisonResult> {
+    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
   }
 
   async compareGroup(comparisonGroupId: string): Promise<CompareGroupStatus> {

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -30,10 +30,11 @@ export type ScenarioComparison = {
   scenarioId: string;
   scenarioName: string;
   required: boolean;
+  verdict?: string;
   reason: string;
   with: ScenarioRunResult;
   without: ScenarioRunResult;
-  pairwiseJudgement: {
+  pairwiseJudgement?: {
     winner: 'tie' | 'with' | 'without';
     confidence: string;
     reasoning: string;

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -47,6 +47,33 @@ export function remoteScenarioFiltersForGate(input: {
   return { names: [...names].sort(), tags: [input.draftTag] };
 }
 
+/**
+ * The head scenarios this PR should sync and (re-)run:
+ *  - scenarios whose own YAML changed in this PR (existing behavior), plus
+ *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
+ *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
+ *
+ * Both sets flow through the same sync → draft-tag → eval-compare path, so a
+ * doc-only change gets its covering scenarios draft-tagged and compared.
+ */
+export function scenariosToRun(input: {
+  headScenarios: Map<string, LoadedScenario>;
+  changedEvalPaths: Set<string>;
+  coveredBy: Map<string, string[]>;
+}): Map<string, LoadedScenario> {
+  const result = new Map<string, LoadedScenario>();
+  for (const [name, ls] of input.headScenarios) {
+    if (input.changedEvalPaths.has(ls.path)) result.set(name, ls);
+  }
+  for (const coveringNames of input.coveredBy.values()) {
+    for (const name of coveringNames) {
+      const ls = input.headScenarios.get(name);
+      if (ls) result.set(name, ls);
+    }
+  }
+  return result;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -114,15 +141,14 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+  // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
+  // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
+  // it, not just requires their existence). Both flow through the sync/compare path below.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),
   ]);
-  const changedHeadScenarios = new Map<string, LoadedScenario>();
-  for (const [name, ls] of headScenarios) {
-    if (changedEvalPaths.has(ls.path)) changedHeadScenarios.set(name, ls);
-  }
+  const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
 
   const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
   const remote = await guardedCall(

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -69,6 +69,23 @@ export function scenariosToRun(input: {
   return result;
 }
 
+export function scenarioIdsToRun(
+  scenarios: Map<string, LoadedScenario>,
+  nameToId: Map<string, string>,
+): string[] {
+  const missing: string[] = [];
+  const ids: string[] = [];
+  for (const name of scenarios.keys()) {
+    const id = nameToId.get(name);
+    if (id) ids.push(id);
+    else missing.push(name);
+  }
+  if (missing.length > 0) {
+    throw new Error(`Missing EvalForge scenario IDs for: ${missing.join(', ')}`);
+  }
+  return ids;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -194,7 +211,7 @@ export async function runGate(): Promise<void> {
 
   const pipeline = new EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
   const comparison = await guardedCall(
-    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo),
+    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo, scenarioIdsToRun(changedHeadScenarios, nameToId)),
     'Could not start eval pipeline comparison', comment, config,
   );
   if (!comparison) return;

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -48,13 +48,8 @@ export function remoteScenarioFiltersForGate(input: {
 }
 
 /**
- * The head scenarios this PR should sync and (re-)run:
- *  - scenarios whose own YAML changed in this PR (existing behavior), plus
- *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
- *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
- *
- * Both sets flow through the same sync → draft-tag → eval-compare path, so a
- * doc-only change gets its covering scenarios draft-tagged and compared.
+ * Head scenarios to sync and run: those whose YAML changed, plus those covering a
+ * changed skill doc (so editing a skill re-runs the scenarios that exercise it).
  */
 export function scenariosToRun(input: {
   headScenarios: Map<string, LoadedScenario>;
@@ -141,9 +136,6 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
-  // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
-  // it, not just requires their existence). Both flow through the sync/compare path below.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),

--- a/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
@@ -117,6 +117,25 @@ describe('comment formatters', () => {
     expect(out).toContain('[View run (prod)](https://bo.wix.com/pages/evalforge/proj-1/results?runId=prod-run');
   });
 
+  it('formatComparisonResult tolerates comparison scenarios without pairwiseJudgement', () => {
+    const out = c.formatComparisonResult(group([scenario({
+      verdict: 'not-sure',
+      reason: 'with-skill has failing assertions',
+      pairwiseJudgement: undefined,
+      with: run({
+        failed: 1,
+        assertions: [
+          { name: 'Tool called with param', type: 'tool_called_with_param', status: 'ASSERTION_RESULT_STATUS_FAILED' },
+          { name: 'LLM judge', type: 'llm_judge', status: 'ASSERTION_RESULT_STATUS_PASSED', score: 10 },
+        ],
+      }),
+    })]), 'proj-1');
+
+    expect(out).toContain('| scenario-a | ✅ | `not-sure` |');
+    expect(out).toContain('- ✅ LLM judge (10/10)');
+    expect(out).toContain('- ❌ Tool called with param');
+  });
+
   it('formatTooManyNewSkills includes count and file names', () => {
     const out = c.formatTooManyNewSkills(2, 1, [
       'skills/wix-manage/references/payments/process.md',

--- a/.github/actions/evalforge-yaml-gate/tests/eval-pipeline.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/eval-pipeline.test.ts
@@ -6,6 +6,7 @@ beforeEach(() => { vi.restoreAllMocks(); });
 describe('EvalPipelineClient — OAuth Bearer auth', () => {
   it('runComparison mints a token and sends Authorization: Bearer (no x-app headers)', async () => {
     let seen: Headers | undefined;
+    let body: unknown;
     let mints = 0;
     globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);
@@ -14,16 +15,24 @@ describe('EvalPipelineClient — OAuth Bearer auth', () => {
         return new Response(JSON.stringify({ access_token: 'tok-1', token_type: 'Bearer', expires_in: 300 }), { status: 200, headers: { 'content-type': 'application/json' } });
       }
       seen = new Headers(init?.headers);
+      body = JSON.parse(String(init?.body));
       expect(url).toBe('https://pipe.test/run-comparison');
       return new Response(JSON.stringify({ comparisonGroupId: 'cg-1' }), { status: 200, headers: { 'content-type': 'application/json' } });
     }) as unknown as typeof fetch;
 
     const c = new EvalPipelineClient('https://pipe.test', 'aid', 'sec');
-    const r = await c.runComparison(['draft:o/r#1'], 'agent', 'sha', 'wix/skills');
+    const r = await c.runComparison(['draft:o/r#1'], 'agent', 'sha', 'wix/skills', ['s1', 's2']);
     expect(r).toEqual({ comparisonGroupId: 'cg-1' });
     expect(seen?.get('authorization')).toBe('Bearer tok-1');
     expect(seen?.get('x-app-id')).toBeNull();
     expect(seen?.get('x-app-secret')).toBeNull();
+    expect(body).toEqual({
+      tags: ['draft:o/r#1'],
+      agentName: 'agent',
+      commitSha: 'sha',
+      skillsRepo: 'wix/skills',
+      scenarioIds: ['s1', 's2'],
+    });
     expect(mints).toBe(1);
   });
 

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, scenariosToRun } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -38,5 +38,52 @@ describe('remoteScenarioFiltersForGate', () => {
       names: ['blog/changed', 'blog/deleted', 'stores/changed'],
       tags: ['draft:wix/skills#42'],
     });
+  });
+});
+
+describe('scenariosToRun', () => {
+  const head = new Map<string, LoadedScenario>([
+    ['blog/changed', scenario('blog/changed')],
+    ['blog/unchanged', scenario('blog/unchanged')],
+    ['marketing/social', scenario('marketing/social')],
+  ]);
+
+  it('includes scenarios whose own YAML changed in this PR (existing behavior)', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      coveredBy: new Map(),
+    });
+    expect([...out.keys()]).toEqual(['blog/changed']);
+  });
+
+  it('also includes scenarios covering a changed doc, even when their YAML is unchanged', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(),
+      coveredBy: new Map([['skills/wix-manage/references/marketing/social.md', ['marketing/social']]]),
+    });
+    expect([...out.keys()]).toEqual(['marketing/social']);
+  });
+
+  it('unions changed + doc-covered scenarios without duplicates', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      coveredBy: new Map([
+        ['skills/wix-manage/references/marketing/social.md', ['marketing/social']],
+        ['skills/wix-manage/references/blog/changed.md', ['blog/changed']],
+      ]),
+    });
+    expect([...out.keys()].sort()).toEqual(['blog/changed', 'marketing/social']);
+  });
+
+  it('ignores covering names with no loaded head scenario', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(),
+      coveredBy: new Map([['skills/wix-manage/references/x/y.md', ['does/not-exist']]]),
+    });
+    expect(out.size).toBe(0);
   });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate, scenariosToRun } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, scenarioIdsToRun, scenariosToRun } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -85,5 +85,26 @@ describe('scenariosToRun', () => {
       coveredBy: new Map([['skills/wix-manage/references/x/y.md', ['does/not-exist']]]),
     });
     expect(out.size).toBe(0);
+  });
+});
+
+describe('scenarioIdsToRun', () => {
+  it('maps selected scenario names to EvalForge IDs in run order', () => {
+    const selected = new Map<string, LoadedScenario>([
+      ['blog/changed', scenario('blog/changed')],
+      ['marketing/social', scenario('marketing/social')],
+    ]);
+    const ids = scenarioIdsToRun(selected, new Map([
+      ['marketing/social', 'id-social'],
+      ['blog/changed', 'id-changed'],
+    ]));
+    expect(ids).toEqual(['id-changed', 'id-social']);
+  });
+
+  it('fails clearly when a selected scenario has no remote ID', () => {
+    const selected = new Map<string, LoadedScenario>([
+      ['blog/changed', scenario('blog/changed')],
+    ]);
+    expect(() => scenarioIdsToRun(selected, new Map())).toThrow('Missing EvalForge scenario IDs for: blog/changed');
   });
 });

--- a/skills/wix-manage/references/marketing/create-and-publish-social-post.md
+++ b/skills/wix-manage/references/marketing/create-and-publish-social-post.md
@@ -434,3 +434,5 @@ The post appears on the site's Social Media Marketing page in the dashboard. To 
 - [Media Manager: Import File](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file)
 - [Media Manager: Generate File Upload URL](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/generate-file-upload-url)
 - [Publisher API sample flows](https://dev.wix.com/docs/api-reference/business-management/marketing/social-media/sample-flows)
+
+<!-- eval-gate test: doc-only edit to verify the covering scenario re-runs (revert after). -->


### PR DESCRIPTION
Throwaway PR to verify PR #601's covered-scenario eval-gate behavior end-to-end. A doc-only edit to `create-and-publish-social-post.md` should cause the gate to sync/draft-tag and run the covering scenario `marketing/create-and-publish-social-post.yml`.

This test branch now carries the covered-scenario run changes plus the comparison formatter fix discovered by this PR run:

- `scenariosToRun` selects YAML scenarios changed in the PR plus existing scenarios covering changed skill docs.
- The gate resolves that selected set to EvalForge scenario IDs and passes `scenarioIds` to eval-pipeline `/run-comparison`, so the pipeline runs the exact selected scenarios instead of falling back to all scenarios matching the draft tag.
- The comparison comment formatter tolerates completed compare-group responses that include scenario `verdict`/`reason` but omit `pairwiseJudgement`, avoiding the `Cannot read properties of undefined (reading 'winner')` crash.
- The local EvalForge YAML gate action now declares `runs.using: node24` to avoid the deprecated Node 20 runtime.

Do not merge — for testing only.