### PR TITLE
docs(skills): add `wix account domain` (suggest, buy) CLI commands

### DIFF
--- a/.github/scripts/check-cli-pinned.sh
+++ b/.github/scripts/check-cli-pinned.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-SUBCMDS="token|whoami|login|env|build|release|preview|dev"
+SUBCMDS="token|whoami|login|env|build|release|preview|dev|account"
 
 bare=$(grep -rnE "npx @wix/cli (${SUBCMDS})([[:space:]]|$)" \
   --include='*.md' --include='*.sh' --include='*.mjs' --include='*.js' --include='*.ts' \

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -123,6 +123,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## Domains
 
+### [CLI Domain Suggest and Buy](references/domains/cli-domain-suggest-and-buy.md)
+**Technical:** Suggest available domains and start a domain purchase from the terminal using the Wix CLI `wix account domain` commands. Covers the account-level `wix account` group, the `--msid` scoping flag, JSON output, and the browser checkout handoff.
+
 ### [Domain Search and Purchase](references/domains/domain-search-and-purchase.md)
 **Technical:** Search for available domains, get domain suggestions, and generate purchase links using Domain Search V2 API. Covers availability checks, TLD filtering, and connecting domains to Wix sites.
 

--- a/skills/wix-manage/references/domains/cli-domain-suggest-and-buy.md
+++ b/skills/wix-manage/references/domains/cli-domain-suggest-and-buy.md
@@ -1,0 +1,124 @@
+---
+name: "CLI Domain Suggest and Buy"
+description: Suggest available domains and start a domain purchase from the terminal using the Wix CLI `wix account domain` commands. Covers the account-level `wix account` command group, the `--msid` scoping flag, JSON output for agents, and the browser checkout handoff for `domain buy`.
+---
+# CLI Domain Suggest and Buy
+
+Use this recipe when a user (or an agent working in a terminal) wants to:
+
+- Find available domains for a keyword, brand, or business idea using the Wix CLI
+- Start buying a domain from the command line
+- Says something like "suggest domains for my coffee shop from the CLI", "wix account domain buy example.com"
+
+This is the **CLI** path. For the REST API / MCP flow (availability checks, pre-configured carts, contact collection), use [Domain Search and Purchase](domain-search-and-purchase.md) instead.
+
+## The `wix account` Command Group
+
+`wix account` holds **account-level admin commands**. Two things apply to every command in the group:
+
+- **Login is required.** All `account` commands use the account OAuth session. Log in first with `npx @wix/cli@latest login`.
+- **`--msid <msid>`** — a group-level option that scopes account commands to a specific site (meta-site ID). It **must be placed right after `account`**, before the subcommand:
+
+  ```bash
+  npx @wix/cli@latest account --msid <metaSiteId> domain buy example.com
+  ```
+
+  If `--msid` is omitted, the CLI falls back to the `siteId` in the local `wix.config.json` / `wix.config.mjs`. If there is no config file either, commands run **account-wide** (no site scope).
+
+---
+
+## `wix account domain suggest <query>`
+
+Suggest available domains for a keyword, brand, or business idea.
+
+**Arguments**:
+
+| Argument | Description |
+|----------|-------------|
+| `<query>` | Keywords, brand, or business idea. 3–100 characters. |
+
+**Options**:
+
+| Option | Description |
+|--------|-------------|
+| `-l, --limit <number>` | Number of suggestions to return, 1–20. |
+| `-t, --tld <tld...>` | Filter by up to 10 TLDs, without the dot (e.g. `com net io`). |
+| `--json` | Output JSON instead of human-readable text. |
+
+**Output**: one available domain per line. All returned domains are available for purchase — no need to re-check availability. With `--json`:
+
+```json
+{
+  "suggestions": [
+    { "domain": "coffeeshop.com" },
+    { "domain": "coffeeshop.net" }
+  ]
+}
+```
+
+**Examples**:
+
+```bash
+npx @wix/cli@latest account domain suggest "coffee shop"
+npx @wix/cli@latest account domain suggest coffee --limit 5 --tld com io
+npx @wix/cli@latest account domain suggest coffee --json
+```
+
+> Agents: prefer `--json` for parsing suggestions programmatically.
+
+---
+
+## `wix account domain buy <domain>`
+
+Start buying a domain. **Payment always completes in the browser** (Wix hosted checkout) — the command opens the browser to the checkout page; it does not charge anything itself.
+
+**Arguments**:
+
+| Argument | Description |
+|----------|-------------|
+| `<domain>` | Full domain including the TLD (e.g. `example.com`). |
+
+**Options**:
+
+| Option | Description |
+|--------|-------------|
+| `--no-open` | Print the purchase URL instead of opening the browser. |
+
+**URL behavior**:
+
+- **With an msid** (from `--msid` or resolved from `wix.config.json`/`wix.config.mjs`), it opens the site-scoped checkout:
+  `https://manage.wix.com/dashboard/{msid}/premium-express-checkout-app/bundle-selection?domainName=<domain>`
+- **Without an msid**, it opens the standalone purchase flow:
+  `https://manage.wix.com/get-domain?domainName=<domain>&flowType=purchase`
+
+**Examples**:
+
+```bash
+npx @wix/cli@latest account domain buy example.com
+npx @wix/cli@latest account domain buy example.com --no-open
+npx @wix/cli@latest account --msid <metaSiteId> domain buy example.com
+```
+
+> **Agents: expect a browser handoff, not a headless purchase.** In CI, non-interactive, or agent environments (or with `--no-open`), the command prints the purchase URL instead of opening a browser. Surface that URL to the user so they can complete payment — do not wait for the purchase to finish.
+
+---
+
+## Example Flows
+
+### Flow 1: Suggest, then buy
+
+1. User: "Find me a domain for my coffee shop and buy it"
+2. `npx @wix/cli@latest account domain suggest "coffee shop" --json` → present the suggestions
+3. User picks `coffeeshop.io`
+4. `npx @wix/cli@latest account domain buy coffeeshop.io --no-open` → share the printed checkout URL with the user to complete payment
+
+### Flow 2: Buy scoped to a site
+
+1. User: "Buy example.com for my site" (meta-site ID known, e.g. from `wix.config.json` or the user)
+2. `npx @wix/cli@latest account --msid <metaSiteId> domain buy example.com --no-open`
+3. Share the site-scoped checkout URL — after payment the domain is set up on that site
+
+### Flow 3: Not logged in
+
+1. Any `account` command fails with an authentication error
+2. Run `npx @wix/cli@latest login`, complete the browser login, then retry the command

--- a/yaml/wix-manage-evals/domains/cli-domain-suggest-and-buy.yml
+++ b/yaml/wix-manage-evals/domains/cli-domain-suggest-and-buy.yml
@@ -1,0 +1,41 @@
+name: domains/cli-domain-suggest-and-buy
+description: >-
+  Verifies the agent reads the cli-domain-suggest-and-buy skill when asked to find and buy a
+  domain from the terminal, and answers with the wix account domain commands — suggest with
+  --json for parsing, buy with the browser checkout handoff, login required, and --msid placed
+  right after account for site scoping.
+triggerPrompt: >-
+  I'm working in a terminal with the Wix CLI installed. How do I get domain name suggestions for
+  my coffee shop and then start buying one of them using CLI commands? I may want the purchase
+  tied to a specific site.
+tags: [domains]
+maxTokens: 25000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/account-level/domains/skills/cli-domain-suggest-and-buy
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request: "I'm working in a terminal with the Wix CLI installed. How do I get
+      domain name suggestions for my coffee shop and then start buying one of them using CLI
+      commands? I may want the purchase tied to a specific site."
+      Intent: surface the Wix CLI `wix account domain` commands — `suggest` for finding domains
+      and `buy` for starting the purchase — with correct flags and flow.
+
+      Pass if the response:
+      - uses `wix account domain suggest <query>` (any invocation form, e.g. npx @wix/cli@latest)
+        for suggestions, mentioning at least one of its options (--limit, --tld, --json), AND
+      - uses `wix account domain buy <domain>` for the purchase and conveys that payment
+        completes in the browser / via a checkout URL (not headlessly in the terminal), AND
+      - for the site-specific case, places `--msid` right after `account`
+        (e.g. `wix account --msid <id> domain buy ...`) or explains the wix.config.json fallback.
+
+      Fail if the response:
+      - answers with REST API endpoints or MCP tools instead of CLI commands, OR
+      - hallucinates CLI commands not in the skill (e.g. `wix account domain check`,
+        `wix domains ls`, `wix account domain connect`), OR
+      - claims the purchase can complete entirely in the terminal without a browser checkout, OR
+      - never mentions that account commands require being logged in when discussing errors,
+        AND also omits the browser handoff (missing both sharp edges).

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Domain Search and Purchase
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
       tags: [domains]
+
+    - file: ../../../skills/wix-manage/references/domains/cli-domain-suggest-and-buy.md
+      title: CLI Domain Suggest and Buy
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
+      tags: [domains]


### PR DESCRIPTION
## What

Documents the newly shipped account-level Wix CLI command group so agents can use it:

- **`wix account`** — account-level admin commands; requires `wix login`; group-level `--msid <msid>` flag (placed right after `account`) to scope to a site, falling back to the `siteId` in `wix.config.json`/`wix.config.mjs`, else account-wide.
- **`wix account domain suggest <query>`** — suggest available domains (`-l/--limit` 1–20, `-t/--tld` up to 10 TLDs, `--json`).
- **`wix account domain buy <domain>`** — start a purchase; payment completes in the Wix hosted browser checkout (`--no-open` prints the URL instead — agents should surface it, not expect a headless purchase). Site-scoped vs account-wide checkout URLs documented.

## Changes

- `skills/wix-manage/references/domains/cli-domain-suggest-and-buy.md` — new reference (CLI counterpart to the existing API-based domain-search-and-purchase recipe).
- `skills/wix-manage/SKILL.md` — entry in the Domains section.
- `yaml/wix-manage/domains/documentation.yaml` — doc entry.
- `yaml/wix-manage-evals/domains/cli-domain-suggest-and-buy.yml` — eval scenario (tool + llm_judge assertions per CONTRIBUTING).
- `.github/scripts/check-cli-pinned.sh` — added `account` to the pinned-subcommand list; all examples use `npx @wix/cli@latest`.

`check-cli-pinned.sh` passes locally; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)