### PR TITLE
Clarify create-from-template verification

### DIFF
--- a/skills/wix-manage/references/sites/create-site-from-template.md
+++ b/skills/wix-manage/references/sites/create-site-from-template.md
@@ -98,6 +98,39 @@ curl -X POST \
   }'
 ```
 
+**Response shape**:
+```json
+{
+  "metaSite": {
+    "metaSiteId": "<NEW_SITE_ID>",
+    "name": "my-new-site",
+    "ownerId": "<ACCOUNT_ID>",
+    "published": false
+  }
+}
+```
+
+When using `ExecuteWixAPI`, read the site ID and name from the nested response:
+
+```js
+const response = await wix.request({
+  scope: "account",
+  method: "POST",
+  url: "https://www.wixapis.com/msm/v1/meta-site/create-from-template",
+  body: { originTemplateId, siteName }
+});
+
+const site = response.data?.metaSite;
+return {
+  metaSiteId: site?.metaSiteId,
+  name: site?.name,
+  ownerId: site?.ownerId,
+  published: site?.published
+};
+```
+
+If `response.data.metaSite.metaSiteId` is missing, do **not** assume the site was created and do **not** immediately retry with a different `siteName`. First verify by listing the account's sites and matching by the requested `siteName` or returned `metaSiteId`.
+
 ### Site Name Requirements
 
 The `siteName` must follow these rules:
@@ -122,9 +155,19 @@ Add `"namespace": "HEADLESS"` to the request body:
 
 **Response** includes the new site's `metaSiteId`.
 
+### Verify the Created Site Before Continuing
+
+After a successful create response:
+
+1. Use the `metaSite.metaSiteId` and `metaSite.name` from the create response as the source of truth for the new site.
+2. Call `listSites` (or the Query Sites recipe for advanced filtering) and match the new site by `metaSiteId` first, then by exact `name`.
+3. If the create response returned a `metaSiteId` but the site is not in the list yet, tell the user the site was created but may take a few minutes to appear in the Sites list. Ask them to refresh/search by the exact name, and offer to check again later.
+4. Do **not** create another site just because the newly-created site is not visible in the Sites list immediately. Retrying a successful create with a new name can create duplicate sites.
+
 ### IMPORTANT NOTES:
 - Only mention headless if user specifically requests it
 - If user doesn't ask for headless, do NOT include the `namespace` field
+- Never publish, duplicate, or retry a site-creation mutation unless the user explicitly confirms that they want another new site.
 
 ---
 

--- a/yaml/wix-manage-evals/sites/create-site-from-template-verify-listing.yml
+++ b/yaml/wix-manage-evals/sites/create-site-from-template-verify-listing.yml
@@ -1,0 +1,32 @@
+name: sites/create-site-from-template-verify-listing
+description: >-
+  Verifies the create-site-from-template skill explains the nested create response shape
+  and tells the agent to verify the new site in the account listing instead of blindly
+  retrying the mutation when the site is not immediately visible.
+triggerPrompt: >-
+  I am building an integration that creates a blank Wix Editor site from a template.
+  What is the safe REST flow, which fields should I read from the create response, and
+  how should I verify the site appears in the account before deciding whether to retry?
+tags: [sites]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/account-level/sites/skills/create-site-from-template
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asks for advisory guidance about safely creating a blank Wix Editor site from a template.
+      Intent: explain the create-from-template flow, the exact nested response fields, and safe verification before retrying.
+
+      Pass if the response:
+      - identifies the Create Site API endpoint `POST https://www.wixapis.com/msm/v1/meta-site/create-from-template`, AND
+      - says the new site's ID and name come from the nested response fields `metaSite.metaSiteId` and `metaSite.name` (or `response.data.metaSite.metaSiteId` / `response.data.metaSite.name` when using ExecuteWixAPI), AND
+      - says to verify the created site by listing/querying the account's sites and matching by `metaSiteId` or exact `name`, AND
+      - explicitly warns not to immediately retry the create mutation with a new name merely because the site is not visible in the Sites list yet, since that can create duplicate sites.
+
+      Fail if the response:
+      - claims the create response has a top-level `metaSiteId` only, OR
+      - recommends retrying site creation with a different name before checking the account's site list, OR
+      - omits the post-create listing verification step, OR
+      - suggests publishing the site without asking the user first.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/cd6ca1a3-474f-4aae-a142-7f4155920820
Feedback: The assistant created a site through `POST https://www.wixapis.com/msm/v1/meta-site/create-from-template`, received a `metaSite` result for `inamigos-254784`, but the user still could not see the site in their Sites list.

## Conversation research

