### PR TITLE
fix(wix-vibe-headless): install per-skill into .agents/skills/wix-*

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -18,45 +18,78 @@ Follow the steps below exactly.
 
 ## STEP 0 — Install the Wix skills locally
 
-Run this via exec_tool:
+Install three skills — they land under `.agents/skills/` as `wix-headless`, `wix-vibe-headless`,
+and `wix-docs`.
+
+**Option A — skills CLI (preferred).** Run via exec_tool (needs Node ≥ 22.20):
 
 ```js
 const { execSync } = require('child_process');
-execSync('mkdir -p /app/skills');
-for (const skill of ['headless', 'vibe-headless', 'docs']) {
-  execSync(`curl -s "https://www.wix.com/skills/${skill}.tgz" | tar xz -C /app/skills`);
+const { readdirSync } = require('fs');
+
+const skills = ['wix-headless', 'wix-vibe-headless', 'wix-docs'];
+const results = {};
+
+for (const skill of skills) {
+  try {
+    const out = execSync(`CI=1 npx -y skills add wix/skills/skills/${skill} --yes 2>&1`, {
+      cwd: '/app', timeout: 60000, shell: '/bin/bash', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const text = out.toString().replace(/\x1b\[[0-9;]*m/g, '');
+    results[skill] = /installed 1 skill|found 1 skill/i.test(text)
+      ? 'success'
+      : text.includes('No valid skills') ? 'not_found' : 'unknown';
+  } catch (e) {
+    results[skill] = 'error: ' + e.message;
+  }
+}
+
+return { results, installed: readdirSync('/app/.agents/skills') };
+```
+
+**Option B — tarball (fallback, if the CLI is unavailable or errors).** Run via exec_tool:
+
+```js
+const { execSync } = require('child_process');
+for (const s of ['headless', 'vibe-headless', 'docs']) {
+  execSync(`mkdir -p /app/.agents/skills/wix-${s} && curl -s "https://www.wix.com/skills/${s}.tgz" | tar xz -C /app/.agents/skills/wix-${s} --strip-components=1`);
 }
 return 'done';
 ```
 
-Each archive nests its own folder under `/app` → `skills/{headless,vibe-headless,docs}`. Read
-them with the `read_file` tool, using workspace-relative paths (`skills/vibe-headless/SKILL.md`),
-not an absolute `/app/...` path (`read_file` is rooted at `/app`). `read_file`'s cap is by line
-(~5000) — well above these docs, so each comes through whole; page past it with its offset/limit
-params only if ever needed. Do **not** `cat` skill files through exec_tool: its output caps at
-~5000 chars and silently truncates them. And don't fetch the skill URLs over the web (truncates/caches).
+Either way you end up with `.agents/skills/{wix-headless,wix-vibe-headless,wix-docs}`. **Read them
+with the `read_file` tool** — it caps by line (~5000, well above these docs, so each comes through
+whole; page with offset/limit only if ever needed), whereas `cat` through exec_tool caps output at
+~5000 chars and silently truncates, and web-fetch tools truncate/summarise. The path form depends
+on the tool:
+- **`read_file` (preferred):** rooted at `/app`, so use the workspace-relative path
+  `.agents/skills/wix-vibe-headless/SKILL.md` — an absolute `/app/...` double-prefixes and fails.
+- **exec_tool / shell** (only if you must): use the absolute path
+  `/app/.agents/skills/wix-vibe-headless/SKILL.md`.
 
 ## STEP 1 — Build the client
 
-Read `/app/skills/vibe-headless/SKILL.md` and follow it **EXACTLY** — it is the single source
-of truth for how the client app is built. To save time, prefer copying ready-made files the
-skill provides (e.g. the Wix client setup) and adapting them over re-generating them from
-scratch.
+Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — it is the single
+source of truth for how the client app is built. To save time, prefer copying ready-made files
+the `wix-vibe-headless` skill provides (e.g. the Wix client setup) and adapting them over
+re-generating them from scratch.
 
 ## STEP 2 — Manage and seed the business
 
