### PR TITLE
fix(wix-vibe-headless): money fields are objects + safer base44 AGENTS.md note

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -40,6 +40,12 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
   it only mints anonymous visitor tokens. It is **not a secret**; hardcoding and committing it
   is fine. The user provides it (their vibe/host platform surfaces a copyable prompt with the
   id filled in). Paste it into `wix-client.js` in place of the `<YOUR-CLIENT-ID>` placeholder.
+- **Money/price fields are objects, never scalars.** Every price/amount a Wix API returns —
+  Stores `price.actualPrice`, Bookings service `payment.fixed.price`, Events ticket
+  `registration.tickets.lowestPrice`, and the rest — has the shape `{ value, currency,
+  formattedValue }`. Render **`formattedValue`** (it already includes the currency symbol), or
+  fall back to building from `value` + `currency`. **Never** drop the object straight into the UI
+  or treat it as a number/string — that renders `[object Object]` or a bare unformatted number.
 - **Visitor token = identity.** `wix-client.js` mints an anonymous visitor token, persists the
   **refresh token to `localStorage`**, and refreshes on expiry. That token IS the identity of
   the cart / reservation / member session — **never re-mint anonymously per load** or the cart

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -69,13 +69,12 @@ one-by-one, to finish faster.
 
 Once the site is built and seeded:
 
-1. **Record how this project is wired to Wix** in the project's agent-instructions file so the
-   next session doesn't rediscover it. If `AGENTS.md` exists (at the project **root**, not
-   `src/`), **`read_file` it first and edit in place — never overwrite**; create it only if it
-   doesn't exist. Keep the "Wix skills" note short and technical — a few bullets:
-   - **Skills:** installed at `/app/skills` from `www.wix.com/skills` — `headless`, `vibe-headless`, `docs`.
-   - **Client:** built per the `vibe-headless` skill; `WIX_CLIENT_ID` exposed via a backend function.
-   - **Seeding / management:** per the `headless` skill, falling back to the `docs` skill where it's not documented — all over the Wix connector.
+1. **Leave a brief "Wix skills" note in `AGENTS.md`** (project root) so a future session has
+   context. If the file already exists, **`read_file` it first and only append your section** —
+   do **not** rewrite, reorder, or remove anything already there; if you can't append cleanly,
+   skip this rather than overwrite. Create the file only if none exists. Keep the note
+   high-level, e.g.: the Wix skills are installed under `/app/skills`; the client is built per
+   the `vibe-headless` skill; seeding/management is done per the `headless` + `docs` skills.
 2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
    you were given): `https://manage.wix.com/dashboard/{metaSiteId}`
 

--- a/skills/wix-vibe-headless/references/events/wix-events-browse.js
+++ b/skills/wix-vibe-headless/references/events/wix-events-browse.js
@@ -24,7 +24,8 @@ import { wixApiRequest } from "./wix-client.js";
  *     type {string} — "RSVP"|"TICKETING"|"EXTERNAL"|"NONE",
  *     status {string} — only OPEN_* statuses accept new registrations,
  *     rsvp.responseType — "YES_AND_NO" allows a "NO" reply,
- *     tickets.currency, tickets.lowestPrice, tickets.soldOut,
+ *     tickets.lowestPrice {object} — money { value, currency, formattedValue }; render
+ *       formattedValue, not the object (see "Money/price fields" in SKILL.md). tickets.soldOut {boolean},
  *     external.url — link out when type === "EXTERNAL",
  *   eventPageUrl {object} — { base, path } (URLS fieldset) — needed for getTicketCheckoutUrl,
  *   form {object} — registration form controls (FORM fieldset),


### PR DESCRIPTION
Two friction fixes from recent builds.

## 1. Wix money/price fields are objects (recurring — Events + Bookings)
Agents render prices as scalars and only catch the break at preview. In the "Sonic Friction" Events run the ticket price `registration.tickets.lowestPrice` was rendered as `{currency} {lowestPrice}` before the agent realised it's `{ value, currency, formattedValue }`; the same class of bug hit a Bookings run (`payment.fixed.price` → "Varies").

- **Shared model (`SKILL.md`)** — added a rule the agent reads before any UI work: *every* Wix price/amount is `{ value, currency, formattedValue }`; render `formattedValue` (or build from `value`+`currency`), never as a scalar. Lists Stores/Bookings/Events examples.
- **`events/wix-events-browse.js`** — fixed the typedef so `registration.tickets.lowestPrice` is documented as that money object, pointing at the shared rule.

(Bookings' `payment.fixed.price` was already fixed in #631; this generalises it so it's correct on first write everywhere.)

## 2. base44 AGENTS.md wrap-up — stop overwriting, keep it high-level
The agent kept **overwriting** the app's existing `AGENTS.md` and writing over-specific detail. STEP 3 is now **append-only** (read first, only add a "Wix skills" section, never rewrite/reorder/remove; skip rather than overwrite; create only if none exists) and the note is high-level (dropped the exact paths, `WIX_CLIENT_ID`/backend-function mechanism, and connector detail).

*Not included:* the `navigation_failed` preview item — that's preview-tooling (`preview_lens`), not a skill gap.