### PR TITLE
Trigger scenario workflow

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35486,6 +35486,8 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
+exports.coveringScenarioNames = coveringScenarioNames;
+exports.selectScenariosToSync = selectScenariosToSync;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35516,6 +35518,36 @@ function remoteScenarioFiltersForGate(input) {
             names.add(name);
     }
     return { names: [...names].sort(), tags: [input.draftTag] };
+}
+/**
+ * Flattens the coverage map (changed doc -> covering scenario names) into the
+ * unique set of scenario names that exercise a changed skill doc.
+ */
+function coveringScenarioNames(coveredBy) {
+    const names = new Set();
+    for (const list of coveredBy.values()) {
+        for (const name of list)
+            names.add(name);
+    }
+    return names;
+}
+/**
+ * Scenarios this PR must draft (and therefore run in the comparison):
+ *   1. scenarios whose own YAML changed in THIS PR, AND
+ *   2. scenarios that COVER a changed skill doc — even when their YAML is untouched.
+ *
+ * (2) closes the gap where a pure skill-doc edit (which can change agent behavior)
+ * would otherwise sync nothing, skip the eval comparison, and pass the gate green
+ * without ever being validated against the scenarios that exercise it.
+ */
+function selectScenariosToSync(input) {
+    const { head, changedEvalPaths, docCoveringNames } = input;
+    const out = new Map();
+    for (const [name, ls] of head) {
+        if (changedEvalPaths.has(ls.path) || docCoveringNames.has(name))
+            out.set(name, ls);
+    }
+    return out;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35571,16 +35603,24 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+    // Draft (and therefore run) scenarios modified in THIS PR PLUS scenarios that
+    // cover a changed skill doc. Restricting to changed evals alone would let a pure
+    // doc edit skip the comparison; folding in doc-covering scenarios validates the
+    // doc change against the scenarios that exercise it. Untouched, uncovered
+    // scenarios are still excluded — avoids spurious PUTs on every push.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),
     ]);
