### PR TITLE
fix(wix-manage): require exact app install matches

### DIFF
--- a/skills/wix-manage/references/app-installation/install-wix-apps.md
+++ b/skills/wix-manage/references/app-installation/install-wix-apps.md
@@ -49,7 +49,12 @@ Use the returned `appId` as the `appDefId` in Step 2.
 
 ### IMPORTANT NOTES
 - The `appDefId` field in the install request and the `appId` field returned here are the same value
-- If multiple results come back, match on `basicInfo.name` to confirm you have the right app before installing
+- Search results are only candidates. Before installing, confirm the exact intended listing by one of:
+  - exact `basicInfo.name` match to the app name the user asked for,
+  - an app URL/app ID the user provided, or
+  - explicit user confirmation after you show the candidate listing name and purpose.
+- Do **not** install an app from a broad or fuzzy match such as `name.includes("sheets")`, category overlap, or the first search result. If the user named a capability or integration rather than a specific app, ask for the exact listing or route to the product/API flow that implements the capability.
+- For workflow/integration requests, verify that the found app performs that workflow before installing it. For example, a user who wants Wix Forms submissions sent to Google Sheets needs a Forms/Automations-to-Sheets workflow; do not install a Google Sheets table display/viewer app just because it matches "Google Sheets".
 - Only listings with `status: "PUBLISHED"` can be installed
 
 ## Install the Wix App
@@ -130,5 +135,6 @@ After installing an app:
 ## Common Pitfalls
 
 - **"I don't have the appDefId"** → Run Step 0. The table in Step 2 only covers Wix-built apps; the App Market has thousands of others.
+- **Broad App Market matches are not install approval** → If the search term is a product family or capability ("Google Sheets", "forms to sheets", "chat", "analytics"), treat results as candidates and stop unless the result is the exact app or the user confirms it. Installing the wrong app is worse than asking one clarifying question.
 - **Don't try to scrape the App Market website to find IDs** — pages are client-rendered and the appId is not in the HTML. Use Search Market Listings instead.
 - **Don't try `InstallAppFromShareUrl` as a workaround for unknown IDs** — `shareUrlId` is an internal identifier you generally don't have either.

--- a/yaml/wix-manage-evals/app-installation/avoid-broad-google-sheets-app-install.yml
+++ b/yaml/wix-manage-evals/app-installation/avoid-broad-google-sheets-app-install.yml
@@ -1,0 +1,32 @@
+name: app-installation/avoid-broad-google-sheets-app-install
+description: >-
+  Verifies the agent does not recommend installing a broad Google Sheets display
+  app when the user wants Wix Forms submissions sent to Google Sheets.
+triggerPrompt: >-
+  I want Wix Forms submissions to go into Google Sheets. The only App Market
+  result I found for "Google Sheets" is "Google Sheets Table Display". Which app
+  should I install with the Apps Installer API?
+tags: [app-installation]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/install-wix-apps
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants Wix Forms submissions sent to Google Sheets, but the only
+      App Market result they found is "Google Sheets Table Display".
+      Intent: prevent the agent from installing a broad/fuzzy App Market match
+      that displays a sheet instead of handling form-submission sync.
+
+      Pass if the response:
+      - says not to install "Google Sheets Table Display" for this Forms-to-Sheets workflow, AND
+      - explains that Apps Installer should only be used after confirming the exact intended app listing/appId or explicit user confirmation, AND
+      - advises using the appropriate Forms/Automations-to-Google-Sheets workflow or finding the exact Forms-to-Sheets listing instead of a display/viewer app.
+
+      Fail if the response:
+      - recommends installing "Google Sheets Table Display", OR
+      - says to install any app just because its name contains "Google Sheets" or "Sheets", OR
+      - provides an appDefId/install request for an unverified App Market search result, OR
+      - treats a table display/viewer app as equivalent to sending Wix Forms submissions to Google Sheets.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/645a8f6c-28f6-481f-b3e4-6a4dcf316231
Feedback: Aria installed or considered the wrong App Market app while the user wanted Wix Forms submissions to sync into Google Sheets. The user reported that this capability used to exist but was no longer available on their account.

## Conversation research

