### PR TITLE
docs(social-post): guard scheduledDate is strictly in the future

### DIFF
--- a/skills/wix-manage/references/marketing/create-and-publish-social-post.md
+++ b/skills/wix-manage/references/marketing/create-and-publish-social-post.md
@@ -21,7 +21,7 @@ Run every post request through these steps, in this order. The principle is **va
    To get an **AI image from a bare idea**, that's `generate-post-data` — it returns a generated image as part of the post. `generate-image` only *edits* an existing image (it returns 400 without a source image); there is no endpoint that turns a prompt into a standalone image.
 5. **Show it and get approval.** Present the tool's actual output — the caption **and** the image (rendered inline, or its URL). Never hand-write the caption or claim generated content you didn't get from the API. Get explicit approval on the final post **before** any delivery step.
 6. **Only now, check delivery — just-in-time.** After the user approves, confirm the channel is connected (STEP 4; connect if needed) and check the plan for publish vs. schedule (STEP 5). This is where connection/plan problems surface — never lead with them. If `SCHEDULE_POST` is disabled, never present scheduling. A positive `quotaInfo.limit` with `remainingUsage: 0` means that action's quota is used up (offer the other action if enabled — a near-future schedule works like publish-now); `limit: 0` means unmetered, so treat the action as available. AI generation is **never** plan-gated; never tell the user it is.
-7. **Publish exactly what was approved.** Create the draft (STEP 6) from the approved content plus the account's IDs, then publish or schedule (STEP 7). Reuse the approved caption, image, and draft on any retry; never regenerate after approval.
+7. **Publish exactly what was approved.** Create the draft (STEP 6) from the approved content plus the account's IDs, then publish or schedule (STEP 7). For a scheduled time, verify the resolved `scheduledDate` is **strictly in the future** right before the call (a "today at 9am"-style time can resolve to the past). Reuse the approved caption, image, and draft on any retry; never regenerate after approval.
 
 The rest of this recipe is the reference for executing each step.
 
@@ -454,7 +454,7 @@ The user already approved this exact content in STEP 3, so publish what was appr
 { "id": "ac01c174-5244-49df-8085-84d87cd0345a" }
 ```
 
-**Schedule for a future date** — include `scheduledDate` (ISO 8601, must be in the future; confirm `SCHEDULE_POST` in STEP 5). Compute it from the current date/time, resolving the user's relative wording ("next Monday 9am") in the site's timezone if known, otherwise UTC, and confirm the resolved date with the user:
+**Schedule for a future date** — include `scheduledDate` (ISO 8601, **must be strictly in the future**; confirm `SCHEDULE_POST` in STEP 5). Resolve the user's relative wording ("next Monday 9am", "today at 9") as a wall-clock time in the site's timezone if known, otherwise UTC, then convert that to an ISO instant. **Immediately before `publish-by-id`, validate `new Date(scheduledDate).getTime() > Date.now()`** — wording like "today at 9am" easily resolves to an instant that has already passed. If it isn't strictly in the future, don't send it: advance to the next matching future occurrence (e.g. tomorrow at 9am) or ask the user to confirm a later time. For a series of scheduled posts, compute and validate **each** occurrence independently. Confirm the resolved date(s) with the user:
 
 ```json
 { "id": "ac01c174-5244-49df-8085-84d87cd0345a", "scheduledDate": "<future-ISO-8601-datetime>" }
@@ -487,6 +487,7 @@ The post appears on the site's Social Media Marketing page in the dashboard. To 
 | Generate Image poll returns `404 GENERATED_IMAGE_NOT_FOUND` | `executionId` invalid or expired | Re-run Generate Image and poll the new `executionId` |
 | STEP 5 shows the publish/schedule feature `enabled: false` or `remainingUsage: 0` | Plan doesn't allow the action, or quota used up | Advise upgrading, or wait for quota reset |
 | `FAILED_PRECONDITION` / `INELIGIBLE_FOR_FEATURE` on publish or schedule | Plan doesn't cover the action, or its quota is 0/exhausted (see the `quotaInfo` from STEP 5) | Don't retry; offer the other action if enabled (schedule vs publish now), or advise upgrading |
+| `SCHEDULED_TIME_ALREADY_PASSED` (or a generic/HTML `400`) on schedule | The resolved `scheduledDate` is in the past — usually a relative time like "today at 9am" that resolved to a past instant | Recompute the wall-clock time in the site's timezone, validate the ISO instant is `> Date.now()`, and advance to the next future occurrence (or confirm a later time) before retrying — don't send-and-catch |
 | `429 RESOURCE_EXHAUSTED` / `PUBLISH_LIMIT_EXCEEDED` | Publishing rate limit hit | Back off and retry later |
 | `ALREADY_EXISTS` / `REFERENCE_ID_ALREADY_EXIST` on create or publish | An item with the same `referenceId` already exists | Expected when safely retrying a create/publish that already succeeded — don't retry with a new `referenceId` |
 | `FAILED_PRECONDITION` / `UNSUPPORTED_CHANNEL` | Targeting an unsupported channel, or X/Twitter after its July 31, 2026 cutoff | Use a supported channel; target X only before the cutoff |

