### PR TITLE
feat(wix-vibe-headless): add platforms/generic.md; drop example lists

### DIFF
--- a/skills/wix-vibe-headless/platforms/README.md
+++ b/skills/wix-vibe-headless/platforms/README.md
@@ -4,6 +4,11 @@ One file per AI-builder platform (Base44, Lovable, Bolt, v0, Manus, …). Each f
 **handoff prompt** the Wix Headless funnel hands to that platform after it creates the site +
 OAuth app: build the client, then seed/manage the business.
 
+`generic.md` is the **platform-agnostic** version — same flow (install skills → build client →
+seed/manage → wrap up) with no assumptions about a specific platform's tooling. Use it as the
+default/fallback for platforms without their own tuned file; `base44.md` is the Base44-specific
+one (its exec tool, secret store, pre-configured connector, etc.).
+
 These are hosted (served at `https://www.wix.com/skills/vibe-headless/platforms/<platform>.md`)
 so the funnel loader can pass a short pointer to the prompt instead of inlining the whole
 script into the launch URL. Inlining tripped the Base44 edge WAF, which scans the POST body

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -45,8 +45,7 @@ scratch.
 
 ## STEP 2 — Manage and seed the business
 
-Seed the site with real content (products, categories, etc.) by following the **`headless`
-skill**'s `references/SEED.md`. Where its seed recipes don't cover what you need, **fall back
+Seed the site with real content by following the **`headless` skill**'s `references/SEED.md`. Where its seed recipes don't cover what you need, **fall back
 to the `docs` skill** (`/app/skills/docs`) to search and read the relevant Wix API docs. Use
 the already-configured Wix connector for these management API calls.
 
@@ -82,8 +81,7 @@ Once the site is built and seeded:
 
 ## Later admin requests
 
-For any admin/management request the user makes after the build (add or edit a service, change
-prices, add a category, adjust content…), work the same way as STEP 2: check the `headless`
-skill's inline recipes first (`references/inline-recipes/`, e.g. `setup-bookings.md`,
-`setup-online-store.md`) and, where the operation isn't documented there, fall back to the
-`docs` skill to search the Wix API docs — all over the Wix connector.
+For any later admin/management request the user makes, work the same way as STEP 2: check the
+`headless` skill's inline recipes first (`references/inline-recipes/`) and, where the operation
+isn't documented there, fall back to the `docs` skill to search the Wix API docs — all over the
+Wix connector.

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -1,0 +1,55 @@
+# Wix Managed Headless — build instructions
+
+You are building a **Wix Managed** headless site. The business to build, and your Wix client id
+and metasite id, are given in your initial prompt. Follow the steps below.
+
+## STEP 0 — Install the Wix skills locally
+
+Get the three skills — `headless`, `vibe-headless`, `docs` — onto local disk so you can read
+them from files (fetching skill docs over the web truncates and caches large files). Use
+whichever fits your environment:
+
+- **Skills CLI:** `npx skills add wix/skills` — installs all Wix skills locally.
+- **Tarball:** download and unpack each `https://www.wix.com/skills/<name>.tgz`; each expands to
+  its own top-level folder (`headless/`, `vibe-headless/`, `docs/`) — extract them side by side.
+- **Raw files:** fetch individual files under `https://www.wix.com/skills/<name>/…` (use
+  `https://www.wix.com/skills/<name>.manifest.json` to list them).
+
+Then read the skill and reference files from your local copies, not over the web.
+
+## STEP 1 — Build the client
+
+Read `vibe-headless/SKILL.md` and follow it **exactly** — it is the single source of truth for
+how the client app is built against the Wix APIs (over the public `WIX_CLIENT_ID`, which is a
+buyer/visitor-facing credential, safe in the frontend). To save time, prefer copying the
+ready-made files the skill provides (e.g. the Wix client setup) and adapting them over
+re-generating them from scratch.
+
+## STEP 2 — Seed and manage the business
+
+Seed the site with real content by following the `headless` skill's `references/SEED.md`. Where
+its seed recipes don't cover what you need, fall back to the `docs` skill to search and read the
+relevant Wix API docs.
+
+These management/admin calls need **elevated Wix credentials** — the public client id is not
+enough. If you don't already have a way to authenticate them, **ask the user for a Wix API
+key / token** (follow the `headless` skill for the exact auth mechanism), or, if they'd rather,
+tell them they can add this content themselves in the Wix dashboard.
+
+Management/admin operations (seeding, `headless`, `docs`) are **separate from the client** — the
+client is built solely per the `vibe-headless` skill.
+
+If possible, run STEP 1 and STEP 2 in parallel — building the client and seeding the business
+are independent. Within each, also parallelize independent work (API calls, seeding multiple
+entities) to finish faster.
+
+## Later admin requests
+
+For any later admin/management request, work the same way as STEP 2: check the `headless`
+skill's inline recipes first (`references/inline-recipes/`) and fall back to the `docs` skill
+where the operation isn't documented there.
+
+## When done
+
+After the site is built and seeded, ask the user to open this URL to complete the setup in Wix
+(substitute the metasite id you were given): `https://manage.wix.com/dashboard/{metaSiteId}`


### PR DESCRIPTION
Adds `platforms/generic.md` — a platform-agnostic handoff prompt — and tidies example lists in both platform files.

### generic.md
Same flow as `base44.md` (install skills → build client per `vibe-headless` → seed/manage per `headless` + `docs` → wrap up), with no Base44-specific tooling assumptions (no `exec_tool`/`read_file`, no `/app/skills`, no pre-configured connector, no `WIX_CLIENT_ID`-as-secret / backend function, no `Deno.serve`/`base44`-declared quirks). Client id comes from the prompt (confirmed: the funnel inlines `My Wix client ID is: …` for non-Base44 platforms).

- **STEP 0** offers install options: skills CLI (`npx skills add wix/skills`), tarball, or raw files.
- **STEP 2** notes management/admin calls need **elevated credentials** — ask the user for a Wix API key/token, or have them add the content in the Wix dashboard (the public client id isn't enough).

### base44.md + generic.md
Dropped the specific example lists ("add or edit a service, change prices, add a category…", "products, categories, etc.") from the seed and later-admin notes.

Also documents `generic.md` in the folder README as the default/fallback.