### PR TITLE
fix(wix-manage): add app uninstall editor-presence guidance

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -26,6 +26,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Install Wix Apps](references/app-installation/install-wix-apps.md)
 **Technical:** Installs Wix apps on a site using Apps Installer API. Covers enabling Velo (Wix Code), app installation, and common app definition IDs.
 
+### [Uninstall Wix Apps](references/app-installation/uninstall-wix-apps.md)
+**Technical:** Uninstalls Wix apps from a site using Apps Installer API. Covers listing installed apps first, required request body, verification, and `HAS_EDITOR_PRESENCE` editor-cleanup handling.
+
 ### [List Installed Apps](references/app-installation/list-installed-apps.md)
 **Technical:** Lists all apps installed on a site using Apps Installer API. Useful for verifying app installations before making API calls and diagnosing authorization errors.
 

--- a/skills/wix-manage/references/app-installation/uninstall-wix-apps.md
+++ b/skills/wix-manage/references/app-installation/uninstall-wix-apps.md
@@ -1,0 +1,148 @@
+---
+name: "Uninstall Wix Apps"
+description: Uninstalls Wix apps from a site using Apps Installer API. Covers listing installed apps first, required request body, verification, and HAS_EDITOR_PRESENCE editor-cleanup handling.
+---
+# Uninstall Wix Apps from a Site
+
+This recipe guides you through uninstalling a Wix app from a site using the Apps Installer REST API.
+
+## Prerequisites
+
+- Site ID where the app is installed
+- The app's `appDefId`
+- Clear user intent to remove the app, because uninstalling is a mutating action
+
+If the user only asks whether an app can be removed or how to remove it, answer with the flow and do not call the uninstall endpoint.
+
+## Required APIs
+
+- **Apps Installer API**: [Get Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/get-installed-apps)
+- **Apps Installer API**: [Uninstall App](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/uninstall-app)
+
+---
+
+## Step 0: Find the App ID (skip if you already have it)
+
+If you already know the `appDefId`, skip to Step 1.
+
+For Wix-built apps, use [Apps Created by Wix](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix). For third-party apps, resolve the app ID using the Search Market Listings API from the [Install Wix Apps](install-wix-apps.md) recipe.
+
+Never guess the `appDefId`. Confirm the app name and ID before uninstalling.
+
+## Step 1: Verify the App Is Installed
+
+Use Get Installed Apps before uninstalling. This prevents unnecessary mutations and lets you report a clear "already not installed" result.
+
+**Endpoint**: `GET https://www.wixapis.com/apps-installer-service/v1/app-instances`
+
+**Request**:
+```bash
+curl -X GET \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instances' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json'
+```
+
+Match the target app by `appDefId`. If it is not present, stop and tell the user the app is already not installed on the site.
+
+## Step 2: Uninstall the App
+
+Only continue when the target app is present and the user has clearly asked to remove it.
+
+**Endpoint**: `POST https://www.wixapis.com/apps-installer-service/v1/app-instance/uninstall`
+
+**Request Body**:
+```json
+{
+  "tenant": {
+    "tenantType": "SITE",
+    "id": "<SITE_ID>"
+  },
+  "appDefId": "<APP_DEF_ID>"
+}
+```
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instance/uninstall' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tenant": {
+      "tenantType": "SITE",
+      "id": "<SITE_ID>"
+    },
+    "appDefId": "<APP_DEF_ID>"
+  }'
+```
+
+The successful response body is empty (`{}`).
+
+## Step 3: Verify Removal
+
+After a successful uninstall response, call Get Installed Apps again and confirm the `appDefId` is no longer present.
+
+If the app still appears after a successful uninstall response, report that the uninstall was requested but the app still appears installed, and include the `appDefId` and site ID in the diagnostic summary.
+
+---
+
+## Error Handling
+
+### `HAS_EDITOR_PRESENCE`
+
+Apps that add editor pages, elements, widgets, or app-managed site structure can return:
+
+```text
+UNINSTALL_FAILED: reason on MetaSite [HAS_EDITOR_PRESENCE]
+```
+
+This is a non-retryable precondition failure. Do not retry the same uninstall call and do not describe it as an auth problem, missing header, bad endpoint, or request-body schema issue.
+
+Tell the user that the app still has editor presence on the site and must be cleaned up in the Editor before the API uninstall can complete. The correct next step is:
+
+1. Open the site in the Editor.
+2. Delete or remove the app's pages, app widgets, sections, or elements from the site.
+3. Remove the app from **Apps** -> **Manage Apps**, or rerun the uninstall flow after editor cleanup.
+
+For Wix Portfolio, this usually means deleting Portfolio pages and removing Portfolio gallery/widgets before removing the app.
+
+### App Not Installed
+
+If the target `appDefId` is not returned by Get Installed Apps, stop and tell the user the app is already not installed on this site.
+
+### Permission Errors
+
+If the API returns `401` or `403`, verify that the caller is a logged-in Wix user or API key admin with Apps Installer uninstall permissions:
+
+- `APPS_INSTALLER.UNINSTALL_SITE_LEVEL`
+- `APPS_INSTALLER.UNINSTALL_ACCOUNT_LEVEL`
+
+### Other `428` Precondition Errors
+
+For any other `428` response, read the `details.applicationError.description` value and report that exact precondition to the user. Do not blindly retry a mutating uninstall call.
+
+---
+
+## Common App Definition IDs
+
+Before uninstalling, refer to [Apps Created by Wix](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix) for the current app IDs.
+
+Some common apps:
+| App | appDefId |
+|-----|----------|
+| Wix Bookings | `13d21c63-b5ec-5912-8397-c3a5ddb27a97` |
+| Wix Blog | `14bcded7-0066-7c35-14d7-466cb3f09103` |
+| Wix Events | `140603ad-af8d-84a5-2c80-a0f60cb47351` |
+| Wix Pricing Plans | `1522827f-c56c-a5c9-2ac9-00f9e6ae12d3` |
+| Wix CMS | `e593b0bd-b783-45b8-97c2-873d42aacaf4` |
+| Wix Portfolio | `d90652a2-f5a1-4c7c-84c4-d4cdcc41f130` |
+
+---
+
+## Common Pitfalls
+
+- **Do not skip the installed-apps check**: it turns "not installed" into a clear answer instead of a failed mutation.
+- **Do not retry `HAS_EDITOR_PRESENCE`**: the same API call will keep failing until editor pages/elements are removed.
+- **Do not invent app IDs**: resolve them from official docs or the App Market listing search.
+- **Do not claim complete removal until verification passes**: a successful uninstall call should be followed by Get Installed Apps.

--- a/yaml/wix-manage-evals/app-installation/uninstall-wix-portfolio-editor-presence.yml
+++ b/yaml/wix-manage-evals/app-installation/uninstall-wix-portfolio-editor-presence.yml
@@ -1,0 +1,31 @@
+name: app-installation/uninstall-wix-portfolio-editor-presence
+description: >-
+  Verifies the agent reads the uninstall-wix-apps skill and explains how to handle
+  HAS_EDITOR_PRESENCE when removing Wix Portfolio.
+triggerPrompt: >-
+  I want to remove Wix Portfolio from my site. What REST endpoint and request body should I use,
+  and what should I do if the uninstall returns HAS_EDITOR_PRESENCE?
+tags: [app-installation]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/uninstall-wix-apps
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked how to uninstall Wix Portfolio and how to handle HAS_EDITOR_PRESENCE.
+      Intent: surface the Apps Installer uninstall endpoint, the correct request body shape, and the non-retryable editor-cleanup precondition.
+
+      Pass if the response:
+      - identifies the Apps Installer uninstall endpoint (POST to .../apps-installer-service/v1/app-instance/uninstall), AND
+      - shows a request body with tenant.tenantType SITE, tenant.id as the site ID, and appDefId for the app to uninstall, AND
+      - says Wix Portfolio uses appDefId `d90652a2-f5a1-4c7c-84c4-d4cdcc41f130` or tells the user to verify that exact appDefId before uninstalling, AND
+      - explains that HAS_EDITOR_PRESENCE means editor pages/elements/widgets are still present and must be removed in the Editor before retrying or completing app removal, AND
+      - warns not to blindly retry the same uninstall call for HAS_EDITOR_PRESENCE.
+
+      Fail if the response:
+      - treats HAS_EDITOR_PRESENCE as an auth, missing header, endpoint, or request-body schema problem, OR
+      - recommends retrying the same uninstall call without editor cleanup, OR
+      - omits the uninstall endpoint or the SITE tenant request body, OR
+      - claims the API can remove editor pages/elements automatically.

--- a/yaml/wix-manage/app-installation/documentation.yaml
+++ b/yaml/wix-manage/app-installation/documentation.yaml
@@ -6,6 +6,10 @@ apiDoc:
       title: Install Wix Apps
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
       tags: [app-installation]
+    - file: ../../../skills/wix-manage/references/app-installation/uninstall-wix-apps.md
+      title: Uninstall Wix Apps
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
+      tags: [app-installation]
     - file: ../../../skills/wix-manage/references/app-installation/list-installed-apps.md
       title: List Installed Apps
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/1212630a-28cd-4429-81da-ef53fc46115e
Feedback: Apps Installer `UninstallApp` returned `UNINSTALL_FAILED` with `HAS_EDITOR_PRESENCE` when Aria tried to remove Wix Portfolio.

## Conversation research

The reported issue is a partial true issue: the turn self-recovered, but the failed mutation is real and recurring.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/1212630a-28cd-4429-81da-ef53fc46115e`: the user asked to remove Wix Portfolio. Aria activated `list-installed-apps`, read the App Installation `Uninstall App` docs, then called `ExecuteWixAPI` with `POST https://www.wixapis.com/apps-installer-service/v1/app-instance/uninstall` for appDefId `d90652a2-f5a1-4c7c-84c4-d4cdcc41f130`. The API returned HTTP 428 with `UNINSTALL_FAILED` and `reason on MetaSite [HAS_EDITOR_PRESENCE]` in log `d1d844ba-a590-47b0-a5d8-f41c1e32aa65`. The final user-facing answer correctly explained editor cleanup, but the tool still burned a failed mutation attempt and filed feedback.
- Sampled recurring logs also show the same `ExecuteWixAPI` + `UNINSTALL_FAILED` + `HAS_EDITOR_PRESENCE` signature in `https://wix-bo.com/ai-assistant/conversations/58f48d45-8329-4b7c-b18f-1b5c4b29b9e8`, `https://wix-bo.com/ai-assistant/conversations/9febe2bc-4ab8-4d0e-967f-a663f37d1056`, and `https://wix-bo.com/ai-assistant/conversations/b060843e-97f2-4db1-99db-c148b592f7b1`.

