### PR TITLE
docs(wix-headless): V3 product-media attach recipe (product wrapper + revision) + base44 connector token

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -160,9 +160,25 @@ The request body is `items` (each with the product's `catalogItemId` and the Sto
 
 **Only when `imagery` is on** (`SEED.md` § "Entity images"). Products were created text-only above; this pass-2 step writes a generated brand image onto each. Generate + import per `references/IMAGE_GENERATION.md`, keep `file.url`, then PATCH the product.
 
-- The field that persists is **`media.itemsInfo.items`**, NOT `media.main`. `PATCH /stores/v3/products/{id}` setting `"media": { "itemsInfo": { "items": [ { "url": "<static.wixstatic.com/…>", "altText": "…" } ] } }`; the image may be referenced by a `static.wixstatic.com` **`url`** or by its Wix Media **`id`** (`<hash>~mv2.png`), either works.
-- **⚠️ `media.main` set ALONE silently no-ops** — a `200` comes back but re-query shows no image; that is the trap. The server promotes the first `itemsInfo.items` entry to `media.main` for you, so **verify success by reading `media.main.image.url`** — it must resolve to a `static.wixstatic.com` URL. Check that nested string, **not** the presence of `media.main` (which can be a non-null object with no image and makes a failed attach look successful). Conversely `media.itemsInfo` is **write-only** — it comes back `null` on read, so never assert on it.
-- **428 prevention:** first `GET /stores/v3/products/{id}` for its **`revision` + `options` + `variantsInfo`** and echo all three back in the PATCH body — do **not** send a field mask (the validator runs before masking).
+**The exact working call — do this per product (getting it right first time avoids a multi-round debug loop):**
+
+1. **`GET https://www.wixapis.com/stores/v3/products/{id}`** → read `revision`, `options`, and `variantsInfo` from **`response.product.*`**. The product is **nested under a `product` key** — the GET response is *not* flat.
+2. **`PATCH https://www.wixapis.com/stores/v3/products/{id}`** with the body below. **⚠️ Everything nests under a `product` wrapper.** Putting `id` / `revision` / `media` at the **root** fails `400 "product is invalid: revision must not be empty"` — the #1 cause of the loop here. **Do not send a field mask** (the validator runs before masking → `428`):
+
+   ```json
+   {
+     "product": {
+       "id": "<product id>",
+       "revision": "<revision from the GET — required; omitting it is the 400 above>",
+       "media": { "itemsInfo": { "items": [ { "url": "<static.wixstatic.com/…>", "altText": "…" } ] } },
+       "options":      "<echo the GET's product.options, unchanged>",
+       "variantsInfo": "<echo the GET's product.variantsInfo, unchanged>"
+     }
+   }
+   ```
+   The image may be referenced by a `static.wixstatic.com` **`url`** or by its Wix Media **`id`** (`<hash>~mv2.png`) — either works.
+
+- The field that persists is **`media.itemsInfo.items`**, NOT `media.main`. **⚠️ `media.main` set ALONE silently no-ops** — a `200` comes back but re-query shows no image; that is the trap. The server promotes the first `itemsInfo.items` entry to `media.main` for you, so **verify success by reading `media.main.image.url`** — it must resolve to a `static.wixstatic.com` URL. Check that nested string, **not** the presence of `media.main` (which can be a non-null object with no image and makes a failed attach look successful). Conversely `media.itemsInfo` is **write-only** — it comes back `null` on read, so never assert on it.
 - Send **one image per product** (primary); a larger gallery is out of scope for the seed.
 - **Never block on image failure** — skip and leave the product text-only.
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -86,10 +86,18 @@ Seed the site with real content by following the **`wix-headless` skill**'s
 don't cover what you need, **fall back to the `wix-docs` skill** (`.agents/skills/wix-docs`) to
 search and read the relevant Wix API docs.
 
-**Auth for these admin calls is the already-configured Wix connector — and nothing else.** With
-the connector in place you can make Wix API calls directly. Do **not** install or run the Wix CLI
-(`@wix/cli`), do a device-login, or follow `wix-headless`'s `references/managed/AUTHENTICATION.md`
-— that managed-project auth flow does not apply to Base44 and will send you down the wrong path.
+**Auth for these admin calls is the already-configured Wix connector — and nothing else.** Get the
+access token from it and send it as a bearer token — do **not** hand-roll a token getter (e.g. a
+custom `getAdminToken()`):
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+// then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
+```
+
+Do **not** install or run the Wix CLI (`@wix/cli`), do a device-login, or follow `wix-headless`'s
+`references/managed/AUTHENTICATION.md` — that managed-project auth flow does not apply to Base44
+and will send you down the wrong path.
 
 When you run seed/management code **inline via exec_tool**, `base44` is already declared — use
 it directly. Do **not** import `@base44/sdk`, re-declare `base44`, or call `createClient()` —


### PR DESCRIPTION
## Why
A real prod Stores build ("Terra-Tension") looped **5 redeploys** on attaching generated images to V3 products before it worked. Two documentation gaps caused the trial-and-error:

1. **Missing `product` wrapper** — `setup-online-store.md` described `media.itemsInfo.items` and the GET-for-`revision` requirement, but never showed the PATCH body **wrapped under `product`**. Sending `{ revision, media }` at the root fails `400 "product is invalid: revision must not be empty"`. The GET response is also nested under `product`, which the agent didn't expect.
2. **How to get the connector token** — `base44.md` said to call Wix APIs "directly" but not *how*, so the agent hand-rolled a `getAdminToken()` before discovering `base44.asServiceRole.connectors.getConnection("wix")`.

## What
- **setup-online-store.md** — rewrote the *Attach images* step to lead with the exact working **GET → PATCH**, showing the full body under the **`product` wrapper** (id, revision, media, echoed options/variantsInfo), with the `400 revision` and `428 field-mask` traps called out. Kept the existing `media.main` verify guidance.
- **base44.md** (STEP 2) — added `base44.asServiceRole.connectors.getConnection("wix")` as the connector-token call; warn off hand-rolled token getters.

Turns a 5-round loop into a one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)