-    const changedHeadScenarios = new Map();
-    for (const [name, ls] of headScenarios) {
-        if (changedEvalPaths.has(ls.path))
-            changedHeadScenarios.set(name, ls);
+    const docCoveringNames = coveringScenarioNames(cov.coveredBy);
+    if (docCoveringNames.size > 0) {
+        core.info(`Drafting ${docCoveringNames.size} scenario(s) covering changed skill docs: ${[...docCoveringNames].sort().join(', ')}`);
     }
+    const changedHeadScenarios = selectScenariosToSync({
+        head: headScenarios,
+        changedEvalPaths,
+        docCoveringNames,
+    });
     const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
     const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -47,6 +47,40 @@ export function remoteScenarioFiltersForGate(input: {
   return { names: [...names].sort(), tags: [input.draftTag] };
 }
 
+/**
+ * Flattens the coverage map (changed doc -> covering scenario names) into the
+ * unique set of scenario names that exercise a changed skill doc.
+ */
+export function coveringScenarioNames(coveredBy: Map<string, string[]>): Set<string> {
+  const names = new Set<string>();
+  for (const list of coveredBy.values()) {
+    for (const name of list) names.add(name);
+  }
+  return names;
+}
+
+/**
+ * Scenarios this PR must draft (and therefore run in the comparison):
+ *   1. scenarios whose own YAML changed in THIS PR, AND
+ *   2. scenarios that COVER a changed skill doc — even when their YAML is untouched.
+ *
+ * (2) closes the gap where a pure skill-doc edit (which can change agent behavior)
+ * would otherwise sync nothing, skip the eval comparison, and pass the gate green
+ * without ever being validated against the scenarios that exercise it.
+ */
+export function selectScenariosToSync(input: {
+  head: Map<string, LoadedScenario>;
+  changedEvalPaths: Set<string>;
+  docCoveringNames: Set<string>;
+}): Map<string, LoadedScenario> {
+  const { head, changedEvalPaths, docCoveringNames } = input;
+  const out = new Map<string, LoadedScenario>();
+  for (const [name, ls] of head) {
+    if (changedEvalPaths.has(ls.path) || docCoveringNames.has(name)) out.set(name, ls);
+  }
+  return out;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -114,15 +148,24 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+  // Draft (and therefore run) scenarios modified in THIS PR PLUS scenarios that
+  // cover a changed skill doc. Restricting to changed evals alone would let a pure
+  // doc edit skip the comparison; folding in doc-covering scenarios validates the
+  // doc change against the scenarios that exercise it. Untouched, uncovered
+  // scenarios are still excluded — avoids spurious PUTs on every push.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),
   ]);
-  const changedHeadScenarios = new Map<string, LoadedScenario>();
-  for (const [name, ls] of headScenarios) {
-    if (changedEvalPaths.has(ls.path)) changedHeadScenarios.set(name, ls);
+  const docCoveringNames = coveringScenarioNames(cov.coveredBy);
+  if (docCoveringNames.size > 0) {
+    core.info(`Drafting ${docCoveringNames.size} scenario(s) covering changed skill docs: ${[...docCoveringNames].sort().join(', ')}`);
   }
+  const changedHeadScenarios = selectScenariosToSync({
+    head: headScenarios,
+    changedEvalPaths,
+    docCoveringNames,
+  });
 
   const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
   const remote = await guardedCall(

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, coveringScenarioNames, selectScenariosToSync } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -38,5 +38,63 @@ describe('remoteScenarioFiltersForGate', () => {
       names: ['blog/changed', 'blog/deleted', 'stores/changed'],
       tags: ['draft:wix/skills#42'],
     });
+  });
+});
+
+describe('coveringScenarioNames', () => {
+  it('flattens and de-duplicates covering scenario names across changed docs', () => {
+    const coveredBy = new Map<string, string[]>([
+      ['skills/wix-manage/references/blog/a.md', ['blog/one', 'blog/two']],
+      ['skills/wix-manage/references/blog/b.md', ['blog/two', 'blog/three']],
+    ]);
+    expect([...coveringScenarioNames(coveredBy)].sort()).toEqual(['blog/one', 'blog/three', 'blog/two']);
+  });
+
+  it('returns empty set when no docs changed', () => {
+    expect(coveringScenarioNames(new Map()).size).toBe(0);
+  });
+});
+
+describe('selectScenariosToSync', () => {
+  const head = new Map<string, LoadedScenario>([
+    ['blog/changed', scenario('blog/changed')],
+    ['blog/covers-doc', scenario('blog/covers-doc')],
+    ['blog/untouched', scenario('blog/untouched')],
+  ]);
+
+  it('includes scenarios whose YAML changed', () => {
+    const out = selectScenariosToSync({
+      head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      docCoveringNames: new Set(),
+    });
+    expect([...out.keys()]).toEqual(['blog/changed']);
+  });
+
+  it('includes scenarios that cover a changed doc even when their YAML is untouched', () => {
+    const out = selectScenariosToSync({
+      head,
+      changedEvalPaths: new Set(),
+      docCoveringNames: new Set(['blog/covers-doc']),
+    });
+    expect([...out.keys()]).toEqual(['blog/covers-doc']);
+  });
+
+  it('unions changed-YAML and doc-covering scenarios without duplicates', () => {
+    const out = selectScenariosToSync({
+      head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      docCoveringNames: new Set(['blog/changed', 'blog/covers-doc']),
+    });
+    expect([...out.keys()].sort()).toEqual(['blog/changed', 'blog/covers-doc']);
+  });
+
+  it('excludes untouched, uncovered scenarios', () => {
+    const out = selectScenariosToSync({
+      head,
+      changedEvalPaths: new Set(),
+      docCoveringNames: new Set(),
+    });
+    expect(out.size).toBe(0);
   });
 });

