### PR TITLE
fix(wix-manage): document bulk product response shape

### DIFF
--- a/skills/wix-manage/references/stores/bulk-create-products-with-options.md
+++ b/skills/wix-manage/references/stores/bulk-create-products-with-options.md
@@ -39,6 +39,25 @@ Learn how to create multiple Wix store products with customizable options like c
 
 * Missing `itemsInfo` section in media (media won't work)
 * Missing URL parameters `?w=400&h=400&fit=crop&crop=center`
+* Treating a successful response as empty because the response does **not** return top-level `products`, `items`, `results`, or `createdProducts` arrays.
+
+**CRITICAL: Successful response shape**
+
+When `returnEntity: true`, parse created products from:
+
+```js
+const productResults = resp.data?.productResults;
+const results = productResults?.results ?? [];
+const created = results
+  .filter(({ itemMetadata }) => itemMetadata?.success !== false)
+  .map(({ item }) => item)
+  .filter(Boolean);
+
+const failed = results.filter(({ itemMetadata }) => itemMetadata?.success === false);
+const metadata = productResults?.bulkActionMetadata;
+```
+
+Use `created.length` or `metadata.totalSuccesses` as the created count, and inspect `failed` / `metadata.totalFailures` before retrying. Do **not** use `resp.data.products`, `resp.data.items`, `resp.data.results`, or `resp.data.createdProducts`; those fields are not the response shape for this endpoint and will make a successful bulk create look empty.
 
 ## Article: Steps for Bulk Creating Wix Store Products with Options
 
@@ -950,6 +969,7 @@ curl -X POST "https://www.wixapis.com/stores/v3/bulk/products-with-inventory/cre
 * **URL**: `https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create`
 * **Body**: `{"products": [array of product objects]}`
 * Each product in the array follows the exact same format as single product creation
+* **Response**: successful product entities are in `productResults.results[].item`; per-product success/failure is in `productResults.results[].itemMetadata`; aggregate success/failure is in `productResults.bulkActionMetadata`; inventory results are separate under `inventoryResults`.
 
 **CRITICAL: Description Format**If you include a description, it MUST use Wix's rich text nodes structure, NOT a plain string. Plain strings will cause "Expected an object" API errors.
 

--- a/yaml/wix-manage-evals/stores/bulk-create-products-response-shape.yml
+++ b/yaml/wix-manage-evals/stores/bulk-create-products-response-shape.yml
@@ -1,6 +1,6 @@
 name: stores/bulk-create-products-response-shape
-description: Verifies the bulk create products skill explains the Catalog V3 response shape without performing a mutating product create.
-triggerPrompt: I am using the Wix Stores Catalog V3 bulk create products with inventory endpoint with returnEntity true. How should I parse the response to get the created product IDs and detect partial failures? Do not create or update any products.
+description: Verifies the bulk create products recipe explains the Catalog V3 products-with-inventory response shape during a non-mutating setup plan.
+triggerPrompt: I want you to set up a new Wix online store catalog for a sneaker shop with 5 products, each with size and color options. Start by loading the relevant Wix Stores setup/product-creation guidance, then pause before making any API calls and tell me the response parsing check you will use after the bulk create products-with-inventory call. Do not call ExecuteWixAPI, do not create products, and do not update the site yet.
 tags: [stores]
 siteSetup:
   mode: template
@@ -13,6 +13,6 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: |
-      Context: the user is asking only how to parse the response from the Catalog V3 Bulk Create Products With Inventory endpoint after using returnEntity true. They explicitly said not to create or update products.
-      Pass if the response (a) loads the bulk-create-products-with-options-catalog-v3 skill, (b) explains that created products are under productResults.results[].item, (c) explains that per-item success/failure is under productResults.results[].itemMetadata and aggregate counts are under productResults.bulkActionMetadata, and (d) does not call a mutating Wix API or tell the user to parse top-level products/items/results/createdProducts arrays.
+      Context: the user is asking for a non-mutating setup plan and specifically asks how the assistant will parse the Catalog V3 Bulk Create Products With Inventory response after using returnEntity true.
+      Pass if the response (a) loads or reads the bulk-create-products-with-options-catalog-v3 guidance, (b) explains that created products are under productResults.results[].item, (c) explains that per-item success/failure is under productResults.results[].itemMetadata and aggregate counts are under productResults.bulkActionMetadata, and (d) does not call a mutating Wix API or tell the user to parse top-level products/items/results/createdProducts arrays.
       Fail if the response treats top-level products, items, results, or createdProducts as the response source, omits partial-failure handling, recommends blindly retrying the whole bulk request after an empty parsed array, or performs a mutating tool call despite the user's instruction.

--- a/yaml/wix-manage-evals/stores/bulk-create-products-response-shape.yml
+++ b/yaml/wix-manage-evals/stores/bulk-create-products-response-shape.yml
@@ -1,0 +1,18 @@
+name: stores/bulk-create-products-response-shape
+description: Verifies the bulk create products skill explains the Catalog V3 response shape without performing a mutating product create.
+triggerPrompt: I am using the Wix Stores Catalog V3 bulk create products with inventory endpoint with returnEntity true. How should I parse the response to get the created product IDs and detect partial failures? Do not create or update any products.
+tags: [stores]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/bulk-create-products-with-options-catalog-v3
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Context: the user is asking only how to parse the response from the Catalog V3 Bulk Create Products With Inventory endpoint after using returnEntity true. They explicitly said not to create or update products.
+      Pass if the response (a) loads the bulk-create-products-with-options-catalog-v3 skill, (b) explains that created products are under productResults.results[].item, (c) explains that per-item success/failure is under productResults.results[].itemMetadata and aggregate counts are under productResults.bulkActionMetadata, and (d) does not call a mutating Wix API or tell the user to parse top-level products/items/results/createdProducts arrays.
+      Fail if the response treats top-level products, items, results, or createdProducts as the response source, omits partial-failure handling, recommends blindly retrying the whole bulk request after an empty parsed array, or performs a mutating tool call despite the user's instruction.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/53c15064-423a-4642-8014-cc27bde8df54
Feedback: Stores V3 bulk create products with inventory returned `createdCount: 0` with no error after calling `POST https://www.wixapis.com/stores/v3/bulk/products-with-inventory/create` with `returnEntity: true`; the agent parsed `resp.data.products` / `resp.data.items`, which are not the actual response fields.

## Conversation research

The reported issue is a true issue, but the turn self-recovered. In https://wix-bo.com/ai-assistant/conversations/53c15064-423a-4642-8014-cc27bde8df54, message `253cb0e1-79da-4923-ae75-1c94f6eed451` called `ExecuteWixAPI` against the bulk create endpoint and returned `createdCount: 0` / `products: []` in log `6ab89bb3-eb04-4af8-92a1-605c1339cfcf`. The code in the preceding tool call read only `resp.data?.products ?? resp.data?.items ?? []`.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/53c15064-423a-4642-8014-cc27bde8df54`: user approved creating a Stores V3 catalog; the assistant initially interpreted a successful bulk-create response as empty, filed `sendFeedback` as Wix MCP, then later recovered after inspecting the API spec and response shape.

The recovery evidence is in the same conversation: the raw/spec-backed response shows `productResults.results[].item` and `productResults.bulkActionMetadata`, and a later tool result in message `34bacc11-ff3f-4088-b98f-ff0e10306881` returned `createdCount: 5` after parsing `productResults.results`.

Impact/frequency: querying `com.wixpress.genie.agent-platform-service` logs from 2026-07-13 through 2026-07-20 found the exact self-feedback signature (`returned createdCount 0` + the bulk create endpoint) on 19 distinct request IDs. The broader endpoint appeared on 1,356 distinct requests in the same window. Even when the turn recovers, this costs extra agent iterations and can cause mutating retries.

## Code/content research

Root cause: the `wix-manage` bulk-create recipe documented request shape and partial-failure retry guidance, but did not document the successful response shape. That left agents to infer a top-level `products` / `items` / `results` array and treat successful creates as empty.

Why this is the owning surface:
- The conversation activated `setup-online-store-catalog-v3`, which explicitly instructs the agent to pull up `bulk-create-products-with-options-catalog-v3` before creating products.
- The activated `bulk-create-products-with-options-catalog-v3` recipe contains request-shape guidance but no `productResults.results[].item` response guidance.
- The official method schema returned by `SearchWixAPISpec` for `Bulk Create Products With Inventory` shows response fields `productResults.results`, `productResults.bulkActionMetadata`, and `inventoryResults`.
- A sibling `wix-headless` recipe already documents that created products are under `productResults.results[]`, so this change aligns the divergent `wix-manage` recipe with existing repo guidance.

Alternatives ruled out:
- Wix MCP runtime/tool mapping: the bad `createdCount: 0` was generated by agent-authored ExecuteWixAPI JavaScript, not by a platform parser.
- Downstream Stores API: the API returned 200 and the schema/raw response contain the successful results under the documented fields.
- Genie platform: the decision/tool logs show the model chose the parser and then self-recovered; no platform validation or execution bug blocked the turn.

## Change

This changes `skills/wix-manage/references/stores/bulk-create-products-with-options.md` so agents parse successful creates from `resp.data.productResults.results[].item`, inspect `itemMetadata` / `bulkActionMetadata` for failures, and avoid retrying based on empty top-level `products`, `items`, `results`, or `createdProducts` fields.

Reviewer-oriented diff:
- `skills/wix-manage/references/stores/bulk-create-products-with-options.md`: adds a response-shape section and reinforces the response fields next to the endpoint/body summary.
- `yaml/wix-manage-evals/stores/bulk-create-products-response-shape.yml`: adds a non-mutating eval that asks how to parse the response and fails if the agent uses top-level arrays, omits partial-failure handling, or calls a mutating API.

## Side effects and rollout risk

This is bounded to the Stores bulk-create recipe guidance. It does not change APIs, tools, schemas, production rollout, or any generated code path. The main side effect is improved agent behavior for agents that read this recipe: fewer false empty results and fewer unsafe retries.

## Verification

- Fix proof: the official `SearchWixAPISpec` result in the broken conversation confirms `BulkCreateProductsWithInventoryResponse` contains `productResults.results`, `productResults.bulkActionMetadata`, and `inventoryResults`; the recipe now instructs exactly that parser.
- Safety & ownership: this clears the Safety & Ownership gate because the fix lands in the authoring content that caused the bad inference, is deterministic docs guidance, does not rewrite another team's runtime output, and is bounded to the relevant skill recipe. The turn self-recovered, but measured recurrence is 19 distinct request IDs in 8 days and the failure can trigger repeated mutating creates, so source guidance is justified.
- `git diff --check`
- Ruby YAML parse/shape check for `yaml/wix-manage-evals/stores/bulk-create-products-response-shape.yml`
- GitHub EvalForge YAML Gate passed on current head `0b1a4c281f9e3fed9af961b288126e5e12949d29`; `check` passed; `skill-eval` skipped as expected. Not run locally: full EvalForge action tests, because the local action dependencies were not installed and Corepack failed while trying to download Yarn.
- Aria AGENT_TESTING smoke through the skills PR override using current head `0b1a4c281f9e3fed9af961b288126e5e12949d29`: https://wix-bo.com/ai-assistant/monitoring/conversations/7917211d-c15c-4156-ba4c-1051a99327bc. The assistant activated `setup-online-store-catalog-v3`, read `bulk-create-products-with-options-catalog-v3`, made no `ExecuteWixAPI` calls, and the `ReadFullDocsArticle` tool-result log `15d5467d-130b-4e83-b103-68b86942b74d` contains the new PR text: `productResults.results[].item`, `itemMetadata`, `bulkActionMetadata`, separate `inventoryResults`, and the warning not to parse top-level `products` / `items` / `results` / `createdProducts` arrays. The smoke message has two `DIAGNOSTIC_DATA_ITEM_ERROR` logs from Business Knowledge failing to extract tenant in AGENT_TESTING without site context; these are not the known `Unknown output type` corruption case and are unrelated to this skills-repo content change.
