### PR TITLE
test(eval-gate)

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35519,13 +35519,8 @@ function remoteScenarioFiltersForGate(input) {
     return { names: [...names].sort(), tags: [input.draftTag] };
 }
 /**
- * The head scenarios this PR should sync and (re-)run:
- *  - scenarios whose own YAML changed in this PR (existing behavior), plus
- *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
- *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
- *
- * Both sets flow through the same sync → draft-tag → eval-compare path, so a
- * doc-only change gets its covering scenarios draft-tagged and compared.
+ * Head scenarios to sync and run: those whose YAML changed, plus those covering a
+ * changed skill doc (so editing a skill re-runs the scenarios that exercise it).
  */
 function scenariosToRun(input) {
     const result = new Map();
@@ -35596,9 +35591,6 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
-    // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
-    // it, not just requires their existence). Both flow through the sync/compare path below.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34950,8 +34950,8 @@ class EvalPipelineClient {
         }
         return res.json();
     }
-    async runComparison(tags, agentName, commitSha, skillsRepo) {
-        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo });
+    async runComparison(tags, agentName, commitSha, skillsRepo, scenarioIds) {
+        return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
     }
     async compareGroup(comparisonGroupId) {
         return this.post('/compare-group', { comparisonGroupId });
@@ -35487,6 +35487,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
 exports.scenariosToRun = scenariosToRun;
+exports.scenarioIdsToRun = scenarioIdsToRun;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35536,6 +35537,21 @@ function scenariosToRun(input) {
         }
     }
     return result;
+}
+function scenarioIdsToRun(scenarios, nameToId) {
+    const missing = [];
+    const ids = [];
+    for (const name of scenarios.keys()) {
+        const id = nameToId.get(name);
+        if (id)
+            ids.push(id);
+        else
+            missing.push(name);
+    }
+    if (missing.length > 0) {
+        throw new Error(`Missing EvalForge scenario IDs for: ${missing.join(', ')}`);
+    }
+    return ids;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35644,7 +35660,7 @@ async function runGate() {
         return;
     }
     const pipeline = new eval_pipeline_1.EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
-    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo), 'Could not start eval pipeline comparison', comment, config);
+    const comparison = await guardedCall(() => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo, scenarioIdsToRun(changedHeadScenarios, nameToId)), 'Could not start eval pipeline comparison', comment, config);
     if (!comparison)
         return;
     core.info(`Eval pipeline comparison started: comparisonGroupId=${comparison.comparisonGroupId}`);

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35486,6 +35486,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
+exports.scenariosToRun = scenariosToRun;
 exports.runGate = runGate;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -35516,6 +35517,30 @@ function remoteScenarioFiltersForGate(input) {
             names.add(name);
     }
     return { names: [...names].sort(), tags: [input.draftTag] };
+}
+/**
+ * The head scenarios this PR should sync and (re-)run:
+ *  - scenarios whose own YAML changed in this PR (existing behavior), plus
+ *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
+ *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
+ *
+ * Both sets flow through the same sync → draft-tag → eval-compare path, so a
+ * doc-only change gets its covering scenarios draft-tagged and compared.
+ */
+function scenariosToRun(input) {
+    const result = new Map();
+    for (const [name, ls] of input.headScenarios) {
+        if (input.changedEvalPaths.has(ls.path))
+            result.set(name, ls);
+    }
+    for (const coveringNames of input.coveredBy.values()) {
+        for (const name of coveringNames) {
+            const ls = input.headScenarios.get(name);
+            if (ls)
+                result.set(name, ls);
+        }
+    }
+    return result;
 }
 async function runGate() {
     const config = (0, config_1.getEvalConfig)();
@@ -35571,16 +35596,14 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
-    // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+    // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
+    // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
+    // it, not just requires their existence). Both flow through the sync/compare path below.
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),
     ]);
-    const changedHeadScenarios = new Map();
-    for (const [name, ls] of headScenarios) {
-        if (changedEvalPaths.has(ls.path))
-            changedHeadScenarios.set(name, ls);
-    }
+    const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
     const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
     const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -113,8 +113,8 @@ export class EvalPipelineClient {
     return res.json() as Promise<T>;
   }
 
