### PR TITLE
feat(eval-gate): run whole reference-graph component for a changed skill doc

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34805,6 +34805,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.registeredDocFiles = registeredDocFiles;
 exports.canonicalDocUrl = canonicalDocUrl;
 const node_fs_1 = __nccwpck_require__(3024);
 const node_path_1 = __nccwpck_require__(6760);
@@ -34847,6 +34848,10 @@ function slugify(displayName) {
         trimmedSlug = trimmedSlug.slice(0, -1);
     }
     return `${shouldAddDollarPrefix ? '$' : ''}${trimmedSlug.toLowerCase()}`;
+}
+/** Repo-relative paths of every doc registered in a documentation.yaml under `workspace`. */
+function registeredDocFiles(workspace) {
+    return [...buildDocIndex(workspace).keys()].map(abs => (0, node_path_1.relative)(workspace, abs));
 }
 function canonicalDocUrl(filePath, workspace) {
     const info = buildDocIndex(workspace).get((0, node_path_1.resolve)(workspace, filePath));
@@ -35500,6 +35505,7 @@ const author_gate_1 = __nccwpck_require__(9916);
 const evals_1 = __nccwpck_require__(1686);
 const doc_url_1 = __nccwpck_require__(8515);
 const coverage_1 = __nccwpck_require__(4035);
+const reference_graph_1 = __nccwpck_require__(7749);
 const sync_1 = __nccwpck_require__(546);
 const evalforge_1 = __nccwpck_require__(280);
 const eval_pipeline_1 = __nccwpck_require__(3942);
@@ -35657,11 +35663,20 @@ async function runGate() {
     const { scenarios: baseScenarios, errors: baseErrors } = (0, evals_1.loadEvals)(baseWorkspace);
     for (const e of baseErrors)
         core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
+    // Expand changed docs to their reference-graph connected components, so editing any skill in a
+    // declared parent/child family re-runs the whole family's scenarios. Coverage gating above is
+    // unaffected — it stays per changed doc; this only widens which scenarios run.
+    // Union the head and base graphs: a PR that DETACHES a skill from its family (removes a
+    // `references` edge) still re-runs the detached skill, because the edge existed at base.
+    const referenceGraph = (0, reference_graph_1.unionGraphs)((0, reference_graph_1.buildReferenceGraph)(workspace), (0, reference_graph_1.buildReferenceGraph)(baseWorkspace));
+    const changedDocs = classifiedChanges.mdFiles.filter(f => f.status !== 'removed').map(f => f.filename);
+    const runDocs = [...(0, reference_graph_1.connectedDocs)(referenceGraph, changedDocs)].map(filename => ({ filename, status: 'modified' }));
+    const runCoverage = (0, coverage_1.computeCoverage)(runDocs, headScenarios, (f) => (0, doc_url_1.canonicalDocUrl)(f, workspace));
     const changedEvalPaths = new Set([
         ...classifiedChanges.evalsAdded.map(f => f.filename),
         ...classifiedChanges.evalsModified.map(f => f.filename),
     ]);
-    const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
+    const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: runCoverage.coveredBy });
     const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
     const remote = await guardedCall(() => listRemoteScenariosForGate(evalforge, config.projectId, filters), 'Could not reach EvalForge', comment, config);
     if (!remote)