--- a/yaml/wix-manage-evals/marketing/create-and-publish-social-post-scheduling-guards.yml
+++ b/yaml/wix-manage-evals/marketing/create-and-publish-social-post-scheduling-guards.yml
@@ -1,0 +1,58 @@
+name: marketing/create-and-publish-social-post-scheduling-guards
+description: >-
+  Advisory scenario for the "Create and Publish a Social Media Post" skill: the
+  agent is asked how to schedule safely when the Social Publisher feature check
+  reports a publish quota of 0 but scheduling is enabled without quotaInfo. The
+  correct behavior is to treat quota as action-specific, proceed with scheduling
+  only if SCHEDULE_POST is allowed, and validate that each scheduledDate resolves
+  to a future ISO instant before making any mutating publish-by-id call.
+triggerPrompt: >-
+  I am using the Wix Social Publisher REST API to schedule posts for tomorrow at
+  9:00 AM America/Chicago. The feature check returns PUBLISH_POST enabled with
+  quotaInfo.remainingUsage 0, and SCHEDULE_POST enabled with no quotaInfo. How
+  should I decide whether scheduling is allowed, and how should I calculate the
+  scheduledDate safely?
+tags: [marketing]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/skills/create-and-publish-a-social-media-post-with-ai-generation
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user is asking for guidance only. They did NOT ask the assistant to
+      create, publish, or schedule an actual post. The feature check says:
+      PUBLISH_POST is enabled with quotaInfo.remainingUsage 0, and SCHEDULE_POST
+      is enabled with no quotaInfo.
+
+      Pass if the response:
+      - uses the Create and Publish a Social Media Post skill / recipe, AND
+      - treats quota as action-specific: PUBLISH_POST remainingUsage 0 blocks
+        publishing now but does NOT block scheduling, AND
+      - explains that SCHEDULE_POST enabled with no quotaInfo means scheduling is
+        allowed unless that action is disabled or its own quotaInfo is exhausted,
+        AND
+      - says scheduledDate must be an ISO 8601 instant strictly in the future, AND
+      - resolves the requested 9:00 AM America/Chicago wall-clock time to UTC/ISO
+        using the site's or requested timezone, then validates immediately before
+        publish-by-id that new Date(scheduledDate).getTime() > Date.now(), AND
+      - says that if the resolved instant is in the past or equal to now, it must
+        advance to the next matching future occurrence or ask the user to confirm
+        a later time before calling the API, AND
+      - for multiple daily posts, says to compute and validate each occurrence
+        independently, AND
+      - does not perform any mutating API calls.
+
+      Fail if the response:
+      - says scheduling is blocked because PUBLISH_POST remainingUsage is 0, OR
+      - borrows quotaInfo between PUBLISH_POST and SCHEDULE_POST, OR
+      - treats missing quotaInfo on SCHEDULE_POST as quota exhausted, OR
+      - suggests sending a scheduledDate that may be in the past and handling the
+        API error afterward, OR
+      - attempts Create Draft Item, Publish Item By ID, or any other mutating API
+        call, OR
+      - falls back to searching the REST docs instead of using the skill.


### PR DESCRIPTION
## Summary

Adds a **future-instant guard** to the Social Publisher recipe's scheduling step so the agent never sends a past `scheduledDate` to `publish-by-id`.

## Root cause (real user flow)

Conversation `1e805856-27e9-4f15-b5e0-2a7a0f607938` hit repeated `SCHEDULED_TIME_ALREADY_PASSED` on `publish-by-id` while scheduling the first day's posts: "today at 9 AM America/Chicago" resolved to a UTC instant that had **already passed** (`executeAt 2026-07-12T14:00:00Z` vs `now 2026-07-13T10:37Z`). A later retry with a future time succeeded.

## Changes

- **STEP 7**: resolve the wall-clock time in the site/requested timezone → ISO, then **validate `new Date(scheduledDate).getTime() > Date.now()` immediately before `publish-by-id`**; if not strictly future, advance to the next matching occurrence or confirm a later time; validate each occurrence of a series independently.
- Protocol rule 7 gets a one-line note; new error-table row for `SCHEDULED_TIME_ALREADY_PASSED` / generic 400.
- Adds a non-mutating eval scenario (`create-and-publish-social-post-scheduling-guards.yml`).

## Relationship to #592

Supersedes #592. #592 was opened against the **pre-#542** recipe and now shows `CONFLICTING`. It bundled two things:
- **Action-specific quota** semantics — **already landed in #542** (merged to `main`), so that half is now redundant.
- **The scheduling/future-instant guard** — the genuinely new fix, which this PR folds cleanly onto current `main` (value-first structure: scheduling is STEP 7).

Credit to the Aria Feedback Loop for surfacing the case. Suggest closing #592 in favor of this once merged.