### PR TITLE
TEST: reference-graph via base=feature-branch (do not merge)

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
@@ -2,7 +2,12 @@
 name: "Pricing: Discount Not Applying"
 description: Diagnostic tree for when a discount rule exists but isn't applying at checkout. Checks active status, time window, scope targeting, revision, and app installation.
 layer: troubleshoot
+references:
+  - name: "Pricing: Create Coupon"
+    path: ecommerce/pricing-create-coupon.md
+    load: false
 ---
+<!-- e2e-refgraph: temp references edge; do not merge -->
 # Troubleshoot: Discount Not Applying
 
 ## When to use


### PR DESCRIPTION
Throwaway test for #610 using the base-branch method: base is the feature branch, so the diff is ONLY the skill edit (no src/dist noise) while the gate still runs the feature code. Edits one doc + a temp `references` edge → expect the gate to run troubleshoot + create-coupon. Close without merging.