### PR TITLE
feat(wix-headless): template-authoring overlay (standing brief + house style)

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -71,6 +71,8 @@ create/connect/iterate are **managed-only**. For `managed`, resolve the operatio
 
 For `self-managed` and `stripe`, the operation is always **backend-only** (the host owns the frontend). Only when there is **genuinely no brought-in design and no connect language** does directory emptiness decide: empty → `create`; an existing frontend on disk → `connect`.
 
+> **Template authoring (overlay, not an operation).** When the deliverable is a **contributable template** — a reusable managed-Astro template for the Wix templates repo, not an ad-hoc site — the run still resolves to `create` or `iterate` as above, but **also reads `references/managed/TEMPLATE_AUTHORING.md`**: a standing brief (pre-resolved intent choices, e.g. custom-branded login) plus the house style (structure, code standards, testing, README) that a contributable template requires and an ad-hoc site doesn't.
+
 ## Preconditions (the host provides these — we read, never create)
 
 1. **The project type** — `managed` | `self-managed` | `stripe` — provided by the caller, else **detected from project signals / user intent** (see Project types § "Resolving the project type"), else asked. It selects `<TYPE_DIR>` (see Path resolution).
@@ -123,6 +125,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | **Deployment** — finalize the live site (project-type-specific) | `<TYPE_DIR>/DEPLOYMENT.md` |
 | Managed **create** flow (scaffold a new project) | `<SKILL_ROOT>/references/managed/CREATE.md` |
 | Managed **connect** flow (wire an existing project) | `<SKILL_ROOT>/references/managed/CONNECT.md` |
+| Managed **template authoring** overlay (contributable templates: standing brief + house style) | `<SKILL_ROOT>/references/managed/TEMPLATE_AUTHORING.md` |
 | Frontend-axis references (how a frontend wires to Wix) | `<SKILL_ROOT>/references/astro.md`, `non-astro.md` |
 
 **Start a run by opening `DISCOVERY.md`.** The flow files (`CAPABILITIES`, `DISCOVERY`, `SETUP`, `SEED`, `SDK_HANDOFF`, `IMAGE_GENERATION`, `AI_FEATURES`) are project-type-agnostic; the per-type specifics live under `<TYPE_DIR>/` (`AUTHENTICATION.md`, `DEPLOYMENT.md`, and — managed only — `CREATE.md`/`CONNECT.md`).

--- a/skills/wix-headless/references/managed/TEMPLATE_AUTHORING.md
+++ b/skills/wix-headless/references/managed/TEMPLATE_AUTHORING.md
@@ -22,29 +22,12 @@ These are the template product's choices. Where the skill's references branch on
 
 ## 2 — House style (where the skill is silent by design)
 
-### 2.1 Project structure
+### 2.1 Project requirements
 
-Every template lives at `astro/<template-name>/` in the templates repo and must contain:
+The on-disk shape comes from the scaffold (`astro.md` §1) — don't restate or hand-build it. On top of it, a template requires:
 
-```
-astro/<template-name>/
-├── .gitignore
-├── .npmrc
-├── .template-config.json        # Wix CLI template config (required)
-├── README.md                    # required sections: §2.4
-├── astro.config.mjs             # per astro.md Caveat A2 — do not diverge
-├── package.json                 # scripts: dev → wix dev, build → wix build, release → wix release
-├── tsconfig.json                # strict: true
-├── tailwind.config.mjs
-├── src/
-│   ├── components/              # UI components, co-located with feature area
-│   ├── pages/
-│   │   ├── index.astro          # home page
-│   │   └── api/                 # server-only API routes (elevation, backend logic)
-│   └── integrations/            # Wix vertical modules: service.ts + types.ts per vertical
-└── public/
-```
-
+- **Location:** every template lives at `astro/<template-name>/` in the templates repo.
+- **`.template-config.json`** — the Wix CLI template config — must exist at the template root.
 - **TypeScript required**, `strict: true`. No `.js` source files in new templates.
 - **Tailwind CSS required.** No CSS modules, no inline styles.
 - **No `.env.template`** — the CLI manages `WIX_CLIENT_*`; custom vars only, per the env-var mechanism (`astro.md` §5).

