### PR TITLE
Clarify semantic model parameter values in analytics recipe

### DIFF
--- a/skills/wix-manage/references/analytics/query-site-analytics.md
+++ b/skills/wix-manage/references/analytics/query-site-analytics.md
@@ -4,7 +4,7 @@ description: Retrieve a Wix site's analytics through the Semantic Model API. Cov
 ---
 # Query Site Analytics
 
-This article shows how to read a site's analytics with the **Semantic Model API**. A semantic model describes one analytics subject area (such as site traffic, revenue, etc.) and defines the **measures**, **dimensions**, and **parameters** you can query.
+This article shows how to read a site's analytics with the **Semantic Model API**. A semantic model describes one analytics subject area (such as site traffic, revenue, etc.) and defines the **measures** and **dimensions** you can query, plus **parameters** that can customize query behavior.
 
 ## Prerequisites
 
@@ -29,13 +29,13 @@ Base path: `https://www.wixapis.com/analytics/semantic-model/v3`
 Always follow **List → Get → Query**. You cannot construct a valid query without first discovering the model's field names from `Get Semantic Model`.
 
 1. **List Semantic Models** — discover which subject areas exist and their IDs.
-2. **Get Semantic Model** — inspect a model's `measures`, `dimensions`, and `parameters` to find the exact `name` values to query and their supported filters/sorting.
+2. **Get Semantic Model** — inspect a model's `measures`, `dimensions`, and `parameters` to find the exact `name` values to query. Treat measures/dimensions as result fields, and treat parameters as constrained query inputs whose allowed values must be copied from the schema.
 3. **Query Semantic Model Data** — request specific field names for a time `interval`, with optional filters, sorting, paging, and formatting.
 
 **Run each step as its own separate API call, and stop to read the result before starting the next step.** The inputs to each step do not exist until the previous step returns:
 
 - You cannot set `semanticModelId` until **List** returns it. **Never fabricate or guess a model ID** — it must be a GUID copied verbatim from a `List Semantic Models` result. A plausible-looking GUID that List did not return will fail (`SEMANTIC_MODEL_NOT_FOUND`).
-- You cannot set `fields`, `filters[].field`, or `sort.fieldName` until you have read the schema from **Get**.
+- You cannot set `fields`, `filters[].field`, `sort.fieldName`, or any parameter/context-filter value until you have read the schema from **Get**.
 
 Choosing the model and the field names is a **reasoning** step you perform by reading the returned JSON — not something to automate with string matching. Do **not** chain List, Get, and Query into a single script/execution.
 
@@ -54,7 +54,7 @@ This guesses field names, ignores each field's `dependencies` (so those fields c
 ✅ **Do this** — three separate calls, reading each result before composing the next:
 
 1. Call **List**. Read the returned models; pick the `id` whose subject area matches the request.
-2. Call **Get** with that `id`. Read `measures`/`dimensions`/`parameters`; choose the exact `name`s you need and note each field's `dependencies`.
+2. Call **Get** with that `id`. Read `measures`/`dimensions`/`parameters`; choose the exact measure/dimension `name`s you need, note each field's `dependencies`, and copy any parameter values only from that parameter's `enumerations`.
 3. Call **Query** with the field names you chose.
 
 ## Before you begin (sharp edges)
@@ -64,7 +64,8 @@ This guesses field names, ignores each field's `dependencies` (so those fields c
 - **`interval` is start-inclusive, end-exclusive (`[start, end)`).** `start` is included, `end` is not — set `end` to the local-midnight instant of the day *after* the last day you want (e.g. for all of January, `end` is Feb 1 local midnight, in UTC).
 - **Convert local midnight → UTC per date, and watch DST.** Compute each boundary as local-midnight-in-UTC using the site's offset **for that specific date** — the offset changes with daylight saving. `America/New_York` is UTC−4 in summer (June local midnight = `04:00:00.000Z`) but UTC−5 in winter (January local midnight = `05:00:00.000Z`), so a range spanning a DST switch has *different* offsets at its two ends. Don't hardcode one offset across a range.
 - **Set `interval.timezone` to the site's time zone to match the Wix dashboard.** Analytics in the Wix business manager are bucketed by the site's time zone. If `interval.timezone` is omitted it defaults to **UTC**, so day boundaries shift and your numbers won't match what the owner sees in the dashboard (and the same goes for using a different time zone). Get the site's IANA time zone from `properties.timeZone` via [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) (`GET https://www.wixapis.com/site-properties/v4/properties`) and pass it through.
