### PR TITLE
feat(wix-vibe-headless): host per-platform handoff prompts

### DIFF
--- a/skills/wix-vibe-headless/platforms/README.md
+++ b/skills/wix-vibe-headless/platforms/README.md
@@ -1,0 +1,17 @@
+# Vibe platform handoff prompts
+
+One file per AI-builder platform (Base44, Lovable, Bolt, v0, Manus, …). Each file is the
+**handoff prompt** the Wix Headless funnel hands to that platform after it creates the site +
+OAuth app: build the client, then seed/manage the business.
+
+These are hosted (served at `https://www.wix.com/skills/vibe-headless/platforms/<platform>.md`)
+so the funnel loader can pass a short pointer to the prompt instead of inlining the whole
+script into the launch URL. Inlining tripped the Base44 edge WAF, which scans the POST body
+for command-injection patterns (`curl … | tar`, `require('child_process')`, etc.); a plain
+GET of a hosted file is not scanned that way.
+
+**Loader contract:** the funnel sends a short prompt that names the business, passes the Wix
+client id + metasite id, and points here — e.g. "Build a site for my Wix managed business:
+&lt;business&gt;. Then fetch and follow https://www.wix.com/skills/vibe-headless/platforms/base44.md
+exactly." The dynamic bits (business description, client id, metasite id) stay in the loader
+prompt; everything static lives in these files.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -1,0 +1,59 @@
+# Wix Managed Headless — Base44 build instructions
+
+You are building a **Wix Managed** headless site inside Base44. The business to build is
+described in your initial prompt. Your Wix client id and metasite id were provided to you in
+that prompt / launch URL. The Wix connector is already configured for this app — use it for
+all Wix API calls.
+
+Follow the steps below exactly.
+
+## STEP 0 — Install the Wix skills locally
+
+Run this via exec_tool:
+
+```js
+const { execSync } = require('child_process');
+execSync('mkdir -p /app/skills');
+for (const skill of ['headless', 'vibe-headless', 'docs']) {
+  execSync(`curl -s "https://www.wix.com/skills/${skill}.tgz" | tar xz -C /app/skills`);
+}
+return 'done';
+```
+
+Every archive already contains its own top-level folder, so you end up with
+`/app/skills/headless`, `/app/skills/vibe-headless`, `/app/skills/docs`.
+
+Always read skill and reference files from the local `/app/skills` copy via exec_tool
+(`execSync('cat …')`) rather than through a web-fetch tool, to avoid caching and truncation.
+
+## STEP 1 — Build the client
+
+Read `/app/skills/vibe-headless/SKILL.md` and follow it **EXACTLY** — it is the single source
+of truth for how the client app is built. To save time, prefer copying ready-made files the
+skill provides (e.g. the Wix client setup) and adapting them over re-generating them from
+scratch.
+
+## STEP 2 — Manage and seed the business
+
+Seed the site with real content (products, categories, etc.) by following
+`/app/skills/headless/references/SEED.md`. For any other admin operations, find the relevant
+Wix APIs with the docs skill at `/app/skills/docs` — it explains how to search and read Wix
+documentation. Use the already-configured Wix connector for these management API calls.
+
+**IMPORTANT:** the Wix connector and the headless skill's seeding instructions are for
+management/admin operations only (STEP 2) — they are **NOT** part of the client. The client is
+built solely per the vibe-headless skill.
+
+## Parallelism
+
+If possible, run STEP 1 and STEP 2 in parallel — building the client and seeding the business
+are independent, so don't wait for one to start the other. Within each step, also work in
+parallel where possible (e.g. independent API calls, seeding multiple entities) instead of
+one-by-one, to finish faster.
+
+## When done
+
+After the site is built and seeded, ask the user to open this URL to complete the setup in Wix
+(substitute the metasite id you were given):
+
+`https://manage.wix.com/dashboard/{metaSiteId}`


### PR DESCRIPTION
## What

Adds `skills/wix-vibe-headless/platforms/` — hosted handoff prompts, one file per AI-builder platform. Starts with `base44.md`.

Once published these serve at `https://www.wix.com/skills/vibe-headless/platforms/<platform>.md`.

## Why

The Wix Headless funnel currently inlines the full build script into the Base44 launch URL (`override-redirect-prompt`). That script ends up in the POST body Base44's frontend sends to `/api/wix/create-app`, where **Cloudflare's WAF rejects it with 403** — the body matches command-injection signatures (`curl … | tar xz`, `require('child_process')`, `$(…)`).

Hosting the prompt lets the funnel pass a **short pointer** in the body (`… fetch and follow https://www.wix.com/skills/vibe-headless/platforms/base44.md`) instead of the script. A plain GET of the hosted file is not scanned that way, so the real install script lives here safely.

## Contents

- `base44.md` — build the client (per `vibe-headless/SKILL.md`) + seed the business (per `headless/references/SEED.md`) using the pre-configured Wix connector, with a client/management split and parallelism guidance.
- `README.md` — folder purpose + loader contract (dynamic bits stay in the loader prompt; static content lives here).

## Follow-ups

- Add the other platforms the funnel supports (`lovable`, `bolt`, `v0`, `manus`) — those aren't auto-connected to a connector, so their prompt differs (CLI login via the headless skill's `entry/bootstrap.mjs`).
- Wire the funnel loader (`headless-bo`) to emit the short-pointer prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)