### PR TITLE
Add Wix Multilingual app ID to install recipe

### DIFF
--- a/skills/wix-manage/references/app-installation/install-wix-apps.md
+++ b/skills/wix-manage/references/app-installation/install-wix-apps.md
@@ -99,6 +99,7 @@ Some common apps:
 | Wix Bookings | `13d21c63-b5ec-5912-8397-c3a5ddb27a97` |
 | Wix Blog | `14bcded7-0066-7c35-14d7-466cb3f09103` |
 | Wix Events | `140603ad-af8d-84a5-2c80-a0f60cb47351` |
+| Wix Multilingual | `14d84998-ae09-1abf-c6fc-3f3cace5bf19` |
 | Wix Pricing Plans | `1522827f-c56c-a5c9-2ac9-00f9e6ae12d3` |
 | Wix CMS | `e593b0bd-b783-45b8-97c2-873d42aacaf4` |
 
@@ -113,6 +114,8 @@ Some common apps:
 
 ### App Not Installed Error
 If you receive an error indicating a required app is not installed, use this recipe to install it before proceeding.
+
+If Locale Settings or Locales APIs return `428 MULTILINGUAL_NOT_INSTALLED`, install **Wix Multilingual** using appDefId `14d84998-ae09-1abf-c6fc-3f3cace5bf19`, then retry enabling multilingual mode or creating locales. Confirm with the user before installing unless they already explicitly asked you to install Wix Multilingual.
 
 ---
 

--- a/yaml/wix-manage-evals/app-installation/install-wix-multilingual-app.yml
+++ b/yaml/wix-manage-evals/app-installation/install-wix-multilingual-app.yml
@@ -1,0 +1,31 @@
+name: app-installation/install-wix-multilingual-app
+description: >-
+  Verifies the agent reads the install-wix-apps skill and gives the correct
+  Wix Multilingual appDefId when Locale Settings APIs require the app.
+triggerPrompt: >-
+  I tried to enable multilingual mode with the Locale Settings API and got
+  428 MULTILINGUAL_NOT_INSTALLED. Which app should I install first, and what
+  appDefId and REST endpoint should I use?
+tags: [app-installation]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/install-wix-apps
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked what to do after Locale Settings returned 428 MULTILINGUAL_NOT_INSTALLED.
+      Intent: explain that Wix Multilingual must be installed before enabling multilingual mode.
+
+      Pass if the response:
+      - says to install Wix Multilingual before retrying Locale Settings or Locales API calls, AND
+      - identifies the Apps Installer install endpoint (POST to .../apps-installer-service/v1/app-instance/install), AND
+      - uses the Wix Multilingual appDefId `14d84998-ae09-1abf-c6fc-3f3cace5bf19`, AND
+      - shows or describes a request body with a SITE tenant and appInstance.appDefId set to that ID.
+
+      Fail if the response:
+      - tells the user to retry Locale Settings without installing Wix Multilingual, OR
+      - guesses, omits, or uses a different appDefId for Wix Multilingual, OR
+      - points only to the Wix App Market UI with no API endpoint, OR
+      - suggests installing an unrelated translation app.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/e128fce5-f5e9-4b53-b373-fc15c2bae432
Feedback: Locale Settings `POST https://www.wixapis.com/locale-settings/v2/settings/mode` returned `428 MULTILINGUAL_NOT_INSTALLED` while the user needed Dutch + Arabic multilingual setup.

## Conversation research

The reported issue is a partial issue. In the reported conversation, the first Locale Settings call really failed with `MULTILINGUAL_NOT_INSTALLED`, but the assistant recovered after user approval: it resolved Wix Multilingual through App Market search, installed appDefId `14d84998-ae09-1abf-c6fc-3f3cace5bf19`, retried Set Multilingual Mode successfully, then created Dutch and Arabic locales successfully.

Sample broken conversation(s):
- https://wix-bo.com/ai-assistant/conversations/e128fce5-f5e9-4b53-b373-fc15c2bae432: user wanted Dutch + Arabic. Message `806d5309-c06a-4d12-966c-42887f842bac` logged `TOOL_FAILED` for `CallWixSiteAPI` on `POST https://www.wixapis.com/locale-settings/v2/settings/mode` with `428 MULTILINGUAL_NOT_INSTALLED`. Message `c245f829-b634-41d2-b12b-c62ed2055d47` then installed Wix Multilingual and retried the multilingual flow successfully.