-- **Field names must come from `Get Semantic Model`.** The `fields`, `filters[].field`, and `sort.fieldName` values must exactly match a `name` returned by the model schema (e.g. `traffic.sessions_count`). Do not guess field names.
+- **Field names must come from `Get Semantic Model`.** The `fields`, `filters[].field`, and `sort.fieldName` values must exactly match a supported `name` returned by the model schema (e.g. `traffic.sessions_count`). Do not guess field names.
+- **Parameters are not ordinary result fields.** `parameters` customize query behavior (for example device type, currency, or date granularity). Do not treat a parameter name as a measure/dimension to return, sort by, or filter with arbitrary guessed values. Before using a parameter as a context filter, read that parameter's `filters` and `enumerations`; copy the allowed value exactly and preserve case. If `enumerations` is empty or you did not read the complete parameter entry, do not guess values such as `desktop`, `mobile`, `tablet`, `day`, or `month`; query without that parameter or say the valid parameter value cannot be determined from the schema.
 - **The field-name prefix is NOT the model slug.** Do not build names as `<slug>.<field>`. A model's fields often use a different prefix — e.g. the model with slug `crm-people-subscribers` exposes its measure as `people.contacts_count`, not `people_subscribers.contacts_count`. Copy the exact `name` strings from `Get Semantic Model`; inferring the prefix from the slug produces a field the model doesn't have.
 - **Read the COMPLETE schema — never sample or truncate it.** When inspecting a model in Step 2, read the full `measures` and `dimensions` lists; do not cap them with `.slice(0, N)` or otherwise return only the first few. Lists are often long and alphabetical, so a cutoff silently hides exactly the field you need (e.g. on `traffic`, a `.slice(0, 25)` drops `traffic.referrer_category_name`, `traffic.referrer_source_name`, and `traffic.visitor_type`). Choosing from a partial list re-introduces guessing — the agent assumes a missing field doesn't exist or fabricates a name. The same applies to a field's full `dependencies` array and to the model list from `List Semantic Models`.
 - **A wrong field name can fail loudly OR fail silently — assume neither.** A `fields`/`filters[].field`/`sort.fieldName` value that isn't a valid model field either (a) rejects the query with a `4XX` error and a self-explanatory string code (e.g. `fieldIsInvalid`), sometimes listing the model's **available field names**, or (b) is **silently dropped** — the query returns `200` and that field just doesn't appear in `results[].fields` (same as a missing dependency). In testing, an unknown field in `fields` was silently omitted, not errored. Never rely on an error to catch a bad field. (See *Handling wrong fields* below.)
@@ -123,9 +124,9 @@ Each `Field` (in `measures`, `dimensions`, and `parameters`):
 
 | Property | Meaning |
 |---|---|
-| `name` | The exact value to use in `fields`, `filters[].field`, and `sort.fieldName`. |
+| `name` | For measures/dimensions, the exact value to use in `fields` and, only when supported, `filters[].field` or `sort.fieldName`. For parameters, the exact context input name; do not use it as a returned field or sort field. |
 | `type` | `STRING`, `NUMBER`, `BOOLEAN`, `DATE`, `DATE_TIME`, `OBJECT`, or `ARRAY`. |
-| `filters` | Supported filter `prefixes` (`IS`/`NOT`) and `conditions` (e.g. `EQUAL`, `RANGE_II`, `CONTAINS_ANY`). |
+| `filters` | Supported filter `prefixes` (`IS`/`NOT`) and `conditions` (e.g. `EQUAL`, `RANGE_II`, `CONTAINS_ANY`). For parameters, this only says which context-filter operations are supported; the value must still come from `enumerations` when the parameter is enumerated. |
 | `sortable` | Whether the field can be used in `sort`. |
 | `enumerations` | Allowed values, for enumerated fields. |
 | `dependencies` | Other field names this field needs present in the query to return data (see sharp edges). |
@@ -188,8 +189,8 @@ curl -X POST \
 |---|---|---|
 | `semanticModelId` | Yes | GUID from List/Get. |
 | `interval` | Yes | `{ start, end }` absolute UTC ISO instants (trailing `Z`), plus `timezone`. `start`/`end` are real points in time, not wall-clock in `timezone` — to capture a local calendar range set them to local-midnight-in-UTC for the site's time zone (offset varies with DST). Range is start-inclusive, end-exclusive (`[start, end)`) — set `end` to the local midnight after the last day you want. Set `timezone` to the site's IANA time zone (see Time zone section) so results align to the Wix dashboard; defaults to UTC when omitted. |