Impact and frequency:
- Grafana `app_logs`, artifact `com.wixpress.genie.agent-platform-service`, July 11-18 2026 UTC: 51 distinct request IDs matched `TOOL_FAILED` + `ExecuteWixAPI` + `UNINSTALL_FAILED` + `HAS_EDITOR_PRESENCE`.
- Per occurrence cost: one failed mutating API attempt, one extra model/tool recovery loop, user-visible error framing, and often automatic feedback noise.

## Code/content research

Root cause: the Wix MCP recipe catalog has install/list app-installation recipes, but no uninstall recipe that tells agents how to handle app uninstall preconditions. The public `Uninstall App` method docs expose the endpoint and request shape, but do not mention `HAS_EDITOR_PRESENCE`, so agents discover only the bare method and learn the precondition after a failed mutation.

Why this is the owning surface:
- `wix/skills` is the source for Wix MCP recipe docs served through Aria's Wix MCP recipe catalog.
- Genie local code only parses and forwards the upstream recipe body via `WixMcpRecipeSkillProvider`; it does not author the app-installation recipe content or `ExecuteWixAPI` error mapping.
- The Apps Installer API behaved consistently: it rejected uninstall with a specific precondition. The durable assistant-facing fix is to add recipe guidance that prevents blind retry and gives the correct editor-cleanup path.

