### PR TITLE
fix(stores): honor user-provided Catalog V3 products

### DIFF
--- a/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
+++ b/skills/wix-manage/references/stores/setup-online-store-catalog-v3.md
@@ -34,18 +34,14 @@ The Categories API is an exception. It uses a v1 endpoint, as it replaces the ol
 `https://www.wixapis.com/categories/v1/categories`
 
 
-### STEP 2: Create 5 new products based on the format specified in the Bulk Create Products with Options recipe (4 in stock, 1 out of stock)
-1. First *YOU MUST* pull up the [Bulk Create Wix Store Products with Options](bulk-create-products-with-options.md) recipe to understand the exact format required for creating products.
-2. Create 5 products according to this format using bulk creation (use a single bulk request). 4 of the created products **MUST** have ALL there variants in-stock, and the last (5th) product **MUST** have all its variants be out-of-stock.
-3. **Make sure** to add in image (using media) using  a url from the web that matches each product.
-4. **YOU MUST** use the price formatting as seen in the example, meaning using actualPrice and compareAtPrice.
-5. **ALL** products **MUST** be created **EXACTLY** from the same format as the full example in the Bulk Create Wix Store Products with Options recipe. **ONLY** information within the strings of the given fields may differ based on the products.
-
-
-**⚠️ CRITICAL: EXACT FORMAT REQUIREMENTS**
-**YOU MUST** use the following recipe to create ALL products with the EXACT same format:
-- **Bulk Create Wix Store Products with Options**
- [Recipe: Bulk Create Products with Options](bulk-create-products-with-options.md)
+### STEP 2: Create the requested products with the right Catalog V3 shape
+1. Determine the product list from the user request. If the user provided product names, prices, descriptions, quantities, or a product count, **honor that exact catalog**. Do not cap the request at 5 products. The Catalog V3 bulk products endpoint supports up to 100 products per request; split into multiple bulk requests only if the requested catalog exceeds that limit.
+2. If the user did not provide a product list or count, create a small starter catalog of 5 relevant sample products. Treat 5 products as the fallback default only, not as a maximum or mandatory count.
+3. Use [Bulk Create Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-create-products) for simple products. Use [Bulk Create Products With Inventory](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-create-products-with-inventory) or the [Bulk Create Wix Store Products with Options](bulk-create-products-with-options.md) recipe only when the user requested options, variants, or inventory quantities.
+4. Media is optional. Include `media` only when the user provided image URLs, uploaded media, or an existing Wix media reference. **Do not invent, search for, or use external image URLs just to satisfy this recipe.** If no reliable media is available, omit the `media` field and create the products as text-only.
+5. Product descriptions are rich-content objects, not plain strings. If adding a description, send a valid rich-content paragraph object; do **not** send `description: "plain text"` because Catalog V3 can reject it with `Expected an object`. If you cannot safely format a description, omit `description` and keep the product name/price.
+6. Use `variantsInfo.variants[].price.actualPrice.amount` for prices. Add `compareAtPrice` only when the user provided a sale/list price relationship or explicitly requested compare-at pricing.
+7. Do not force an in-stock/out-of-stock mix unless the user requested stock status or quantities. When inventory is not part of the request, create the products first and leave inventory setup for a follow-up user-confirmed step.
 
 
 ### STEP 3: Prepare Three Store Categories
@@ -101,6 +97,8 @@ If you keep the verification (e.g., for high-stakes catalogs):
 ## Conclusion
 Following these steps **in order** guarantees the creation flow for new V3 Wix Online Store sites:
 - Contains exactly **3** categories
-- Contains exactly **5** products (unless the user explicitly requests fewer)
+- Contains the user-requested products, or 5 relevant sample products only when the user did not provide a catalog
 - Each product is connected to at least one category.
-- All products follow the correct Catalog V3 API format as specified in the referenced recipe.
+- Product media and compare-at pricing are included only when supported by user-provided data.
+- Product descriptions use Catalog V3 rich-content objects, or are omitted when only plain text is available.
+- All products follow the correct Catalog V3 API format for the requested catalog complexity.

