### PR TITLE
docs-extract(wix-headless): thin how-to-code-cms to doc links + labeled divergences

### DIFF
--- a/skills/wix-headless/references/inline-recipes/how-to-code-cms.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-cms.md
@@ -8,13 +8,17 @@ A concise contract for writing the **frontend code** that reads Wix CMS collecti
 
 > **This recipe is for CODING the frontend, not for seeding it.** It assumes the collections and items already exist and are **public-read** (created by `setup-cms.md`). It says nothing about creating collections or inserting data — only how to read them from frontend code.
 
-> **⚠️ Reading rule — always append `.md?apiView=SDK` to every doc link below.** The Wix docs render two views of the same page. The **bare / REST view** describes the REST shape — items nested under `item.data.<field>` and queried via a `POST /items/query` body. The **`?apiView=SDK` view** describes the SDK shape — items with **fields on the item itself** and a chainable `items.query(...)` builder. The SDK is what your frontend calls; reading the REST view by mistake is the source of the `item.data.title`-returns-`undefined` bug below. Fetch the `.md?apiView=SDK` form directly.
+> **⚠️ Reading rule — read the SDK view, not the REST view.** Wix Data docs render two shapes of the same API. Append **`?apiView=SDK`** to `/api-reference/…` doc links, or read the `/docs/sdk/…` pages directly. Reading the REST shape by mistake is the root of the `item.data.title`-returns-`undefined` and `item.id`-`undefined` bugs called out below — those two shapes are a live product divergence (see **Known SDK↔REST divergences**), so the SDK-side rules here are load-bearing, not stylistic.
+
+The canonical, working end-to-end examples the docs already provide (read these for full setup + code):
+- **Read + render a collection (headless React/Next):** <https://dev.wix.com/docs/go-headless/self-managed-headless/self-managed-tutorials/java-script-sdk-tutorials/data-quick-start.md>
+- **Render Ricos rich content:** <https://dev.wix.com/docs/go-headless/self-managed-headless/self-managed-tutorials/other-tutorials/working-with-rich-content.md>
 
 ---
 
 ## The module and the client (read this first)
 
-**⚠️ CRITICAL: the Wix Data items API is the `items` named export of `@wix/data`** — `import { items } from "@wix/data"`, then `items.query` / `items.get` / `items.insert` / `items.update` / `items.remove` (plus `items.bulkInsert` / `items.queryReferenced`). Do **not** import from the internal `@wix/wix-data-items-sdk` — `@wix/data` is the single documented package.
+**The Wix Data items API is the `items` named export of `@wix/data`** — `import { items } from "@wix/data"`, then `items.query` / `items.get` / `items.insert` / `items.update` / `items.remove` (plus `items.bulkInsert` / `items.queryReferenced`). Do **not** import from the internal `@wix/wix-data-items-sdk`. Module + method reference: <https://dev.wix.com/docs/sdk/business-solutions/data/items/query.md>
 
 | Need | Package | Module / export |
 |---|---|---|
@@ -24,25 +28,14 @@ A concise contract for writing the **frontend code** that reads Wix CMS collecti
 **Collection id has NO namespace.** A native collection's id is just the name the seed created (`"team-members"`, `"faq"`, `"Projects"`) — pass it straight to `items.query("team-members")`. The `<namespace>/<name>` form is only for Wix App collections. Stay consistent with the `collectionId` the seed recipe kept.
 
 **Auth / client — framework split:**