Alternatives ruled out:
- Genie platform code: no validation/runtime defect was found; logs show the tool executed and the model recovered.
- Portfolio app owner: the same Apps Installer precondition appears across multiple conversations and is not specific to Portfolio implementation.
- Generic `ExecuteWixAPI` error rewriting: that would patch a consumer/error surface and risk masking other 428 preconditions. The recipe adds scoped, transparent source guidance for app uninstall flows.
- API docs change: useful as a follow-up, but `wix/skills` is the reachable recipe authoring surface that Aria uses for Wix MCP task routing and can be covered by eval.

## Change

This adds a focused `Uninstall Wix Apps` app-installation recipe so Wix MCP agents:
- list installed apps before uninstalling,
- use the correct `POST /apps-installer-service/v1/app-instance/uninstall` request body,
- verify removal afterward,
- treat `HAS_EDITOR_PRESENCE` as a non-retryable editor-cleanup precondition,
- avoid calling the mutating uninstall endpoint for advisory "how do I" requests.

Reviewer-oriented diff:
- `skills/wix-manage/references/app-installation/uninstall-wix-apps.md`: new recipe with endpoint, request body, verification, and error handling.
- `skills/wix-manage/SKILL.md`: adds the recipe to the App Installation catalog.
- `yaml/wix-manage/app-installation/documentation.yaml`: registers the recipe for docs generation.
- `yaml/wix-manage-evals/app-installation/uninstall-wix-portfolio-editor-presence.yml`: adds a non-mutating eval that verifies `HAS_EDITOR_PRESENCE` guidance for Wix Portfolio removal.