-  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string): Promise<ComparisonResult> {
-    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo });
+  async runComparison(tags: string[], agentName: string, commitSha?: string, skillsRepo?: string, scenarioIds?: string[]): Promise<ComparisonResult> {
+    return this.post<ComparisonResult>('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
   }
 
   async compareGroup(comparisonGroupId: string): Promise<CompareGroupStatus> {

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -47,6 +47,33 @@ export function remoteScenarioFiltersForGate(input: {
   return { names: [...names].sort(), tags: [input.draftTag] };
 }
 
+/**
+ * The head scenarios this PR should sync and (re-)run:
+ *  - scenarios whose own YAML changed in this PR (existing behavior), plus
+ *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
+ *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
+ *
+ * Both sets flow through the same sync → draft-tag → eval-compare path, so a
+ * doc-only change gets its covering scenarios draft-tagged and compared.
+ */
+export function scenariosToRun(input: {
+  headScenarios: Map<string, LoadedScenario>;
+  changedEvalPaths: Set<string>;
+  coveredBy: Map<string, string[]>;
+}): Map<string, LoadedScenario> {
+  const result = new Map<string, LoadedScenario>();
+  for (const [name, ls] of input.headScenarios) {
+    if (input.changedEvalPaths.has(ls.path)) result.set(name, ls);
+  }
+  for (const coveringNames of input.coveredBy.values()) {
+    for (const name of coveringNames) {
+      const ls = input.headScenarios.get(name);
+      if (ls) result.set(name, ls);
+    }
+  }
+  return result;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -114,15 +141,14 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Restrict head to scenarios authored or modified in THIS PR — avoids spurious PUTs on every push.
+  // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
+  // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
+  // it, not just requires their existence). Both flow through the sync/compare path below.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),
   ]);
-  const changedHeadScenarios = new Map<string, LoadedScenario>();
-  for (const [name, ls] of headScenarios) {
-    if (changedEvalPaths.has(ls.path)) changedHeadScenarios.set(name, ls);
-  }
+  const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
 
   const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
   const remote = await guardedCall(

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -69,6 +69,23 @@ export function scenariosToRun(input: {
   return result;
 }
 
+export function scenarioIdsToRun(
+  scenarios: Map<string, LoadedScenario>,
+  nameToId: Map<string, string>,
+): string[] {
+  const missing: string[] = [];
+  const ids: string[] = [];
+  for (const name of scenarios.keys()) {
+    const id = nameToId.get(name);
+    if (id) ids.push(id);
+    else missing.push(name);
+  }
+  if (missing.length > 0) {
+    throw new Error(`Missing EvalForge scenario IDs for: ${missing.join(', ')}`);
+  }
+  return ids;
+}
+
 export async function runGate(): Promise<void> {
   const config = getEvalConfig();
   const octokit = github.getOctokit(config.githubToken);
@@ -194,7 +211,7 @@ export async function runGate(): Promise<void> {
 
   const pipeline = new EvalPipelineClient(config.evalPipelineUrl, config.appId, config.appSecret);
   const comparison = await guardedCall(
-    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo),
+    () => pipeline.runComparison([draftTag], config.agentName, config.headSha, config.mcpSkillsRepo, scenarioIdsToRun(changedHeadScenarios, nameToId)),
     'Could not start eval pipeline comparison', comment, config,
   );
   if (!comparison) return;

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -48,13 +48,8 @@ export function remoteScenarioFiltersForGate(input: {
 }
 
 /**
- * The head scenarios this PR should sync and (re-)run:
- *  - scenarios whose own YAML changed in this PR (existing behavior), plus
- *  - scenarios that cover a changed skill doc, even when their YAML is unchanged —
- *    a doc edit changes agent behavior, so the scenarios exercising it should re-run.
- *
- * Both sets flow through the same sync → draft-tag → eval-compare path, so a
- * doc-only change gets its covering scenarios draft-tagged and compared.
+ * Head scenarios to sync and run: those whose YAML changed, plus those covering a
+ * changed skill doc (so editing a skill re-runs the scenarios that exercise it).
  */
 export function scenariosToRun(input: {
   headScenarios: Map<string, LoadedScenario>;
@@ -141,9 +136,6 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
-  // Scenarios to sync + run: those whose own YAML changed in this PR, plus those that
-  // cover a changed skill doc (so editing a skill re-runs the scenarios that exercise
-  // it, not just requires their existence). Both flow through the sync/compare path below.
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),

--- a/.github/actions/evalforge-yaml-gate/tests/eval-pipeline.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/eval-pipeline.test.ts
@@ -6,6 +6,7 @@ beforeEach(() => { vi.restoreAllMocks(); });
 describe('EvalPipelineClient — OAuth Bearer auth', () => {
   it('runComparison mints a token and sends Authorization: Bearer (no x-app headers)', async () => {
     let seen: Headers | undefined;
+    let body: unknown;
     let mints = 0;
     globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);
@@ -14,16 +15,24 @@ describe('EvalPipelineClient — OAuth Bearer auth', () => {
         return new Response(JSON.stringify({ access_token: 'tok-1', token_type: 'Bearer', expires_in: 300 }), { status: 200, headers: { 'content-type': 'application/json' } });
       }
       seen = new Headers(init?.headers);
+      body = JSON.parse(String(init?.body));
       expect(url).toBe('https://pipe.test/run-comparison');
       return new Response(JSON.stringify({ comparisonGroupId: 'cg-1' }), { status: 200, headers: { 'content-type': 'application/json' } });
     }) as unknown as typeof fetch;
 
     const c = new EvalPipelineClient('https://pipe.test', 'aid', 'sec');
-    const r = await c.runComparison(['draft:o/r#1'], 'agent', 'sha', 'wix/skills');
+    const r = await c.runComparison(['draft:o/r#1'], 'agent', 'sha', 'wix/skills', ['s1', 's2']);
     expect(r).toEqual({ comparisonGroupId: 'cg-1' });
     expect(seen?.get('authorization')).toBe('Bearer tok-1');
     expect(seen?.get('x-app-id')).toBeNull();
     expect(seen?.get('x-app-secret')).toBeNull();
+    expect(body).toEqual({
+      tags: ['draft:o/r#1'],
+      agentName: 'agent',
+      commitSha: 'sha',
+      skillsRepo: 'wix/skills',
+      scenarioIds: ['s1', 's2'],
+    });
     expect(mints).toBe(1);
   });
 

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, scenariosToRun } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -38,5 +38,52 @@ describe('remoteScenarioFiltersForGate', () => {
       names: ['blog/changed', 'blog/deleted', 'stores/changed'],
       tags: ['draft:wix/skills#42'],
     });
+  });
+});
+
+describe('scenariosToRun', () => {
+  const head = new Map<string, LoadedScenario>([
+    ['blog/changed', scenario('blog/changed')],
+    ['blog/unchanged', scenario('blog/unchanged')],
+    ['marketing/social', scenario('marketing/social')],
+  ]);
+
+  it('includes scenarios whose own YAML changed in this PR (existing behavior)', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      coveredBy: new Map(),
+    });
+    expect([...out.keys()]).toEqual(['blog/changed']);
+  });
+
+  it('also includes scenarios covering a changed doc, even when their YAML is unchanged', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(),
+      coveredBy: new Map([['skills/wix-manage/references/marketing/social.md', ['marketing/social']]]),
+    });
+    expect([...out.keys()]).toEqual(['marketing/social']);
+  });
+
+  it('unions changed + doc-covered scenarios without duplicates', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      coveredBy: new Map([
+        ['skills/wix-manage/references/marketing/social.md', ['marketing/social']],
+        ['skills/wix-manage/references/blog/changed.md', ['blog/changed']],
+      ]),
+    });
+    expect([...out.keys()].sort()).toEqual(['blog/changed', 'marketing/social']);
+  });
+
+  it('ignores covering names with no loaded head scenario', () => {
+    const out = scenariosToRun({
+      headScenarios: head,
+      changedEvalPaths: new Set(),
+      coveredBy: new Map([['skills/wix-manage/references/x/y.md', ['does/not-exist']]]),
+    });
+    expect(out.size).toBe(0);
   });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { remoteScenarioFiltersForGate, scenariosToRun } from '../src/utils/gate';
