### PR TITLE
fix(wix-vibe-headless): members login fails fast + surfaces a one-click approve deep link

### DIFF
--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -41,7 +41,9 @@ have). Don't blend their exchange calls — the helper handles each internally.
    roles) or custom field definitions. Pure "logged-in vs. not" gating needs no app — see the
    identity-vs-profile split below.
 2. The site's public headless **`WIX_CLIENT_ID`** (from the handoff prompt), pasted into
-   `src/rest/wix-client.js`. Public, buyer-facing credential — safe to hardcode/commit.
+   `src/rest/wix-client.js`. Public, buyer-facing credential — safe to hardcode/commit. Also set
+   **`WIX_META_SITE_ID`** there (same prompt) — optional, only used to build the one-click
+   "approve this domain" link on an allow-listing failure; leave the placeholder if you don't have it.
 3. **OAuth-app allow-listing — the #1 gotcha. Two *different* fields gate the two mechanisms:**
 
    | Mechanism | What must be allow-listed | OAuth-app field | On `localhost:4321`? |
@@ -68,11 +70,16 @@ have). Don't blend their exchange calls — the helper handles each internally.
    > dead until they do it** (a client-only front has no account token to register it via the API).
    > See "Point the user to their dashboard" below for the deep link and the exact values.
    >
-   > **Self-serve fallback (newer authorize servers):** when an origin/callback isn't approved, the
-   > Wix authorize flow now returns an actionable error carrying an **`approveUrl`** — a one-click
-   > "Approve this domain/URI" deep link into the OAuth app. The helper attaches it to the thrown
-   > `MemberAuthError` as `err.approveUrl`; **render it as an "Approve" button** so the user fixes it
-   > themselves in one click. (Older servers just fail fast with a `timeout` — still tell the user.)
+   > **Self-serve on failure — render the approve link.** For **credential** login, when the origin
+   > isn't approved the helper throws `MemberAuthError` with code `redirect_uri_not_allowed` and an
+   > **`err.approveUrl`** — a one-click "Approve this domain" deep link into the OAuth app. It builds
+   > this **client-side** (needs `WIX_META_SITE_ID`), so it works today; it also uses the authorize
+   > server's `approveUrl` when present. **Render `err.approveUrl` as an "Approve" button** in your
+   > auth error state (and it's `console.warn`'d for the developer regardless). This is a
+   > build/test-time safety net — a correctly-registered site never hits it — so surface it plainly;
+   > no need to distinguish owner vs visitor (matches the platform's checkout "approve domain" page).
+   > **Social/SSO** fails on a Wix-rendered page that never returns to your app, so it can't be caught
+   > client-side — for social, the proactive registration above is the only lever.
 
 ## The API (copy as-is; do not re-derive it)
 Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIENT_ID`. Exports of

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -67,6 +67,12 @@ have). Don't blend their exchange calls — the helper handles each internally.
    > origin), **tell the user** the exact URIs to add and where, and note that **social login stays
    > dead until they do it** (a client-only front has no account token to register it via the API).
    > See "Point the user to their dashboard" below for the deep link and the exact values.
+   >
+   > **Self-serve fallback (newer authorize servers):** when an origin/callback isn't approved, the
+   > Wix authorize flow now returns an actionable error carrying an **`approveUrl`** — a one-click
+   > "Approve this domain/URI" deep link into the OAuth app. The helper attaches it to the thrown
+   > `MemberAuthError` as `err.approveUrl`; **render it as an "Approve" button** so the user fixes it
+   > themselves in one click. (Older servers just fail fast with a `timeout` — still tell the user.)
 
 ## The API (copy as-is; do not re-derive it)
 Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIENT_ID`. Exports of

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -43,7 +43,7 @@ have). Don't blend their exchange calls — the helper handles each internally.
 2. The site's public headless **`WIX_CLIENT_ID`** (from the handoff prompt), pasted into
    `src/rest/wix-client.js`. Public, buyer-facing credential — safe to hardcode/commit. Also set
    **`WIX_META_SITE_ID`** there (same prompt) — optional, only used to build the one-click
-   "approve this domain" link on an allow-listing failure; leave the placeholder if you don't have it.
+   "approve" link on an allow-listing failure; leave the placeholder if you don't have it.
 3. **OAuth-app allow-listing — the #1 gotcha. Two *different* fields gate the two mechanisms:**
 
    | Mechanism | What must be allow-listed | OAuth-app field | On `localhost:4321`? |
@@ -70,16 +70,19 @@ have). Don't blend their exchange calls — the helper handles each internally.
    > dead until they do it** (a client-only front has no account token to register it via the API).
    > See "Point the user to their dashboard" below for the deep link and the exact values.
    >
