### PR TITLE
Fix Forms recipe to install Wix Forms before create

### DIFF
--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -10,9 +10,35 @@ Create a form on a Wix site that appears in the Forms & Submissions dashboard. T
 
 ---
 
+## Step 0: Ensure Wix Forms is installed
+
+The `wix.form_app.form` namespace is provided by **Wix Forms (New)**. Before the first Form Schemas `POST`, install or verify the Wix Forms app on the site.
+
+- Use appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2` for Wix Forms (New).
+- Do **not** use `14ce1214-b278-a7e4-1373-00cebd1bef7c` for this flow — that is Wix Forms (Old) and does not reliably activate the `wix.form_app.form` namespace for new form creation.
+- If the user has not already explicitly asked you to create or configure the form, ask before installing the app because app installation changes the site.
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instance/install' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  -d '{
+    "tenant": {
+      "tenantType": "SITE",
+      "id": "<SITE_ID>"
+    },
+    "appInstance": {
+      "appDefId": "225dd912-7dea-4738-8688-4b8c6955ffc2"
+    }
+  }'
+```
+
+After Wix Forms (New) is installed, create the form with `namespace: "wix.form_app.form"` as shown below.
+
 ## Create the form
 
-Call the Create Form endpoint with the `wix.form_app.form` namespace. The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) is usually already installed on sites.
+Call the Create Form endpoint with the `wix.form_app.form` namespace.
 
 ```bash
 curl -X POST \
@@ -290,7 +316,7 @@ The `postSubmissionTriggers.upsertContact` object maps form field targets to con
 
 ### Prerequisites
 
-The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be installed on the site. It is usually pre-installed, but if the API returns a "missing installed app" error, install it first using the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
+The Wix Forms (New) app (appDefId: `225dd912-7dea-4738-8688-4b8c6955ffc2`) must be installed on the site before creating a form in the `wix.form_app.form` namespace. Install it first using the Apps Installer API shown in Step 0, or the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe.
 
 ## Troubleshooting
 
@@ -300,8 +326,8 @@ The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be ins
 | Field silently missing from created form | Custom `identifier` value (e.g., `"product_name"`) | Use a recognized identifier like `TEXT_INPUT` and set display name via `label` |
 | Choice field rendered as a plain text box | `radioGroupOptions`/`dropdownOptions` malformed (wrong key, option missing `id`, empty `validation.enum`) — API silently falls back to `TEXT_INPUT` | Match the § "Choice fields" shape exactly: `componentType` in `stringOptions`, `options[]` each with a UUID `id`, and `validation.enum` listing all option values |
 | `maximum number of forms reached` / form-cap error | Sites cap at ~4 forms; reached by creating throwaway test forms | `GET form-schema-service/v4/forms` then `DELETE` the unwanted forms; build the real form in one call (don't probe) |
-| `Permissions for given namespace not found` | `wix.form_app.form` namespace not active | Ensure the Wix Forms app is installed; try creating a form through the UI first to activate the namespace |
-| `missing installed app` | Wix Forms app not installed | Install app `14ce1214-b278-a7e4-1373-00cebd1bef7c` via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
+| `Permissions for given namespace not found` / `UNSUPPORTED_FORM_NAMESPACE` | Wix Forms (New) is not installed or the `wix.form_app.form` namespace is not active for the site | Install Wix Forms (New) app `225dd912-7dea-4738-8688-4b8c6955ffc2` with the Apps Installer API, then retry the create call. Do not keep retrying the same Form Schemas request before installing the app |
+| `missing installed app` | Wix Forms (New) app not installed | Install app `225dd912-7dea-4738-8688-4b8c6955ffc2` via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |
 
 ## Related Documentation
 

--- a/yaml/wix-manage-evals/forms/create-form-install-wix-forms.yml
+++ b/yaml/wix-manage-evals/forms/create-form-install-wix-forms.yml
@@ -8,7 +8,6 @@ triggerPrompt: >-
   not be installed yet. Which API do you call first, which appDefId do you use,
   and what namespace should the form use?
 tags: [forms]
-maxTokens: 25000
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/forms/create-form-install-wix-forms.yml
+++ b/yaml/wix-manage-evals/forms/create-form-install-wix-forms.yml
@@ -1,0 +1,44 @@
+name: forms/create-form-install-wix-forms
+description: >-
+  Verifies the agent reads the create-form skill and knows to install Wix Forms
+  (New) before creating a form schema in the wix.form_app.form namespace.
+triggerPrompt: >-
+  Before changing my site, explain exactly how you would create a Wix Forms
+  payment confirmation form through the REST API on a site where Wix Forms might
+  not be installed yet. Which API do you call first, which appDefId do you use,
+  and what namespace should the form use?
+tags: [forms]
+maxTokens: 25000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/forms/skills/create-form
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asks for a non-mutating plan to create a Wix Forms payment
+      confirmation form by REST on a site where Wix Forms might not be installed.
+      Intent: explain the safe API order so the agent does not discover the
+      missing namespace by first failing Form Schemas create.
+
+      Pass ONLY if the response:
+      - says to install or verify Wix Forms (New) before the first Create Form
+        call, AND
+      - identifies the Apps Installer endpoint
+        POST .../apps-installer-service/v1/app-instance/install, AND
+      - uses Wix Forms (New) appDefId
+        `225dd912-7dea-4738-8688-4b8c6955ffc2`, AND
+      - says the Form Schemas create request should use namespace
+        `wix.form_app.form`, AND
+      - does not perform a mutation because the user asked for an explanation
+        before changing the site.
+
+      Fail if the response:
+      - creates the form before installing or verifying Wix Forms, OR
+      - uses Wix Forms (Old) appDefId `14ce1214-b278-a7e4-1373-00cebd1bef7c`,
+        OR
+      - says to handle `UNSUPPORTED_FORM_NAMESPACE` primarily by retrying the
+        same create call or creating a form through the UI first, OR
+      - omits the app installation endpoint or the `wix.form_app.form`
+        namespace.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/c0ec5068-021c-43dc-83cf-eddfa9faa99d

Feedback: Wix MCP / Forms create-form failed with `400 UNSUPPORTED_FORM_NAMESPACE` because the agent called `POST https://www.wixapis.com/form-schema-service/v4/forms` with `namespace: "wix.form_app.form"` before Wix Forms (New) was installed on the site.