--- a/skills/wix-manage/references/cms/cms-data-items-crud.md
+++ b/skills/wix-manage/references/cms/cms-data-items-crud.md
@@ -7,6 +7,8 @@ description: "Add, query, update, and delete items in CMS collections. Use this 
 > **Standard call shape (every curl below).** The `<AUTH>` placeholder is shorthand for `Authorization: Bearer <TOKEN>` only. Body-bearing requests also need `Content-Type: application/json`.
 
 This recipe covers basic Create, Read, Update, Delete (CRUD) operations for Wix CMS data items.
+<!-- Touch to trigger EvalForge YAML gate (paired with cms/cms-data-items-crud-install-app scenario). -->
+
 
 ## Prerequisites
 

--- a/yaml/wix-manage-evals/analytics/query-site-analytics-required-interval.yml
+++ b/yaml/wix-manage-evals/analytics/query-site-analytics-required-interval.yml
@@ -1,0 +1,32 @@
+name: analytics/query-site-analytics-required-interval
+description: >-
+  Verifies the agent reads the query-site-analytics skill and explains that Semantic Model
+  queries require an explicit time interval instead of relying on an implicit default range.
+triggerPrompt: >-
+  I want to query Wix Analytics semantic model data for sessions by traffic source. Can I omit
+  the date range and let the API choose a default, or do I need to send a time interval?
+tags: [analytics]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/analytics/skills/query-site-analytics
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked whether they can omit the date range when querying Wix Analytics Semantic
+      Model data for sessions by traffic source.
+      Intent: confirm that Query Semantic Model Data requires an explicit time interval and that
+      fields should be selected from the semantic model schema.
+
+      Pass if the response:
+      - states that the query must include an explicit time interval/date range, AND
+      - references the Query Semantic Model Data flow for Wix Analytics, AND
+      - explains that fields such as sessions and traffic source/referrer should be chosen from
+        the schema returned by Get Semantic Model instead of guessed.
+
+      Fail if the response:
+      - says the API will choose a safe default date range when omitted, OR
+      - omits the required interval/date range requirement, OR
+      - recommends unrelated Analytics APIs instead of the Semantic Model API, OR
+      - invents fixed field names without saying to inspect the semantic model schema.

--- a/yaml/wix-manage-evals/analytics/query-site-analytics.yml
+++ b/yaml/wix-manage-evals/analytics/query-site-analytics.yml
@@ -2,7 +2,7 @@ name: analytics/query-site-analytics
 description: >-
   Verifies the agent reads the query-site-analytics skill and explains how to retrieve a Wix
   site's analytics via the Semantic Model API using the List -> Get -> Query flow with a
-  required time interval.
+  required time interval. Additional dummy touch for scenario workflow validation.
 triggerPrompt: >-
   How do I retrieve my Wix site's traffic analytics (like sessions and page views by referrer)
   through the REST API? Please reference the relevant Semantic Model API methods and the request

--- a/yaml/wix-manage-evals/app-installation/install-cms-app.yml
+++ b/yaml/wix-manage-evals/app-installation/install-cms-app.yml
@@ -2,7 +2,7 @@ name: app-installation/install-cms-app
 description: >-
   Verifies the agent reads the install-wix-apps skill and explains how to install
   the Wix CMS app via the Apps Installer API using the correct appDefId. Dummy
-  PR trigger for scenario workflow validation.
+  PR trigger for scenario workflow validation. Touch to trigger EvalForge YAML gate.
 triggerPrompt: >-
   I need to install the Wix CMS (Wix Data) app on my site so I can start using collections.
   Which REST endpoint do I call and what request body do I send?

--- a/yaml/wix-manage-evals/app-installation/install-cms-app.yml
+++ b/yaml/wix-manage-evals/app-installation/install-cms-app.yml
@@ -1,7 +1,8 @@
 name: app-installation/install-cms-app
 description: >-
   Verifies the agent reads the install-wix-apps skill and explains how to install
