### PR TITLE
docs(wix-headless): emit the site dashboard link at the end of managed builds

### DIFF
--- a/skills/wix-headless/references/managed/CONNECT.md
+++ b/skills/wix-headless/references/managed/CONNECT.md
@@ -71,4 +71,4 @@ static-hosting fixes in **`references/managed/DEPLOYMENT.md`** — the entry fil
 `index.html`, and `outputDirectory` must point at the directory holding it (init's `./dist` default is
 wrong for static). Then finalize per **`references/managed/DEPLOYMENT.md`** (`npx @wix/cli@latest release` — Wix
 publishes + registers the origin OOTB). Close with a short summary (apps installed, content seeded, what
-was wired, live URL).
+was wired) and **both links — the live site URL and the site dashboard `https://manage.wix.com/dashboard/<SITE_ID>`** (see `managed/DEPLOYMENT.md` § "Give the user both links"; `<SITE_ID>` is the `siteId` in scratch).

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -127,4 +127,4 @@ depends on `frontendFramework` (§0):
 - **Non-Astro** → the framework's own build (e.g. `npm run build`); a static (no-build) site skips this.
   `release` publishes whatever `site.outputDirectory` points at (default `./dist`).
 
-Close with a short summary (apps installed, content seeded, pages built, live URL).
+Close with a short summary (apps installed, content seeded, pages built) and **both links — the live site URL and the site dashboard `https://manage.wix.com/dashboard/<SITE_ID>`** (see `managed/DEPLOYMENT.md` § "Give the user both links"; `<SITE_ID>` is the `siteId` in scratch).

--- a/skills/wix-headless/references/managed/DEPLOYMENT.md
+++ b/skills/wix-headless/references/managed/DEPLOYMENT.md
@@ -14,6 +14,20 @@ CI=1 npx @wix/cli@latest release
 - The deployed origin is registered on the OAuth app automatically — the frontend's visitor SDK calls are accepted from the live URL with no extra step.
 - The published URL is printed on stdout (`Site published on <url>`).
 
+## Give the user both links — the live site **and** the dashboard
+
+When you close the run, surface **two** links, not one:
+
+1. **The live site URL** — the `Site published on <url>` value from release above.
+2. **The site dashboard (Business Manager)** — `https://manage.wix.com/dashboard/<SITE_ID>`, where `<SITE_ID>` is the `siteId` held in scratch (read from `wix.config.json`). This is where the owner manages the site behind the headless frontend — view store orders, edit content, manage members, etc. **Always include it**: a headless site has no editor button, so without this link the owner has no obvious way back into their own backend, and the seeded content/apps look unreachable.
+
+Present them plainly, e.g.:
+
+```
+Live site:  <published-url>
+Dashboard:  https://manage.wix.com/dashboard/<SITE_ID>
+```
+
 ## Member login on a **non-Astro** frontend — register the callback URI (post-release)
 
 **Only when the run has member login on a non-Astro SPA/static frontend using the Wix login page** (`inline-recipes/how-to-code-members-non-astro.md` — the `getAuthUrl` → `/callback` handshake). Astro's built-in `/api/auth/*` callback shapes are auto-registered; a **non-Astro SPA's own callback path is not** — and **login stays dead (4xx on the login redirect) until you register it**. This is a genuine gap `wix release` does *not* close for you.


### PR DESCRIPTION
## What

Managed `create` / `connect` / `iterate` runs closed with **only the live site URL**. A headless site has no editor button, so the site owner had no obvious way back into their own backend (store orders, content, members) — the seeded apps and content looked unreachable.

This makes the closing step emit **both** links: the live site URL **and** the site dashboard, `https://manage.wix.com/dashboard/<SITE_ID>`.

## Changes

- **`references/managed/DEPLOYMENT.md`** — new canonical section *"Give the user both links — the live site and the dashboard"* right after Release, explaining the dashboard URL shape and *why* it's mandatory for headless.
- **`references/managed/CREATE.md`** — closing summary now requires both links, referencing the DEPLOYMENT section.
- **`references/managed/CONNECT.md`** — same update (also covers `iterate`, which reuses `CONNECT.md`).

`SITE_ID` is already held in scratch from scaffold/`init`, so no new lookup is needed. Backend-only runs (self-managed / stripe) are intentionally untouched — they don't own the frontend/release and aren't hosted on `manage.wix.com`.

## Why

Reported in [Slack](https://wix.slack.com/archives/C0BCMUDTZPV/p1784552648237299): a user built a storefront via `wix.com/headless/skill.md` and got the site but no link to Business Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)