The reported issue is a true issue. In the broken conversation, Aria handled a Forms-to-Google-Sheets integration request by activating the `install-wix-apps` recipe, searching the App Market broadly for `Google Sheets`, and installing `Google Sheets Table Display` (`appDefId: 843b20e7-7224-46f2-9963-9a8900e92caa`). That app is a display/viewer app, not a Wix Forms submissions-to-Google-Sheets workflow.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/645a8f6c-28f6-481f-b3e4-6a4dcf316231`: the user asked for Wix Forms submissions to go to Google Sheets. Message `6c620848-ac56-446b-b7b4-b63fea214ffc` activated `install-wix-apps`, searched broadly for `Google Sheets`, and installed `Google Sheets Table Display`. Later message `204e8b05-cd56-4007-b242-99961c9861e8` searched the exact `Wix Forms to Google Sheets` listing and found no published match, which confirms the earlier broad match should not have been treated as install approval.

## Code/content research

Root cause: the `install-wix-apps` recipe said to match on `basicInfo.name` when multiple results came back, but it did not explicitly forbid broad/fuzzy App Market matches before a mutating install. That left room for the agent to treat a `Google Sheets` display result as satisfying a Forms-to-Sheets integration request.

Why this is the owning surface:
- The bad turn was driven by the `install-wix-apps` wix-manage recipe guidance.
- The App Market search and Apps Installer APIs behaved as requested; the unsafe behavior was the recipe's install decision policy.
- The durable fix is to narrow when a search result becomes an installable candidate.

Alternatives ruled out:
- Product/API gap only: the exact Forms-to-Sheets listing appears unavailable, but the user-visible damage came from installing the wrong app before reaching that conclusion.
- Genie platform bug: no orchestration/runtime failure was needed to explain the behavior.
- App Market search bug: keyword search returning display apps for `Google Sheets` is expected; the agent must not install from a broad match without confirmation.

## Change

This changes the App Market lookup instructions so search results are treated only as candidates. The agent may install only after an exact `basicInfo.name` match to the requested app, a user-provided app URL/app ID, or explicit user confirmation after showing the candidate listing name and purpose.

Reviewer-oriented diff:
- `skills/wix-manage/references/app-installation/install-wix-apps.md`: adds an explicit decision policy forbidding broad/fuzzy matches such as `name.includes("sheets")`, category overlap, or first-result installs; adds a Forms/Automations-to-Sheets warning not to install Google Sheets display/viewer apps for submission-sync workflows.
- `yaml/wix-manage-evals/app-installation/avoid-broad-google-sheets-app-install.yml`: adds a non-mutating advisory eval covering this failure mode and requiring the agent to avoid recommending `Google Sheets Table Display` for Wix Forms-to-Sheets.

## Side effects and rollout risk

This affects App Market app installation decisions. It should reduce wrong-app installs for broad capability requests and may add one clarifying question when the user has not named an exact app listing. The change is intentionally bounded to the install decision step and still allows installs when the user provides an exact app, app URL, app ID, or confirms the candidate.

## Verification

- Fix proof: AGENT_TESTING smoke conversation https://wix-bo.com/ai-assistant/conversations/355fcfe0-2b6f-4024-b5f0-66eaea281a33 used `metadata.additionalMetadata` overrides for `skillsRepo: wix/skills` and `skillsPr: 8b1ccff15622971b67781b0651a4c1035640ab54`. The `activateSkill` tool-result log served the new recipe text, including "Search results are only candidates", "Do not install an app from a broad or fuzzy match", and the Forms/Automations-to-Sheets warning. The assistant response then explicitly said not to install `Google Sheets Table Display`.
- Safety & ownership: the fix lands in the authored wix/skills recipe that caused the unsafe decision. It is deterministic, transparent, and bounded to the install-candidate policy; it does not patch Genie platform behavior or add an opaque workaround.
- Local checks: Ruby YAML parse passed for the new eval scenario.
- Local checks: `git diff --check main...HEAD` passed.
- Local checks: eval name uniqueness was checked under `yaml/wix-manage-evals`.
- Residual risk: the smoke test also logged an unrelated Aria dynamic-knowledge diagnostic error. The served skill content and install decision path were still verified through the `activateSkill` log; the diagnostic is outside this wix/skills change.