-| `fields` | Yes | Up to 60 field `name`s from the model schema. |
-| `filters` | No | Array of `{ field, values[], condition, prefix }`. `condition` defaults to `EQUAL`, `prefix` defaults to `IS`. For `RANGE_*` conditions provide exactly 2 values. |
+| `fields` | Yes | Up to 60 measure/dimension field `name`s from the model schema. |
+| `filters` | No | Array of `{ field, values[], condition, prefix }`. `field` must be a supported model field/filter. For enumerated fields or parameters, `values[]` must be copied exactly from that field's `enumerations`; do not invent lowercase or friendly labels. `condition` defaults to `EQUAL`, `prefix` defaults to `IS`. For `RANGE_*` conditions provide exactly 2 values. |
 | `sort` | No | `{ fieldName, order, nullsLast }`. `order` defaults to `ASC`; field must be `sortable`. `nullsLast` (default `false`) applies only to `DESC` order — set it to `true` when the sorted measure can contain nulls, otherwise nulls sort before real values. |
 | `paging` | No | `{ limit, offset }`. Defaults: `limit` 50, `offset` 0. |
 | `formattingEnabled` | No | Default `false`. Adds `formattedValue` per cell. |
@@ -271,6 +272,7 @@ Analytics questions are answered from the site's **semantic models**, discovered
 | HTTP | Code | Meaning |
 |---|---|---|
 | 4XX | `fieldIsInvalid` | A `fields`/`filters[].field`/`sort.fieldName` value doesn't exist in the model, and this query rejected it (some invalid fields are instead silently dropped from a `200` — see *Handling wrong fields*). When present, the error lists the model's **available field names** — pick the correct one and re-query. |
+| 400 | `INVALID_CONTEXT_FILTER_VALUE` | A parameter/context filter recognized the field name but rejected the supplied value (for example a guessed `deviceType` or `timeframeGranularity` value). Recovery: re-open **Get Semantic Model**, read the complete parameter entry, and retry only with a value from `enumerations` exactly as returned. If the allowed values are not exposed, omit that parameter or explain that the requested segment/granularity cannot be queried safely. |
 | 401 | `NO_ACCOUNT_IDENTITY` / `UNAUTHENTICATED` | Caller isn't authenticated; provide valid credentials. |
 | 404 | `SEMANTIC_MODEL_NOT_FOUND` | The `semanticModelId` doesn't exist for this site. |
 
