### PR TITLE
Clarify Blog richContent image and layout boundaries

### DIFF
--- a/skills/wix-manage/references/blog/how-to-create-blog-posts.md
+++ b/skills/wix-manage/references/blog/how-to-create-blog-posts.md
@@ -249,6 +249,27 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
    }
    ```
 
+#### Cover media vs. embedded body images
+
+`draftPost.media` sets the post cover media only. It does **not** insert an image into the article body. If the user asks for images in the post body, place imported Wix Media IDs in `richContent.nodes` using `IMAGE` or `GALLERY` nodes at the requested positions. The same imported Media Manager file ID can be used both in `draftPost.media` for the cover and in an `IMAGE` node for the article body.
+
+Do not claim that images were embedded in the body unless the request payload actually contains at least one body `IMAGE` or `GALLERY` node. If the payload only sets `draftPost.media`, say that the image was set as the cover.
+
+#### Layout and typography boundaries
+
+This recipe is validated for creating Blog posts with semantic Ricos content, cover media, embedded images, image width/alignment, lists, headings, and related metadata. It does not by itself prove Blog editor rendering for exact page layouts such as a 50/50 text-and-image intro, side-by-side columns, or site-wide font/theme changes.
+
+When the user asks for an exact layout or typography treatment:
+
+- Only promise the layout or font result if the `richContent` payload you are sending explicitly and verifiably represents that result for Wix Blog.
+- Do not use `LAYOUT` / `LAYOUT_CELL` nodes for a 50/50 Blog layout unless you have first checked current Ricos documentation and have a verified Blog-compatible example for that structure.
+- If you cannot verify the exact layout through the API, create the supported content structure instead (for example, intro text followed by an embedded image) and tell the user that the exact side-by-side layout or theme typography must be adjusted in the Blog editor.
+- Make progress/status messages match the payload. A draft created with text nodes plus `draftPost.media` is a draft with a cover image, not a draft with embedded body images or a 50/50 body layout.
+
+❌ **Wrong:** create a post with `richContent` text nodes and `draftPost.media`, then say "the post has embedded images and a 50/50 text-left/image-right intro."
+
+✅ **Allowed:** create a post with an `IMAGE` node in `richContent` and say "I embedded the image in the body." If the user requested a 50/50 layout and you cannot verify a Blog-compatible layout node, say "I created the draft with the supported body image structure; the exact 50/50 side-by-side layout needs to be adjusted in the Blog editor."
+
 4. Set `publish: true` to immediately publish the post rather than saving as draft.
 
 ### Part 3: Handle Categories and Tags (Optional)
@@ -266,6 +287,7 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 - External images MUST be imported via Import File API before use in blog posts - direct external URLs will not work
 - For 3rd-party app integrations, `memberId` is mandatory - use the [List Members](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/list-members) API if needed to get member ID
 - Use ONLY the file ID (without `wix:image://v1/` prefix) for both cover images and embedded images
+- `draftPost.media` is only the cover image. Body images require `IMAGE` or `GALLERY` nodes in `richContent.nodes`
 - Rich content IMAGE nodes require both `width` and `height` properties in the `image` object
 - Images with `"operationStatus": "PENDING"` from import can be used immediately in blog posts
 - Set `publish: true` in the request to publish immediately rather than save as draft
@@ -274,6 +296,7 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 - Handle image import failures gracefully - continue without images if import fails
 - Provide meaningful `displayName` values during image import for better organization
 - Use appropriate Ricos node types (PARAGRAPH, HEADING, LIST, etc.) for semantic content structure
+- Do not claim exact Blog editor layouts, side-by-side sections, 50/50 intros, or site font/theme changes unless the sent payload verifiably represents them
 - Consider batching image imports when creating multiple posts with many images
 
 ### CRITICAL RICOS JSON STRUCTURE RULES:
@@ -293,3 +316,5 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 | "memberIds ... do not exist"               | Invalid member ID           | Query members first using List Members API to get valid IDs         |
 | "Expected a paragraph node but found TEXT" | Invalid Ricos structure     | Wrap TEXT nodes in PARAGRAPH nodes (see structure rules above)      |
 | Image not displaying                       | Using external URL directly | Import image via Media Manager first, then use the returned file ID |