-Seed the site with real content by following the **`headless` skill**'s `references/SEED.md`. Where its seed recipes don't cover what you need, **fall back
-to the `docs` skill** (`/app/skills/docs`) to search and read the relevant Wix API docs. Use
-the already-configured Wix connector for these management API calls.
+Seed the site with real content by following the **`wix-headless` skill**'s
+`references/SEED.md` (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes
+don't cover what you need, **fall back to the `wix-docs` skill** (`.agents/skills/wix-docs`) to
+search and read the relevant Wix API docs. Use the already-configured Wix connector for these
+management API calls.
 
 When you run seed/management code **inline via exec_tool**, `base44` is already declared — use
 it directly. Do **not** import `@base44/sdk`, re-declare `base44`, or call `createClient()` —
 that pattern is only for standalone `.js` skill files, and inline it throws *"Identifier
 'base44' has already been declared."*
 
-**IMPORTANT:** the Wix connector and the headless skill's seeding instructions are for
+**IMPORTANT:** the Wix connector and the `wix-headless` skill's seeding instructions are for
 management/admin operations only (STEP 2) — they are **NOT** part of the client. The client is
-built solely per the vibe-headless skill.
+built solely per the `wix-vibe-headless` skill.
 
 ## Parallelism
 
@@ -73,14 +106,15 @@ Once the site is built and seeded:
    context. If the file already exists, **`read_file` it first and only append your section** —
    do **not** rewrite, reorder, or remove anything already there; if you can't append cleanly,
    skip this rather than overwrite. Create the file only if none exists. Keep the note
-   high-level, e.g.: the Wix skills are installed under `/app/skills`; the client is built per
-   the `vibe-headless` skill; seeding/management is done per the `headless` + `docs` skills.
+   high-level, e.g.: the Wix skills are installed under `.agents/skills/`; the client is built
+   per the `wix-vibe-headless` skill; seeding/management is done per the `wix-headless` +
+   `wix-docs` skills.
 2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
    you were given): `https://manage.wix.com/dashboard/{metaSiteId}`
 
 ## Later admin requests
 
 For any later admin/management request the user makes, work the same way as STEP 2: check the
-`headless` skill's inline recipes first (`references/inline-recipes/`) and, where the operation
-isn't documented there, fall back to the `docs` skill to search the Wix API docs — all over the
-Wix connector.
+`wix-headless` skill's inline recipes first (`.agents/skills/wix-headless/references/inline-recipes/`)
+and, where the operation isn't documented there, fall back to the `wix-docs` skill to search the
+Wix API docs — all over the Wix connector.

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -5,41 +5,48 @@ and metasite id, are given in your initial prompt. Follow the steps below.
 
 ## STEP 0 — Install the Wix skills locally
 
-Get the three skills — `headless`, `vibe-headless`, `docs` — onto local disk so you can read
-them from files (fetching skill docs over the web truncates and caches large files). Use
-whichever fits your environment:
+Install three skills — they land under `.agents/skills/` as `wix-headless`, `wix-vibe-headless`,
+and `wix-docs` — so you can read them from files as you go (fetching skill docs over the web
+truncates or summarises large files). Either approach works — use whichever fits your environment:
 
-- **Skills CLI:** `npx skills add wix/skills` — installs all Wix skills locally.
-- **Tarball:** download and unpack each `https://www.wix.com/skills/<name>.tgz`; each expands to
-  its own top-level folder (`headless/`, `vibe-headless/`, `docs/`) — extract them side by side.
-- **Raw files:** fetch individual files under `https://www.wix.com/skills/<name>/…` (use
-  `https://www.wix.com/skills/<name>.manifest.json` to list them).
-
-Then read the skill and reference files from your local copies, not over the web.
+- **Skills CLI, if available** (needs Node ≥ 22.20):
+  ```bash
+  CI=1 npx skills@latest add wix/skills/skills/wix-headless --yes
+  CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
+  CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
+  ```
+- **curl + gzip:** download each bundle and extract it into `.agents/skills/wix-<name>/`, then
+  read the files from there as you go:
+  ```bash
+  for s in headless vibe-headless docs; do
+    mkdir -p ".agents/skills/wix-$s"
+    curl -s "https://www.wix.com/skills/$s.tgz" | tar xz -C ".agents/skills/wix-$s" --strip-components=1
+  done
+  ```
 
 ## STEP 1 — Build the client
 
