### PR TITLE
fix(bookings): correct price shape + clean default sample services

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-bookings.md
+++ b/skills/wix-headless/references/inline-recipes/setup-bookings.md
@@ -20,7 +20,11 @@ A concise checklist for turning a freshly provisioned Wix site with the **Wix Bo
 
 **⚠️ CRITICAL ORDER REQUIREMENT: resolve a staff resource (STEP 1) and a category (STEP 2) BEFORE creating services (STEP 3).** An APPOINTMENT service is rejected (`MISSING_APPOINTMENT_RESOURCES`) unless `staffMemberIds` is non-empty, and **any service without a `category.id` is invisible on the live site** (see STEP 3). For CLASS services, sessions are created **after** the service (STEP 4) because they need the service's returned `schedule.id`.
 
-There is **no clean-up step** — a fresh Wix Bookings install ships no sample *services* (only a default "Business Owner" staff resource, which you reuse in STEP 1), so there is nothing to delete first.
+**Check for pre-existing services first.** A freshly provisioned Wix Bookings app may ship demo/sample services (e.g. "Sample service" rows) that would otherwise appear in the live storefront alongside yours — so before STEP 1, check and clean up only if needed:
+1. **List** — `POST https://www.wixapis.com/bookings/v2/services/query` `<AUTH>` with body `{"query": {"paging": {"limit": 100}}}`; collect every `service.id`.
+2. **If any come back, delete them** — `DELETE https://www.wixapis.com/bookings/v2/services/<serviceId>` `<AUTH>` for each. If the list is empty, there's nothing to clean — move on.
+
+Doing this before you create yours keeps it unambiguous: anything present at this point is the install's leftover sample data, never your own. (The default **"Business Owner" staff resource** is a resource, **not** a service — leave it; you reuse it in STEP 1.)
 
 ### STEP 1: Resolve a staff resource (REQUIRED for APPOINTMENT)
 

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -58,7 +58,11 @@ the full API reference for anything not shown.
 ## How to wire it (UI is the project's choice)
 - **Service list** — `queryServices()` for the listing (visitor-visible services only). Render
   `name`, `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price
-  from `payment.fixed.price.formattedValue` (already includes the currency). Pass the returned
+  from `payment.fixed.price`. `value` + `currency` are always present; `formattedValue` is
+  **optional** (it may be missing), so don't depend on it — build the price from `value`+`currency`
+  and use `formattedValue` only when present. e.g. `new Intl.NumberFormat(undefined, { style:
+  'currency', currency }).format(Number(value))`. (Rendering `formattedValue` alone leaves the price
+  blank — or your "Varies" fallback — whenever it's absent.) Pass the returned
   `nextOffset` back as `offset` to load the next page. Books **APPOINTMENT and CLASS** services
   (see the slot picker below); COURSE is whole-course enrollment and out of scope.
 - **Service detail** — `getService(serviceId)` keyed off the URL/route; returns null on miss —

--- a/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/wix-bookings-services.js
@@ -12,7 +12,9 @@ import { wixApiRequest } from "./wix-client.js";
  *   media.items {array} — [{ image: { id, url, width, height, altText } }]
  *     (url may be a bare Wix media handle — pass through mediaUrl() before rendering),
  *   payment.rateType "FIXED"|"CUSTOM"|"VARIED"|"NO_FEE"|"SUBSCRIPTION",
- *   payment.fixed.price { value, currency, formattedValue },
+ *   payment.fixed.price { value, currency, formattedValue } — value + currency are always
+ *     present; formattedValue is optional (may be missing), so format the price from
+ *     value+currency and use formattedValue only when present,
  *   payment.options { online, inPerson, deposit, pricingPlan },
  *   schedule.id {string}, onlineBooking.enabled {boolean},
  *   category { id, name }, staffMemberIds {string[]}, locations {array},


### PR DESCRIPTION
Two friction fixes from a real Bookings build ("Kinetic Equilibrium", yoga studio) — both surfaced only at preview verification, where the agent had shipped a wrong assumption from the skill docs.

### F1 — service prices rendered as "Varies"
The vibe-headless bookings skill told the agent to render the price from `payment.fixed.price.formattedValue` (`references/bookings/INSTRUCTIONS.md`, and the helper typedef in `wix-bookings-services.js`). But the services query **reliably returns `value` + `currency` and often omits `formattedValue`**, so the agent's price came out blank / "Varies" and it had to rewrite two components at preview. Fixed the guidance to build the price from `value`+`currency` (using `formattedValue` only when present).

### F2 — default "Sample service" rows appeared in the live storefront
`setup-bookings.md` explicitly claimed *"There is no clean-up step — a fresh Wix Bookings install ships no sample services… nothing to delete first."* The run found **5** default "Sample service" rows showing alongside the real services. Replaced the false claim with a cleanup step (list `POST /bookings/v2/services/query`, then `DELETE /bookings/v2/services/<id>` each, **before** creating) — mirroring the Stores recipe, which already cleans sample products (the divergence that made this bite Bookings and not Stores).

*Not included:* F3 (`preview_screenshot` `navigation_failed` on same-route nav) is preview-tooling behavior, not a skill gap — the report says so too.

Docs/recipe only.