### PR TITLE
TEST: E2E covered + added scenario selection (do not merge)

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
@@ -93,3 +93,5 @@ Are other active discount rules conflicting with or overriding this one?
 | 4 | Revision mismatch | Retry the update with correct revision |
 | 5 | App installation | Install Wix Stores app |
 | 6 | Stacking interference | Review and resolve overlapping rules |
+
+<!-- e2e-gate-test: temporary edit to exercise doc-covered scenario selection; do not merge -->

--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -192,3 +192,5 @@ Check the response `pagingMetadata` to determine if more pages exist.
 ## Conclusion
 
 To find products by name or free text, use `POST https://www.wixapis.com/stores/v3/products/search`. To list, page, sort, or structurally filter products, use `POST https://www.wixapis.com/stores/v3/products/query`. Use `fields: []` for defaults, or pass valid enum values like `DESCRIPTION`, `URL`, `ALL_CATEGORIES_INFO` for additional data. Never pass property names as field values.
+
+<!-- e2e-gate-test: temporary edit; covered by the added stores/e2e-find-products-smoke scenario; do not merge -->

--- a/yaml/wix-manage-evals/stores/e2e-find-products-smoke.yml
+++ b/yaml/wix-manage-evals/stores/e2e-find-products-smoke.yml
@@ -1,0 +1,14 @@
+name: stores/e2e-find-products-smoke
+description: E2E gate smoke — find and search products in the store catalog.
+triggerPrompt: For my site Gracia (331d0c05-2ab0-4edb-91a6-4078c7e500b9), help me find and search products in my store catalog.
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Pass if the response loads the find-products recipe and explains how to query/search the store catalog to locate products.
+      Fail if it ignores the catalog, fabricates product data, or routes to an unrelated flow.


### PR DESCRIPTION
**Throwaway E2E** for the merged `run scenarios covering a changed skill doc` feature (#601). Do not merge — close to also verify cleanup.

Exercises both selection paths in one PR:

| Change | Expected gate behavior |
|---|---|
| Edit `ecommerce/…/ecom-pricing-troubleshoot-not-applying.md` (scenario YAML unchanged) | pulls in existing scenario `ecommerce/pricing-promotions/troubleshoot-not-applying` via **doc-coverage** |
| Edit `stores/find-products-query-and-search-catalog-v3.md` + add `stores/e2e-find-products-smoke` scenario covering its canonical URL | new scenario runs (**added-YAML**) and satisfies coverage for the touched doc |

Checklist:
1. Both docs report covered → gate proceeds (no missing-coverage failure).
2. Comparison runs **both** scenarios (per-side assertions; pairwise winner will be absent until `ANTHROPIC_API_KEY` is restored on the pipeline — expected).
3. On close: `EvalForge YAML Gate Cleanup` restores the edited docs' scenario state and deletes the PR-only `stores/e2e-find-products-smoke` draft. (The legacy `Skill Eval Cleanup` will also run and fail — unrelated, pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)