Source: https://wix.slack.com/archives/C0BBRK0G7L7/p1784556061374089?thread_ts=1784556061.374089&cid=C0BBRK0G7L7

## Conversation research

The reported issue is a true source-content issue, with one important qualification: the conversation recovered in the next user-confirmed turn. The broken behavior is the first failed mutating create attempt and the extra recovery turn it forced.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/c0ec5068-021c-43dc-83cf-eddfa9faa99d`: assistant message `1a3ca453-9238-411d-a16a-83b42e8e72aa` activated `create-form` and served the old recipe body in `TOOL_CALL_RESULT` log `601c11ec-ff85-4bcb-b1fa-3f40a5c7216c`, which said the form could be created with `wix.form_app.form` and that Wix Forms appDefId `14ce1214-b278-a7e4-1373-00cebd1bef7c` was usually installed. The same turn called `ExecuteWixAPI`, and `TOOL_FAILED` log `daa5cbdc-2fcb-48fb-af45-4b56cf82b8e9` returned `HTTP 400` with `field: "form.namespace"`, `description: "Form has unsupported namespace"`, and `ruleName: "UNSUPPORTED_FORM_NAMESPACE"`.
- The follow-up assistant message `e7e92b1c-cf7d-4d29-9701-e55d92666a25` recovered after user confirmation. `TOOL_CALL_RESULT` log `977896ec-baa4-42f6-a52e-52b787fd7073` shows `wixFormsInstallAttempt.ok: true`, appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2`, and the requested form created successfully.

Impact & frequency:
- Grafana app logs for `com.wixpress.genie.agent-platform-service`, `2026-07-14` through `2026-07-21`, found 112 distinct failed requests and 144 failed logs matching `Tool failed` + `UNSUPPORTED_FORM_NAMESPACE`.
- Daily distinct failed requests: 24, 16, 12, 10, 13, 20, and 17. Because each hit burns an extra failed tool call and recovery turn, this clears the self-recovered-turn threshold for a source fix.