-- **Astro (Wix-managed):** authentication is ambient. Call `items.query(...)` directly from server components and backend routes (`src/pages/api/*.ts`) — **no `createClient`, no `OAuthStrategy`, no `clientId`.**
-- **Non-Astro (Vite/React/Vue/static):** build one manual visitor client and reuse it:
-  ```js
-  import { createClient, OAuthStrategy } from '@wix/sdk';
-  import { items } from '@wix/data';
+- **Astro (Wix-managed):** authentication is ambient. Call `items.query(...)` directly from server components and backend routes (`src/pages/api/*.ts`) — **no `createClient`, no `OAuthStrategy`, no `clientId`.** See <https://dev.wix.com/docs/go-headless/wix-managed-headless/authentication/about-the-astro-integration.md>
+- **Non-Astro (Vite/React/Vue/static):** build one manual visitor client with `createClient` + `OAuthStrategy({ clientId })` and reuse it — the full setup is in the [data-quick-start tutorial](https://dev.wix.com/docs/go-headless/self-managed-headless/self-managed-tutorials/java-script-sdk-tutorials/data-quick-start.md). The `clientId` is public, not a secret.
 
-  const client = createClient({
-    modules: { items },
-    auth: OAuthStrategy({ clientId: /* the project's PUBLIC OAuth client id */ }),
-  });
-  // then: client.items.query('team-members').find()
-  ```
-  The `clientId` is public, not a secret.
-
-**⚠️ CRITICAL: do NOT call `auth.elevate` — public collections are public-read, and member-scoped ones use the member token.** `setup-cms.md` creates a public collection with `read: "ANYONE"`, so the visitor token reads it directly. A pure SPA/static frontend has **no server and cannot elevate** at all; even on Astro the read is visitor-scoped and needs no elevation. (Elevation is only for collections that genuinely can't be public — not the case here.) **If a query on a PUBLIC collection comes back empty, it wasn't seeded public-read — that's a permissions bug in the seed, not a query bug** (re-check the collection's `read` permission); don't reach for `elevate` to paper over it.
+**⚠️ CRITICAL: do NOT call `auth.elevate` — public collections are public-read, and member-scoped ones use the member token.** `setup-cms.md` creates a public collection with `read: "ANYONE"`, so the visitor token reads it directly. A pure SPA/static frontend has **no server and cannot elevate** at all; even on Astro the read is visitor-scoped and needs no elevation. (Elevation is only for collections that genuinely can't be public — not the case here.) **If a query on a PUBLIC collection comes back empty, it wasn't seeded public-read — that's a permissions bug in the seed, not a query bug** (re-check the collection's `read` permission); don't reach for `elevate` to paper over it. Permission roles reference: <https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-permissions/introduction.md>
 
 **Member-scoped collections (only when the run includes members login).** A collection seeded member-scoped (`setup-cms.md` → `SITE_MEMBER_AUTHOR` for per-user-private, or `SITE_MEMBER` for member-only) is read/written with the **logged-in member's token** — the same client, just after the member has logged in (see `how-to-code-members-astro.md` / `how-to-code-members-non-astro.md`). Key rules:
 - **Still NO `auth.elevate`.** The member token carries the identity; the platform scopes the rows server-side. Reaching for elevate here is the wrong axis (it's for admin/site-wide reads, not a member's own data).
-- **`SITE_MEMBER_AUTHOR` returns only the caller's OWN rows automatically** (matched on the item's `_owner`) — you don't filter by owner in the query, and you **must not** set `_owner` on insert (the platform stamps it from the member identity). `items.query('my-notes').find()` as member A returns A's notes; as member B, B's.
+- **`SITE_MEMBER_AUTHOR` returns only the caller's OWN rows automatically** (matched on the item's `_owner`) — you don't filter by owner in the query, and you **must not** set `_owner` on insert (the platform stamps it from the member identity; per the docs it can only be changed with site-owner permissions). `items.query('my-notes').find()` as member A returns A's notes; as member B, B's. (Role + `_owner` semantics: see the data-permissions and Insert Data Item references.)
 - **An anonymous / not-yet-logged-in read returns ZERO items — that's the gate, not a bug.** Don't render a member-scoped surface to anonymous visitors: gate the route/page behind login first (bounce to the login flow), *then* query. An empty result after a confirmed login on a `SITE_MEMBER_AUTHOR` collection just means that member has no rows yet (show an empty state), not a permissions error.
 
 ---
@@ -59,7 +52,13 @@ item = {
 // result also has: result.length, result.hasNext(), result.pageSize
 ```
 
