### PR TITLE
🦞 igor-claw: fix wrong Wix Forms appDefId in Create Form recipe

### DIFF
--- a/skills/wix-manage/references/app-installation/install-wix-apps.md
+++ b/skills/wix-manage/references/app-installation/install-wix-apps.md
@@ -101,6 +101,9 @@ Some common apps:
 | Wix Events | `140603ad-af8d-84a5-2c80-a0f60cb47351` |
 | Wix Pricing Plans | `1522827f-c56c-a5c9-2ac9-00f9e6ae12d3` |
 | Wix CMS | `e593b0bd-b783-45b8-97c2-873d42aacaf4` |
+| Wix Forms (New) | `225dd912-7dea-4738-8688-4b8c6955ffc2` |
+
+> **Wix Forms has two apps — use the New one.** `225dd912-7dea-4738-8688-4b8c6955ffc2` ("Wix Forms (New)") owns the `wix.form_app.form` namespace used by the Form Schemas v4 API (see the [Create Form](../forms/create-form.md) recipe). `14ce1214-b278-a7e4-1373-00cebd1bef7c` ("Wix Forms (Old)", aka "Wix Forms & Payments") is a different, legacy app — installing it will not activate that namespace, even though the install call itself succeeds.
 
 ### IMPORTANT NOTES:
 - NEVER guess the `appDefId`. For Wix-built apps, use the table above. For any other app, resolve the ID using Step 0 (Search Market Listings).

--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -12,7 +12,9 @@ Create a form on a Wix site that appears in the Forms & Submissions dashboard. T
 
 ## Create the form
 
-Call the Create Form endpoint with the `wix.form_app.form` namespace. The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) is usually already installed on sites.
+Call the Create Form endpoint with the `wix.form_app.form` namespace. This requires the **"Wix Forms" (New)** app — appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2` — which is usually already installed on sites.
+
+> **Do not confuse this with "Wix Forms (Old)" (appDefId `14ce1214-b278-a7e4-1373-00cebd1bef7c`).** That is a different, legacy app ("Wix Forms & Payments") — installing it does **not** grant permissions on the `wix.form_app.form` namespace and Create Form will keep failing with `UNSUPPORTED_FORM_NAMESPACE` even after a successful-looking install. Always use `225dd912-7dea-4738-8688-4b8c6955ffc2` for this recipe. See [Apps Created by Wix](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix) for the disambiguated list.
 
 ```bash
 curl -X POST \
@@ -290,7 +292,7 @@ The `postSubmissionTriggers.upsertContact` object maps form field targets to con
 
 ### Prerequisites
 
-The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be installed on the site. It is usually pre-installed, but if the API returns a "missing installed app" error, install it first using the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
+The **"Wix Forms" (New)** app (appDefId: `225dd912-7dea-4738-8688-4b8c6955ffc2`) must be installed on the site — not "Wix Forms (Old)" (`14ce1214-b278-a7e4-1373-00cebd1bef7c`), which does not own the `wix.form_app.form` namespace. It is usually pre-installed, but if the API returns a "missing installed app" error, install `225dd912-7dea-4738-8688-4b8c6955ffc2` first using the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
 
 ## Troubleshooting
 
