### PR TITLE
chore(ci): disable legacy Skill Eval Cleanup workflow

### DIFF
--- a/.github/workflows/skill-eval-cleanup.yml
+++ b/.github/workflows/skill-eval-cleanup.yml
@@ -11,7 +11,10 @@ concurrency:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    # Disabled: skill-eval is superseded by the evalforge-yaml-* gate, and its own gate is already
+    # off (skill-eval.yml `if: false`). With no gate creating MCP versions there is nothing to clean
+    # up, and this job failed on every PR close — so turn it off instead of leaving a red check.
+    if: false
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What
Disables the `Skill Eval Cleanup` workflow job (`if: false`), matching how its gate sibling `skill-eval.yml` was already disabled.

## Why
`skill-eval` is superseded by the `evalforge-yaml-*` gate. Its gate job is already off, so no MCP versions are ever created — leaving this cleanup with nothing to do. Since the EvalForge **V1 cutover on 2026-07-08**, its `listMcpVersions` call (`GET …/capabilities/<mcp>/versions`) returns **404 on the empty version list** (the pre-V1 base returned an empty array), and the cleanup treats any error as fatal.

Net effect: a **red `Skill Eval Cleanup` check on every PR close** since 7/08 (last success 2026-07-07, failing continuously since). Pure noise — unrelated to the actual gate.

## Scope
- One line: `if: false` on the `cleanup` job (+ explanatory comment).
- Does **not** touch the active `evalforge-yaml-*` cleanup/promote/gate (those are healthy).
- Leaves `skill-eval-ci.yml` alone (separate; can be retired later if also noise).
- Follow-up option: delete the legacy `skill-eval-*` files outright once we're sure nothing depends on them; this PR just stops the failing checks with minimal risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)