### PR TITLE
Clarify Semantic Model typed value access

### DIFF
--- a/skills/wix-manage/references/analytics/query-site-analytics.md
+++ b/skills/wix-manage/references/analytics/query-site-analytics.md
@@ -72,6 +72,7 @@ This guesses field names, ignores each field's `dependencies` (so those fields c
 - **Sorting a nullable measure — set `sort.nullsLast: true`.** `nullsLast` defaults to `false` and only affects **descending** (`DESC`) order. If a measure can return null and you sort it `DESC`, the null rows sort *first* — so a "top N" query surfaces nulls before your real values. Set `nullsLast: true` to push nulls to the end.
 - **Result cap: 1,000 rows per query.** `results` is capped at 1,000 rows — paginate with `paging.offset` for larger datasets.
 - **Formatting is opt-in.** Set `formattingEnabled: true` to also receive a human-readable `formattedValue` per cell (e.g. `1500` → `"$1,500.00"` or `1.5K`). Raw typed values are always returned.
+- **Typed values are primitives — not `{ value }` wrappers.** In each `results[].fields[fieldName]` cell, `numericValue` is the number itself, `stringValue` is the string itself, `booleanValue` is the boolean itself, and `timestampValue` is the ISO timestamp string itself. Do **not** read `cell.numericValue.value`, `cell.stringValue.value`, or similar nested `.value` properties — they will be `undefined` and make real data look null.
 - **Totals are opt-in.** Set `totalsIncluded: true` to get a `totals` row summing numeric fields across the **full (unpaginated)** result set.
 - **Unique fields are not additive.** For `unique` measures (e.g. unique visitors), query the exact time range you want in a **single request** — never sum values from separate date-range queries. Uniques are deduplicated within each queried range, so adding per-range results double-counts anyone who appears in more than one range and overstates the true total.
 
@@ -214,6 +215,29 @@ curl -X POST \
 
 Each cell in `results[].fields` is a typed value — one of `numericValue`, `stringValue`, `booleanValue`, `timestampValue`, `arrayValue`, or `objectValue` — plus `formattedValue` when `formattingEnabled` is `true`. `totals` is present only when `totalsIncluded` is `true`.
 
+When transforming rows in code, read the typed values directly:
+
+```js
+function rawCellValue(row, fieldName) {
+  const cell = row?.fields?.[fieldName];
+  if (!cell) return null;
+  if ("numericValue" in cell) return cell.numericValue;
+  if ("stringValue" in cell) return cell.stringValue;
+  if ("booleanValue" in cell) return cell.booleanValue;
+  if ("timestampValue" in cell) return cell.timestampValue;
+  if ("arrayValue" in cell) return cell.arrayValue;
+  if ("objectValue" in cell) return cell.objectValue;
+  return null;
+}
+
+function displayCellValue(row, fieldName) {
+  const cell = row?.fields?.[fieldName];
+  return cell?.formattedValue ?? rawCellValue(row, fieldName);
+}
+```
+
+Do not use `row.fields[fieldName].numericValue.value` or `row.fields[fieldName].stringValue.value`; those paths do not exist in the Semantic Model API response.
+
 ## Time zone (match the Wix dashboard)
 
 Analytics shown in the Wix business manager are aggregated by the **site's time zone**. To return numbers that match what the site owner sees, pass that time zone in `interval.timezone` on every query. **When `timezone` is omitted, the API defaults to UTC** — which shifts day boundaries and produces totals that don't line up with the dashboard (the same applies to any non-site time zone).
