### PR TITLE
docs(wix-app): document @wix/ecom order-cancel & @wix/payments refund events

### DIFF
--- a/skills/wix-app/references/backend-event/COMMON-EVENTS.md
+++ b/skills/wix-app/references/backend-event/COMMON-EVENTS.md
@@ -12,10 +12,15 @@ This reference lists common event types, SDK imports, permissions, and links. Fo
 
 ## eCommerce Events
 
+Order events use **`@wix/ecom`** (namespace `orders`). Order **refund** events are the exception: they live in **`@wix/payments`** (namespace `refunds`), not `@wix/ecom`.
+
 | Event | Import | Handler Call | Permission | API Reference |
 | --- | --- | --- | --- | --- |
 | Order created | `import { orders } from "@wix/ecom"` | `orders.onOrderCreated(handler)` | `SCOPE.DC-STORES.READ-ORDERS` | [onOrderCreated](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/orders/orders/order-created?apiView=SDK) |
 | Order approved | `import { orders } from "@wix/ecom"` | `orders.onOrderApproved(handler)` | `SCOPE.DC-STORES.READ-ORDERS` | [onOrderApproved](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/orders/orders/order-approved?apiView=SDK) |
+| Order canceled | `import { orders } from "@wix/ecom"` | `orders.onOrderCanceled(handler)` | `SCOPE.DC-STORES.READ-ORDERS` | [onOrderCanceled](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/orders/orders/order-canceled?apiView=SDK) |
+| Refund created | `import { refunds } from "@wix/payments"` | `refunds.onRefundCreated(handler)` | `SCOPE.DC-PAYMENTS.READ-REFUNDS` | [onRefundCreated](https://dev.wix.com/docs/api-reference/business-management/payments/refunds/refund-created?apiView=SDK) |
+| Refund updated | `import { refunds } from "@wix/payments"` | `refunds.onRefundUpdated(handler)` | `SCOPE.DC-PAYMENTS.READ-REFUNDS` | [onRefundUpdated](https://dev.wix.com/docs/api-reference/business-management/payments/refunds/refund-updated?apiView=SDK) |
 | Cart created | `import { cart } from "@wix/ecom"` | `cart.onCartCreated(handler)` | `SCOPE.DC-STORES.READ-ORDERS` | [onCartCreated](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart/cart/cart-created?apiView=SDK) |
 | Cart updated | `import { cart } from "@wix/ecom"` | `cart.onCartUpdated(handler)` | `SCOPE.DC-STORES.READ-ORDERS` | [onCartUpdated](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart/cart/cart-updated?apiView=SDK) |
 


### PR DESCRIPTION
## What
Add order **cancel** and **refund** events to the wix-app backend-event eCommerce reference (`skills/wix-app/references/backend-event/COMMON-EVENTS.md`).

## Why
The reference listed only order created/approved and cart events. For order **cancel/refund** handlers the correct imports weren't documented, which is easy to get wrong — order refund events are not part of `@wix/ecom` at all; they live in `@wix/payments` (`refunds` namespace).

## Changes
- `Order canceled` → `orders.onOrderCanceled` (`@wix/ecom`, `SCOPE.DC-STORES.READ-ORDERS`)
- `Refund created` / `Refund updated` → `refunds.onRefundCreated` / `onRefundUpdated` (`@wix/payments`, `SCOPE.DC-PAYMENTS.READ-REFUNDS`)
- A note clarifying that refund events live in `@wix/payments`, not `@wix/ecom`

All imports, handlers, scope IDs, and doc links were verified against the current Wix SDK documentation.