### PR TITLE
fix(wix-vibe-headless): scope wix-headless to seeding only; forbid its @wix/cli managed auth

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -22,9 +22,11 @@ Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
   APIs. This is your main source of truth (STEP 1).
 - **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only as a seeding reference** — its
-  `references/SEED.md` (and inline API recipes) for populating/managing the business in STEP 2.
-  Ignore the rest of it.
+  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
+  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 2. **Ignore
+  everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
+  "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
+  That is **not** how auth works here — auth is handled per STEP 2 below.
 - **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
   the seeding recipes above don't cover.
 
@@ -88,8 +90,12 @@ re-generating them from scratch.
 Seed the site with real content by following the **`wix-headless` skill**'s
 `references/SEED.md` (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes
 don't cover what you need, **fall back to the `wix-docs` skill** (`.agents/skills/wix-docs`) to
-search and read the relevant Wix API docs. Use the already-configured Wix connector for these
-management API calls.
+search and read the relevant Wix API docs.
+
+**Auth for these admin calls is the already-configured Wix connector — and nothing else.** With
+the connector in place you can make Wix API calls directly. Do **not** install or run the Wix CLI
+(`@wix/cli`), do a device-login, or follow `wix-headless`'s `references/managed/AUTHENTICATION.md`
+— that managed-project auth flow does not apply to Base44 and will send you down the wrong path.
 
 When you run seed/management code **inline via exec_tool**, `base44` is already declared — use
 it directly. Do **not** import `@base44/sdk`, re-declare `base44`, or call `createClient()` —

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -9,9 +9,11 @@ Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
   APIs. This is your main source of truth (STEP 1).
 - **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only as a seeding reference** — its
-  `references/SEED.md` (and inline API recipes) for populating/managing the business in STEP 2.
-  Ignore the rest of it.
+  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
+  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 2. **Ignore
+  everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
+  "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
+  That is **not** how auth works here — auth is handled per STEP 2 below.
 - **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
   the seeding recipes above don't cover.
 
@@ -49,11 +51,17 @@ Seed the site with real content by following the `wix-headless` skill's `referen
 need, fall back to the `wix-docs` skill to search and read the relevant Wix API docs.
 
 These management/admin calls need **elevated Wix credentials** — the public client id is not
-enough. If you don't already have a way to authenticate them, **ask the user for a Wix API
-key / token** and store it in your platform's built-in **connector / secrets (env) manager** —
-never hardcode or commit it — then use it to authenticate the REST admin calls (the `wix-docs`
-skill covers Wix API-key auth). Or, if the user prefers, tell them they can add this content
-themselves in the Wix dashboard instead.
+enough. If you don't already have a way to authenticate them, either **connect your platform's
+Wix connector** (if it has one) or **ask the user for a Wix API key / token** and store it in your
+platform's built-in **connector / secrets (env) manager** — never hardcode or commit it. **Once
+the connector is connected (or the API key is in place), you can make Wix REST admin calls
+directly** — authenticate each call with that credential (the `wix-docs` skill covers Wix API-key
+auth). Or, if the user prefers, tell them they can add this content themselves in the Wix
+dashboard instead.
+
+Authenticate admin calls with **only** that connector/API key. Do **not** install or run the Wix
+CLI (`@wix/cli`), do a device-login, or follow `wix-headless`'s `references/managed/AUTHENTICATION.md`
+— that managed-project auth flow does not apply here.
 
 Management/admin operations (seeding, `wix-headless`, `wix-docs`) are **separate from the
 client** — the client is built solely per the `wix-vibe-headless` skill.


### PR DESCRIPTION
## Why
A base44 run followed `wix-headless`'s `references/managed/AUTHENTICATION.md` and did a **Wix CLI (`@wix/cli`) device-login** — that skill's 'managed project' auth flow. That is wrong for these prompts: **base44** auths via the already-configured **Wix connector**, and **generic** auths via the **client id (client) + a Wix API key (admin)**. The `wix-headless` skill is broad (full Wix-SDK app building) and we use it **only** for its seeding/inline-recipe content.

## What
- **STEP 0 one-liner** (both files): use `wix-headless` **only** for `references/SEED.md` + `references/inline-recipes/`; **ignore everything else**, in particular its auth / `@wix/cli` / `references/managed/` setup.
- **STEP 2** (both files): explicit auth guard —
  - base44: auth is the Wix connector and nothing else; with it in place you call Wix APIs directly; do not run `@wix/cli` / device-login / `references/managed/AUTHENTICATION.md`.
  - generic: connect the connector or get an API key; **once connected / key in place, make Wix REST admin calls directly**; don't follow the `@wix/cli` managed auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)