+import { remoteScenarioFiltersForGate, scenarioIdsToRun, scenariosToRun } from '../src/utils/gate';
 import type { LoadedScenario } from '../src/utils/evals';
 import type { Scenario } from '../src/utils/schema';
 
@@ -85,5 +85,26 @@ describe('scenariosToRun', () => {
       coveredBy: new Map([['skills/wix-manage/references/x/y.md', ['does/not-exist']]]),
     });
     expect(out.size).toBe(0);
+  });
+});
+
+describe('scenarioIdsToRun', () => {
+  it('maps selected scenario names to EvalForge IDs in run order', () => {
+    const selected = new Map<string, LoadedScenario>([
+      ['blog/changed', scenario('blog/changed')],
+      ['marketing/social', scenario('marketing/social')],
+    ]);
+    const ids = scenarioIdsToRun(selected, new Map([
+      ['marketing/social', 'id-social'],
+      ['blog/changed', 'id-changed'],
+    ]));
+    expect(ids).toEqual(['id-changed', 'id-social']);
+  });
+
+  it('fails clearly when a selected scenario has no remote ID', () => {
+    const selected = new Map<string, LoadedScenario>([
+      ['blog/changed', scenario('blog/changed')],
+    ]);
+    expect(() => scenarioIdsToRun(selected, new Map())).toThrow('Missing EvalForge scenario IDs for: blog/changed');
   });
 });

--- a/skills/wix-manage/references/marketing/create-and-publish-social-post.md
+++ b/skills/wix-manage/references/marketing/create-and-publish-social-post.md
@@ -434,3 +434,5 @@ The post appears on the site's Social Media Marketing page in the dashboard. To 
 - [Media Manager: Import File](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file)
 - [Media Manager: Generate File Upload URL](https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/generate-file-upload-url)
 - [Publisher API sample flows](https://dev.wix.com/docs/api-reference/business-management/marketing/social-media/sample-flows)
+
+<!-- eval-gate test: doc-only edit to verify the covering scenario re-runs (revert after). -->


### PR DESCRIPTION
Today the gate only (re)runs scenarios whose own YAML changed in the PR, so
editing a skill's instructions passes green without executing any eval — the
coverage check only requires a covering scenario to *exist*, never runs it.

Extend the set of scenarios the gate syncs + runs to also include those that
cover a changed skill doc (from the coverage map the gate already computes),
even when their YAML is unchanged. Both sets flow through the same
sync → draft-tag → eval-compare path, so a doc edit now re-runs the scenarios
that exercise it. The existing "scenario YAML changed" flow is unchanged.

Extracted the selection into a pure `scenariosToRun` helper with unit tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>