-  the Wix CMS app via the Apps Installer API using the correct appDefId.
+  the Wix CMS app via the Apps Installer API using the correct appDefId. Dummy
+  PR trigger for scenario workflow validation.
 triggerPrompt: >-
   I need to install the Wix CMS (Wix Data) app on my site so I can start using collections.
   Which REST endpoint do I call and what request body do I send?

--- a/yaml/wix-manage-evals/cms/cms-data-items-crud-install-app.yml
+++ b/yaml/wix-manage-evals/cms/cms-data-items-crud-install-app.yml
@@ -2,6 +2,7 @@ name: cms/cms-data-items-crud-install-app
 description: >-
   Verifies the agent reads the cms-data-items-crud skill and recovers from a WDE0110
   error by installing the Wix CMS app (correct appDefId) and then retrying the insert.
+  Touch to trigger EvalForge YAML gate.
 triggerPrompt: >-
   I'm inserting a data item into my Wix CMS collection through the REST API, but the call
   fails with error code WDE0110. What does this mean and how do I get the insert to succeed?

--- a/yaml/wix-manage-evals/cms/cms-data-items-crud-install-app.yml
+++ b/yaml/wix-manage-evals/cms/cms-data-items-crud-install-app.yml
@@ -2,7 +2,7 @@ name: cms/cms-data-items-crud-install-app
 description: >-
   Verifies the agent reads the cms-data-items-crud skill and recovers from a WDE0110
   error by installing the Wix CMS app (correct appDefId) and then retrying the insert.
-  Touch to trigger EvalForge YAML gate.
+  Touch to trigger EvalForge YAML gate. Dummy trigger #2.
 triggerPrompt: >-
   I'm inserting a data item into my Wix CMS collection through the REST API, but the call
   fails with error code WDE0110. What does this mean and how do I get the insert to succeed?


### PR DESCRIPTION
## Summary
- feat(eval-gate): run scenarios covering a changed skill doc (see below).
- Includes the bookings availability recipe refactor currently present on the PR branch.
- Adds dummy YAML touches to eval scenario files (and a paired skill reference) used to validate the gate trigger.
- Adds a new analytics eval scenario for the Semantic Model API required time interval behavior.

## feat(eval-gate): run scenarios covering a changed skill doc
Previously a pure skill-doc edit (`skills/wix-manage/references/<area>/*.md`) passed the gate **green without running any eval**: the coverage check only required a changed doc to *have* a covering scenario, and eval execution was triggered solely by scenario YAML changes. A doc edit can change agent behavior, so it was never validated against the scenarios that exercise it (e.g. PR #542 edited `create-and-publish-social-post.md` and logged "No scenarios created or updated — skipping eval pipeline comparison").

Fix: fold scenarios that cover a changed doc into the set that gets drafted (tagged) and compared, even when their YAML is untouched.
- `coveringScenarioNames()` — flatten the coverage map to unique scenario names.
- `selectScenariosToSync()` — union of changed-YAML + doc-covering scenarios.
- Rebuilt `dist/index.js`; added unit tests (gate.test.ts).

Files:
- .github/actions/evalforge-yaml-gate/src/utils/gate.ts
- .github/actions/evalforge-yaml-gate/tests/gate.test.ts
- .github/actions/evalforge-yaml-gate/dist/index.js

## Dummy trigger touches (description/comment-only, no logic changes)
- yaml/wix-manage-evals/app-installation/install-cms-app.yml
- yaml/wix-manage-evals/cms/cms-data-items-crud-install-app.yml (scenario)
- skills/wix-manage/references/cms/cms-data-items-crud.md (paired skill — same cms folder)

## Validation
- yarn test (176 passing), yarn typecheck clean, dist rebuilt via ncc.
- Confirmed the branch is pushed and up to date with origin/codex/dummy-yaml-scenario-trigger.

## Notes
- New scenario: yaml/wix-manage-evals/analytics/query-site-analytics-required-interval.yml.