### PR TITLE
Fix Stores collection lookup in discount rule recipe

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
@@ -17,6 +17,7 @@ layer: config
 - [Query Discount Rules](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/discount-rules/query-discount-rules)
 - [Update Discount Rule](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/discount-rules/update-discount-rule)
 - [Delete Discount Rule](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/extensions/discounts/discount-rules/delete-discount-rule)
+- [Query Data Items](https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-data-items) for looking up Wix Stores collection IDs from the `Stores/Collections` app collection
 
 ---
 
@@ -123,6 +124,29 @@ Filterable fields: `id`, `name`, `active`, `revision`, `created_date`, `updated_
 ```
 
 Note existing rules and their scopes to avoid stacking conflicts.
+
+---
+
+## Before creating a collection-scoped rule: resolve the Stores collection ID
+
+If the merchant names a Wix Stores collection/category but doesn't provide its ID, resolve the ID before creating the discount rule. Use the Wix Data Items API against the Stores app collection:
+
+```json
+POST https://www.wixapis.com/wix-data/v2/items/query
+{
+  "dataCollectionId": "Stores/Collections",
+  "query": {
+    "filter": {
+      "name": { "$eq": "Summer" }
+    },
+    "paging": { "limit": 100 }
+  }
+}
+```
+
+Read the collection GUID from the returned `dataItems` entry (`data._id`, or `id` if the response exposes it on the wrapper) and the display name from `data.name`. If there is no exact match, return the closest collection names/IDs and ask the merchant to choose; do not create a collection-scoped rule with a guessed ID.
+
+Do **not** use `POST https://www.wixapis.com/categories/v1/categories/query` to look up legacy Wix Stores collections. That endpoint is Catalog V3 Categories and may require the Categories app, causing `APP_NOT_INSTALLED` even when Wix Stores is installed. Use it only when the task is explicitly about Catalog V3 categories, not Stores collections used in discount scopes.
 
 ---
 
@@ -603,7 +627,7 @@ All recommendation-created rules use these fixed settings:
 | `INVALID_DISCOUNT_TYPE` | Unsupported discount type | Use `PERCENTAGE` or `FIXED_AMOUNT` |
 | Both `productIds` and `categoryIds` set | Scope mutual exclusivity violation | Use only one: ITEMS with productIds OR CATEGORY with categoryIds |
 | `productIds` empty when scope is ITEMS | Missing required IDs | Query products and provide at least 1 product UUID |
-| `categoryIds` empty when scope is CATEGORY | Missing required IDs | Call getCategoryIds to convert category names to GUIDs |
+| `categoryIds` empty when scope is CATEGORY | Missing required IDs | Query `Stores/Collections` with the Wix Data Items API to convert collection names to GUIDs |
 
 ## References
 

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule-collection-lookup.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule-collection-lookup.yml
@@ -1,0 +1,31 @@
+name: ecommerce/pricing-promotions/create-discount-rule-collection-lookup
+description: Verifies that collection-scoped discount-rule guidance resolves Wix Stores collection names through Stores/Collections instead of Catalog V3 Categories.
+triggerPrompt: |
+  For my Wix store, prepare the API calls to apply a 15% automatic discount to every product in the "Summer" collection.
+
+  Do not execute any mutating calls. I only need the lookup call and the discount-rule payload shape you would use after the collection ID is resolved.
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants a non-mutating plan for a 15% automatic discount scoped to the "Summer" Wix Stores collection.
+
+      Pass if ALL of these are true:
+        1. The agent loaded the `pricing-create-discount-rule` recipe.
+        2. The plan resolves the collection ID by querying `POST https://www.wixapis.com/wix-data/v2/items/query` with `dataCollectionId: "Stores/Collections"` and a name-based lookup for "Summer".
+        3. The discount-rule payload uses a collection/CATEGORY scope with `customFilter.appId` (or equivalent catalog app ID field) set to `215238eb-22a5-4c36-9e7b-e7c08025e04e` and `collectionIds` populated from the lookup result.
+        4. The response stays non-mutating: it does not actually create or update a discount rule.
+
+      Fail if ANY of these are true:
+        - The agent uses `POST https://www.wixapis.com/categories/v1/categories/query` for the Stores collection lookup.
+        - The agent treats a human-readable collection name as the collection ID.
+        - The agent makes the discount catalog-wide instead of collection-scoped.
+        - The agent asks the user to manually provide the collection ID without showing the documented lookup path.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/3aa0eb73-9e90-4a06-881a-5704733e1d97
Feedback: Applying a 15% automatic discount to the "Summer" Stores collection failed because the agent tried `POST https://www.wixapis.com/categories/v1/categories/query`, which returned `428 APP_NOT_INSTALLED` for appId `f534c0d3-dd59-4047-a86a-be3234d4591f`.

