### PR TITLE
fix(wix-vibe-headless): drop Node >=22.20 note from skills-CLI install

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -21,7 +21,7 @@ Follow the steps below exactly.
 Install three skills — they land under `.agents/skills/` as `wix-headless`, `wix-vibe-headless`,
 and `wix-docs`.
 
-**Option A — skills CLI (preferred).** Run via exec_tool (needs Node ≥ 22.20):
+**Option A — skills CLI (preferred).** Run via exec_tool:
 
 ```js
 const { execSync } = require('child_process');

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -9,7 +9,7 @@ Install three skills — they land under `.agents/skills/` as `wix-headless`, `w
 and `wix-docs` — so you can read them from files as you go (fetching skill docs over the web
 truncates or summarises large files). Either approach works — use whichever fits your environment:
 
-- **Skills CLI, if available** (needs Node ≥ 22.20):
+- **Skills CLI, if available:**
   ```bash
   CI=1 npx skills@latest add wix/skills/skills/wix-headless --yes
   CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes


### PR DESCRIPTION
The `(needs Node ≥ 22.20)` caveat on Option A was steering agents to the tarball fallback even when npx works fine. Real runs install cleanly on lower Node (observed on Node 20.20), so the note causes agents to skip the preferred CLI path unnecessarily.

Removes the caveat from both platform prompts:
- `skills/wix-vibe-headless/platforms/base44.md`
- `skills/wix-vibe-headless/platforms/generic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)