### PR TITLE
fix(wix-vibe-headless): generic — store admin token in the platform's secret manager

### DIFF
--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -33,8 +33,10 @@ relevant Wix API docs.
 
 These management/admin calls need **elevated Wix credentials** — the public client id is not
 enough. If you don't already have a way to authenticate them, **ask the user for a Wix API
-key / token** (follow the `headless` skill for the exact auth mechanism), or, if they'd rather,
-tell them they can add this content themselves in the Wix dashboard.
+key / token** and store it in your platform's built-in **connector / secrets (env) manager** —
+never hardcode or commit it — then use it to authenticate the REST admin calls (the `docs` skill
+covers Wix API-key auth). Or, if the user prefers, tell them they can add this content themselves
+in the Wix dashboard instead.
 
 Management/admin operations (seeding, `headless`, `docs`) are **separate from the client** — the
 client is built solely per the `vibe-headless` skill.


### PR DESCRIPTION
STEP 2 of `generic.md` now tells the agent to store the Wix API key/token the user provides in the platform's built-in **connector / secrets (env) manager** (never hardcode or commit it) and read it from there for the management/admin calls — rather than just "ask the user for a token". Keeps the dashboard-instead fallback.