The reported issue is a true issue. The create API did not fail, but the recipe-guided flow let the agent mis-handle verification and retry a mutating create:

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/cd6ca1a3-474f-4aae-a142-7f4155920820`: the user asked for a new InAmigos Foundation site from a template. The assistant activated `create-site-from-template` (`TOOL_CALL_RESULT` log `83a88ec0-0e9a-419b-81ad-81b1629a3614`). The first `ExecuteWixAPI` call (`TOOL_CALL` log `78933e6c-b71d-4827-bb33-316d10bc0f0a`) read `created.data?.metaSiteId`, so its result (`b7a1c8ed-e000-4eee-8d81-e6e443509476`) returned only `siteName: inamigos-foundation`. After the user said they did not see it, the assistant retried the mutation with a different generated name (`TOOL_CALL` log `4f118999-4932-4f3f-8022-4c10d9a44718`). The second result (`1a5a4f59-3059-4c3d-b0b6-573fdb1cee95`) returned `raw.metaSite.metaSiteId = 8419c254-54c0-4a47-996b-45d9308f551b` and `raw.metaSite.name = inamigos-254784`, but the assistant still told the user it should now appear instead of verifying through the account site list.

Impact/frequency checked in `com.wixpress.genie.agent-platform-service` app logs for 2026-07-13 through 2026-07-20:
- Broad `ExecuteWixAPI` calls to the `create-from-template` endpoint: 90 request-level invocations.
- Exact unsafe retry signature (`Retry creating... not visible in the user's Sites list`): 1 request-level occurrence.

## Code/content research

Root cause: the `Create Site from Template` recipe said the response includes `metaSiteId`, but did not show the actual nested response shape (`metaSite.metaSiteId` / `metaSite.name`) and did not instruct the agent to verify the new site through account listing before retrying. That made the assistant treat a missing top-level field as unverified and then retry a successful account-level mutation.

Why this is the owning surface:
- The failing flow was driven by the activated Wix MCP recipe content, not a `TOOL_FAILED`, validation error, or downstream API error.
- The second API result proves the API returned the nested `metaSite` object successfully.
- Fixing the recipe source is deterministic and owned by this repo; patching Aria/platform behavior would be a broader workaround.

Alternatives ruled out:
- API outage/tool failure: no create API `TOOL_FAILED`; second result was successful and contained the new `metaSite`.
- Platform enum/validation issue: no validation-error logs.
- Aria-only prompt issue: the unsafe guidance came from the shared `create-site-from-template` recipe and can affect any assistant that loads it.

## Change

This changes the recipe so future agents:
- parse the nested create response correctly,
- use `metaSite.metaSiteId` and `metaSite.name` as source-of-truth fields,
- verify the created site by `listSites`/Query Sites before continuing,
- avoid duplicate site creation when listing propagation lags.

Reviewer-oriented diff:
- `skills/wix-manage/references/sites/create-site-from-template.md`: adds response-shape and `ExecuteWixAPI` parsing guidance, plus a post-create verification section and no-blind-retry guard.
- `yaml/wix-manage-evals/sites/create-site-from-template-verify-listing.yml`: adds an advisory/non-mutating eval covering nested response parsing and listing verification.

## Side effects and rollout risk

This is a narrow documentation/recipe fix. It does not remove site creation capability; it only changes the agent's post-create verification and retry policy for this recipe. The main behavioral impact is fewer duplicate create mutations when the create API succeeds but the Sites list is delayed.

## Verification

- Fix proof: AGENT_TESTING smoke conversation https://wix-bo.com/ai-assistant/conversations/fdf3b271-3860-4f62-a254-dd93825ffb20 used `metadata.additionalMetadata` overrides `skillsRepo=wix/skills` and `skillsPr=6904c5c84c23cfcc6ee3adfa2500fd4fc06d520c`. The `activateSkill` result log `d7066336-2028-4c2d-b371-6002cea604eb` served the new recipe text, including `Response shape`, `response.data.metaSite.metaSiteId`, `Verify the Created Site Before Continuing`, and the duplicate-create warning. The assistant response then instructed reading `metaSite.metaSiteId` / `metaSite.name`, listing/querying sites by ID/name, and never retrying a create that returned a `metaSiteId`.
- Safety & ownership: this lands in the authored Wix MCP recipe source, not in a platform wrapper or brittle text rewrite. The mechanism is deterministic, bounded to this recipe, and transparent to reviewers.
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("yaml/wix-manage-evals/sites/create-site-from-template-verify-listing.yml"); puts "YAML OK"'`
- Residual: the AGENT_TESTING smoke turn logged unrelated `DIAGNOSTIC_DATA_ITEM_ERROR` entries for dynamic knowledge tenant extraction in the test account. The response completed and the served recipe content was verified. The PR eval gate should run the covering scenario against the PR content.