## Code/content research

Root cause: the `install-wix-apps` recipe told agents not to guess appDefIds, but its common Wix-built app table did not include Wix Multilingual. That omission pushes agents into App Market search, which feedback shows is unreliable for this app and can lead to wrong IDs or extra failed retries.

Why this is the owning surface:
- The conversation activated the `install-wix-apps` recipe before installing the app.
- The public Wix Docs “Apps Created by Wix” article lists Wix Multilingual as `14d84998-ae09-1abf-c6fc-3f3cace5bf19`.
- The reported conversation independently confirmed the same ID through App Market search and a successful Apps Installer call.

Alternatives ruled out:
- Locale Settings service bug: the first 428 is an expected precondition when the app is absent.
- Wix MCP execution bug for the reported turn: the assistant was able to install the app, enable multilingual mode, and create locales after approval.
- Platform/tool-schema fix: the failure was caused by missing recipe guidance, not a validation or orchestration defect.

## Change

This updates the app-installation recipe so agents have the first-party Wix Multilingual appDefId in the same common-ID table as other Wix-built apps, and adds explicit handling for `428 MULTILINGUAL_NOT_INSTALLED`.

Reviewer-oriented diff:
- `skills/wix-manage/references/app-installation/install-wix-apps.md`: add Wix Multilingual appDefId `14d84998-ae09-1abf-c6fc-3f3cace5bf19` and a targeted note to install it before retrying Locale Settings or Locales calls.
- `yaml/wix-manage-evals/app-installation/install-wix-multilingual-app.yml`: add an advisory eval covering the 428 flow without mutating a real site.

## Side effects and rollout risk

The change is bounded to one recipe and one eval. It does not alter tool schemas, permissions, or runtime behavior. The main risk is if the appDefId changes, but both public docs and the live successful install path point to the same ID.

## Verification

- Fix proof: local recipe now contains the documented Wix Multilingual appDefId and a covering eval asserts the expected endpoint/body/appDefId response. GitHub Actions `check` and `gate` passed on this PR; `skill-eval` was skipped by the workflow.
- Safety & ownership: this clears the gate because the fix lands in the authoring recipe that supplied the missing guidance; it avoids regex/consumer-side rewriting and does not loosen any API guard. Although the reported turn self-recovered, Slack search found many `MULTILINGUAL_NOT_INSTALLED` feedback cards in the same week, and downstream logs showed 303 `MultilingualNotInstalledException` requests from 2026-07-10 through 2026-07-17, so preventing repeated search/guess/retry cost is justified at the recipe source.
- AGENT_TESTING smoke: https://wix-bo.com/ai-assistant/conversations/586a3d60-9d15-42c6-affe-5ab00799b987 used `skillsRepo=wix/skills` and `skillsPr=12a650d93bc9cac6482f637ec6e4dc9dc3de8f20`; the assistant answered with Wix Multilingual appDefId `14d84998-ae09-1abf-c6fc-3f3cace5bf19`. The decisive `activateSkill` proof was not obtained: Aria first emitted an invalid internal docs-skill name (`assistant/Install Wix Apps`) and recovered through `SearchWixRESTDocumentation` / `ReadFullDocsArticle`; `ReadFullDocsArticle` log `2c7fccd2-5b7c-4638-b3e9-a665654ab29b` contained the Wix Multilingual ID. A stricter prompt naming `install-wix-apps` was blocked by Aria's internal-skill guard. Reviewer-runnable proof remains the PR eval gate scenario `app-installation/install-wix-multilingual-app`.
- `ruby -e 'require "yaml"; YAML.load_file("yaml/wix-manage-evals/app-installation/install-wix-multilingual-app.yml"); puts "yaml ok"'`
- `git diff --check`
- Residual: the documentation-review smoke logged one no-site dynamic-knowledge diagnostic and the validation error above before recovering. This PR does not modify Aria config or dynamic knowledge; no site mutation was attempted.
