### PR TITLE
fix(wix-vibe-headless): base44 — don't re-import base44 in inline exec_tool

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -59,6 +59,11 @@ Seed the site with real content (products, categories, etc.) by following
 Wix APIs with the docs skill at `/app/skills/docs` — it explains how to search and read Wix
 documentation. Use the already-configured Wix connector for these management API calls.
 
+When you run seed/management code **inline via exec_tool**, `base44` is already declared — use
+it directly. Do **not** import `@base44/sdk`, re-declare `base44`, or call `createClient()` —
+that pattern is only for standalone `.js` skill files, and inline it throws *"Identifier
+'base44' has already been declared."*
+
 **IMPORTANT:** the Wix connector and the headless skill's seeding instructions are for
 management/admin operations only (STEP 2) — they are **NOT** part of the client. The client is
 built solely per the vibe-headless skill.


### PR DESCRIPTION
Follow-up build-friction fix (F5) on `platforms/base44.md`.

**What happened:** during seeding, the agent ran the `.js`-skill client pattern (`import { createClient } from '@base44/sdk'` + `const base44 = createClient(...)`) inside an **inline exec_tool** run and hit `SyntaxError: Identifier 'base44' has already been declared`. It recovered on the next call by using the pre-declared `base44` directly.

**Root cause:** two correct-but-conflicting guidances in the base44 runtime — exec_tool pre-declares `base44` (its preamble warns *"do not declare `base44`, import '@base44/sdk' or call createClient()"*, `exec_tool/tool.py:15`), while the connector rules show the SDK import pattern for standalone `.js` skill files (`connector_rules.py:~214`). The agent applied the `.js` pattern inline.

**Fix:** one line in STEP 2 telling the agent that inline via exec_tool, `base44` is already declared — use it directly; the SDK import is only for `.js` skill files.

Scoped to base44.md (base44-specific) rather than the platform-neutral Wix `SEED.md`. The deeper source-level fix would be a caveat in apper's `connector_rules.py:214` — tracked separately.