--- a/skills/wix-headless/references/managed/TEMPLATE_AUTHORING.md
+++ b/skills/wix-headless/references/managed/TEMPLATE_AUTHORING.md
@@ -1,0 +1,93 @@
+# Template Authoring — building a *contributable template* with this skill
+
+Read this file when the deliverable is a **contributable template** — a reusable, maintained, managed-Astro CLI template (for the Wix templates repo) — rather than an ad-hoc site. It is an **overlay on the normal managed flow**, not a replacement: the run still rides `CREATE.md` (new template) or `CONNECT.md`-as-iterate (extending one), with Discovery → Setup → Seed → build → release unchanged.
+
+**Scope:** Wix-managed Astro CLI only (`@wix/cli` + `@wix/astro`). Self-managed, Next.js, and React Native templates are out of scope.
+
+The file has three parts, matching how each relates to the rest of the skill:
+
+1. **The standing brief** — intent choices the template product has already made. The skill's intent-conditionals ("only when the brief asks…") consume these; stating them here *is* the brief.
+2. **House style** — requirements where the skill is deliberately silent (structure, code standards, testing, docs), because an ad-hoc site doesn't need them and a maintained template does.
+3. **Platform facts & mechanics** — nothing restated; a pointer table into the canonical references. If anything here ever seems to conflict with those, the canonical reference wins.
+
+---
+
+## 1 — The standing brief (intent, pre-resolved)
+
+These are the template product's choices. Where the skill's references branch on intent, resolve the branch with these — no need to ask.
+
+- **Login is custom-branded.** A template ships its **own login / sign-up UI** — treat this as the brief explicitly asking for custom login and build it per `../inline-recipes/how-to-code-members-custom-login.md`. The Wix-hosted login page is **not** used in templates (a template's auth pages are part of the design deliverable). Dashboard prerequisites: allow-list the exact callback URIs on the OAuth app, and set the OAuth app **Login URL** to the template's login page — business flows (e.g. checkout) use it to redirect unauthenticated visitors.
+- **Scaffold blank.** Bare `--site-template` (the blank starter) — same as the skill's normal create path. The template's design is authored, never adopted from a business starter.
+- **Verification is asked for.** The skill's "don't smoke-test unless the user asks to verify" conditional is resolved for template runs: the template's golden path **must pass its tests** (§2.3) before it is contributed. Release rules are unchanged (release once, at the very end).
+
+## 2 — House style (where the skill is silent by design)
+
+### 2.1 Project structure
+
+Every template lives at `astro/<template-name>/` in the templates repo and must contain:
+
+```
+astro/<template-name>/
+├── .gitignore
+├── .npmrc
+├── .template-config.json        # Wix CLI template config (required)
+├── README.md                    # required sections: §2.4
+├── astro.config.mjs             # per astro.md Caveat A2 — do not diverge
+├── package.json                 # scripts: dev → wix dev, build → wix build, release → wix release
+├── tsconfig.json                # strict: true
+├── tailwind.config.mjs
+├── src/
+│   ├── components/              # UI components, co-located with feature area
+│   ├── pages/
+│   │   ├── index.astro          # home page
+│   │   └── api/                 # server-only API routes (elevation, backend logic)
+│   └── integrations/            # Wix vertical modules: service.ts + types.ts per vertical
+└── public/
+```
+
+- **TypeScript required**, `strict: true`. No `.js` source files in new templates.
+- **Tailwind CSS required.** No CSS modules, no inline styles.
+- **No `.env.template`** — the CLI manages `WIX_CLIENT_*`; custom vars only, per the env-var mechanism (`astro.md` §5).
+
+### 2.2 Code standards
+
+- No `any` without an explanatory comment.
+- No `console.log` in committed code.
+- No hardcoded Wix App IDs without a comment saying what they identify.
+- **Keep pages thin.** Wix calls live in `src/integrations/<vertical>/service.ts` with typed exports; `.astro` pages consume the services. (SSR guards per `astro.md` A3 apply inside the services and any remaining frontmatter calls alike.)
+
+### 2.3 Testing (ad-hoc runs skip this — template runs must not)
+
+- **Vitest** unit tests for integration service files: `src/integrations/**/*.test.ts`.
+- **Playwright** e2e for the template's golden-path flow(s).
+- `data-testid` on every interactive element; centralize the IDs in `src/utils/test-ids.ts`.
+- Screenshot baselines where applicable.
+
+### 2.4 Documentation
+
+Every template's `README.md` is **its own distinct content** — never copied from another template — with:
+
+1. Template name + one-line description
+2. Live demo URL (Wix-hosted — required)
+3. Features list (which Wix verticals are used)
+4. Prerequisites: Node ≥ 20.11, Wix account
+5. Quick start: `git clone` → `npm install --ignore-scripts` → `wix dev`
+6. What to configure in the Wix dashboard (installed apps, content seeding)
+7. How to release: `wix build && wix release`
+
+## 3 — Platform facts & mechanics: reference, don't restate
+
+Everything below is owned by the canonical references — read them there; this file deliberately carries none of it, so it can't drift.
+
+| Concern | Canonical reference |
+|---|---|
+| Scaffold / link / init (`npm create @wix/new@latest -- headless …`) | `../astro.md` §1 |
+| Required `astro.config.mjs` (`wix()` + `wixPages()` + `react()`, `output: 'server'`, `checkOrigin: false`) | `../astro.md` Caveat **A2** |
+| Auth model (auto-auth, no client) · custom login flow | `../astro.md` §2 · `../inline-recipes/how-to-code-members-custom-login.md` |
+| Custom env vars (`envField` schema, `astro:env/*`, `wix env set`/`pull`) | `../astro.md` §5 |
+| SEO — main pages (automatic) · item/detail pages (coded) | `../astro.md` §6 + the vertical's `../inline-recipes/how-to-code-*.md` |
+| Wix media / rich text (`wix:image://` resolution, Ricos) | `../astro.md` Caveat **A6** |
+| SSR error guards · island hydration · no HTML comments in frontmatter | Caveats **A3 / A4 / A5** |
+| Dependency install (`npm install --ignore-scripts`; sharp is a non-issue) | Caveat **A9** |
+| Dev / build / release workflow (release once, at the end) | `../astro.md` §4 · `DEPLOYMENT.md` |
+| Backend setup & content seeding | `../SETUP.md` · `../SEED.md` |


### PR DESCRIPTION
## What

Adds **`references/managed/TEMPLATE_AUTHORING.md`** — an overlay read when the deliverable is a **contributable managed-Astro template** (for the Wix templates repo) rather than an ad-hoc site. The run still rides the normal `create`/`iterate` flow; this file adds what a reusable, maintained template needs on top.

It condenses the human-written template `GUIDELINES.md` (~480 lines) down to only what the skill doesn't already carry, in three parts:

1. **The standing brief** — intent choices pre-resolved by the template product, consumed by the skill's existing intent-conditionals (custom-branded login, blank scaffold, verification required). Not overrides: the skill's conditionals ("only when the brief explicitly asks…") are designed to take exactly this input.
2. **House style** — where the skill is deliberately silent because ad-hoc sites don't need it: fixed project structure + `.template-config.json`, TS-strict/Tailwind mandates, code standards (thin pages, `src/integrations/<vertical>/service.ts`), **testing** (Vitest + Playwright + `data-testid`), README required sections.
3. **Platform facts** — restates nothing; a pointer table into the canonical refs (`astro.md` sections/caveats, inline recipes) so the two can't drift.

`SKILL.md` gets a pointer in the managed-operations section + a path-resolution row. `entry/` untouched.

## ⚠️ Points needing reconciliation (with the guidelines author)

Three **factual** disagreements between the original GUIDELINES.md and the skill surfaced while condensing. The new file deliberately takes no side (it defers login mechanics to the recipe), but the canonical files should be corrected once resolved:

1. **Custom login on managed Astro — client or no client?**
   GUIDELINES §4: *"do not call `createClient` or instantiate `OAuthStrategy` manually — the CLI pre-configures the SDK; auth methods are available directly through the imported SDK modules."*
   Skill (`inline-recipes/how-to-code-members-custom-login.md`): *"Astro's auto-auth ships **no client**… custom login means stepping outside auto-auth — instantiate an explicit `OAuthStrategy` client."*
   These contradict; whichever is right determines what template login code looks like. Needs an empirical check against current `@wix/astro`.

2. **Token refresh API name.** GUIDELINES: `auth.refreshTokens(storedRefreshToken)` (4h expiry, 14-day cookie). Skill recipe: `auth.renewToken(refreshToken)`. One is wrong or renamed.

3. **Image domain config in `astro.config.mjs`.** GUIDELINES §3: *"do not add image domain config for Wix media."* Skill (`astro.md` §1) notes `headless link` itself **writes** an image domain into the config. Is the rule "don't add manually" or "remove what link adds"?

## Follow-ups (out of scope here)

- Enrich `astro.md` with the four managed-stack flows GUIDELINES §9 covers and the skill currently lacks entirely: **multilingual, analytics, extensions, Wix-hosted/redirect pages** — they benefit every managed run, not just templates.
- Shrink the templates repo's `GUIDELINES.md` to a thin pointer at `TEMPLATE_AUTHORING.md` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)