-   > **Self-serve on failure — render the approve link.** For **credential** login, when the origin
-   > isn't approved the helper throws `MemberAuthError` with code `redirect_uri_not_allowed` and an
-   > **`err.approveUrl`** — a one-click "Approve this domain" deep link into the OAuth app. It builds
-   > this **client-side** (needs `WIX_META_SITE_ID`), so it works today; it also uses the authorize
-   > server's `approveUrl` when present. **Render `err.approveUrl` as an "Approve" button** in your
-   > auth error state (and it's `console.warn`'d for the developer regardless). This is a
-   > build/test-time safety net — a correctly-registered site never hits it — so surface it plainly;
-   > no need to distinguish owner vs visitor (matches the platform's checkout "approve domain" page).
-   > **Social/SSO** fails on a Wix-rendered page that never returns to your app, so it can't be caught
-   > client-side — for social, the proactive registration above is the only lever.
+   > **Self-serve on failure — render the approve link.** When this app isn't allow-listed yet, both
+   > mechanisms surface a **one-click "Approve" deep link** into the OAuth-app dashboard that pre-fills
+   > **both** allow-list fields at once — the app **origin** *and* the `/callback` URI — so the owner
+   > approves **once** and both credential *and* social work afterward (no matter which one failed first):
+   > - **Credential:** the helper throws `MemberAuthError` (code `redirect_uri_not_allowed`) carrying
+   >   **`err.approveUrl`**, built client-side from the authorize server's `metaSiteId` + `rejectedOrigin`
+   >   (falls back to `WIX_META_SITE_ID`). **Render `err.approveUrl` as an "Approve" button** in your auth
+   >   error state (it's also `console.warn`'d for the developer). See the wiring snippet under (A) below.
+   > - **Social/SSO:** fails on a Wix-rendered **gate page** (a full-page redirect that doesn't return to
+   >   your app, so you can't catch it client-side) — but that page renders the **same** one-click approve
+   >   button, so the owner fixes it right there and retries.
+   > This is a build/test-time safety net — a correctly-registered site never hits it — so surface it
+   > plainly; no need to distinguish owner vs visitor (matches the platform's checkout "approve" page).
 
 ## The API (copy as-is; do not re-derive it)
 Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIENT_ID`. Exports of
@@ -121,8 +124,29 @@ try {
   else if (res.state === "REQUIRE_EMAIL_VERIFICATION") promptForCode(res.stateToken);
   else if (res.state === "REQUIRE_OWNER_APPROVAL") showPending();
 } catch (e) {
-  if (e instanceof MemberAuthError) showError(e.message); else throw e;
+  if (!(e instanceof MemberAuthError)) throw e;
+  // ⚠️ Store the whole error object — NOT just `e.message`. On an allow-listing failure the error
+  // carries an `e.approveUrl` (a one-click dashboard deep link). Doing `setError(e.message)` throws
+  // that away and the "Approve" button can never render — the single most common wiring mistake here.
+  setAuthError(e);
 }
+```
+
+Then render the message **and**, when present, `authError.approveUrl` as a button (opens the dashboard
+in a new tab). One click there approves **both** allow-list fields at once (see the allow-listing
+gotcha above), so the owner fixes it once and comes back:
+
+```jsx
+{authError && (
+  <div className="login-error">
+    <p>{authError.message}</p>
+    {authError.approveUrl && (
+      <a href={authError.approveUrl} target="_blank" rel="noopener noreferrer" className="btn btn-primary">
+        Approve this app
+      </a>
+    )}
+  </div>
+)}
 ```
 
 Custom sign-up fields go in `register`'s `profile` (`{ firstName, lastName, nickname, addresses, … }`).
@@ -204,7 +228,9 @@ Some setup only happens in the Wix dashboard — always give the user the deep l
   - the **exact `/callback` URL** (e.g. `https://myapp.example.com/callback`) — required for social/SSO;
   - also add password-reset / logout return URLs if you use them.
   Tell the user these exact values; the callback URL must match your `startSocialLogin` `callbackUri`
-  character-for-character.
+  character-for-character. **Faster path:** the in-app "Approve" button / gate approve page deep-links
+  straight here with the origin **and** `/callback` pre-filled, so the owner approves both in one click
+  rather than typing them — this manual list is the fallback for when that link can't be built.
 - **Custom SSO connection** (to obtain a `connectionId`) — created under the project's IAM / SSO
   settings in the Business Manager.
 

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -63,6 +63,8 @@ have). Don't blend their exchange calls — the helper handles each internally.
      **before** returning — so the client can't catch it; you must register it up front.
    - Google & Facebook are enabled by default; **custom SSO** also needs an IDP connection created in
      the Business Manager, whose **connection id** you pass as `idp` (see "Custom SSO" below).
+   - **Docs — read this for the allow-listing setup (the authority on both fields):**
+     https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains
 
    > **⚠️ AGENT: this is a manual, owner-only step you cannot do from client-only code — surface it
    > proactively.** As soon as a run uses social/SSO (or deploys credential login to a non-`4321`
@@ -212,6 +214,7 @@ create in the Business Manager (dashboard link below).
 The helper covers sign-up / login / social / SSO / logout / current-member. For a genuine gap, extend
 with `wixApiRequest` — but confirm the endpoint, method, and body in the API reference first (or via
 the co-installed **`wix-docs`** skill). Never guess.
+- Allow redirect URIs & domains (allow-listing setup — this vertical's #1 gotcha; what the `approveUrl` pre-fills): https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains
 - Custom login (JS SDK, concepts mirror the REST calls): https://dev.wix.com/docs/go-headless/self-managed-headless/authentication/members/custom-login-page/custom-login/custom-login-using-the-js-sdk.md
 - External / social login (REST): https://dev.wix.com/docs/rest/business-management/headless-authentication/redirects/create-redirect-session
 - Retrieve Tokens (REST): https://dev.wix.com/docs/rest/business-management/headless-authentication/authentication/retrieve-tokens

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -86,18 +86,14 @@ have). Don't blend their exchange calls — the helper handles each internally.
    > This is a build/test-time safety net — a correctly-registered site never hits it — so surface it
    > plainly; no need to distinguish owner vs visitor (matches the platform's checkout "approve" page).
 
-## Why login routes through the Wix "gate" (and a TODO to carry forward)
+## Why login routes through the Wix "gate"
 Both mechanisms send the browser to a **headless gate** (`/_serverless/wix-to-headless-redirect/…`)
 instead of straight to identity's authorize URL. The gate checks this app against the OAuth app's
 allow-list and either **forwards** to identity (allowed) or **fails fast with a one-click approve
 link** (not allowed). Without it, the *pure* identity flow dead-ends when the app isn't allow-listed:
 credential login silently hangs (the `web_message` postMessage is dropped), and social shows a generic
-"Invalid redirect URI" page that never returns to your app — neither is actionable.
-
-> **⚠️ AGENT: leave a `TODO` in the app** next to the login wiring (and note the helper's `TODO(gate)`
-> marker): the gate hop is a **stopgap** in the headless layer. If/when identity's official authorize
-> flow supports fail-fast + approve natively, drop the gate and point the flow straight back at the
-> redirect-session `fullUrl`. Don't remove the gate now — it's what makes the approve UX work today.
+"Invalid redirect URI" page that never returns to your app — neither is actionable. Keep routing
+through the gate (the helper does this for you) — it's what makes the approve UX work.
 
 ## The API (copy as-is; do not re-derive it)
 Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIENT_ID`. Exports of

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -214,9 +214,10 @@ create in the Business Manager (dashboard link below).
 The helper covers sign-up / login / social / SSO / logout / current-member. For a genuine gap, extend
 with `wixApiRequest` — but confirm the endpoint, method, and body in the API reference first (or via
 the co-installed **`wix-docs`** skill). Never guess.
+- About member login (the mechanism map — which flow to use when): https://dev.wix.com/docs/go-headless/authentication/members/about-member-login.md
+- Build a custom login page (REST) — the credential flow this vertical implements, steps 1-10: https://dev.wix.com/docs/go-headless/authentication/members/custom-login-page/build-a-custom-login-page-rest.md
+- Sign in with Google or Facebook (REST) — social/SSO, with the `idp` connection ids: https://dev.wix.com/docs/go-headless/authentication/members/identity-providers/sign-in-with-google-or-facebook-rest.md
 - Allow redirect URIs & domains (allow-listing setup — this vertical's #1 gotcha; what the `approveUrl` pre-fills): https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains
-- Custom login (JS SDK, concepts mirror the REST calls): https://dev.wix.com/docs/go-headless/self-managed-headless/authentication/members/custom-login-page/custom-login/custom-login-using-the-js-sdk.md
-- External / social login (REST): https://dev.wix.com/docs/rest/business-management/headless-authentication/redirects/create-redirect-session
 - Retrieve Tokens (REST): https://dev.wix.com/docs/rest/business-management/headless-authentication/authentication/retrieve-tokens
 - Members API (read/update profile, query members): https://dev.wix.com/docs/api-reference/members/members/members-v1/introduction
 

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -86,6 +86,19 @@ have). Don't blend their exchange calls — the helper handles each internally.
    > This is a build/test-time safety net — a correctly-registered site never hits it — so surface it
    > plainly; no need to distinguish owner vs visitor (matches the platform's checkout "approve" page).
 
+## Why login routes through the Wix "gate" (and a TODO to carry forward)
+Both mechanisms send the browser to a **headless gate** (`/_serverless/wix-to-headless-redirect/…`)
+instead of straight to identity's authorize URL. The gate checks this app against the OAuth app's
+allow-list and either **forwards** to identity (allowed) or **fails fast with a one-click approve
+link** (not allowed). Without it, the *pure* identity flow dead-ends when the app isn't allow-listed:
+credential login silently hangs (the `web_message` postMessage is dropped), and social shows a generic
+"Invalid redirect URI" page that never returns to your app — neither is actionable.
+
+> **⚠️ AGENT: leave a `TODO` in the app** next to the login wiring (and note the helper's `TODO(gate)`
+> marker): the gate hop is a **stopgap** in the headless layer. If/when identity's official authorize
+> flow supports fail-fast + approve natively, drop the gate and point the flow straight back at the
+> redirect-session `fullUrl`. Don't remove the gate now — it's what makes the approve UX work today.
+
 ## The API (copy as-is; do not re-derive it)
 Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIENT_ID`. Exports of
 `wix-members-auth.js`:

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -2,10 +2,28 @@ import {
   wixApiRequest,
   WIX_API_BASE,
   WIX_CLIENT_ID,
+  WIX_META_SITE_ID,
   setSessionTokens,
   clearSession,
   isMember,
 } from "./wix-client.js";
+
+// One-click "approve this domain" dashboard deep link for when login fails because this app's
+// ORIGIN isn't in the OAuth app's allowed domains. Built client-side (no server change needed —
+// the ?addAllowedDomain= param already exists) so the UI can offer a fix. Returns undefined when
+// WIX_META_SITE_ID isn't set (the deep link needs it) — the caller then just shows the message.
+function pageOrigin() {
+  return typeof window !== "undefined" ? window.location.origin : "";
+}
+
+function buildApproveDomainUrl(origin) {
+  if (!origin || !WIX_META_SITE_ID || WIX_META_SITE_ID.startsWith("<")) return undefined;
+  return (
+    `https://manage.wix.com/dashboard/${encodeURIComponent(WIX_META_SITE_ID)}` +
+    `/oauth-apps-settings/manage/${encodeURIComponent(WIX_CLIENT_ID)}` +
+    `?addAllowedDomain=${encodeURIComponent(origin)}`
+  );
+}
 
 /**
  * Custom member login for a client-only headless front end — the REST analog of
@@ -305,11 +323,11 @@ function authorizeViaHiddenIframe(authUrl, expectedState) {
       cleanup();
       if (e.data.error) {
         const err = new MemberAuthError(e.data.error, e.data.error_description || e.data.error);
-        // When the origin isn't allow-listed, the authorize server now returns a benign
-        // `redirect_uri_not_allowed` error carrying an `approveUrl` (a one-click dashboard deep
-        // link to approve this origin). Surface it so the UI can render an "Approve this domain"
-        // CTA instead of a dead end. (Absent on older server versions — harmless.)
-        if (e.data.approveUrl) err.approveUrl = e.data.approveUrl;
+        // Origin not allow-listed. Prefer the authorize server's `approveUrl` (newer servers send
+        // a benign `redirect_uri_not_allowed` carrying it); otherwise build it client-side. Either
+        // way the UI gets a one-click "Approve this domain" deep link instead of a dead end.
+        err.approveUrl = e.data.approveUrl || buildApproveDomainUrl(pageOrigin());
+        if (err.approveUrl) console.warn(`Wix member login: approve this origin — ${err.approveUrl}`);
         reject(err);
       } else resolve({ code: e.data.code, state: e.data.state });
     };
@@ -317,15 +335,18 @@ function authorizeViaHiddenIframe(authUrl, expectedState) {
     const timer = setTimeout(() => {
       if (!settled) {
         cleanup();
-        // Fast-fail fallback for older authorize servers that *silently drop* the postMessage
-        // when this app's ORIGIN isn't in the OAuth app's allowed domains (newer servers return
-        // an actionable `redirect_uri_not_allowed` + `approveUrl` immediately — handled above).
-        // The fix: add this origin to the OAuth app's allowed domains — see INSTRUCTIONS.md.
-        reject(new MemberAuthError(
-          "timeout",
-          `Login timed out. This app's origin (${typeof window !== "undefined" ? window.location.origin : "?"}) ` +
-            `is most likely not in the Wix OAuth app's allowed domains — add it in the site's Headless Settings.`,
-        ));
+        // Fast-fail fallback for older authorize servers that *silently drop* the postMessage when
+        // this app's ORIGIN isn't in the OAuth app's allowed domains. Build the approve deep link
+        // client-side so the UI can still offer the one-click fix (no server change needed).
+        const approveUrl = buildApproveDomainUrl(pageOrigin());
+        if (approveUrl) console.warn(`Wix member login: approve this origin — ${approveUrl}`);
+        const err = new MemberAuthError(
+          "redirect_uri_not_allowed",
+          `This app's origin (${pageOrigin() || "?"}) is not in the Wix OAuth app's allowed domains — ` +
+            `add it in the site's Headless Settings.`,
+        );
+        if (approveUrl) err.approveUrl = approveUrl;
+        reject(err);
       }
     }, 30000);
     iframe.src = authUrl;

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -16,10 +16,14 @@ function pageOrigin() {
   return typeof window !== "undefined" ? window.location.origin : "";
 }
 
-function buildApproveDomainUrl(origin) {
-  if (!origin || !WIX_META_SITE_ID || WIX_META_SITE_ID.startsWith("<")) return undefined;
+function buildApproveDomainUrl(origin, metaSiteId) {
+  // Prefer the metaSiteId the authorize server returns in the error payload (a client-only front
+  // usually doesn't know it); fall back to the optional WIX_META_SITE_ID constant if it's set.
+  const msid =
+    metaSiteId || (WIX_META_SITE_ID && !WIX_META_SITE_ID.startsWith("<") ? WIX_META_SITE_ID : undefined);
+  if (!origin || !msid) return undefined;
   return (
-    `https://manage.wix.com/dashboard/${encodeURIComponent(WIX_META_SITE_ID)}` +
+    `https://manage.wix.com/dashboard/${encodeURIComponent(msid)}` +
     `/oauth-apps-settings/manage/${encodeURIComponent(WIX_CLIENT_ID)}` +
     `?addAllowedDomain=${encodeURIComponent(origin)}`
   );
@@ -323,10 +327,12 @@ function authorizeViaHiddenIframe(authUrl, expectedState) {
       cleanup();
       if (e.data.error) {
         const err = new MemberAuthError(e.data.error, e.data.error_description || e.data.error);
-        // Origin not allow-listed. Prefer the authorize server's `approveUrl` (newer servers send
-        // a benign `redirect_uri_not_allowed` carrying it); otherwise build it client-side. Either
-        // way the UI gets a one-click "Approve this domain" deep link instead of a dead end.
-        err.approveUrl = e.data.approveUrl || buildApproveDomainUrl(pageOrigin());
+        // Origin not allow-listed. The authorize server returns the facts (`metaSiteId` +
+        // `rejectedOrigin`); build the one-click "Approve this domain" deep link from them so the UI
+        // offers a fix instead of a dead end. Falls back to this page's origin / WIX_META_SITE_ID.
+        const origin = e.data.rejectedOrigin || pageOrigin();
+        err.rejectedOrigin = origin;
+        err.approveUrl = buildApproveDomainUrl(origin, e.data.metaSiteId);
         if (err.approveUrl) console.warn(`Wix member login: approve this origin — ${err.approveUrl}`);
         reject(err);
       } else resolve({ code: e.data.code, state: e.data.state });

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -207,7 +207,18 @@ export async function startSocialLogin(idp, callbackUri, returnTo = "/") {
     OAUTH_STASH_KEY,
     JSON.stringify({ codeVerifier: pkce.codeVerifier, state: pkce.state, redirectUri: callbackUri, returnTo }),
   );
-  window.location.href = fullUrl;
+  // Route through the headless gate instead of straight to identity's authorize URL: it validates
+  // the callback and either forwards to identity or shows a one-click "Approve this URI" page — so a
+  // not-yet-allow-listed callback gets a fix, not a dead-end error. (Identity stays generic; the gate
+  // lives in the headless layer, same pattern as Wix-hosted checkout.) The gate is on the Wix host,
+  // which we take from the authorize URL's origin; forwarding is a relative path (no open redirect).
+  const u = new URL(fullUrl);
+  const gateUrl =
+    `${u.origin}/_serverless/wix-to-headless-redirect/authorize-or-approve` +
+    `?authorizePath=${encodeURIComponent(u.pathname + u.search)}` +
+    `&clientId=${encodeURIComponent(WIX_CLIENT_ID)}` +
+    `&redirectUri=${encodeURIComponent(callbackUri)}`;
+  window.location.href = gateUrl;
 }
 
 /**

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -303,24 +303,31 @@ function authorizeViaHiddenIframe(authUrl, expectedState) {
       if (!e.data || e.data.state !== expectedState) return; // not our message
       settled = true;
       cleanup();
-      if (e.data.error) reject(new MemberAuthError(e.data.error, e.data.error_description || e.data.error));
-      else resolve({ code: e.data.code, state: e.data.state });
+      if (e.data.error) {
+        const err = new MemberAuthError(e.data.error, e.data.error_description || e.data.error);
+        // When the origin isn't allow-listed, the authorize server now returns a benign
+        // `redirect_uri_not_allowed` error carrying an `approveUrl` (a one-click dashboard deep
+        // link to approve this origin). Surface it so the UI can render an "Approve this domain"
+        // CTA instead of a dead end. (Absent on older server versions — harmless.)
+        if (e.data.approveUrl) err.approveUrl = e.data.approveUrl;
+        reject(err);
+      } else resolve({ code: e.data.code, state: e.data.state });
     };
     window.addEventListener("message", onMessage);
     const timer = setTimeout(() => {
       if (!settled) {
         cleanup();
-        // The overwhelmingly common cause: this app's ORIGIN is not an allowed
-        // authorization redirect URI on the OAuth app, so the browser silently
-        // blocks the iframe's postMessage (check the console for a "target origin
-        // … does not match" error). Register the origin — see INSTRUCTIONS.md.
+        // Fast-fail fallback for older authorize servers that *silently drop* the postMessage
+        // when this app's ORIGIN isn't in the OAuth app's allowed domains (newer servers return
+        // an actionable `redirect_uri_not_allowed` + `approveUrl` immediately — handled above).
+        // The fix: add this origin to the OAuth app's allowed domains — see INSTRUCTIONS.md.
         reject(new MemberAuthError(
           "timeout",
-          `Login timed out. Most likely this app's origin (${typeof window !== "undefined" ? window.location.origin : "?"}) ` +
-            `is not an allowed authorization redirect URI on the Wix OAuth app — register it in the site's Headless Settings.`,
+          `Login timed out. This app's origin (${typeof window !== "undefined" ? window.location.origin : "?"}) ` +
+            `is most likely not in the Wix OAuth app's allowed domains — add it in the site's Headless Settings.`,
         ));
       }
-    }, 120000);
+    }, 30000);
     iframe.src = authUrl;
     document.body.appendChild(iframe);
   });

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -84,6 +84,23 @@ const REDIRECT_SESSION_URL = "/_api/redirects-api/v1/redirect-session";
 const CURRENT_MEMBER_URL = "/members/v1/members/my";
 const OAUTH_STASH_KEY = `wix-oauth-data-${WIX_CLIENT_ID}`;
 
+// ── The headless "gate" — why we don't hit identity's authorize URL directly ──────────────────────
+// `createRedirectSession` returns `fullUrl`, which is identity's authorize endpoint. The PURE flow
+// points the iframe (credential) / full-page redirect (social) straight at it. The problem: when this
+// app isn't allow-listed, identity DEAD-ENDS with no way to fix it — credential (web_message) silently
+// drops the postMessage so the iframe just hangs, and social (fragment) shows a generic "Invalid
+// redirect URI" page that never returns to your app. So instead we hop through the headless GATE (a
+// Wix-owned serverless on the same Wix host): it checks this app against the OAuth app's allow-list
+// and either FORWARDS to identity's authorize path (allowed) or fails fast with the facts to build a
+// one-click approve link (not allowed) — keeping this approve UX out of generic identity, the same
+// pattern Wix-hosted checkout already uses.
+//
+// TODO(gate): this gate hop is a headless-layer stopgap. If/when identity's official authorize flow
+// gains fail-fast + approve natively, drop the gate and point the iframe / redirect straight back at
+// `fullUrl` (remove GATE_BASE and the two gateUrl builders below; use `u.pathname + u.search` on
+// `u.origin`). Until then, keep routing through the gate.
+const GATE_BASE = "/_serverless/wix-to-headless-redirect";
+
 /**
  * `idp` connection ids for social login. Google & Facebook are enabled by default
  * on every headless client. For custom SSO / OIDC (Okta, Auth0, …) pass the
@@ -195,7 +212,7 @@ async function completeDirectLogin(sessionToken) {
   // one-click approve link — instead of the browser silently dropping identity's postMessage.
   const u = new URL(fullUrl);
   const gateUrl =
-    `${u.origin}/_serverless/wix-to-headless-redirect/web-message-authorize-or-approve` +
+    `${u.origin}${GATE_BASE}/web-message-authorize-or-approve` +
     `?authorizePath=${encodeURIComponent(u.pathname + u.search)}` +
     `&clientId=${encodeURIComponent(WIX_CLIENT_ID)}` +
     `&origin=${encodeURIComponent(pageOrigin())}` +
@@ -234,7 +251,7 @@ export async function startSocialLogin(idp, callbackUri, returnTo = "/") {
   // which we take from the authorize URL's origin; forwarding is a relative path (no open redirect).
   const u = new URL(fullUrl);
   const gateUrl =
-    `${u.origin}/_serverless/wix-to-headless-redirect/authorize-or-approve` +
+    `${u.origin}${GATE_BASE}/authorize-or-approve` +
     `?authorizePath=${encodeURIComponent(u.pathname + u.search)}` +
     `&clientId=${encodeURIComponent(WIX_CLIENT_ID)}` +
     `&redirectUri=${encodeURIComponent(callbackUri)}`;

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -94,11 +94,6 @@ const OAUTH_STASH_KEY = `wix-oauth-data-${WIX_CLIENT_ID}`;
 // and either FORWARDS to identity's authorize path (allowed) or fails fast with the facts to build a
 // one-click approve link (not allowed) — keeping this approve UX out of generic identity, the same
 // pattern Wix-hosted checkout already uses.
-//
-// TODO(gate): this gate hop is a headless-layer stopgap. If/when identity's official authorize flow
-// gains fail-fast + approve natively, drop the gate and point the iframe / redirect straight back at
-// `fullUrl` (remove GATE_BASE and the two gateUrl builders below; use `u.pathname + u.search` on
-// `u.origin`). Until then, keep routing through the gate.
 const GATE_BASE = "/_serverless/wix-to-headless-redirect";
 
 /**

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -8,24 +8,30 @@ import {
   isMember,
 } from "./wix-client.js";
 
-// One-click "approve this domain" dashboard deep link for when login fails because this app's
-// ORIGIN isn't in the OAuth app's allowed domains. Built client-side (no server change needed —
-// the ?addAllowedDomain= param already exists) so the UI can offer a fix. Returns undefined when
-// WIX_META_SITE_ID isn't set (the deep link needs it) — the caller then just shows the message.
+// One-click "approve" dashboard deep link for when login fails because this app isn't allow-listed on
+// the OAuth app. It pre-fills BOTH allow-list fields so the owner configures ONCE (in a single
+// dashboard visit) and BOTH mechanisms work afterward — regardless of which one they hit first:
+//   • addAllowedDomain      → this app's ORIGIN            (credential / web_message postMessage target)
+//   • addAllowedRedirectUri → the social/SSO callback URL  (defaults to `<origin>/callback`, the skill's convention)
+// Built client-side (no server change needed — both params already exist on the dashboard). Returns
+// undefined when the metaSiteId is unknown (the deep link needs it) — the caller then just shows the
+// message. Pass `callbackUri` to override the `<origin>/callback` default if your app uses another path.
 function pageOrigin() {
   return typeof window !== "undefined" ? window.location.origin : "";
 }
 
-function buildApproveDomainUrl(origin, metaSiteId) {
+function buildApproveUrl(origin, metaSiteId, callbackUri) {
   // Prefer the metaSiteId the authorize server returns in the error payload (a client-only front
   // usually doesn't know it); fall back to the optional WIX_META_SITE_ID constant if it's set.
   const msid =
     metaSiteId || (WIX_META_SITE_ID && !WIX_META_SITE_ID.startsWith("<") ? WIX_META_SITE_ID : undefined);
   if (!origin || !msid) return undefined;
+  const redirectUri = callbackUri || `${origin}/callback`;
   return (
     `https://manage.wix.com/dashboard/${encodeURIComponent(msid)}` +
     `/oauth-apps-settings/manage/${encodeURIComponent(WIX_CLIENT_ID)}` +
-    `?addAllowedDomain=${encodeURIComponent(origin)}`
+    `?addAllowedDomain=${encodeURIComponent(origin)}` +
+    `&addAllowedRedirectUri=${encodeURIComponent(redirectUri)}`
   );
 }
 
@@ -354,8 +360,8 @@ function authorizeViaHiddenIframe(authUrl, expectedState) {
         // offers a fix instead of a dead end. Falls back to this page's origin / WIX_META_SITE_ID.
         const origin = e.data.rejectedOrigin || pageOrigin();
         err.rejectedOrigin = origin;
-        err.approveUrl = buildApproveDomainUrl(origin, e.data.metaSiteId);
-        if (err.approveUrl) console.warn(`Wix member login: approve this origin — ${err.approveUrl}`);
+        err.approveUrl = buildApproveUrl(origin, e.data.metaSiteId);
+        if (err.approveUrl) console.warn(`Wix member login: approve this app — ${err.approveUrl}`);
         reject(err);
       } else resolve({ code: e.data.code, state: e.data.state });
     };
@@ -366,8 +372,8 @@ function authorizeViaHiddenIframe(authUrl, expectedState) {
         // Fast-fail fallback for older authorize servers that *silently drop* the postMessage when
         // this app's ORIGIN isn't in the OAuth app's allowed domains. Build the approve deep link
         // client-side so the UI can still offer the one-click fix (no server change needed).
-        const approveUrl = buildApproveDomainUrl(pageOrigin());
-        if (approveUrl) console.warn(`Wix member login: approve this origin — ${approveUrl}`);
+        const approveUrl = buildApproveUrl(pageOrigin());
+        if (approveUrl) console.warn(`Wix member login: approve this app — ${approveUrl}`);
         const err = new MemberAuthError(
           "redirect_uri_not_allowed",
           `This app's origin (${pageOrigin() || "?"}) is not in the Wix OAuth app's allowed domains — ` +

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -72,6 +72,8 @@ function buildApproveUrl(origin, metaSiteId, callbackUri) {
  * Docs (curl the .md): custom login <https://dev.wix.com/docs/go-headless/self-managed-headless/authentication/members/custom-login-page/custom-login/custom-login-using-the-js-sdk.md>
  * · external/social login <https://dev.wix.com/docs/rest/business-management/headless-authentication/redirects/create-redirect-session>
  * · Retrieve Tokens <https://dev.wix.com/docs/rest/business-management/headless-authentication/authentication/retrieve-tokens>
+ * · allow redirect URIs & domains (the allow-listing this vertical's #1 gotcha is about, and what the
+ *   `approveUrl` deep link pre-fills) <https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains>
  */
 
 const AUTH_BASE = "/_api/iam/authentication/v2";

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -69,8 +69,9 @@ function buildApproveUrl(origin, metaSiteId, callbackUri) {
  * Members Area app or they're silently dropped. Social (B) can't collect any of
  * these — that's the reason to pick direct-credential.
  *
- * Docs (curl the .md): custom login <https://dev.wix.com/docs/go-headless/self-managed-headless/authentication/members/custom-login-page/custom-login/custom-login-using-the-js-sdk.md>
- * · external/social login <https://dev.wix.com/docs/rest/business-management/headless-authentication/redirects/create-redirect-session>
+ * Docs (curl the .md): about member login — the mechanism map <https://dev.wix.com/docs/go-headless/authentication/members/about-member-login.md>
+ * · custom login page (REST) — the credential flow this file implements, steps 1-10 <https://dev.wix.com/docs/go-headless/authentication/members/custom-login-page/build-a-custom-login-page-rest.md>
+ * · sign in with Google/Facebook (REST) — social/SSO, with the idp connection ids <https://dev.wix.com/docs/go-headless/authentication/members/identity-providers/sign-in-with-google-or-facebook-rest.md>
  * · Retrieve Tokens <https://dev.wix.com/docs/rest/business-management/headless-authentication/authentication/retrieve-tokens>
  * · allow redirect URIs & domains (the allow-listing this vertical's #1 gotcha is about, and what the
  *   `approveUrl` deep link pre-fills) <https://dev.wix.com/docs/go-headless/authentication/setup/allow-redirect-uris-and-domains>

--- a/skills/wix-vibe-headless/references/members/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/wix-members-auth.js
@@ -180,7 +180,18 @@ async function completeDirectLogin(sessionToken) {
   const { fullUrl } = await createRedirectSession({
     authRequest: { responseMode: "web_message", sessionToken, pkce },
   });
-  const { code } = await authorizeViaHiddenIframe(fullUrl, pkce.state);
+  // Route the hidden iframe through the headless gate: it checks this app's origin against the
+  // OAuth app's allowed domains and either forwards to identity's web_message authorize (origin
+  // allowed) or posts a benign { error, rejectedOrigin, metaSiteId } back so we fail fast with a
+  // one-click approve link — instead of the browser silently dropping identity's postMessage.
+  const u = new URL(fullUrl);
+  const gateUrl =
+    `${u.origin}/_serverless/wix-to-headless-redirect/web-message-authorize-or-approve` +
+    `?authorizePath=${encodeURIComponent(u.pathname + u.search)}` +
+    `&clientId=${encodeURIComponent(WIX_CLIENT_ID)}` +
+    `&origin=${encodeURIComponent(pageOrigin())}` +
+    `&state=${encodeURIComponent(pkce.state)}`;
+  const { code } = await authorizeViaHiddenIframe(gateUrl, pkce.state);
   const tokens = await exchangeCode(code, pkce.codeVerifier);
   setSessionTokens(tokens);
   return getCurrentMember();

--- a/skills/wix-vibe-headless/references/shared/wix-client.js
+++ b/skills/wix-vibe-headless/references/shared/wix-client.js
@@ -14,6 +14,14 @@
  */
 export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
 
+/**
+ * WIX_META_SITE_ID — the site's metasite id (from the same prompt). Optional: only used to build a
+ * one-click "approve this domain" dashboard deep link when member login fails because this app's
+ * origin isn't allow-listed (see wix-members-auth.js). Leave the placeholder if you don't have it —
+ * the helper falls back to a plain error message.
+ */
+export const WIX_META_SITE_ID = "<YOUR-METASITE-ID>";
+
 export const WIX_API_BASE = "https://www.wixapis.com";
 const OAUTH_TOKEN_URL = `${WIX_API_BASE}/oauth2/token`;
 


### PR DESCRIPTION
## C · wix-vibe-headless — members login fails fast + one-click approve

A member's credential login (`getMemberTokensForDirectLogin`, hidden `web_message` iframe) silently hangs when the app's origin isn't in the OAuth app's allowed domains. This makes the helper **fail fast** and surface a one-click **"Approve this domain"** deep link, built from the facts **A** returns (`metaSiteId` + `rejectedOrigin`); falls back to the page origin / optional `WIX_META_SITE_ID` for older servers. Also a 30s fast-fail for servers that silently drop the message.

## Headless member-login allow-listing — coordinated PRs

Member login breaks when the app's **origin** (credential) or **callback** (social) isn't registered on the OAuth app. Enforcement lives in `oauth2-ng` at `/_api/oauth2/authorize`. These PRs turn both failures into a self-serve **"Approve"** flow — and, per @yuvalrap1's review, keep `oauth2-ng` **out of the dashboard-URL/UX business**: identity emits **facts** or **hands off**; the deep link + page live in BO-owned code.

- **A · server** — `oauth2-ng` — wix-private/server-infra#63914
  - credential (`web_message`): returns facts `{ state, error: 'redirect_uri_not_allowed', rejectedOrigin, metaSiteId }` → the client builds the `?addAllowedDomain=` link.
  - social (`fragment`): `302` (relative) to **D**. No hardcoded URL, no identity-rendered page.
- **B · dashboard** — `oauth-apps-settings` — wix-private/headless-bo#706 — adds the `?addAllowedRedirectUri=` one-click deep link (sibling of `?addAllowedDomain=` / #673).
- **C · client** — `wix-vibe-headless` — wix/skills#659 — builds the approve link from A's facts (falls back to page origin / optional `WIX_META_SITE_ID`).
- **D · approve page** — `wix-to-headless-redirect` — wix-private/wix-anywhere#3747 — the BO-owned **"Approve this URI"** page A hands social off to; targets B's param.

**Merge order:** B before (or with) D — D's button links to B's `?addAllowedRedirectUri=`. A & C are independently mergeable.

Mirrors @gonengar's checkout self-serve pattern (`domain-not-allowed-page` + headless-bo#673), applied to the login path.


🤖 Generated with [Claude Code](https://claude.com/claude-code)