--- a/yaml/wix-manage-evals/stores/setup-online-store-catalog-v3-user-products.yml
+++ b/yaml/wix-manage-evals/stores/setup-online-store-catalog-v3-user-products.yml
@@ -1,0 +1,24 @@
+name: stores/setup-online-store-catalog-v3-user-products
+description: Verifies the Catalog V3 setup recipe honors a user-provided product list and does not require fabricated media URLs.
+triggerPrompt: I need to set up a Wix Stores Catalog V3 shop for my gelato business with 11 named products, prices, and short descriptions, but I do not have product images yet. Please summarize the safe setup flow before making any changes.
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/setup-online-store-catalog-v3
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Context: the user asks for a non-mutating summary before setup. They have an 11-product gelato catalog with short text descriptions and no product images.
+
+      Pass if the response:
+      - loads the setup-online-store-catalog-v3 skill,
+      - says to honor the user's full product list/count instead of forcing exactly 5 products,
+      - says product media is optional and should be omitted when the user has not provided image URLs or uploaded media,
+      - warns not to invent, search for, or use external product image URLs just to satisfy setup,
+      - notes that Catalog V3 descriptions must be rich-content objects or omitted, not plain strings,
+      - describes using the Catalog V3 bulk products endpoint for simple products, with options/inventory-specific flows only when those are requested, and
+      - stays non-mutating by summarizing or asking for confirmation before creating products.
+
+      Fail if the response says the recipe must create exactly 5 products, requires web image URLs, fabricates image URLs, sends descriptions as plain strings, ignores the user's 11-product catalog, or starts mutating the site without confirmation.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/ca614e6f-3a03-4ec1-b5d8-b54be4dabbbe

Feedback: Aria reported that `setup-online-store-catalog-v3` conflicts with a user-provided Hugmill gelato catalog: the recipe forced exactly 5 products and required web image URLs even though the user had 11 products and no images. The same execution turn later failed twice on `ExecuteWixAPI` with `400 Expected an object`.

## Conversation research

