### PR TITLE
fix(stores): avoid Catalog V3 category revision conflicts

### DIFF
--- a/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
+++ b/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
@@ -56,7 +56,8 @@ The Categories API is an exception. It uses a v1 endpoint, as it replaces the ol
   - **Fashion** → Men, Women, Kids
   - **Other industries** → any logical grouping that fits the catalog.
 4. Use the Categories API to create each category. **YOU MUST USE** the endpoint: [Create Category](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/create-category) based on the example below. Endpoint path: `POST https://www.wixapis.com/categories/v1/categories`. **There is no bulk-create endpoint for `/categories/v1/`** (the `events/v1/bulk/categories/create` URL is for the Events product, not Stores).
-5. **Fire all N category-create calls as a single concurrent batch.** Each call is independent (creates a different category), so issue them as siblings in one assistant message — do not serialize. For 3 categories this saves ~6–8 s of wall vs. sequential calls.
+5. **Create categories sequentially, one request at a time.** Do **not** use `Promise.all`, parallel tool calls, or any other concurrent batch for `POST /categories/v1/categories`. These calls mutate the same Wix Stores category tree (`treeReference.appNamespace: "@wix/stores"`) and concurrent creates can fail with `409 INVALID_REVISION` / `Outdated revision for entity id "@wix/stores"` after one request succeeds. Wait for each create response before starting the next category.
+6. If a category create returns `409 INVALID_REVISION`, retry only the failed category after a short delay, still sequentially. Do not re-create categories that already succeeded.
 
 When calling the endpoint, make sure the request body includes a top-level `treeReference` field. It must **not** be nested inside the `category` object.
 

--- a/yaml/wix-manage-evals/stores/setup-online-store-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/setup-online-store-catalog-v3.yml
@@ -1,0 +1,22 @@
+name: stores/setup-online-store-catalog-v3
+description: Verifies the setup online store recipe teaches sequential category creation for the shared Wix Stores category tree, while keeping category item assignment efficient.
+triggerPrompt: How should I set up a Wix Stores Catalog V3 shop with five products and three categories? Please summarize the safe API flow before making any changes.
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/setup-online-store-catalog-v3
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Context: the user asks for a non-mutating summary of the Catalog V3 store setup flow before making changes.
+
+      Pass if the response:
+      - loads the setup-online-store-catalog-v3 skill,
+      - says products should be created first with the Catalog V3 bulk products-with-inventory endpoint,
+      - says each `POST /categories/v1/categories` create-category call must run sequentially, one at a time, for the `@wix/stores` tree,
+      - warns not to use `Promise.all`, parallel tool calls, or concurrent category creates because they can cause `409 INVALID_REVISION` / stale tree revision conflicts, and
+      - allows bulk add-items/category assignment calls to run after categories exist.
+
+      Fail if the response recommends concurrent category creation, suggests using a nonexistent Stores bulk-create categories endpoint, omits the sequential category-create requirement, or starts mutating the site instead of summarizing the safe flow.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/76c1c2c2-c837-4e16-9b33-8faf78259289
Feedback: Setup Online Store (Catalog V3) created multiple Stores categories through `POST https://www.wixapis.com/categories/v1/categories`; the second create failed with `409 INVALID_REVISION` / `Outdated revision for entity id "@wix/stores"`.

## Conversation research

The reported issue is a true issue, but the sampled turn self-recovered.

Sample broken conversation(s):
- https://wix-bo.com/ai-assistant/conversations/76c1c2c2-c837-4e16-9b33-8faf78259289: user selected products for a Catalog V3 setup flow; assistant message `7c9f840e-08e6-4cb6-bae3-255b24766aa4` completed with severity `ERROR`. Tool call log `f0f6d1c1-6aa0-445c-9c1c-8104f1b88ab0` generated `Promise.all(categoriesToCreate.map(... POST /categories/v1/categories ...))`. Tool failure log `9e9d5d52-f66c-46f6-ab76-4d64d5cef846` returned `409 INVALID_REVISION` after one category create succeeded. Follow-up tool call `e25ccaaf-0ef7-45ec-822d-313be8917783` retried the remaining categories sequentially, and result log `b3d368d1-9145-4208-b663-c6e37ce22476` returned `ok: true` for `Postres` and `Galletas y brownies`.