@@ -284,9 +286,10 @@ Silent gap (no error): a requested field returns no data because none of its `de
 2. Pass the site's time zone (`properties.timeZone` from Get Site Properties) in `interval.timezone` **and** set `start`/`end` to local-midnight-in-UTC for that zone (DST-aware) so results match the Wix dashboard. `start`/`end` are absolute instants, not wall-clock.
 3. Include a field's `dependencies` in the query, or expect that field to be silently dropped.
 4. After each query, validate the response — confirm every requested field appears in `results[].fields`. A wrong field either errors (`4XX`, e.g. `fieldIsInvalid`) or is silently dropped from a `200`; a missing field means an unknown name or a missing dependency. Fix and re-query rather than trusting the partial result. Choose fields by reading their `description` (honoring "do not use" notes), never by name pattern.
-5. Use `formattingEnabled: true` for anything shown directly to a user; keep raw values for calculations.
-6. Use `totalsIncluded: true` to get period totals alongside a paged breakdown in a single call.
-7. Keep `fields` minimal (projection) and paginate large result sets with `offset`.
+5. For semantic-model `parameters`, use only the exact values exposed in `enumerations`; never guess common labels such as device types or date granularities. An `INVALID_CONTEXT_FILTER_VALUE` means the value is wrong, not that you should keep trying nearby guesses.
+6. Use `formattingEnabled: true` for anything shown directly to a user; keep raw values for calculations.
+7. Use `totalsIncluded: true` to get period totals alongside a paged breakdown in a single call.
+8. Keep `fields` minimal (projection) and paginate large result sets with `offset`.
 
 ## Related Documentation
 

--- a/yaml/wix-manage-evals/analytics/query-site-analytics-parameters.yml
+++ b/yaml/wix-manage-evals/analytics/query-site-analytics-parameters.yml
@@ -1,0 +1,38 @@
+name: analytics/query-site-analytics-parameters
+description: >-
+  Verifies the agent handles Semantic Model parameters as constrained context inputs and does not
+  guess invalid device type or timeframe granularity values.
+triggerPrompt: >-
+  I am querying the Site Performance semantic model through the REST API. Get Semantic Model shows
+  deviceType and timeframeGranularity under parameters. Can I filter with desktop/mobile/tablet or
+  day/month values to break down the data? Please explain the safe request shape.
+tags: [analytics]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/analytics/skills/query-site-analytics
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants to query the Site Performance semantic model and asks whether parameters such
+      as deviceType and timeframeGranularity can be filtered with guessed values like
+      desktop/mobile/tablet or day/month.
+
+      Pass if the response:
+      - distinguishes measures/dimensions from Semantic Model parameters, AND
+      - explains that parameter/context-filter values must come from the complete Get Semantic Model
+        parameter entry, especially its enumerations, and must be copied exactly rather than guessed, AND
+      - warns that guessed values such as desktop/mobile/tablet or day/month may cause
+        INVALID_CONTEXT_FILTER_VALUE, AND
+      - says to omit the parameter or report that the segment/granularity cannot be determined if
+        allowed values are not exposed.
+
+      Fail if the response:
+      - recommends using filters with guessed values like { field: "deviceType", values: ["desktop"] }
+        without first checking exact enumerations, OR
+      - invents a top-level parameters request field that is not in the Query Semantic Model Data
+        request schema, OR
+      - treats parameter names as ordinary returned fields or sort fields, OR
+      - gives generic analytics advice without addressing Semantic Model parameters and
+        INVALID_CONTEXT_FILTER_VALUE.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/10972a59-d094-40f4-b43b-5ed28cbf7cfe

Feedback: Site performance semantic model `site-performace` exposes `deviceType` under `parameters`, but the assistant queried `filters: [{ field: "deviceType", condition: "EQUAL", values: ["desktop" | "mobile" | "tablet"] }]` and the Analytics backend rejected each value with `INVALID_CONTEXT_FILTER_VALUE`.

## Conversation research

The reported issue is a partial issue: the exact failing event occurred, but the assistant self-recovered and the final user-visible turn completed successfully.

Sample broken conversation(s):
- https://wix-bo.com/ai-assistant/conversations/10972a59-d094-40f4-b43b-5ed28cbf7cfe: the user asked to grow site traffic. On final assistant message `8fe44a7f-20c8-497f-98d8-ce0449e46fb4`, tool call log `ed34c820-7401-4ab6-b587-326f5acd356e` queried `Query Semantic Model Data` with `deviceTypes = ["desktop", "mobile", "tablet"]` and `filters: [{ field: "deviceType", condition: "EQUAL", values: [deviceType] }]`. Tool-result log `d4bb42f0-f940-4c07-b51a-e44088ed823a` returned three backend errors: `Invalid context filter value for deviceType: desktop`, `mobile`, and `tablet`. The assistant then called `sendFeedback`, retried without the device filter (`605c6ff9-653a-4448-8db7-c4f732354df6`), and result log `961f2942-9272-44c0-9024-a67035968e34` returned overall performance data. The final message status was `COMPLETED`, severity `NONE`, and reported homepage LCP p75 around 1.29s.

## Code/content research

Root cause: the `Query Site Analytics` recipe blurred semantic model `parameters` together with measures/dimensions. It said each `Field.name` from `measures`, `dimensions`, and `parameters` was the exact value to use in `fields`, `filters[].field`, and `sort.fieldName`, but the public `Query Semantic Model Data` schema only lists `semanticModelId`, `interval`, `fields`, `sort`, `filters`, `paging`, `formattingEnabled`, and `totalsIncluded` in the request body. Its `filters[].field` description says the field must match a semantic model measure or dimension. The schema exposes `parameters` as optional inputs that customize query behavior and `Field.enumerations` as the allowed values for enumerated fields.

Why this is the owning surface:
- The production path used the Wix MCP `query-site-analytics` recipe, served from `wix/skills`, before the bad query.
- The API guard was correct to reject bad context values; the bad values were produced by model-authored code after reading ambiguous/misleading recipe guidance.
- The fix belongs in `skills/wix-manage/references/analytics/query-site-analytics.md`, not in Genie runtime code or the Analytics backend guard.

Alternatives ruled out:
- Genie platform: the tool infrastructure executed the assistant-authored read-only request and surfaced the backend error; no platform validation or dispatch bug was found.
- Analytics API guard: the guard rejected invalid parameter/context values. Relaxing it would be a symptom patch and fails the value-provenance gate.
- Aria assistant prompt: the serving assistant self-recovered; the misleading reusable instruction is in the shared Wix MCP recipe used by this path.
- A top-level `parameters` request field: current public API schema does not expose one, so the recipe should not teach agents to invent that body shape.

## Change

This changes the analytics recipe so agents treat semantic model `parameters` as constrained query inputs, not as ordinary result fields or arbitrary filters.

Reviewer-oriented diff:
- `skills/wix-manage/references/analytics/query-site-analytics.md`: clarifies that measures/dimensions are query result fields, while parameters customize query behavior and require exact values from the complete parameter entry, especially `enumerations`.
- `skills/wix-manage/references/analytics/query-site-analytics.md`: narrows the `Field.name`, `filters`, request-fields, best-practices, and common-errors guidance so agents do not guess values such as `desktop`, `mobile`, `tablet`, `day`, or `month`.
- `yaml/wix-manage-evals/analytics/query-site-analytics-parameters.yml`: adds a covering advisory eval that asks about `deviceType` and `timeframeGranularity` parameters and fails if the response guesses values, treats parameters as ordinary fields/sort fields, or invents a top-level `parameters` request field.

## Safety & ownership gate

- Conversation validity: true partial issue. The API error occurred, but the turn self-recovered and completed.
- Generic failure mode: semantic model parameters/context filters are used with guessed values because the recipe does not clearly separate measures/dimensions from parameters or require exact `enumerations`.
- Impact & frequency: app logs for `com.wixpress.analytics-ng.analytics-ng-reports` from 2026-07-14 through 2026-07-21 showed 26 distinct request IDs with `Invalid context filter value`: 23 for `timeframeGranularity` and 3 for `deviceType`. The exact `deviceType` hits were the three parallel requests from this conversation. Per occurrence, the cost is at least one failed Analytics API request plus model/tool iteration; the reported turn also spent a fallback iteration.
- Value provenance: the invalid values were produced in assistant-authored `ExecuteWixAPI` code (`desktop`, `mobile`, `tablet`) after the recipe told the agent to inspect `parameters` but did not give safe value-selection guidance. The values rode unchanged into `filters[].values[]`, then to Analytics `ModelService#queryModelData`, where the guard rejected them.
- Existing bound: the official semantic model schema exposes `Field.enumerations` as the source of allowed values. The fix reuses that bound rather than adding literals.
- Legitimacy: guessed lowercase labels should not be accepted as valid context values. The guard is not the defect.
- Downstream contamination: before the guard, the bad values affected the API request only; the user-visible final answer used the fallback unfiltered query.
- Minimal fix: update the existing recipe and add one focused eval. No runtime guard, broad prompt, or backend API change.
- Side effects: bounded to one analytics recipe. The change may make agents omit a parameter when valid values are not discoverable, which is safer than issuing guessed context filters and retrying on backend errors.

