### PR TITLE
TEST: reference-graph detachment (do not merge)

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-troubleshoot-not-applying.md
@@ -2,10 +2,6 @@
 name: "Pricing: Discount Not Applying"
 description: Diagnostic tree for when a discount rule exists but isn't applying at checkout. Checks active status, time window, scope targeting, revision, and app installation.
 layer: troubleshoot
-references:
-  - name: "Pricing: Create Coupon"
-    path: ecommerce/pricing-create-coupon.md
-    load: false
 ---
 # Troubleshoot: Discount Not Applying
 


### PR DESCRIPTION
Detachment E2E for #610. Base has troubleshoot -> coupon `references` edge; this PR REMOVES it. Expect the gate to still run BOTH troubleshoot-not-applying AND create-coupon — the coupon is pulled in via the BASE graph (head∪base union), proving a detach re-tests the severed skill. Diff should be just the one .md. Close without merging.