## Side effects and rollout risk

The change is bounded to Wix MCP app-installation recipe content. It should only affect routing and guidance for app uninstall requests. The eval prompt is advisory and explicitly asks what to do rather than performing a removal, so the PR gate should not mutate the shared test site.

## Verification

- Fix proof: GitHub PR checks passed for `check` and `gate` on `741cce7d4ad2caf19534ef4171dad80c433de588`; the repository workflow skipped `skill-eval`.
- PR-override `AGENT_TESTING` smoke tests were attempted with `skillsRepo=wix/skills` and `skillsPr=741cce7d4ad2caf19534ef4171dad80c433de588`, but the production assistant path did not provide a usable recipe-serving proof: advisory uninstall prompts were blocked by safety policy before recipe activation (`5b0507bf-d2a2-417e-abbf-d513d5b0ad0c`, `9ab2bb41-a27c-4bee-b69f-a51d0729f405`), and synthetic recipe-id activation did not load a recipe (`62f3fd29-21b9-4415-b73d-6f2c0ef094c2`, `01b0dbef-b7f4-4a9b-9f91-9a0a8df75ade`).
- Direct `assistant-spi-host-service.ExecuteTool(ReadFullDocsArticle)` verification through Fire Console was attempted with the same `skillsRepo`/`skillsPr` metadata, but the service rejected both BO and host server-signature identities with `PermissionDenied`. Reviewer-runnable repro: run the PR gate or call `ReadFullDocsArticle` for `https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/uninstall-wix-apps` with this PR override and confirm the returned recipe contains the `HAS_EDITOR_PRESENCE` non-retryable editor-cleanup guidance.
- Safety & ownership: clears the gate because the fix is deterministic recipe guidance in the `wix/skills` authoring owner, not a regex transform of foreign output or a runtime enforcement patch. The reported production turn self-recovered, but measured recurrence is high enough to fix the source guidance.
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' yaml/wix-manage/app-installation/documentation.yaml yaml/wix-manage-evals/app-installation/uninstall-wix-portfolio-editor-presence.yml`
