### PR TITLE
contributing fork warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ In this repo, many requests to add a "new skill" should actually be added as a n
 
 Use `wix-manage` for REST API operations that configure, set up, or manage Wix business entities and account/site resources.
 
+If you are adding or changing `wix-manage` skills, do not open the PR from a fork. The automated evaluation bot verifies the PR branch against eval scenarios, and fork-based PRs cannot be used for that workflow.
+
+If you do not have write permissions for this repository, please read [bo.wix.com/github-assist](https://bo.wix.com/github-assist) for the approved contribution path.
+
 When adding a `wix-manage` skill:
 
 1. Add the skill markdown under `skills/wix-manage/references/<area>/<skill>.md`.


### PR DESCRIPTION
## What
- Clarify that `wix-manage` skill changes should not be opened from a fork because eval verification runs against the PR branch.
- Point contributors without write access to [bo.wix.com/github-assist](https://bo.wix.com/github-assist).

## Why
- The eval bot needs a branch-backed PR workflow for `wix-manage` skill changes.

## Validation
- Documentation-only change.