The reported issue is a true source-content issue, with one important correction: in the actual broken turn, Aria did not create only 5 products and did not fabricate media URLs. The model attempted all 11 user products without media, but the recipe content it activated still contained the bad instructions and the API payload sent plain string descriptions, which Catalog V3 rejected.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/ca614e6f-3a03-4ec1-b5d8-b54be4dabbbe`: user gave WhatsApp/business details for the Hugmill gelato setup. Message `20d9d3b0-18ca-4078-8f87-3a7fb4326555` activated `setup-online-store-catalog-v3` (`TOOL_CALL` log `cec8224c-7b7e-4aa5-a1f8-c11919d26b47`). The served recipe said to create exactly 5 products and add web-image media URLs (`TOOL_CALL_RESULT` log `6387d8e9-f31b-4bd5-a491-16586d96c491`). The two `ExecuteWixAPI` attempts (`TOOL_CALL` logs `2133b845-d8a8-4fe6-91c4-ae30d33234e8`, `eb52a160-0677-410d-87b6-c7acaffa88dc`) attempted 11 products but sent `description: p.desc` as a string. Both failed with `TOOL_FAILED` logs `fbc02c59-9e28-44cf-8f50-c263a796def3` and `8b044248-c389-4d72-a150-1d1c60bef108`: `Execute error: Wix API error (400): {"message":"Expected an object","details":{}}`.

Impact & frequency:
- Grafana `app_logs`, `com.wixpress.genie.agent-platform-service`, `2026-07-14T00:00:00Z` through `2026-07-21T23:59:59Z`: 391 distinct requests actually invoked `activateSkill` with `skillName: setup-online-store-catalog-v3`; 3 of those also hit the `ExecuteWixAPI` / `Expected an object` failure signature.

## Code/content research

Root cause: the `wix/skills` recipe source for Catalog V3 setup over-constrained product creation. Step 2 told agents to create exactly 5 products, require relevant web image URLs, force compare-at pricing and stock mix, and copy the options recipe format even for simple product catalogs. For this conversation, the shape issue that produced the concrete API failure was plain string `description`; the related product recipe docs identify Catalog V3 descriptions as object-shaped/rich content and warn that plain strings can cause `Expected an object`.

Why this is the owning surface:
- `activateSkill` served the recipe body directly from `skills/wix-manage/references/stores/setup-online-store-catalog-v3.md`.
- Official Catalog V3 docs found during the turn say `Bulk Create Products` creates up to 100 products, so a 5-product cap is not an API limit.
- The product media and options recipe is only appropriate when options/variants/inventory/media are actually requested, not as a mandatory shape for every simple catalog.

Alternatives ruled out:
- Not a platform enum/validation issue: `activateSkill` succeeded and served the recipe.
- Not solely a downstream Stores API defect: the rejected request body contained recipe-induced/generated shape problems (`description` as plain string) and the recipe source contained the product count/media constraints.
- Not an Aria prompt-only fix: the bad guidance was authored in the `wix/skills` recipe served by Wix MCP; changing Aria would patch a consumer instead of the source.

## Change

This changes the Catalog V3 setup recipe so future agents:
- honor user-provided product lists/counts instead of forcing exactly 5 products,
- use 5 products only as a fallback starter catalog when the user did not provide a catalog,
- omit media unless the user provided image URLs, uploaded media, or Wix media references,
- use simple bulk products for simple products, and reserve options/inventory-specific flows for those requested cases,
- avoid plain string `description` values by using Catalog V3 rich-content objects or omitting descriptions,
- add compare-at pricing and stock status only when user-provided/requested.

Reviewer-oriented diff:
- `skills/wix-manage/references/stores/setup-online-store-catalog-v3.md`: rewrites Step 2 and the conclusion bullets around product count, media, description shape, compare-at pricing, and stock defaults.
- `yaml/wix-manage-evals/stores/setup-online-store-catalog-v3-user-products.yml`: adds a non-mutating eval for an 11-product gelato catalog with short descriptions and no images.

## Side effects and rollout risk

The fix is bounded to `setup-online-store-catalog-v3`. It does not change the general `bulk-create-products-with-options` recipe or the Wix MCP tool implementation. The expected side effect is that agents will create fewer fabricated sample/media fields and ask/omit when data is unavailable. Existing flows that truly need options, inventory, compare-at prices, or media still point to the relevant endpoints/recipe.

This PR intentionally does not include the separate category-sequencing fix from #628, which touches a different Step 3 behavior in the same recipe.

## Verification

- Fix proof: local recipe diff removes the exact bad instructions served in log `6387d8e9-f31b-4bd5-a491-16586d96c491`, and the new eval asserts the Hugmill-style scenario: 11 user products, no images, no mutations, no plain string descriptions.
- Safety & ownership: this edits the authoring source in `wix/skills`, not an Aria prompt or platform wrapper. The mechanism is deterministic, transparent, and scoped to one recipe. No regex/scrubbing of foreign content.
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("yaml/wix-manage-evals/stores/setup-online-store-catalog-v3-user-products.yml"); puts "yaml ok"'`
- `fnm use && yarn install` was attempted after branch creation as required by local workflow, but Corepack failed to download Yarn from `registry.yarnpkg.com` with `ENOTCONN`; package-dependent local checks were not runnable in this session.
- GitHub PR checks: `EvalForge YAML Gate / gate` passed; `Check @wix/cli pinned to @latest / check` passed; `Skill Eval / skill-eval` was skipped by the repo workflow.
- PR skills-override smoke test: `AGENT_TESTING` conversation `https://wix-bo.com/ai-assistant/conversations/05d4b7c9-c991-40ad-aabd-719e8818e279` used `skillsRepo=wix/skills` and `skillsPr=8ba1206bff5dff556137b4e190c53a88bf77bcb5` with the affected recipe as the initial skill. The assistant summarized the fixed behavior for an 11-product gelato setup: keep all 11 products, omit media fields, and use rich-content descriptions rather than plain strings.
- Residual verification note: the first two routing smoke prompts did not activate the recipe, and the successful initial-skill smoke path does not produce an `activateSkill` tool-result log. Its turn also logged one existing `DIAGNOSTIC_DATA_ITEM_ERROR` from dynamic knowledge. The PR eval/YAML gate remains the reviewer-runnable end-to-end gate for served recipe content.