@@ -284,9 +308,10 @@ Silent gap (no error): a requested field returns no data because none of its `de
 2. Pass the site's time zone (`properties.timeZone` from Get Site Properties) in `interval.timezone` **and** set `start`/`end` to local-midnight-in-UTC for that zone (DST-aware) so results match the Wix dashboard. `start`/`end` are absolute instants, not wall-clock.
 3. Include a field's `dependencies` in the query, or expect that field to be silently dropped.
 4. After each query, validate the response — confirm every requested field appears in `results[].fields`. A wrong field either errors (`4XX`, e.g. `fieldIsInvalid`) or is silently dropped from a `200`; a missing field means an unknown name or a missing dependency. Fix and re-query rather than trusting the partial result. Choose fields by reading their `description` (honoring "do not use" notes), never by name pattern.
-5. Use `formattingEnabled: true` for anything shown directly to a user; keep raw values for calculations.
-6. Use `totalsIncluded: true` to get period totals alongside a paged breakdown in a single call.
-7. Keep `fields` minimal (projection) and paginate large result sets with `offset`.
+5. Read typed cell values directly (`numericValue`, `stringValue`, `booleanValue`, `timestampValue`); do not append `.value`. Use `formattedValue` for display when present, and keep raw values for calculations.
+6. Use `formattingEnabled: true` for anything shown directly to a user.
+7. Use `totalsIncluded: true` to get period totals alongside a paged breakdown in a single call.
+8. Keep `fields` minimal (projection) and paginate large result sets with `offset`.
 
 ## Related Documentation
 

--- a/yaml/wix-manage-evals/analytics/query-site-analytics-primitive-values.yml
+++ b/yaml/wix-manage-evals/analytics/query-site-analytics-primitive-values.yml
@@ -1,0 +1,36 @@
+name: analytics/query-site-analytics-primitive-values
+description: >-
+  Verifies the agent reads the query-site-analytics skill and explains that Semantic Model API
+  typed cell values are primitives, not nested value wrappers.
+triggerPrompt: >-
+  I'm querying Wix Semantic Model API traffic data with formattingEnabled and totalsIncluded.
+  My JavaScript maps sessions with row.fields["traffic.sessions_count"].numericValue.value and
+  source names with row.fields["traffic.referrer_source_name"].stringValue.value, but everything
+  becomes null even though the fields are present. What is the correct way to read these values?
+tags: [analytics]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/analytics/skills/query-site-analytics
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user is mapping Wix Semantic Model API response cells in JavaScript and is incorrectly
+      reading `numericValue.value` and `stringValue.value`, which makes present fields look null.
+      Intent: explain the actual response shape and show the correct access pattern.
+
+      Pass ONLY if the response:
+      - states that `numericValue`, `stringValue`, `booleanValue`, and `timestampValue` are the
+        primitive values themselves, not objects with a nested `.value`, AND
+      - explicitly corrects `row.fields["traffic.sessions_count"].numericValue.value` to reading
+        `row.fields["traffic.sessions_count"].numericValue` directly, AND
+      - explains that `formattedValue` is optional display text when `formattingEnabled` is true,
+        while raw typed values should be used for calculations.
+
+      Fail if the response:
+      - keeps or recommends `.numericValue.value`, `.stringValue.value`, or any nested `.value`
+        accessor for Semantic Model field cells, OR
+      - says the nulls mean the metric field is absent, the API has no data, or permissions failed
+        without first identifying the wrong accessor, OR
+      - gives generic JavaScript null-checking advice without the Semantic Model response shape.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/c2afbc1c-7bd9-4327-ac74-73ee04ef9761

Source: https://wix.slack.com/archives/C0BBRK0G7L7/p1784536694309129?thread_ts=1784536694.309129&cid=C0BBRK0G7L7

Feedback: Wix MCP / query-site-analytics returned rows and dimensions, but all numeric measures appeared as null, blocking the traffic baseline step.

## Conversation research

The reported issue is a true issue, but the feedback's proposed root cause was only a hypothesis. The logs show successful API/tool execution with no error logs, and the assistant-generated mapping code turned present typed values into nulls by reading nested `.value` fields that do not exist.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/c2afbc1c-7bd9-4327-ac74-73ee04ef9761`: the user asked Aria to grow site traffic, then approved the plan. Assistant message `d5e7f858-46f8-42a0-baa0-edf67cefcbea` called `ExecuteWixAPI` in log `a1d2e26f-e464-4995-a6b3-171b36c20ce7` and mapped totals as `totalsRow["traffic.sessions_count"]?.numericValue?.value ?? null`; result log `3b696e5a-eef1-4721-9693-2d07553bc9b5` showed page/source dimensions but null sessions/visitors/views. The retry message `ca622686-faf2-487e-acd8-212ed4aae633` repeated the same bad accessor in log `714fc69b-4d5a-4db5-8742-49bc6de7a6cf`, with null numeric output in result log `c6e431e1-766f-48d8-90a4-b6eafcb7f572`.
- Both affected turns had zero `errors` log-group entries (`d5e7f858-46f8-42a0-baa0-edf67cefcbea`, `ca622686-faf2-487e-acd8-212ed4aae633`), so this was not a `TOOL_FAILED`, auth, validation, or upstream 4xx/5xx failure.