+| Body image missing but cover appears       | Image ID was set only in `draftPost.media` | Add an `IMAGE` or `GALLERY` node to `richContent.nodes`             |
+| 50/50 or side-by-side layout not rendered  | Exact Blog editor layout was promised without a verified `richContent` layout payload | Use verified Ricos layout docs before promising it, or tell the user the exact layout must be adjusted in the Blog editor |

--- a/yaml/wix-manage-evals/blog/create-post-image-layout-boundaries.yml
+++ b/yaml/wix-manage-evals/blog/create-post-image-layout-boundaries.yml
@@ -1,0 +1,55 @@
+name: blog/create-post-image-layout-boundaries
+description: >-
+  Advisory scenario for the Blog post creation recipe: the agent must distinguish
+  cover media from embedded richContent images and avoid promising exact 50/50
+  Blog editor layouts or typography unless the payload can verifiably represent
+  them.
+triggerPrompt: >-
+  I am using the Wix Blog REST API to create a draft post. Before you make any
+  API calls, explain how you would handle one imported image that should be both
+  the cover and embedded in the intro, plus a requested 50/50 text-and-image
+  intro layout and custom site fonts. Do not create or update anything yet.
+tags: [blog]
+maxTokens: 60000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user is asking for guidance only. They explicitly said not to create
+      or update anything yet. The scenario covers a draft blog post with one
+      imported image that should be used as both cover media and an embedded
+      intro image, plus a requested exact 50/50 text-and-image intro layout and
+      custom site fonts.
+
+      Pass if the response:
+      - uses the How to Create Blog Posts recipe, AND
+      - clearly states that `draftPost.media` sets only the post cover media, AND
+      - says body images require `IMAGE` or `GALLERY` nodes in
+        `richContent.nodes`, AND
+      - says the same imported Wix Media file ID may be used for both the cover
+        and an embedded body image, AND
+      - says not to claim embedded images unless the payload includes an
+        embedded body image node, AND
+      - explains that exact 50/50 side-by-side Blog layout and custom site fonts
+        must not be promised unless a verified Blog-compatible Ricos payload can
+        represent them, AND
+      - offers the supported fallback of creating semantic rich content with an
+        embedded image and telling the user that exact layout/font adjustments
+        may need to be completed in the Blog editor, AND
+      - does not perform any mutating API calls.
+
+      Fail if the response:
+      - implies that setting `draftPost.media` embeds an image in the post body,
+        OR
+      - claims it can guarantee a 50/50 text-left/image-right Blog body layout
+        or custom site fonts from the create-draft request without a verified
+        Blog-compatible payload, OR
+      - omits the need for `IMAGE` or `GALLERY` richContent nodes for body
+        images, OR
+      - says the image can only be cover media or only be embedded, OR
+      - attempts Import File, Create Draft Post, Bulk Create Draft Posts, or any
+        other mutating API call.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/89e3a527-3ce2-4776-be9e-78ea65efde11

Feedback: the user reported that a newly created Wix Blog draft had no embedded images and no side-by-side/50/50 intro layout, although the assistant indicated the draft used the requested image/layout treatment.

## Conversation research

The reported issue is a true issue.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/89e3a527-3ce2-4776-be9e-78ea65efde11`: the user asked Aria to create a new draft Blog post using existing content/images and expected a 50/50 text+image intro. On message `9446e189-d884-4cb5-afc8-01ea0d83d8de`, Aria first imported a single image to Media Manager (`175f5a99-ae4d-450b-9530-1eb5700b3898`), then created a draft via `POST https://www.wixapis.com/blog/v3/draft-posts` (`09674401-10ba-490b-b805-b1190534c5f5`). The create payload used text/list/headings in `richContent.nodes` and set `draftPost.media.wixMedia.image.id` for the cover, but it did not include any body `IMAGE`, `GALLERY`, `LAYOUT`, or `LAYOUT_CELL` nodes. Decision/status logs still claimed a 50/50 text-left/image-right layout.

## Code/content research

Root cause: the Blog creation recipe correctly shows an `IMAGE` richContent example, but it did not explicitly distinguish `draftPost.media` cover media from embedded body image nodes, and it had no payload-grounded guard for exact Blog editor layouts or typography claims. That left the agent free to create a payload with only cover media while reporting embedded images and a 50/50 layout.