## Code/content research

Root cause: `skills/wix-manage/references/forms/create-form.md` told agents to create the form first and treated app installation as a later troubleshooting fallback. It also referenced Wix Forms (Old) appDefId `14ce1214-b278-a7e4-1373-00cebd1bef7c`, while the successful recovery used Wix Forms (New) appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2` before creating the form.

Why this is the owning surface:
- The failing turn's `activateSkill` result served the `wix/skills` `create-form` recipe verbatim before the bad create call.
- The API error says the namespace permission/app installation is missing, not that the Form Schemas endpoint or body shape is unknown.
- Official Wix API/spec lookup in the investigation confirmed Wix Forms (New) appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2` and the public Create Form endpoint `https://www.wixapis.com/form-schema-service/v4/forms`.

Alternatives ruled out:
- Not a Genie platform execution bug: `ExecuteWixAPI` correctly surfaced the upstream `400` from the real Form Schemas API.
- Not a downstream Forms API defect: installing Wix Forms (New) first allowed the same flow to create the form successfully.
- Not an Aria prompt-only fix: the wrong ordering and stale appDefId came from the shared `wix/skills` recipe served by Wix MCP, so patching Aria would leave the source content broken for other consumers.
- Related prior work: #538 added a preflight-only policy for another conversation, but it is still open and does not update the stale Forms appDefId or document the successful Wix Forms (New) install-before-create path confirmed here.

## Change

This updates the Create Form recipe so future agents install or verify Wix Forms (New) before the first Form Schemas create call, using appDefId `225dd912-7dea-4738-8688-4b8c6955ffc2`.

Reviewer-oriented diff:
- `skills/wix-manage/references/forms/create-form.md`: adds Step 0 for Wix Forms (New) installation, documents the Apps Installer API call, removes the stale old Forms appDefId from the create path, and updates prerequisites/troubleshooting for `UNSUPPORTED_FORM_NAMESPACE`.
- `yaml/wix-manage-evals/forms/create-form-install-wix-forms.yml`: adds a non-mutating eval requiring the agent to explain the correct order, appDefId, Apps Installer endpoint, and `wix.form_app.form` namespace before changing the site.

## Side effects and rollout risk

The change is bounded to one Forms recipe and one eval scenario. It does not change MCP execution, API permissions, Aria prompts, or production rollout. The only intended behavior change is ordering: agents should avoid discovering the missing namespace through a failed create call, and should ask before installing Wix Forms when the user has not already asked to create or configure a form.

## Verification

- Fix proof: the old served recipe text in log `601c11ec-ff85-4bcb-b1fa-3f40a5c7216c` is replaced with Step 0 guidance to install Wix Forms (New) first, matching the successful recovery evidence from log `977896ec-baa4-42f6-a52e-52b787fd7073`.
- Safety & ownership: this clears the gate because it edits deterministic authored content in `wix/skills`, the source that triggered the wasted work. It is not a regex rewrite, platform wrapper, guard relaxation, or consumer-only prompt patch. The original conversation self-recovered, but the measured production frequency makes a source fix justified.
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' yaml/wix-manage-evals/forms/create-form-install-wix-forms.yml yaml/wix-manage/forms/documentation.yaml`
- PR EvalForge YAML Gate passed for head `09a706dc3776d8420dad8728f78388d62edaee08`. The PR-version scenario `forms/create-form-install-wix-forms` passed both assertions, including the LLM judge score 10/10 for installing/verifying Wix Forms (New) before creating the form.
- Aria smoke attempts were not accepted as fix proof: one non-mutating `AGENT_TESTING` run (`https://wix-bo.com/ai-assistant/conversations/ff19cb16-81ad-4ad5-883b-7805322ef1b4`) answered from generic docs without activating the recipe, and one initial-skill run (`https://wix-bo.com/ai-assistant/conversations/4d864016-3bee-43b6-8033-37b2917f905a`) was blocked before tool use. The reviewer-runnable proof is the repo's passing PR EvalForge gate, which serves the branch through `skillsRepo=wix/skills&skillsPr=<headSha>`.