Impact and frequency:
- Production app-log query over `com.wixpress.genie.agent-platform-service` from `2026-07-14T00:00:00Z` through `2026-07-21T23:59:59Z` found 4,607 distinct request IDs whose logged Semantic Model code used `numericValue?.value`. Daily request counts: Jul 14 1,390; Jul 15 1,382; Jul 16 1,050; Jul 17 141; Jul 18 205; Jul 19 155; Jul 20 199; Jul 21 partial 85.
- Narrow self-report phrase `Semantic Model analytics measures returning null` appeared on 3 distinct requests on Jul 20. The broader code-pattern count is not a verified broken-conversation count, but it proves this bad generated code path is recurring at production scale. Per occurrence, real analytics values can be interpreted as null, wasting at least one model/tool iteration and potentially blocking the user's analytics answer.

## Code/content research

Root cause: the `query-site-analytics` recipe showed the response shape, but did not explicitly warn that Semantic Model cell typed values are primitive one-of fields. The agent generated JavaScript that treated `numericValue` and `stringValue` like wrapper objects (`numericValue.value`, `stringValue.value`), so present data became `undefined` and then `null`.

Why this is the owning surface:
- The activated skill was `query-site-analytics`, sourced from `skills/wix-manage/references/analytics/query-site-analytics.md`.
- Official method schema for Query Semantic Model Data says `results[].fields` values are `Map<string, FieldValue>`, where `numericValue` is `type: number`, `stringValue` is `type: string`, `booleanValue` is `type: boolean`, and `timestampValue` is `type: string`; `formattedValue` is optional display text.
- The code/content fix belongs in the recipe because the agent's generated API-handling code followed that recipe and did not have a platform/tool execution failure.

Alternatives ruled out:
- API outage/auth/permissions: no error logs and successful `ExecuteWixAPI` tool results.
- Invalid field names/dependencies: the assistant first fetched the `traffic` model schema; the queried numeric measures in the schema had empty dependencies.
- Platform wrapper bug: the bad value was produced by assistant-generated JavaScript, not by a shared platform mapper or enforcement point.

## Change

This updates the analytics recipe so future generated code reads Semantic Model typed cells directly.

Reviewer-oriented diff:
- `skills/wix-manage/references/analytics/query-site-analytics.md`: adds a sharp-edge warning that `numericValue`, `stringValue`, `booleanValue`, and `timestampValue` are primitive fields, not `{ value }` wrappers; adds raw/display helper functions; updates best practices to forbid nested `.value` access.
- `yaml/wix-manage-evals/analytics/query-site-analytics-primitive-values.yml`: adds a covering eval that asks about `numericValue.value` / `stringValue.value` nulls and fails if the agent keeps the nested `.value` accessor or misroutes the issue to data absence/permissions first.

## Side effects and rollout risk

Low. This is scoped to one Wix Manage analytics recipe and one eval. It does not alter APIs, tool schemas, assistant rollout, or platform code. It should only change generated code for Semantic Model API response parsing.

Residual risk: this does not solve real analytics outages or missing-data cases; it only prevents a present typed value from being converted to null by bad generated JavaScript. The PR eval gate is the end-to-end verification path for `wix/skills` content.

## Verification

- Fix proof: official Query Semantic Model Data schema confirms `numericValue` is `number` and `stringValue` is `string`; the changed recipe now explicitly says to read `cell.numericValue` / `cell.stringValue` directly and the new eval enforces that behavior.
- Safety & ownership: passes. The turn did not self-recover; the user was blocked twice. The fix is deterministic, bounded to the authoring `wix/skills` recipe, and does not patch a downstream guard or rewrite foreign content.
- `git diff --check`
- `ruby -e 'require "yaml"; files = Dir["yaml/wix-manage-evals/**/*.yml"]; files.each { |f| YAML.load_file(f) }; puts "parsed #{files.length} eval YAML files"'` -> `parsed 43 eval YAML files`
- `node scripts/check-truncation.mjs --limit=10000` ran as a diagnostic. The analytics recipe remains over 10k chars, but the new primitive-value warning is before the 10k cutoff; no broad restructuring was included in this feedback fix.
- Not run locally: EvalForge skill execution. The PR's `wix/skills` eval gate is expected to run the covering scenario against the PR-version docs.
