### PR TITLE
fix(wix-vibe-headless): storefront — plainDescription is HTML, hide "All Products"

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -50,8 +50,9 @@ reference for anything not shown.
 
 ## How to wire it (UI is the project's choice)
 - **Product grid** — `queryProducts()` for the listing (visible products only); pass
-  `nextCursor` back as `cursor` to load the next page. Render fields directly from the Wix
-  product object (see the `Product` typedef in `wix-store.js` for key fields). For price, use
+  `nextCursor` back as `cursor` to load the next page. Render most fields directly from the Wix
+  product object (see the `Product` typedef in `wix-store-catalog.js` for key fields) — the one
+  exception is `plainDescription`, which is HTML (see PDP below). For price, use
   `actualPriceRange.minValue.formattedAmount` (already includes the currency symbol) — no
   manual formatting needed.
 - **PDP** — `getProductBySlug(slug)` keyed off the URL slug; returns null on miss — show
@@ -65,6 +66,10 @@ reference for anything not shown.
   **mandatory** modifier (e.g. "gift wrap?") whose control isn't rendered can never be added: the
   buyer can't satisfy the requirement, so `add-to-cart` returns 200 with an **empty** `lineItems`
   and the add silently no-ops.
+  Render `product.plainDescription` as **HTML** — despite the name it contains markup (`<p>`,
+  `<br>`, `<strong>`), so `dangerouslySetInnerHTML={{ __html: product.plainDescription }}` (React)
+  or `el.innerHTML = product.plainDescription`, never as a plain text node (that shows raw `<p>`
+  tags). Strip tags only for plain-text contexts (SEO/meta description, a truncated card teaser).
 - **Gate the Add-to-cart button** — disable it only until the requirements the product *actually
   has* are met, computed from the product object (never assume every product has options or
   modifiers): if `product.options` is non-empty, a variant must resolve from the selections; every
@@ -86,6 +91,10 @@ reference for anything not shown.
 - **Categories** — `queryCategories()` for a category menu; `getCategoryBySlug(slug)` for
   a category landing page. Pass `category.id` to `queryProductsByCategory(categoryId, { limit?, cursor? })`
   to list only the products in that category; paginate exactly like `queryProducts`.
+  `queryCategories()` includes Wix's auto-created **"All Products" system category** (`slug:
+  "all-products"`) — it mirrors the full catalog, so drop it from the category menu
+  (`categories.filter(c => c.slug !== "all-products")`). Filter by that slug, not by name (renames/
+  localizes) or `visible` (it's `visible: true` like any other).
 - **Cart** — `addToCart(catalogItemId, variantId?, qty?, { modifierChoices?, customTextFields? }?)`,
   `updateCartItemQuantity(lineItemId, qty)`, `removeFromCart(lineItemId)`.
   - `variantId` (`variantsInfo.variants[].id` from `getProductBySlug`) — required for products with

--- a/skills/wix-vibe-headless/references/storefront/wix-store-catalog.js
+++ b/skills/wix-vibe-headless/references/storefront/wix-store-catalog.js
@@ -20,7 +20,9 @@ import { wixApiRequest } from "./wix-client.js";
  *   modifiers {array} — non-variant customizations (engraving, gift wrap):
  *     [{ id, name, mandatory, modifierRenderType "TEXT_CHOICES"|"FREE_TEXT",
  *        key, choicesSettings.choices, freeTextSettings.key }],
- *   plainDescription {string} — HTML product description,
+ *   plainDescription {string} — product description as an HTML string (contains <p>, <br>,
+ *     <strong>…) despite the "plain" name — NOT plain text. Render with innerHTML /
+ *     dangerouslySetInnerHTML; strip tags only for plain-text contexts (meta description, teaser),
  *   variantsInfo.variants {array} — returned only by getProductBySlug:
  *     [{ id, visible, choices [{ optionChoiceIds: { optionId, choiceId } }],
  *        price: { actualPrice, compareAtPrice }, media, inventoryStatus: { inStock } }]
@@ -28,6 +30,8 @@ import { wixApiRequest } from "./wix-client.js";
  *     match all selected { optionId, choiceId } pairs, then pass variant.id to addToCart.
  *
  * Category: { id, name, slug, visible, description, image, itemCounter, parentCategory.id }
+ *   NB: queryCategories includes the auto-created system category { slug: "all-products" } —
+ *   filter it out of a category menu (see INSTRUCTIONS.md). `visible` does not flag it.
  * Full model: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories
  */
 


### PR DESCRIPTION
## What

Two documentation/helper gaps in the vibe-headless **storefront** skill that agents hit while building a store, plus a stale filename reference.

### 1. `plainDescription` is HTML, not plain text
`wix-store-catalog.js` documented the field as "HTML product description" but INSTRUCTIONS said to "render fields directly from the Wix product object" — applied to `plainDescription` that renders raw `<p>` tags as visible text (an agent hit exactly this). Now:
- typedef flags it as an HTML string despite the "plain" name;
- PDP guidance says render via `innerHTML` / `dangerouslySetInnerHTML`, and strip tags only for plain-text contexts (meta description, card teaser).

### 2. Hide the auto-created "All Products" category
`queryCategories()` returns Wix's system "All Products" category, which mirrors the whole catalog and shouldn't appear as its own menu item. Nothing mentioned it. Added a note to filter it out by **`slug === "all-products"`**.

Confirmed against two live stores that the default category is reliably `slug: "all-products"` while real categories have distinct slugs; it is **not** distinguishable by name (renames/localizes) or `visible` (it's `visible: true` like any other). The `wix-manage` skill already treats "All Products" as a system category to exclude — this brings the storefront skill in line.

### 3. Stale reference
`INSTRUCTIONS.md` pointed at `wix-store.js`; the file is `wix-store-catalog.js`.

## Notes
Docs-only (comments + INSTRUCTIONS + one filename); no code/behavior change. Deliberately left rendering-vs-stripping as the app's choice rather than shipping a helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)