@@ -300,8 +302,8 @@ The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be ins
 | Field silently missing from created form | Custom `identifier` value (e.g., `"product_name"`) | Use a recognized identifier like `TEXT_INPUT` and set display name via `label` |
 | Choice field rendered as a plain text box | `radioGroupOptions`/`dropdownOptions` malformed (wrong key, option missing `id`, empty `validation.enum`) — API silently falls back to `TEXT_INPUT` | Match the § "Choice fields" shape exactly: `componentType` in `stringOptions`, `options[]` each with a UUID `id`, and `validation.enum` listing all option values |
 | `maximum number of forms reached` / form-cap error | Sites cap at ~4 forms; reached by creating throwaway test forms | `GET form-schema-service/v4/forms` then `DELETE` the unwanted forms; build the real form in one call (don't probe) |
-| `Permissions for given namespace not found` | `wix.form_app.form` namespace not active | Ensure the Wix Forms app is installed; try creating a form through the UI first to activate the namespace |
-| `missing installed app` | Wix Forms app not installed | Install app `14ce1214-b278-a7e4-1373-00cebd1bef7c` via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
+| `Permissions for given namespace not found` | The wrong Forms app is installed — most commonly "Wix Forms (Old)" (`14ce1214-b278-a7e4-1373-00cebd1bef7c`) instead of "Wix Forms" (New) (`225dd912-7dea-4738-8688-4b8c6955ffc2`) | Install/re-check for appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2` specifically — installing the old app looks successful (`enabled: true`) but never activates this namespace. Retrying the identical request or waiting for propagation will not help since it's the wrong app, not a timing issue. |
+| `missing installed app` | Wix Forms (New) app not installed | Install app `225dd912-7dea-4738-8688-4b8c6955ffc2` (not `14ce1214-b278-a7e4-1373-00cebd1bef7c`) via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
 
 ## Related Documentation
 

--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -294,6 +294,14 @@ The `postSubmissionTriggers.upsertContact` object maps form field targets to con
 
 The **"Wix Forms" (New)** app (appDefId: `225dd912-7dea-4738-8688-4b8c6955ffc2`) must be installed on the site — not "Wix Forms (Old)" (`14ce1214-b278-a7e4-1373-00cebd1bef7c`), which does not own the `wix.form_app.form` namespace. It is usually pre-installed, but if the API returns a "missing installed app" error, install `225dd912-7dea-4738-8688-4b8c6955ffc2` first using the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
 
+### If the site already has "Wix Forms (Old)" installed
+
+Some older sites have only "Wix Forms (Old)" (`14ce1214-...`) installed, with no way to tell from the site itself. If you're unsure which Forms app a site has, call `GET form-schema-service/v4/forms/providers-config` — it lists every namespace the site can create forms under, keyed by the owning app's `appId`. A site with only the old app shows an entry like `{"namespace": "wix.old_form_app.form", "appId": "14ce1214-...", "restrictions": {"maxFieldsAmount": 16, ...}}` and **no** `wix.form_app.form` entry.
+
+**Do not create into `wix.old_form_app.form`, even though this endpoint lists it as a valid namespace for the site.** Its create/update permission is restricted to Wix's own internal service identity — no OAuth scope, API key, or Wix user token can ever satisfy it, so Create/Update Form calls into it always fail with an opaque `403 Forbidden` (empty body). This isn't a propagation delay or a missing-scope issue you can fix by reconnecting or re-granting permissions — it's a permanent, by-design restriction on that namespace, and it also caps forms at 16 fields even if it did work.
+
+The fix: install "Wix Forms" (New) (`225dd912-...`) **alongside** the old app — this is additive and doesn't require removing the old one — then create using the `wix.form_app.form` namespace as shown above. This works immediately with no other setup.
+
 ## Troubleshooting
 
 | Error | Cause | Fix |
@@ -304,6 +312,7 @@ The **"Wix Forms" (New)** app (appDefId: `225dd912-7dea-4738-8688-4b8c6955ffc2`)
 | `maximum number of forms reached` / form-cap error | Sites cap at ~4 forms; reached by creating throwaway test forms | `GET form-schema-service/v4/forms` then `DELETE` the unwanted forms; build the real form in one call (don't probe) |
 | `Permissions for given namespace not found` | The wrong Forms app is installed — most commonly "Wix Forms (Old)" (`14ce1214-b278-a7e4-1373-00cebd1bef7c`) instead of "Wix Forms" (New) (`225dd912-7dea-4738-8688-4b8c6955ffc2`) | Install/re-check for appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2` specifically — installing the old app looks successful (`enabled: true`) but never activates this namespace. Retrying the identical request or waiting for propagation will not help since it's the wrong app, not a timing issue. |
 | `missing installed app` | Wix Forms (New) app not installed | Install app `225dd912-7dea-4738-8688-4b8c6955ffc2` (not `14ce1214-b278-a7e4-1373-00cebd1bef7c`) via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
+| `403 Forbidden` (empty body) on Create/Update Form | Namespace is `wix.old_form_app.form` — its write permission is service-identity-only, permanently unreachable via any external auth | Don't retry or re-auth. Install "Wix Forms" (New) (`225dd912-7dea-4738-8688-4b8c6955ffc2`) alongside the old app and use `wix.form_app.form` instead — see "If the site already has 'Wix Forms (Old)' installed" above |
 
 ## Related Documentation
 


### PR DESCRIPTION
## What's broken

The **Create Form** recipe (`skills/wix-manage/references/forms/create-form.md`) tells agents to install appDefId `14ce1214-b278-a7e4-1373-00cebd1bef7c` as "the Wix Forms app" before calling `POST form-schema-service/v4/forms` with namespace `wix.form_app.form`.

That appDefId is actually **"Wix Forms (Old)"** (aka "Wix Forms & Payments") — a different, legacy app. Installing it succeeds (`enabled: true`, `status: "UNKNOWN"`) but it does **not** grant permissions on the `wix.form_app.form` namespace. Create Form then fails with:

```
400 "Permissions for given namespace not found. Please make sure you provided supported
namespace and/or have your app installed on site." (UNSUPPORTED_FORM_NAMESPACE)
```

...even after installing the (wrong) app and retrying multiple times — because it's the wrong app, not a propagation delay. The recipe's own troubleshooting table papered over this with "try creating a form through the UI first to activate the namespace," instead of naming the actual fix.

## Root cause (verified live)

The correct app is **"Wix Forms (New)"**, appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2`:
- Already used correctly in `skills/wix-headless/references/inline-recipes/setup-forms.md` and `SETUP.md` — the two Forms skills disagree on the app ID.
- Listed as a distinct app from "Wix Forms (Old)" in the official ["Apps Created by Wix"](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix) reference table.
- Repro: on a fresh blank-template site, installing `14ce1214-...` and calling Create Form fails 3/3 times (incl. after delay). Installing `225dd912-...` instead and immediately calling Create Form **succeeds on the first try**, no UI step needed.

## Fix

- `forms/create-form.md`: point every reference (prerequisites text + troubleshooting table, 3 spots) at `225dd912-7dea-4738-8688-4b8c6955ffc2`, and explicitly call out that the old ID looks-installed but doesn't activate the namespace.
- `app-installation/install-wix-apps.md`: add Wix Forms (New) to the common appDefId table, so the "missing installed app" fallback path also lands on the right ID.

## Context

Filed from an investigation into a Wix MCP feedback report (a user hit exactly this error building a waitlist form via the Wix MCP). This PR was opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com) — no human reviewed this description before posting.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1784538000311399