## Verification

- Fix proof: the changed recipe now explicitly says parameter/context-filter values must come from `enumerations` exactly and that `INVALID_CONTEXT_FILTER_VALUE` should be recovered by re-reading the complete parameter entry or omitting the parameter when values are unavailable. The new eval encodes this behavior.
- API contract check: `SearchWixAPISpec` confirmed `Query Semantic Model Data` request body fields are `semanticModelId`, `interval`, `fields`, `sort`, `filters`, `paging`, `formattingEnabled`, and `totalsIncluded`; `filters[].field` must match a measure or dimension; `SemanticModel.parameters` are optional inputs; `Field.enumerations` are allowed values.
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' yaml/wix-manage-evals/analytics/query-site-analytics.yml yaml/wix-manage-evals/analytics/query-site-analytics-timezone-interval.yml yaml/wix-manage-evals/analytics/query-site-analytics-parameters.yml`
- Not run: `.github/actions/evalforge-yaml-gate` unit tests, because the local worktree lacks the Yarn dependency state (`Couldn't find the node_modules state file`).
- Current PR checks: `Check @wix/cli pinned to @latest` passed. `EvalForge YAML Gate` is blocked by a scenario lock from open PR https://github.com/wix/skills/pull/625 (`analytics/query-site-analytics`, `analytics/query-site-analytics-timezone-interval`, and `analytics/query-site-analytics-sort-nulls-last` are draft-held there). This is a gate coordination blocker, not a failure from this PR's new scenario content.
- Attempted but not counted as proof: `ai-assistant__SendMessage` with `skillsRepo=wix/skills` and `skillsPr=141b97a0f34041254f970db78734e1b008ab9a55`. Two documentation-only prompts did not activate the recipe, and the site-context prompt failed at conversation creation with `UNAUTHENTICATED`. Reviewer can exercise the PR content through the EvalForge PR gate, which serves `skillsRepo=wix/skills&skillsPr=<headSha>` and checks the new scenario.

## Side effects and rollout risk

Low. This is a documentation/recipe clarification plus a new eval. It does not change runtime code, permissions, API contracts, or production rollout. The main residual risk is that some semantic model parameter mechanics remain underdocumented in the public API; the recipe now chooses the safer behavior: use exact enumerations when available, otherwise omit the parameter or explain the limitation instead of guessing.