-`result.items[]` is the array; paging via `result.hasNext()` / a follow-up `.find()`. A `wix:image://` value in an IMAGE field and a Ricos object in a RICH_TEXT/RICH_CONTENT field both need resolving before render (see below).
+`result.items[]` is the array; paging via `result.hasNext()` / a follow-up `.find()`. A `wix:image://` value in an IMAGE field and a Ricos object in a RICH_TEXT/RICH_CONTENT field both need resolving before render (see below). Full response shape: the [query reference](https://dev.wix.com/docs/sdk/business-solutions/data/items/query.md).
+
+> **⚠️ Known SDK↔REST divergences (live product traps — do not cross-wire the two views).** The Wix Data proto renders a different shape in the REST view than in the SDK your frontend actually calls. Each item below is the SDK-correct form; the REST form silently fails in SDK code. These workarounds stay until the divergence is resolved upstream.
+> - **Fields are top-level: `item.name`, NOT `item.data.name`.** `item.data.name` is the REST shape and reads `undefined` in SDK code — the silent "every field is blank" bug. If you're reaching through `.data`, you're reading the REST doc view; switch to `?apiView=SDK`.
+> - **The id is `_id`, never `id`.** `item.id` is `undefined`; use `item._id` for keys, links, and reference lookups.
+> - **The query entry point is `items.query("collectionId")`, not `items.queryDataItems(...)`.** `queryDataItems` is the REST operation name and does not exist on the SDK module.
+> - **Filters are builder methods, not a `$`-operator JSON body.** The `$`-operator query body is the REST shape.
 
 ---
 
@@ -67,24 +66,19 @@ item = {
 
 Each section is a **self-contained feature** — implement only what the site uses, in any order.
 
-### Listing / reading (and the field-access rule)
+### Listing / reading
 
-Query a collection with the chainable builder; `.find()` resolves to `{ items, ... }`.
-Doc: <https://dev.wix.com/docs/sdk/business-solutions/data/items/query.md?apiView=SDK>
+Query a collection with the chainable builder; `.find()` resolves to `{ items, ... }`. Builder methods, response shape, and paging are in the reference: <https://dev.wix.com/docs/sdk/business-solutions/data/items/query.md>
 
 ```js
 const { items: rows } = await items.query('team-members')
   .ascending('order')
   .limit(50)
   .find();
-// rows[0] === { _id, name, role, bio, order, _createdDate, ... }
+// rows[0] === { _id, name, role, bio, order, _createdDate, ... }  ← fields top-level, id is _id
 ```
 
-**⚠️ CRITICAL: fields are on the item itself — `item.name`, NOT `item.data.name`.** The SDK returns each field as a top-level property of the item (the API was revised to match the Velo `wix-data` shape). `item.data.name` is the **REST** response shape and reads `undefined` in SDK code — the silent "every field is blank" bug. If you're reaching through `.data`, you're reading the REST doc view; re-open it with `?apiView=SDK`.
-
-**⚠️ CRITICAL: the id is `_id`, never `id`.** `item.id` is `undefined`; use `item._id` for keys, links, and reference lookups.
-
-**⚠️ `items.queryDataItems(...)` does NOT exist in the SDK.** The chainable entry point is `items.query("collectionId")` — `queryDataItems` is a REST/method name. Don't mix the two.
+(Field-access and `_id` traps: see **Known SDK↔REST divergences** above.)
 
 ### Filtering and single-item lookup
 
@@ -98,21 +92,21 @@ const { items: rows } = await items.query('products')
   .eq('inStock', true).gt('price', 25).ascending('title').limit(50).find();
 ```
 
-Builder methods: `.eq` / `.ne` / `.gt` / `.ge` / `.lt` / `.le` / `.contains` / `.startsWith` / `.hasSome` / `.ascending` / `.descending` / `.limit` / `.skip`. (No `$`-operator JSON body — that's the REST `/items/query` shape; in the SDK the operators are builder methods.)
+Full builder-method list (`.eq`/`.ne`/`.gt`/`.ge`/`.lt`/`.le`/`.contains`/`.startsWith`/`.hasSome`/`.ascending`/`.descending`/`.limit`/`.skip`): the [`WixDataQuery` reference](https://dev.wix.com/docs/sdk/business-solutions/data/items/query.md).
 
 ### Following references
 
-A `REFERENCE` / `MULTI_REFERENCE` field stores only ids by default. To inline the referenced items, add `.include("<fieldKey>")`:
+A `REFERENCE` / `MULTI_REFERENCE` field stores only ids by default. Add `.include("<fieldKey>")` to inline the referenced items:
 
 ```js
 const { items: rows } = await items.query('projects').include('teamMembers').find();
 // rows[0].teamMembers is now an array of full team-member items, not ids
 ```
-Doc: <https://dev.wix.com/docs/sdk/business-solutions/data/items/query-referenced.md?apiView=SDK> (for `items.queryReferenced`, the alternative when a multi-reference set is large). Without `.include(...)`, the field is just ids — resolve them yourself or use `include`.
+For a large multi-reference set, use `items.queryReferenced`: <https://dev.wix.com/docs/sdk/business-solutions/data/items/query-referenced.md>
 
 ### Rendering images (IMAGE fields)
 
-An `IMAGE` field comes back as a **`wix:image://v1/<hash>/<file>#…` identifier, not a ready URL** — putting it straight into `<img src>` shows nothing (`ERR_UNKNOWN_URL_SCHEME`). Resolve it with the SDK media module, and reuse one helper on every render path:
+An `IMAGE` field comes back as a **`wix:image://…` identifier, not a ready URL** — putting it straight into `<img src>` shows nothing (`ERR_UNKNOWN_URL_SCHEME`). Resolve it with the SDK `media` module (`media.getScaledToFillImageUrl` / `getScaledToFitImageUrl` / `getImageUrl`), and reuse one helper on every render path. Module reference: <https://dev.wix.com/docs/sdk/core-modules/sdk/media.md>
 
 ```js
 import { media } from '@wix/sdk';
@@ -123,15 +117,13 @@ function imgSrc(v, w = 800, h = 600) {
 }
 ```
 
-**Never hand-build a `static.wixstatic.com/.../v1/fit/...` URL** — the format is easy to get wrong and the image then **403s**. Only `wix:image://` values need resolving; an already-absolute `https://` URL (e.g. an Unsplash placeholder seeded when imagery was off) goes straight into `<img src>`. Doc: <https://dev.wix.com/docs/sdk/core-modules/sdk/media>
+Don't hand-build a `static.wixstatic.com/.../v1/fit/...` URL — the format is easy to get wrong and the image then **403s**; always resolve via `media`. An already-absolute `https://` URL (e.g. an Unsplash placeholder seeded when imagery was off) goes straight into `<img src>`.
 
 **⚠️ When imagery is OFF (the seed default), IMAGE fields are EMPTY — fall back, don't render a broken `<img>`.** The seed is text-only unless imagery is on, so a `photo`/`coverImage`/`headshot` field is often **absent or empty** on every item. Guard the render: only emit `<img>` when the field resolves to a real URL, otherwise show a graceful fallback (an initials avatar, a colored placeholder, or simply omit the image) — never an empty/broken `<img src="">`. A missing image is expected content state here, not an error.
 
 ### Rendering rich text (RICH_TEXT / RICH_CONTENT fields)
 
-Wix CMS stores `RICH_TEXT` / `RICH_CONTENT` as **Ricos JSON** — a structured node tree (PARAGRAPH, HEADING, BULLETED_LIST…), not HTML and not a string.
-
-**⚠️ Do NOT `set:html={item.bio}` or `String(item.bio)` directly.** That dumps `[object Object]` or `{"nodes":...}` into the page. Render the Ricos node tree — either with a small SSR Ricos→HTML walker (covers PARAGRAPH, HEADING, lists, BLOCKQUOTE, BOLD/ITALIC/LINK; renders anything else defensively as a `<p>`), or with `@wix/ricos`'s React `RicosViewer` as a client island when the content carries the full feature set (galleries, embeds). For short bound fields a plain-text variant is fine; for a body field, render it **formatted**.
+Wix CMS stores `RICH_TEXT` / `RICH_CONTENT` as **Ricos JSON** — a structured node tree, not HTML and not a string. **Do NOT `set:html={item.bio}` or `String(item.bio)` directly** — that dumps `[object Object]` or `{"nodes":...}` into the page. Render the Ricos node tree with `@wix/ricos`'s `RicosViewer` (a client island; use `"use client"` for RSC), or a small SSR Ricos→HTML walker for short bound fields. Full pattern (retrieve + `RicosViewer` + plugins): <https://dev.wix.com/docs/go-headless/self-managed-headless/self-managed-tutorials/other-tutorials/working-with-rich-content.md>
 
 ### Writing from the frontend (only to a visitor-writable collection)
 
@@ -145,7 +137,7 @@ await items.update('community-board', { ...item, status: 'claimed' });          
 await items.remove('community-board', item._id);
 ```
 
-**⚠️ CRITICAL: `items.update()` REPLACES the whole item — it does NOT patch.** Per the docs: *"If the existing item had fields with values and those fields aren't included in the updated item, the values in those properties are lost."* So `update('c', { _id, status })` **wipes `title`, `note`, and every other field** — the classic "toggling status erases the row" bug. **Always pass the FULL item** on update (spread the record you already hold in state: `{ ...item, status }`). If you only have the id + one changed field and not the whole record, use **`items.bulkPatch('c', [id]).setField('status', v).run()`** instead — `bulkPatch` modifies only the named fields. Doc: <https://dev.wix.com/docs/sdk/business-solutions/data/items/update.md?apiView=SDK>
+**⚠️ CRITICAL: `items.update()` REPLACES the whole item — it does NOT patch.** Fields you omit are wiped — so `update('c', { _id, status })` erases `title`, `note`, and every other field (the classic "toggling status erases the row" bug). **Always pass the FULL item** on update (`{ ...item, status }`). If you only hold the id + one changed field, use **`items.bulkPatch(...)`** instead — it modifies only the named fields. Docs: [update](https://dev.wix.com/docs/sdk/business-solutions/data/items/update.md) · [bulk-patch](https://dev.wix.com/docs/sdk/business-solutions/data/items/bulk-patch.md).
 
 **⚠️ A write needs the collection seeded with the matching open permission — else it 403s.** `items.insert`/`update`/`remove` only succeed if the collection was created with that verb at `ANYONE` (`setup-cms.md`). A write to an `ADMIN`-write collection 403s from the visitor client (there's no `auth.elevate` on this path to get around it). If writes 403, fix the seed permission, not the call.
 
@@ -156,8 +148,8 @@ await items.remove('community-board', item._id);
 ## Conclusion
 A correct Wix CMS frontend:
 - imports the **`items`** export of **`@wix/data`** (never `@wix/wix-data-items-sdk`), and `media` from `@wix/sdk` for images;
-- queries with **`items.query("collectionId")` + builder methods + `.find()`** (no namespace on the id; `queryDataItems` doesn't exist);
-- reads fields **on the item** (`item.name`) and the id as **`item._id`** — never `item.data.name`, never `item.id`;
+- queries with **`items.query("collectionId")` + builder methods + `.find()`** (no namespace on the id; `queryDataItems` doesn't exist in the SDK);
+- reads fields **on the item** (`item.name`) and the id as **`item._id`** — never `item.data.name`, never `item.id` (see **Known SDK↔REST divergences**);
 - does **no `auth.elevate`** — a public collection is read on the visitor token (an empty result there is a seed permissions bug, not a query bug), and a **member-scoped** collection (opt-in, `SITE_MEMBER_AUTHOR`/`SITE_MEMBER`) is read on the **logged-in member's token** with the same no-elevate rule (an anonymous read returning empty is the gate, not a bug);
-- resolves `wix:image://` via `media.getScaledToFillImageUrl` and renders Ricos rich text formatted (never raw `set:html`/`String`);
+- resolves `wix:image://` via the `media` module and renders Ricos rich text formatted (never raw `set:html`/`String`);
 - treats CMS as **read-only by default** (fire-and-forget input → Forms); writes to a **visitor-writable** collection use `items.insert`/`update`/`remove` — always passing the **full item** on `update` (it replaces, not patches), expecting the data to be **shared/unscoped**, and relying on the collection's seeded `ANYONE` write permission (no `auth.elevate`). For **per-user-private** data (opt-in, members login in the run) the same calls run under the **member token** against a `SITE_MEMBER_AUTHOR` collection — each member sees/edits only their own `_owner`-matched rows, `_owner` is never set by hand, and the surface is gated behind login.


### PR DESCRIPTION
## What & why

Docs-extraction pass over the `wix-headless` inline recipe `how-to-code-cms.md`. This is a **proposal for review**, not a finished merge.

Claim-level classification (31 chunks) found the recipe is mostly content that is **already documented and correct** in the Wix Data SDK reference + the two headless tutorials, wrapped in **headless orchestration glue** and a cluster of **REST↔SDK view-divergence workarounds**. This PR moves the already-documented facts to deep links and keeps everything skill-specific verbatim.

### Changes
- **Already-documented API facts → deep links** (no behavior change): the `items.query` builder + `WixDataQuery` methods, `media` image resolution, Ricos rendering (`RicosViewer`), `update` replaces-the-whole-item + `bulkPatch`, permission roles / `_owner`, and non-Astro client setup now point at the SDK reference and the `data-quick-start` / `working-with-rich-content` tutorials.
- **REST↔SDK divergences consolidated** into one labeled **"Known SDK↔REST divergences"** block (`item.data.field` vs top-level, `id` vs `_id`, `queryDataItems` vs `query()`, `$`-operators vs builder methods). These are a live product/tooling divergence, so the **workarounds are kept in the skill** — see the product-issue report below.
- **Orchestration glue kept verbatim**: framework auth split (Astro ambient vs manual client), `setup-cms.md` cross-refs, run-flags (imagery OFF default, members-login opt-in), Forms-vs-CMS routing, empty-result-means-seed-bug diagnostics.

Net diff: −40 / +32 lines. Behavior is unchanged — every glue instruction, ordering, and workaround the recipe depended on is still present.

### ⚠️ Sequencing / gate (please read)
Per the docs-extractor pipeline, this thinned skill should be validated **after** its companion docs change merges and publishes, and the post-publish eval must be **≥** the original before merge. It is being opened early at the maintainer's request. Two dependencies:
1. A companion **docs bug fix** (separate PR against `wix-private/developer-docs`) corrects the `data-quick-start` tutorial's field access (`example.data.title` → `example.title`), which this recipe now links to. Until that publishes, the linked tutorial still shows the buggy shape.
2. The links here were verified to resolve (HTTP 200) at authoring time.

### Related outputs (not in this PR)
- **Product-issue report** on the Wix Data REST↔SDK shape divergence (can't be fixed by a doc edit; workaround stays in-skill).
- **Docs fix** for the `data-quick-start` tutorial field-access bug (developer-docs).