## Conversation research

The reported issue is a true issue. The user asked: "Apply a 15% discount to all items in the Summer collection." The assistant activated `pricing-create-discount-rule`, tried to discover the collection ID, hit an `ExecuteWixAPI` `TOOL_FAILED`, then responded that it was blocked and asked the merchant to provide the collection ID instead of completing the requested discount.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/3aa0eb73-9e90-4a06-881a-5704733e1d97`: assistant message `468ae115-f243-4bb2-9897-6b61a041fc3d`; activated skill log `763bbf12-b6d7-492a-a4cf-18abe3bcadf1` (`pricing-create-discount-rule`); failing tool call log `78198519-f558-40c9-a122-39e2741e1c00`; failing result log `7be80abf-5044-419e-96f7-e2d8d5562198`.

## Code/content research

Root cause: the discount-rule recipe covered collection-scoped discount payloads, but did not document how to resolve a merchant-provided Wix Stores collection name to a collection GUID. The model filled that gap by reading Catalog V3 Categories docs and calling `categories/v1/categories/query` with `treeReference.appNamespace: "@wix/stores"`. That endpoint is not the right legacy Stores collection lookup for this flow and can require the Categories app even when Wix Stores is installed.

Why this is the owning surface:
- The conversation's `activateSkill` call loaded `pricing-create-discount-rule`.
- The recipe's error table said `categoryIds` empty -> "Call getCategoryIds to convert category names to GUIDs", but no concrete Wix MCP/API path was provided.
- Official docs for Wix Stores app collections document `POST https://www.wixapis.com/wix-data/v2/items/query` with `dataCollectionId: "Stores/Collections"` for querying Stores collections, and the Data Item FQDN identifies `QueryDataItems` as `POST /v2/items/query` returning `dataItems`.

Alternatives ruled out:
- Wix MCP execution infra: it correctly surfaced the upstream 428 from the wrong API call; the bad decision was which lookup API to call.
- Categories API owner: the Catalog V3 Categories endpoint is valid for Catalog V3 categories; the defect is using it for legacy Stores collection IDs.
- No-fix/self-recovered: the assistant status was `COMPLETED`, but the requested discount was not created and the user was asked to provide an ID manually, so this was not a successful recovery.

Impact & frequency:
- App logs for `com.wixpress.genie.agent-platform-service`, 2026-07-14T02:02:01Z through 2026-07-21T02:02:01Z, found 21 distinct requests matching `categories/v1/categories/query` + `APP_NOT_INSTALLED` across 2026-07-14, 2026-07-15, 2026-07-16, and 2026-07-20.

## Change

This updates the `pricing-create-discount-rule` recipe so agents resolve Wix Stores collection names through the Wix Data `Stores/Collections` app collection before creating collection-scoped discount rules.

Reviewer-oriented diff:
- `skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md`: adds Query Data Items as a required API, documents the non-mutating `Stores/Collections` lookup by name, warns not to use `categories/v1/categories/query` for legacy Stores collection lookup, and replaces the vague `getCategoryIds` instruction.
- `yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule-collection-lookup.yml`: adds a non-mutating eval that requires the correct lookup path and fails if the agent uses the Catalog V3 Categories endpoint or treats a collection name as an ID.

## Side effects and rollout risk

The change is bounded to the Wix Manage discount-rule recipe and a covering eval. It does not change MCP tool code, API behavior, assistant rollout, or any mutating runtime path. The main residual risk is response-shape nuance for Wix Data app collections; the recipe tells agents to read from returned `dataItems` and preserve ambiguity by asking the merchant to choose if no exact match is found.

## Verification

- Fix proof: added an eval scenario that exercises the original generic failure mode without mutating a site. The PR eval gate will serve this branch's skill content via `skillsRepo=wix/skills&skillsPr=<headSha>` and verify the agent uses `wix-data/v2/items/query` with `Stores/Collections`, not `categories/v1/categories/query`.
- Safety & ownership: clears the gate because the fix is deterministic authored content in `wix/skills`, not a regex rewrite, guard-side relaxation, or consumer patch. It lands in the recipe that omitted the lookup path and is bounded by a direct eval.
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.yml yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule-collection-lookup.yml`
- `git diff --check`
- Not run locally: AGENT_TESTING `ai-assistant__SendMessage` with `skillsRepo=wix/skills` and `skillsPr=a8aaea9837f6f37354e3298ca6b0e44ff133642c` failed at chat-service `CreateConversation` with `UNAUTHENTICATED` (request IDs `1784599721.88725687563156` and `1784599741.49325406375155`). The reviewer-runnable proof path is the PR eval scenario `ecommerce/pricing-promotions/create-discount-rule-collection-lookup`, which serves the PR content via the same skills override.
