### PR TITLE
🦞 igor-claw: add WDE0110 error row to CMS Schema Management recipe

### DIFF
--- a/skills/wix-manage/references/cms/cms-schema-management.md
+++ b/skills/wix-manage/references/cms/cms-schema-management.md
@@ -140,6 +140,12 @@ curl -X GET \
 | `SITE_MEMBER_AUTHOR` | Members who created the item |
 | `ADMIN` | Site admins only |
 
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `WDE0110` | Wix CMS (Wix Data) app is not installed on the site | Install it: `POST https://www.wixapis.com/apps-installer-service/v1/app-instance/install` with body `{"tenant":{"tenantType":"SITE","id":"<SITE_ID>"},"appInstance":{"appDefId":"e593b0bd-b783-45b8-97c2-873d42aacaf4"}}`, then retry. See the [Install Wix Apps recipe](../app-installation/install-wix-apps.md). |
+
 ## Related Documentation
 
 - [Data Collections API Reference](https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/introduction)


### PR DESCRIPTION
## What's broken

A user reported (via MCP feedback) that an agent hit `400 WDE0110: Wix CMS app is not installed for site` calling `create-data-collection`, couldn't find the fix, and fell back to guiding the user through the dashboard manually — which didn't work for them, blocking the whole catalog-building task.

## Root cause

`create-data-collection` (and the rest of the schema-management surface) is documented in `skills/wix-manage/references/cms/cms-schema-management.md`. This recipe has **no Error Handling section at all** — even though the sibling `cms-data-items-crud.md` recipe already documents this exact `WDE0110` row. An agent reading the recipe actually relevant to its task (schema management, not CRUD) had no signal that this error maps to a one-call fix, and no obvious next step other than telling the user to enable CMS manually via the dashboard/editor.

## Verified fix (tested end-to-end on a fresh blank site)

```
POST https://www.wixapis.com/apps-installer-service/v1/app-instance/install
{ "tenant": { "tenantType": "SITE", "id": "<siteId>" },
  "appInstance": { "appDefId": "e593b0bd-b783-45b8-97c2-873d42aacaf4" } }
```

After this call, `create-data-collection` succeeds immediately. (`install-wix-apps.md` in this repo already lists the correct `Wix CMS` appDefId — no change needed there.)

## Change

Add a `WDE0110` row to `cms-schema-management.md`'s new Error Handling section, matching the format already used in `cms-data-items-crud.md`.

---

Supersedes wix-private/igor-tools#1471 — opened against the legacy igor-tools copy of this recipe before this canonical `wix/skills` repo was pointed out as the right target. That PR has been closed.

This PR was opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com), researching MCP feedback.
Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1784247423166999