### PR TITLE
🦞 igor-claw: add Blog SEO recipe, fix 403 diagnosis dead-end

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -40,6 +40,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## Blog
 
+### [Fix Blog SEO: Distinct Title Tag from H1](references/blog/fix-blog-seo-title-tag-duplicates-h1.md)
+**Technical:** Sets a distinct SEO <title> tag on blog posts and categories without changing the visible H1, using seoData.tags on UpdateDraftPost and UpdateCategory. Fixes "H1 duplicates title tag" findings from SEO audit tools (e.g. Semrush, Ahrefs).
+
 ### [How to Create Blog Posts](references/blog/how-to-create-blog-posts.md)
 **Technical:** Creates and publishes blog posts using Blog Posts API. Covers Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
 

--- a/skills/wix-manage/references/app-installation/list-installed-apps.md
+++ b/skills/wix-manage/references/app-installation/list-installed-apps.md
@@ -95,12 +95,13 @@ if (!hasBookings) {
 
 ### Diagnose Authorization Errors
 
-If you receive `401 Unauthorized` or `403 Forbidden` errors from Wix APIs:
+If you receive `401 Unauthorized` or `403 Forbidden` errors from Wix APIs, first tell the two failure modes apart — they need different fixes:
 
-1. **List installed apps** using this recipe
-2. **Check if the required app** is in the response
-3. **If missing**: Install the app using the [Install Wix Apps](install-wix-apps.md) recipe
-4. **Retry the original API call**
+- **App not installed** — typically a `401` with a message like `"No <app> instanceId found"`. Fix: **list installed apps** using this recipe; if the required app is missing, install it with the [Install Wix Apps](install-wix-apps.md) recipe, then retry.
+- **App installed, but the calling identity lacks the permission scope for that app's API** — typically a `403` with a message like `"The auth identity is not allowed on this resource for this site/account"`. Installing the app again will **not** fix this — the app is already there. This means the token making the call doesn't carry the required scope (e.g. Blog, Stores) for this identity:
+  - **API key**: open the [API Keys Manager](https://manage.wix.com/account/api-keys) and check the key's assigned permissions; add the missing one and retry.
+  - **OAuth app**: check the app's granted [permission scopes](https://dev.wix.com/docs/build-apps/develop-your-app/access/authorization/configure-permissions-for-your-app) in the Dev Center and add the missing one.
+  - **Wix MCP connector (e.g. the built-in Claude connector)**: disconnecting/reconnecting does **not** let you add scopes — the connector's OAuth grant is fixed by its registration, not chosen per-session, and there's currently no self-service scope picker. If a required scope is missing, report it as feedback rather than repeatedly retrying reconnect.
 
 ---
 
@@ -120,5 +121,5 @@ If you receive `401 Unauthorized` or `403 Forbidden` errors from Wix APIs:
 
 After checking installed apps:
 - **If app is missing**: Use the [Install Wix Apps](install-wix-apps.md) recipe to install required apps
-- **If app is installed but API fails**: Check API permissions and authentication
+- **If app is installed but API fails with 403**: See [Diagnose Authorization Errors](#diagnose-authorization-errors) above — this is almost always a missing permission scope on the caller's token, not an installation problem
 - **For Bookings APIs**: See [Bookings recipes](../../SKILL.md) for service setup

--- a/skills/wix-manage/references/blog/fix-blog-seo-title-tag-duplicates-h1.md
+++ b/skills/wix-manage/references/blog/fix-blog-seo-title-tag-duplicates-h1.md
@@ -1,0 +1,72 @@
+---
+name: "Fix Blog SEO: Distinct Title Tag from H1"
+description: Sets a distinct SEO <title> tag on blog posts and categories without changing the visible H1, using seoData.tags on UpdateDraftPost and UpdateCategory. Fixes "H1 duplicates title tag" findings from SEO audit tools (e.g. Semrush, Ahrefs).
+---
+# Fix Blog SEO: Distinct Title Tag from H1
+
+SEO audit tools commonly flag blog posts and category pages for "H1 duplicates title tag" — the page's visible H1 heading and its SEO `<title>` tag are identical, which hurts search ranking. The fix is to set a distinct SEO title via `seoData.tags`, leaving the visible H1 (the post/category `title`/`label`) untouched.
+
+This applies to both:
+- **Blog posts**: via [Update Draft Post](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/update-draft-post)
+- **Blog categories**: via [Update Category](https://dev.wix.com/docs/api-reference/business-solutions/blog/category/update-category)
+
+## Prerequisites
+
+- Wix Blog app installed on the site (see [List Installed Apps](../app-installation/list-installed-apps.md) to verify)
+- The post/category `id` you want to fix
+
+## Step 1: Update a draft post's SEO title
+
+Call `UpdateDraftPost` with `draftPost.seoData.tags` containing a `title` tag. Do **not** change `draftPost.title` — that's the H1.
+
+```bash
+curl -X PATCH "https://www.wixapis.com/blog/v3/draft-posts/{draftPostId}" \
+  -H "Authorization: <AUTH>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "draftPost": {
+      "id": "{draftPostId}",
+      "seoData": {
+        "tags": [
+          { "type": "title", "children": "A distinct, keyword-rich SEO title" }
+        ]
+      }
+    }
+  }'
+```
+
+> **Known API quirk:** The `UpdateDraftPost` response omits `seoData`, `seoSlug`, and returns a placeholder `slugs: [""]` — even though the update **did** persist correctly. This happens on every update, not just SEO changes. Don't treat the response as authoritative for these fields; call [Get Draft Post](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/get-draft-post) immediately after to confirm the write, especially before reporting success to a user.
+
+If the post is already published, this recipe still applies — `UpdateDraftPost` edits the draft layer of a published post; the live page picks up the new SEO title without a separate publish step for `seoData` changes alone. If in doubt, follow with `action: "UPDATE_PUBLICATION"`.
+
+## Step 2: Update a category's SEO title
+
+Same pattern, on `UpdateCategory`:
+
+```bash
+curl -X PATCH "https://www.wixapis.com/blog/v3/categories/{categoryId}" \
+  -H "Authorization: <AUTH>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "category": {
+      "id": "{categoryId}",
+      "seoData": {
+        "tags": [
+          { "type": "title", "children": "A distinct, keyword-rich SEO title" }
+        ]
+      }
+    }
+  }'
+```
+
+> **Fieldset gotcha:** Unlike draft posts, a category's `seoData` is gated behind the `SEO` response fieldset — `GetCategory`/`ListCategories` won't return it unless you pass `fieldsets: ["SEO"]` (REST: `?fieldsets=SEO`). This is expected behavior, not a bug — don't confuse a missing `seoData` in a plain `GET` response with the update having failed.
+
+## Step 3: Bulk-fixing many pages (typical after an SEO audit)
+
+SEO audits usually flag many pages at once. Loop over the flagged post/category IDs and call the corresponding update method for each — there is no bulk endpoint for `seoData` alone, but [Bulk Update Draft Posts](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/bulk-update-draft-posts) accepts up to 20 posts per call and supports the same `seoData.tags` shape per item.
+
+## Common mistakes
+
+- **Changing `title`/`label` instead of `seoData.tags`** — that changes the H1, not the SEO title, and doesn't fix the audit finding.
+- **Assuming the `UpdateDraftPost` response reflects the final state** — see the quirk above; re-fetch to confirm.
+- **Forgetting `fieldsets: ["SEO"]` when reading back a category's SEO title** — it will look unset even when it isn't.

--- a/yaml/wix-manage-evals/app-installation/list-installed-apps-diagnose-403-scope.yml
+++ b/yaml/wix-manage-evals/app-installation/list-installed-apps-diagnose-403-scope.yml
@@ -1,0 +1,34 @@
+name: app-installation/list-installed-apps-diagnose-403-scope
+description: >-
+  Verifies the agent reads the list-installed-apps skill and, when an app is
+  confirmed installed but the API still returns 403, correctly diagnoses it as
+  a missing permission scope rather than a missing-app problem.
+triggerPrompt: >-
+  I confirmed the Wix Blog app is installed on my site, but every call to the Blog API
+  still returns "403 Forbidden: the auth identity is not allowed on this resource for
+  this site/account". What's going on and how do I fix it?
+tags: [app-installation]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/list-installed-apps
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user already confirmed the required app is installed, and is still getting a 403
+      "auth identity not allowed" error.
+      Intent: distinguish app-not-installed (401) from missing-permission-scope (403) failure modes,
+      and explain that reinstalling the app will not fix a 403 caused by a missing scope.
+
+      Pass if the response:
+      - explains that this 403 is a permission/scope issue on the caller's token, not a missing-app issue, AND
+      - does NOT tell the user to (re)install the app as the fix, AND
+      - gives at least one concrete next step matched to how the caller authenticates (e.g. checking an API
+        key's assigned permissions, an OAuth app's granted scopes, or noting that reconnecting an MCP/OAuth
+        connector does not add scopes on its own).
+
+      Fail if the response:
+      - tells the user to install or reinstall the app as the fix, OR
+      - treats this the same as the "app not installed" 401 case, OR
+      - gives no actionable next step beyond "check your permissions".

--- a/yaml/wix-manage-evals/blog/fix-blog-seo-title-tag-duplicates-h1.yml
+++ b/yaml/wix-manage-evals/blog/fix-blog-seo-title-tag-duplicates-h1.yml
@@ -1,0 +1,32 @@
+name: blog/fix-blog-seo-title-tag-duplicates-h1
+description: >-
+  Verifies the agent reads the fix-blog-seo-title-tag-duplicates-h1 skill and
+  fixes an "H1 duplicates title tag" SEO finding by setting a distinct SEO
+  title via seoData.tags, without changing the post's H1/title.
+triggerPrompt: >-
+  Our SEO audit flagged this blog post for "H1 duplicates title tag" — draft post id
+  abc123 has the same text for its H1 and its SEO title tag. Fix it so the SEO title
+  is distinct from the H1, without changing the visible heading.
+tags: [blog]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/fix-blog-seo-distinct-title-tag-from-h1
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked to fix an "H1 duplicates title tag" SEO finding on a specific blog draft post
+      without changing the visible H1.
+      Intent: use UpdateDraftPost's seoData.tags to set a distinct SEO <title>, leaving draftPost.title untouched.
+
+      Pass if the response:
+      - calls out that the fix is `seoData.tags` (a tag with `type: "title"`) on Update Draft Post
+        (PATCH https://www.wixapis.com/blog/v3/draft-posts/{draftPostId}), AND
+      - explicitly does NOT change `draftPost.title` (the H1), AND
+      - sets a new, distinct title string in `seoData.tags[].children` different from the H1.
+
+      Fail if the response:
+      - changes `draftPost.title` instead of (or in addition to) `seoData.tags`, OR
+      - invents a different field name for the SEO title (e.g. `seoTitle`, `metaTitle`) instead of `seoData.tags`, OR
+      - claims the response body's `seoData`/`slugs` are unreliable without recommending a follow-up GET to confirm the write.

--- a/yaml/wix-manage/blog/documentation.yaml
+++ b/yaml/wix-manage/blog/documentation.yaml
@@ -2,6 +2,10 @@ apiDoc:
   title: Wix Blog Management Recipes
 
   docs:
+    - file: ../../../skills/wix-manage/references/blog/fix-blog-seo-title-tag-duplicates-h1.md
+      title: "Fix Blog SEO: Distinct Title Tag from H1"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/blog
+      tags: [blog]
     - file: ../../../skills/wix-manage/references/blog/how-to-create-blog-posts.md
       title: How to Create Blog Posts
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/blog


### PR DESCRIPTION
## What's broken

A Wix MCP user hit a hard wall doing routine Blog SEO cleanup (fixing "H1 duplicates title tag" findings from an SEO audit). Two gaps in `skills/wix-manage` contributed:

1. **No recipe for the task.** `skills/wix-manage/references/blog/` only has "How to Create Blog Posts" — nothing for updating SEO metadata on existing posts/categories. The user's agent had to reverse-engineer `seoData.tags` from the API spec cold.
2. **`list-installed-apps.md`'s "Diagnose Authorization Errors" flow dead-ends.** It only handles the missing-app case. For "app is installed but I still get 403", step 4 was just *"Check API permissions and authentication"* — no actionable next step. That's exactly what happened: the user's Blog app **was** installed, they got `403 "auth identity not allowed on this resource for this site/account"` on every Blog call, and had no path forward. Reconnecting the Wix connector doesn't help either — traced separately to `public-mcp-remote-server`'s OAuth authorize request only ever requesting `scope=offline_access` (no named permission scopes), so there's no scope picker to fix this from the connector side.

## Fix

- **New skill**: `references/blog/fix-blog-seo-title-tag-duplicates-h1.md` — sets a distinct SEO `<title>` via `seoData.tags` on `UpdateDraftPost`/`UpdateCategory` without touching the H1. Tested live via `CallWixSiteAPI` against a real site. Documents two verified API quirks along the way:
  - `UpdateDraftPost`'s response omits `seoData`/`seoSlug` and returns a placeholder `slugs: [""]` even though the write persists correctly (confirmed via immediate `GetDraftPost`) — reproduced twice, unrelated to `seoData` specifically (a bare `excerpt` update shows the same `slugs: [""]`).
  - `Category.seoData` requires `fieldsets: ["SEO"]` on read (by design, unlike `DraftPost` where `seoData` is a base field) — noted so agents don't mistake a missing-fieldset read for a failed write.
- **`list-installed-apps.md`**: split "Diagnose Authorization Errors" into the two distinct failure modes (app-not-installed 401 vs. token-missing-scope 403), with concrete next steps per auth method (API key permissions, OAuth app scopes, or — for the Wix MCP connector case — a note that reconnecting won't add scope).
- Updated `SKILL.md` and `yaml/wix-manage/blog/documentation.yaml` for the new recipe.
- Added required eval coverage per `CONTRIBUTING.md` for both changed skills (`yaml/wix-manage-evals/blog/...`, `yaml/wix-manage-evals/app-installation/...`), each with a `tool` assertion on the skill's doc URL (slug verified against `.github/actions/evalforge-yaml-gate/src/utils/doc-url.ts`'s slugify logic) and an `llm_judge` assertion.

## Not included here

The `UpdateDraftPost` response bug and the connector's fixed OAuth scope set are real, but their fixes live in different services (`blog-node`'s write path, and Blog-scope registration for the MCP's OAuth client outside this repo) — flagged separately, not fixed in this PR.

Supersedes the earlier PR opened against `wix-private/igor-tools` (closed — that tree is a legacy copy; this repo is canonical).

Opened automatically from Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1783973919309219