@@ -36110,6 +36125,154 @@ function loadEvalsWithWarnings(root) {
     for (const e of errors)
         core.warning(`Eval load issue at ${root}/${e.path}: ${e.message}`);
     return scenarios;
+}
+
+
+/***/ }),
+
+/***/ 7749:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.buildGraph = buildGraph;
+exports.buildReferenceGraph = buildReferenceGraph;
+exports.unionGraphs = unionGraphs;
+exports.connectedDocs = connectedDocs;
+const node_fs_1 = __nccwpck_require__(3024);
+const node_path_1 = __nccwpck_require__(6760);
+const jsYaml = __importStar(__nccwpck_require__(4281));
+const core = __importStar(__nccwpck_require__(7484));
+const doc_url_1 = __nccwpck_require__(8515);
+const paths_1 = __nccwpck_require__(6621);
+/**
+ * Builds the undirected reference graph. A doc is linked to each doc its frontmatter references,
+ * resolved by canonical slug (a slug shared across areas is disambiguated to the referrer's own
+ * area); an unresolvable reference is warned about and skipped rather than failing the gate.
+ * Pure over `nodes`, so it can be unit-tested without the filesystem.
+ */
+function buildGraph(nodes, warn = () => { }) {
+    const bySlug = new Map();
+    for (const node of nodes) {
+        if (node.slug)
+            (bySlug.get(node.slug) ?? bySlug.set(node.slug, []).get(node.slug)).push(node);
+    }
+    const graph = new Map();
+    const link = (a, b) => {
+        (graph.get(a) ?? graph.set(a, new Set()).get(a)).add(b);
+        (graph.get(b) ?? graph.set(b, new Set()).get(b)).add(a);
+    };
+    for (const node of nodes) {
+        for (const ref of node.refs) {
+            const slug = (ref.split('/').pop() ?? ref).replace(/\.md$/i, '');
+            const hits = bySlug.get(slug) ?? [];
+            const target = hits.length === 1 ? hits[0] : hits.find(h => h.area === node.area);
+            if (!target) {
+                warn(`reference-graph: unresolved reference "${ref}" (slug "${slug}") in ${node.file} — skipping`);
+                continue;
+            }
+            if (target.file !== node.file)
+                link(node.file, target.file);
+        }
+    }
+    return graph;
+}
+/** Reads registered docs and their frontmatter references to build the graph for a workspace. */
+function buildReferenceGraph(workspace) {
+    const nodes = (0, doc_url_1.registeredDocFiles)(workspace).map(file => ({
+        file,
+        area: file.match(paths_1.AREA_RE)?.[1] ?? null,
+        slug: (0, doc_url_1.canonicalDocUrl)(file, workspace)?.split('/skills/')[1]?.split('/')[0] ?? null,
+        refs: frontmatterReferences((0, node_path_1.resolve)(workspace, file)),
+    }));
+    return buildGraph(nodes, message => core.warning(message));
+}
+/** Merges graphs into one adjacency map holding the union of all their edges. */
+function unionGraphs(...graphs) {
+    const merged = new Map();
+    for (const graph of graphs) {
+        for (const [doc, neighbors] of graph) {
+            const set = merged.get(doc) ?? merged.set(doc, new Set()).get(doc);
+            for (const neighbor of neighbors)
+                set.add(neighbor);
+        }
+    }
+    return merged;
+}
+/** The union of the connected components containing `seeds` (an isolated seed returns itself). */
+function connectedDocs(graph, seeds) {
+    const seen = new Set();
+    const stack = [...seeds];
+    while (stack.length > 0) {
+        const doc = stack.pop();
+        if (seen.has(doc))
+            continue;
+        seen.add(doc);
+        for (const neighbor of graph.get(doc) ?? []) {
+            if (!seen.has(neighbor))
+                stack.push(neighbor);
+        }
+    }
+    return seen;
+}
+function frontmatterReferences(absFile) {
+    let raw;
+    try {
+        raw = (0, node_fs_1.readFileSync)(absFile, 'utf8');
+    }
+    catch {
+        return [];
+    }
+    const fm = raw.match(/^---\n([\s\S]*?)\n---/);
+    if (!fm)
+        return [];
+    let parsed;
+    try {
+        parsed = jsYaml.load(fm[1], { schema: jsYaml.CORE_SCHEMA });
+    }
+    catch {
+        return [];
+    }
+    const refs = parsed?.references;
+    if (!Array.isArray(refs))
+        return [];
+    return refs
+        .map(r => (typeof r?.path === 'string' ? r.path : null))
+        .filter((p) => p !== null);
 }
 
 

--- a/.github/actions/evalforge-yaml-gate/src/utils/doc-url.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/doc-url.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { dirname, resolve as resolvePath } from 'node:path';
+import { dirname, relative, resolve as resolvePath } from 'node:path';
 import { glob } from 'glob';
 import * as jsYaml from 'js-yaml';
 import { DOC_YAML_GLOB } from './paths';
@@ -48,6 +48,11 @@ function slugify(displayName: string): string {
     trimmedSlug = trimmedSlug.slice(0, -1);
   }
   return `${shouldAddDollarPrefix ? '$' : ''}${trimmedSlug.toLowerCase()}`;