Measured impact: querying `com.wixpress.genie.ai-assistant-mcp-proxy-v2` logs for `categories/v1/categories` plus `INVALID_REVISION` / `Outdated revision for entity id` over `2026-07-11T03:04:40Z` to `2026-07-18T03:04:40Z` found distinct request IDs per UTC day: 16, 19, 28, 35, 14, 28, 20, and 5. Samples match the same shape: Stores V3 setup/product creation followed by category create 409s on `@wix/stores`.

## Code/content research

Root cause: `skills/wix-manage/references/stores/setup-online-store-catalog-v3.md` explicitly told agents to fire all category-create calls concurrently. The Categories API service metadata maps `POST /categories/v1/categories` to `com.wix.categories.api.v1.CategoriesService`, owned by `online-stores-server`, and the error is an optimistic-revision conflict on the shared Stores category tree. The unsafe instruction is authored in this recipe, so the durable fix belongs in `wix/skills`, not in the API guard or a runtime rewrite.

Why this is the owning surface:
- The served recipe is `https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/setup-online-store-catalog-v3`.
- The recipe's Step 3 instructed concurrent category creates.
- The assistant followed that instruction with `Promise.all`, producing the exact 409.

Alternatives ruled out:
- Categories API bug: not the primary fix surface; rejecting stale shared-tree revisions is expected optimistic locking behavior.
- Wix MCP execution bug: the tool executed the generated code and surfaced the API error correctly.
- Broad platform retry handling: unsafe here because it would patch the consumer/recovery layer while the authored recipe still tells agents to create the conflict.

## Change

This changes the setup recipe so category creation is explicitly sequential for `POST /categories/v1/categories`, with a narrow retry instruction for the failed category only. It keeps the later add-items calls parallel because those run after category IDs exist and were not the source of the shared tree revision conflict.

Reviewer-oriented diff:
- `skills/wix-manage/references/stores/setup-online-store-catalog-v3.md`: replace the concurrent category-create instruction with sequential one-at-a-time guidance and an `INVALID_REVISION` recovery note.
- `yaml/wix-manage-evals/stores/setup-online-store-catalog-v3.yml`: add a non-mutating eval that asserts the recipe is read and that responses warn against `Promise.all` / concurrent category creates.

## Side effects and rollout risk

This trades a few seconds of happy-path wall time for eliminating repeated failed API calls, extra model iterations, and duplicate/confusing recovery code in setup flows. Scope is bounded to the Stores setup recipe's category-create step; product bulk creation and category item assignment guidance are unchanged.

## Verification

- Fix proof: local content check confirms the old `Fire all N category-create` instruction is gone and the new recipe/eval both require sequential category creates for `@wix/stores`.
- Safety & ownership: the fix lands in the authored recipe that produced the unsafe value/behavior. It is deterministic, transparent, and does not rewrite upstream API/tool output. Although the sampled turn self-recovered, the 7-day log measurement shows recurring costly handled failures, so fixing the source instruction clears the Safety & Ownership gate.
- `ruby -e 'require "yaml"; Dir["yaml/**/*.yml", "yaml/**/*.yaml"].each { |f| YAML.load_file(f) }; puts "yaml ok"'`
- `git diff --check`
- PR-override Aria smoke test: conversation https://wix-bo.com/ai-assistant/monitoring/conversations/5fb813d7-b6c4-4db7-9909-dc513511c4ff used `skillsRepo=wix/skills` and `skillsPr=dd9868afcfa31ca02777ffa02567399d0d940b31`; assistant log `6af83f1b-c97f-4f49-8387-13586a7519de` activated `setup-online-store-catalog-v3`; the response instructed category creates for `treeReference.appNamespace: "@wix/stores"` to run sequentially, not concurrently, and warned that concurrent creates can fail with `409 INVALID_REVISION` / `Outdated revision for entity id "@wix/stores"`. The smoke was intentionally no-site and non-mutating; it had an unrelated tenant-context knowledge error, but no mutating API calls were made.