-Read `vibe-headless/SKILL.md` and follow it **exactly** — it is the single source of truth for
-how the client app is built against the Wix APIs (over the public `WIX_CLIENT_ID`, which is a
-buyer/visitor-facing credential, safe in the frontend). To save time, prefer copying the
-ready-made files the skill provides (e.g. the Wix client setup) and adapting them over
-re-generating them from scratch.
+Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **exactly** — it is the single
+source of truth for how the client app is built against the Wix APIs (over the public
+`WIX_CLIENT_ID`, which is a buyer/visitor-facing credential, safe in the frontend). To save time,
+prefer copying the ready-made files the `wix-vibe-headless` skill provides (e.g. the Wix client
+setup) and adapting them over re-generating them from scratch.
 
 ## STEP 2 — Seed and manage the business
 
-Seed the site with real content by following the `headless` skill's `references/SEED.md`. Where
-its seed recipes don't cover what you need, fall back to the `docs` skill to search and read the
-relevant Wix API docs.
+Seed the site with real content by following the `wix-headless` skill's `references/SEED.md`
+(`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes don't cover what you
+need, fall back to the `wix-docs` skill to search and read the relevant Wix API docs.
 
 These management/admin calls need **elevated Wix credentials** — the public client id is not
 enough. If you don't already have a way to authenticate them, **ask the user for a Wix API
 key / token** and store it in your platform's built-in **connector / secrets (env) manager** —
-never hardcode or commit it — then use it to authenticate the REST admin calls (the `docs` skill
-covers Wix API-key auth). Or, if the user prefers, tell them they can add this content themselves
-in the Wix dashboard instead.
+never hardcode or commit it — then use it to authenticate the REST admin calls (the `wix-docs`
+skill covers Wix API-key auth). Or, if the user prefers, tell them they can add this content
+themselves in the Wix dashboard instead.
 
-Management/admin operations (seeding, `headless`, `docs`) are **separate from the client** — the
-client is built solely per the `vibe-headless` skill.
+Management/admin operations (seeding, `wix-headless`, `wix-docs`) are **separate from the
+client** — the client is built solely per the `wix-vibe-headless` skill.
 
 If possible, run STEP 1 and STEP 2 in parallel — building the client and seeding the business
 are independent. Within each, also parallelize independent work (API calls, seeding multiple
@@ -47,9 +54,9 @@ entities) to finish faster.
 
 ## Later admin requests
 
-For any later admin/management request, work the same way as STEP 2: check the `headless`
-skill's inline recipes first (`references/inline-recipes/`) and fall back to the `docs` skill
-where the operation isn't documented there.
+For any later admin/management request, work the same way as STEP 2: check the `wix-headless`
+skill's inline recipes first (`.agents/skills/wix-headless/references/inline-recipes/`) and fall
+back to the `wix-docs` skill where the operation isn't documented there.
 
 ## When done
 


### PR DESCRIPTION
Both platform prompts now install just the three needed skills (not the whole repo) into `.agents/skills`, using the `wix-` prefixed folder names the skills CLI produces, and reference them by those paths throughout.

## STEP 0 — install options
- **Skills CLI (single skill):** `CI=1 npx skills@latest add wix/skills/skills/wix-headless --yes` (+ `wix-vibe-headless`, `wix-docs`). The path is **repo-root-relative** — `skills/wix-headless`, not `wix-headless` (that's the fix for "CLI can't install one skill"; the skills live under `skills/`). Needs Node ≥ 22.20.
- **curl + gzip:** extract each `.tgz` into `.agents/skills/wix-<name>` with `--strip-components=1`.
- **base44:** CLI is Option A (preferred, via exec_tool); tarball is Option B (fallback). **generic:** the two as equal options.

## Alignment
- Everything lands in `.agents/skills/{wix-headless,wix-vibe-headless,wix-docs}` (matches where `npx skills add` installs). Verified the `--strip-components=1` extraction yields exactly that layout with `references/SEED.md` + `references/inline-recipes/` intact.
- All references (STEP 1/2/3, later-admin, AGENTS.md note) updated to the `.agents/skills/wix-*` paths and the `wix-`-prefixed skill names.

Supersedes the earlier "two equal options / .agents/skills" scope of this PR.