### PR TITLE
fix(wix-vibe-headless): instruct the skills-CLI install path + describe each skill

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -21,10 +21,12 @@ Follow the steps below exactly.
 Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
   APIs. This is your main source of truth (STEP 1).
-- **`wix-headless`** — seeding & admin recipes (`references/SEED.md` + inline API recipes) for
-  populating and managing the business (STEP 2).
-- **`wix-docs`** — how to search and read the full Wix API reference, for anything the recipes
-  above don't cover.
+- **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
+  of which does not apply to how you build here**. Use it **only as a seeding reference** — its
+  `references/SEED.md` (and inline API recipes) for populating/managing the business in STEP 2.
+  Ignore the rest of it.
+- **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
+  the seeding recipes above don't cover.
 
 **Option A — skills CLI.** This is the Base44-verified install path — run it first via
 exec_tool, exactly as written:

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -18,10 +18,16 @@ Follow the steps below exactly.
 
 ## STEP 0 — Install the Wix skills locally
 
-Install three skills — they land under `.agents/skills/` as `wix-headless`, `wix-vibe-headless`,
-and `wix-docs`.
+Install three skills — they land under `.agents/skills/` as:
+- **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
+  APIs. This is your main source of truth (STEP 1).
+- **`wix-headless`** — seeding & admin recipes (`references/SEED.md` + inline API recipes) for
+  populating and managing the business (STEP 2).
+- **`wix-docs`** — how to search and read the full Wix API reference, for anything the recipes
+  above don't cover.
 
-**Option A — skills CLI (preferred).** Run via exec_tool:
+**Option A — skills CLI.** This is the Base44-verified install path — run it first via
+exec_tool, exactly as written:
 
 ```js
 const { execSync } = require('child_process');
@@ -47,7 +53,8 @@ for (const skill of skills) {
 return { results, installed: readdirSync('/app/.agents/skills') };
 ```
 
-**Option B — tarball (fallback, if the CLI is unavailable or errors).** Run via exec_tool:
+**Option B — tarball.** Use this **only if Option A actually errored** (check its `results`) —
+do not skip Option A on a guess. Run via exec_tool:
 
 ```js
 const { execSync } = require('child_process');

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -8,10 +8,12 @@ and metasite id, are given in your initial prompt. Follow the steps below.
 Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
   APIs. This is your main source of truth (STEP 1).
-- **`wix-headless`** — seeding & admin recipes (`references/SEED.md` + inline API recipes) for
-  populating and managing the business (STEP 2).
-- **`wix-docs`** — how to search and read the full Wix API reference, for anything the recipes
-  above don't cover.
+- **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
+  of which does not apply to how you build here**. Use it **only as a seeding reference** — its
+  `references/SEED.md` (and inline API recipes) for populating/managing the business in STEP 2.
+  Ignore the rest of it.
+- **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
+  the seeding recipes above don't cover.
 
 Install them so you can read them from files as you go (fetching skill docs over the web
 truncates or summarises large files).

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -5,24 +5,32 @@ and metasite id, are given in your initial prompt. Follow the steps below.
 
 ## STEP 0 — Install the Wix skills locally
 
-Install three skills — they land under `.agents/skills/` as `wix-headless`, `wix-vibe-headless`,
-and `wix-docs` — so you can read them from files as you go (fetching skill docs over the web
-truncates or summarises large files). Either approach works — use whichever fits your environment:
+Install three skills — they land under `.agents/skills/` as:
+- **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
+  APIs. This is your main source of truth (STEP 1).
+- **`wix-headless`** — seeding & admin recipes (`references/SEED.md` + inline API recipes) for
+  populating and managing the business (STEP 2).
+- **`wix-docs`** — how to search and read the full Wix API reference, for anything the recipes
+  above don't cover.
 
-- **Skills CLI, if available:**
-  ```bash
-  CI=1 npx skills@latest add wix/skills/skills/wix-headless --yes
-  CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
-  CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
-  ```
-- **curl + gzip:** download each bundle and extract it into `.agents/skills/wix-<name>/`, then
-  read the files from there as you go:
-  ```bash
-  for s in headless vibe-headless docs; do
-    mkdir -p ".agents/skills/wix-$s"
-    curl -s "https://www.wix.com/skills/$s.tgz" | tar xz -C ".agents/skills/wix-$s" --strip-components=1
-  done
-  ```
+Install them so you can read them from files as you go (fetching skill docs over the web
+truncates or summarises large files).
+
+**Run the Skills CLI** — this is the install path to use:
+```bash
+CI=1 npx skills@latest add wix/skills/skills/wix-headless --yes
+CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
+CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
+```
+
+**Only if the CLI above actually errors** (not on a guess), fall back to curl + gzip — download
+each bundle and extract it into `.agents/skills/wix-<name>/`:
+```bash
+for s in headless vibe-headless docs; do
+  mkdir -p ".agents/skills/wix-$s"
+  curl -s "https://www.wix.com/skills/$s.tgz" | tar xz -C ".agents/skills/wix-$s" --strip-components=1
+done
+```
 
 ## STEP 1 — Build the client
 


### PR DESCRIPTION
## Why
STEP 0 presented the install as a **choice** — `Option A (preferred)` vs `Option B (fallback)` on base44, and *"Either approach works — use whichever fits your environment"* on generic. In real Base44 runs the agent kept jumping straight to the curl/tarball path and **never even tried npx**, rationalizing that the CLI 'might not be available'. Removing the Node-version note (#641) wasn't enough — the choice framing itself is the problem.

## What
- **Reframe as a directive**, not a choice:
  - base44: Option A is the **"Base44-verified install path — run it first, exactly as written"** (dropped "preferred").
  - generic: **"Run the Skills CLI — this is the install path to use"** (dropped "Either approach works / use whichever fits").
  - Both: fall back to the tarball **only if the CLI actually errored — not on a guess**.
- **Describe each skill** with a one-liner (`wix-vibe-headless` = client build guide / main source of truth, `wix-headless` = seeding & admin recipes, `wix-docs` = API reference search).

No command changes — same npx + tarball commands, just the surrounding instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)