+}
+
+/** Repo-relative paths of every doc registered in a documentation.yaml under `workspace`. */
+export function registeredDocFiles(workspace: string): string[] {
+  return [...buildDocIndex(workspace).keys()].map(abs => relative(workspace, abs));
 }
 
 export function canonicalDocUrl(filePath: string, workspace: string): string | null {

--- a/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/gate.ts
@@ -7,6 +7,7 @@ import { assertWixAuthor } from './author-gate';
 import { loadEvals, type LoadedScenario } from './evals';
 import { canonicalDocUrl } from './doc-url';
 import { computeCoverage } from './coverage';
+import { buildReferenceGraph, connectedDocs, unionGraphs } from './reference-graph';
 import { diffSyncPlan } from './sync';
 import { EvalForgeClient, draftTagFor, evalRunUrl, parseDraftTag, uniqueRemoteScenarios, type RemoteScenario } from './evalforge';
 import { EvalPipelineClient, pollUntilComparisonDone, ComparisonTimeoutError } from './eval-pipeline';
@@ -211,11 +212,24 @@ export async function runGate(): Promise<void> {
   const { scenarios: baseScenarios, errors: baseErrors } = loadEvals(baseWorkspace);
   for (const e of baseErrors) core.warning(`Base SHA eval issue (${e.path}): ${e.message}`);
 
+  // Expand changed docs to their reference-graph connected components, so editing any skill in a
+  // declared parent/child family re-runs the whole family's scenarios. Coverage gating above is
+  // unaffected — it stays per changed doc; this only widens which scenarios run.
+  // Union the head and base graphs: a PR that DETACHES a skill from its family (removes a
+  // `references` edge) still re-runs the detached skill, because the edge existed at base.
+  const referenceGraph = unionGraphs(
+    buildReferenceGraph(workspace),
+    buildReferenceGraph(baseWorkspace),
+  );
+  const changedDocs = classifiedChanges.mdFiles.filter(f => f.status !== 'removed').map(f => f.filename);
+  const runDocs: ChangedFile[] = [...connectedDocs(referenceGraph, changedDocs)].map(filename => ({ filename, status: 'modified' }));
+  const runCoverage = computeCoverage(runDocs, headScenarios, (f) => canonicalDocUrl(f, workspace));
+
   const changedEvalPaths = new Set<string>([
     ...classifiedChanges.evalsAdded.map(f => f.filename),
     ...classifiedChanges.evalsModified.map(f => f.filename),
   ]);
-  const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: cov.coveredBy });
+  const changedHeadScenarios = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy: runCoverage.coveredBy });
 
   const filters = remoteScenarioFiltersForGate({ changedHead: changedHeadScenarios, head: headScenarios, base: baseScenarios, draftTag });
   const remote = await guardedCall(

--- a/.github/actions/evalforge-yaml-gate/src/utils/reference-graph.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/reference-graph.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+import * as jsYaml from 'js-yaml';
+import * as core from '@actions/core';
+import { canonicalDocUrl, registeredDocFiles } from './doc-url';
+import { AREA_RE } from './paths';
+
+/** Undirected adjacency: doc file -> doc files linked to it via frontmatter references. */
+export type ReferenceGraph = Map<string, Set<string>>;
+
+/** A doc plus the references it declares — the input to the pure graph builder. */
+export type DocNode = { file: string; area: string | null; slug: string | null; refs: string[] };
+
+/**
+ * Builds the undirected reference graph. A doc is linked to each doc its frontmatter references,
+ * resolved by canonical slug (a slug shared across areas is disambiguated to the referrer's own
+ * area); an unresolvable reference is warned about and skipped rather than failing the gate.
+ * Pure over `nodes`, so it can be unit-tested without the filesystem.
+ */
+export function buildGraph(nodes: DocNode[], warn: (message: string) => void = () => {}): ReferenceGraph {
+  const bySlug = new Map<string, DocNode[]>();
+  for (const node of nodes) {
+    if (node.slug) (bySlug.get(node.slug) ?? bySlug.set(node.slug, []).get(node.slug)!).push(node);
+  }
+
+  const graph: ReferenceGraph = new Map();
+  const link = (a: string, b: string) => {
+    (graph.get(a) ?? graph.set(a, new Set()).get(a)!).add(b);
+    (graph.get(b) ?? graph.set(b, new Set()).get(b)!).add(a);
+  };
+
+  for (const node of nodes) {
+    for (const ref of node.refs) {
+      const slug = (ref.split('/').pop() ?? ref).replace(/\.md$/i, '');
+      const hits = bySlug.get(slug) ?? [];
+      const target = hits.length === 1 ? hits[0] : hits.find(h => h.area === node.area);
+      if (!target) {
+        warn(`reference-graph: unresolved reference "${ref}" (slug "${slug}") in ${node.file} — skipping`);
+        continue;
+      }
+      if (target.file !== node.file) link(node.file, target.file);
+    }
+  }
+  return graph;
+}
+
+/** Reads registered docs and their frontmatter references to build the graph for a workspace. */
+export function buildReferenceGraph(workspace: string): ReferenceGraph {
+  const nodes: DocNode[] = registeredDocFiles(workspace).map(file => ({
+    file,
+    area: file.match(AREA_RE)?.[1] ?? null,
+    slug: canonicalDocUrl(file, workspace)?.split('/skills/')[1]?.split('/')[0] ?? null,
+    refs: frontmatterReferences(resolvePath(workspace, file)),
+  }));
+  return buildGraph(nodes, message => core.warning(message));
+}
+
+/** Merges graphs into one adjacency map holding the union of all their edges. */
+export function unionGraphs(...graphs: ReferenceGraph[]): ReferenceGraph {
+  const merged: ReferenceGraph = new Map();
+  for (const graph of graphs) {
+    for (const [doc, neighbors] of graph) {
+      const set = merged.get(doc) ?? merged.set(doc, new Set()).get(doc)!;
+      for (const neighbor of neighbors) set.add(neighbor);
+    }
+  }
+  return merged;
+}
+
+/** The union of the connected components containing `seeds` (an isolated seed returns itself). */
+export function connectedDocs(graph: ReferenceGraph, seeds: string[]): Set<string> {
+  const seen = new Set<string>();
+  const stack = [...seeds];
+  while (stack.length > 0) {
+    const doc = stack.pop()!;
+    if (seen.has(doc)) continue;
+    seen.add(doc);
+    for (const neighbor of graph.get(doc) ?? []) {
+      if (!seen.has(neighbor)) stack.push(neighbor);
+    }
+  }
+  return seen;
+}
+
+function frontmatterReferences(absFile: string): string[] {
+  let raw: string;
+  try { raw = readFileSync(absFile, 'utf8'); } catch { return []; }
+  const fm = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return [];
+  let parsed: unknown;
+  try { parsed = jsYaml.load(fm[1], { schema: jsYaml.CORE_SCHEMA }); } catch { return []; }
+  const refs = (parsed as { references?: unknown } | null)?.references;
+  if (!Array.isArray(refs)) return [];
+  return refs
+    .map(r => (typeof (r as { path?: unknown })?.path === 'string' ? (r as { path: string }).path : null))
+    .filter((p): p is string => p !== null);
+}

--- a/.github/actions/evalforge-yaml-gate/tests/reference-graph.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/reference-graph.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildGraph, connectedDocs, unionGraphs, type DocNode } from '../src/utils/reference-graph';
+
+const R = 'skills/wix-manage/references';
+
+// A small family: recommend (parent) -> goal-aov + coupons (children); find-products is unrelated.
+const NODES: DocNode[] = [
+  { file: `${R}/ecommerce/recommend.md`, area: 'ecommerce', slug: 'recommend', refs: ['ecommerce/goal-aov.md', 'ecommerce/coupons.md'] },
+  { file: `${R}/ecommerce/pricing/goal-aov.md`, area: 'ecommerce', slug: 'goal-aov', refs: [] },
+  { file: `${R}/ecommerce/pricing/coupons.md`, area: 'ecommerce', slug: 'coupons', refs: [] },
+  { file: `${R}/stores/find-products.md`, area: 'stores', slug: 'find-products', refs: [] },
+];
+
+describe('buildGraph', () => {
+  it('links a doc to each doc it references, resolved by canonical slug, undirected', () => {
+    const g = buildGraph(NODES);
+    const parent = `${R}/ecommerce/recommend.md`;
+    const child = `${R}/ecommerce/pricing/goal-aov.md`;
+    expect(g.get(parent)?.has(child)).toBe(true);
+    expect(g.get(child)?.has(parent)).toBe(true);
+  });
+
+  it('warns and skips an unresolvable reference instead of throwing', () => {
+    const warn = vi.fn();
+    const g = buildGraph([{ file: `${R}/ecommerce/recommend.md`, area: 'ecommerce', slug: 'recommend', refs: ['ecommerce/missing.md'] }], warn);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(g.size).toBe(0);
+  });
+
+  it('disambiguates a slug shared across areas to the referrer’s own area', () => {
+    const warn = vi.fn();
+    const g = buildGraph([
+      { file: `${R}/ecommerce/ref.md`, area: 'ecommerce', slug: 'ref', refs: ['whatever/dup.md'] },
+      { file: `${R}/ecommerce/dup.md`, area: 'ecommerce', slug: 'dup', refs: [] },
+      { file: `${R}/stores/dup.md`, area: 'stores', slug: 'dup', refs: [] },
+    ], warn);
+    expect(g.get(`${R}/ecommerce/ref.md`)?.has(`${R}/ecommerce/dup.md`)).toBe(true);
+    expect(g.get(`${R}/ecommerce/ref.md`)?.has(`${R}/stores/dup.md`)).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('connectedDocs', () => {
+  it('returns the transitive component in both directions', () => {
+    const g = buildGraph(NODES);
+    const child = `${R}/ecommerce/pricing/goal-aov.md`;
+    // from a child, reach the parent (up) and the sibling coupons doc (across, via the parent)
+    expect(connectedDocs(g, [child])).toEqual(new Set([
+      child,
+      `${R}/ecommerce/recommend.md`,
+      `${R}/ecommerce/pricing/coupons.md`,
+    ]));
+  });
+
+  it('returns an isolated seed unchanged, even one absent from the graph', () => {
+    const g = buildGraph(NODES);
+    expect(connectedDocs(g, [`${R}/stores/find-products.md`])).toEqual(new Set([`${R}/stores/find-products.md`]));
+    expect(connectedDocs(g, [`${R}/blog/unknown.md`])).toEqual(new Set([`${R}/blog/unknown.md`]));
+  });
+});
+
+describe('unionGraphs (base ∪ head — detachment)', () => {
+  const parent = `${R}/ecommerce/parent.md`;
+  const child = `${R}/ecommerce/child.md`;
+
+  it('re-runs a detached neighbor by unioning base and head edges', () => {
+    // head: the PR removed parent's reference to child (edge gone)
+    const head = buildGraph([
+      { file: parent, area: 'ecommerce', slug: 'parent', refs: [] },
+      { file: child, area: 'ecommerce', slug: 'child', refs: [] },
+    ]);
+    // base: parent still referenced child
+    const base = buildGraph([
+      { file: parent, area: 'ecommerce', slug: 'parent', refs: ['ecommerce/child.md'] },
+      { file: child, area: 'ecommerce', slug: 'child', refs: [] },
+    ]);
+
+    // head alone drops the child; the union keeps it reachable from the edited parent
+    expect(connectedDocs(head, [parent])).toEqual(new Set([parent]));
+    expect(connectedDocs(unionGraphs(head, base), [parent])).toEqual(new Set([parent, child]));
+  });
+
+  it('merges disjoint edges from both graphs', () => {
+    const a = buildGraph([{ file: parent, area: 'ecommerce', slug: 'parent', refs: ['ecommerce/child.md'] }, { file: child, area: 'ecommerce', slug: 'child', refs: [] }]);
+    const b = buildGraph([{ file: child, area: 'ecommerce', slug: 'child', refs: ['ecommerce/grandchild.md'] }, { file: `${R}/ecommerce/grandchild.md`, area: 'ecommerce', slug: 'grandchild', refs: [] }]);
+    expect(connectedDocs(unionGraphs(a, b), [parent])).toEqual(new Set([parent, child, `${R}/ecommerce/grandchild.md`]));
+  });
+});


### PR DESCRIPTION
## What
When a changed skill doc participates in a declared parent/child family (frontmatter `references`), expand the gate's **run set** to the whole connected component — so editing any skill in a family re-runs every family member's scenarios (both directions, transitive).

## Why
Parent skills dispatch to child skills (e.g. `recommend-ecommerce-strategy` → its goal/setup children). Today a child edit only runs the child's own scenario; the parent flow that depends on it is never re-tested. This closes that gap.

## How
- **`reference-graph.ts`** (new): builds an undirected graph from frontmatter `references[].path`, resolving each reference to a doc by **canonical slug** (same-area tiebreak). An unresolvable reference is `core.warning`-ed and skipped — never fails the gate. `connectedDocs` returns the component union (isolated docs → just themselves).
- **`gate.ts`**: expands changed docs → connected component, then runs every scenario covering any component node (unioned with YAML-changed scenarios).
- **`doc-url.ts`**: exposes `registeredDocFiles`.

## Scope / safety
- **Opt-in & self-bounding**: only docs with `references` frontmatter form edges, so it can't balloon the run set. Grows as authors adopt `references`.
- **Coverage gate unchanged**: the missing-coverage block still applies *per changed doc*; this only widens *what runs*.
- No prose-link inference, no frontmatter schema change.

## Known data gap (not fixed here)
On the one current adopter (`recommend-ecommerce-strategy`), 5 of 6 references resolve; `setup-coupons` doesn't — its declared slug doesn't match any doc's canonical slug (the real coupon skill is `pricing-create-coupon`). That edge warns+skips. Resolving it is a skill-content fix for the doc owner, not a gate change.

## Tests
`reference-graph.test.ts`: slug resolution, same-area tiebreak, unresolved→warn+skip, transitive/both-direction component, isolated seed. Full suite green (184); `tsc` clean; `dist` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)