Why this is the owning surface:
- The failing turn activated `how-to-create-blog-posts` and used the documented Blog create endpoint.
- Wix Blog Draft Post schema describes `media` as "Post cover media" and `richContent` as the body document.
- Ricos schema contains `IMAGE` nodes for body images. Layout node data is present but marked as reserved/future-use in the Blog create schema path, so the recipe should not make an unverified 50/50 rendering promise.
- The Wix API call succeeded; this was not a Genie runtime, auth, permissions, or downstream API failure.

Alternatives ruled out:
- Genie/platform tool execution: both Media Manager import and Blog draft creation completed successfully.
- API outage or validation failure: no tool errors were present on the failing message.
- Aria-only prompt fix: the misleading guidance came from an activated public Wix Blog recipe that can affect all agents using `wix/skills`, so the source recipe is the narrower durable owner.

## Change

This changes the Blog post creation recipe so future agents:
- treat `draftPost.media` as cover media only,
- add `IMAGE` or `GALLERY` richContent nodes when users request body images,
- only claim embedded images when the payload actually contains body image nodes,
- avoid promising exact 50/50 Blog editor layouts or site typography unless the sent payload is verified to represent that result,
- tell users when exact layout/font edits must be completed in the Blog editor.

Reviewer-oriented diff:
- `skills/wix-manage/references/blog/how-to-create-blog-posts.md`: adds cover-vs-body image guidance, layout/typography boundary guidance, payload-grounded status/confirmation rules, and troubleshooting rows.
- `yaml/wix-manage-evals/blog/create-post-image-layout-boundaries.yml`: adds a non-mutating advisory eval that covers the recipe and verifies the assistant explains cover media, body image nodes, shared Media IDs, 50/50 layout boundaries, and no mutation.

## Side effects and rollout risk

Risk is low and bounded to the Wix Blog creation recipe. The change does not remove any existing API path or tell agents not to embed images; it makes body-image creation more explicit and prevents unverified layout/font claims. Agents can still use verified Ricos layout docs if a Blog-compatible payload is available.

Impact check: over the last week in `com.wixpress.genie.agent-platform-service` logs, I found 1,302 request IDs containing Blog draft creation with `richContent`, 2,003 request IDs containing `blog` plus `50/50`, and 108 request IDs containing the exact `image as the cover` blog pattern. The broad skill-name activation query was too noisy because skill catalogs appear in prompts.

## Verification

- Fix proof: added a covering Blog eval that asserts the recipe is loaded and that the response distinguishes cover media from embedded richContent images while refusing to overpromise exact 50/50/font rendering without a verified payload. Note: GitHub marked `EvalForge YAML Gate` as skipped for this fork PR because the workflow only runs when `github.event.pull_request.head.repo.full_name == github.repository`; legacy `Skill Eval` is hard-disabled with `if: false`.
- Aria skills-override smoke: https://wix-bo.com/ai-assistant/conversations/674bbbc7-2434-469e-99de-3d912bf53776, message `273aaa93-bc87-4e4f-9bd2-2b73b5e102f2`, loaded this PR's recipe content through `activateSkill` (tool-result log `c55c73bb-1232-4932-9c36-6d1b8fbc6606`) with the new `Cover media vs. embedded body images` and `Layout and typography boundaries` sections present. The assistant response distinguished `draftPost.media = cover only` from body `IMAGE` nodes in `richContent.nodes`, reused the same `mediaId`, refused to promise exact 50/50/custom-font rendering without verified Blog-compatible payload support, and made no mutating function calls.
- Safety & ownership: this clears the Safety & Ownership gate because it edits the authored Wix Blog recipe, not a downstream consumer or enforcement layer; the mechanism is deterministic documentation/eval guidance, not a brittle rewrite of another team's output; it is bounded to the Blog recipe and has observable eval coverage.
- Local checks:
  - `ruby -e 'require "yaml"; ...' yaml/wix-manage-evals/blog/create-post-image-layout-boundaries.yml`
  - `rg -n "https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts" yaml/wix-manage-evals/blog/create-post-image-layout-boundaries.yml`
  - `git diff --check`
  - `yarn install --immutable` in `.github/actions/evalforge-yaml-gate`
  - `yarn test` in `.github/actions/evalforge-yaml-gate` (178 tests passed)
  - `yarn typecheck` in `.github/actions/evalforge-yaml-gate`
- Residual: the smoke was deliberately run without a site ID to avoid mutations; Aria logged existing dynamic-knowledge tenant-context errors (`Failed to extract tenant`) unrelated to the recipe content. The activated skill content and final answer path still completed.
