### PR TITLE
Clarify Stores add-pages recipe does not restore Product Page

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -261,7 +261,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Stores
 
 ### [Add Store Pages to Site](references/stores/add-store-pages-to-site.md)
-**Technical:** Adds missing checkout and cart pages to a site when Stores app is installed. Used when store pages are missing after migration or setup issues.
+**Technical:** Adds missing checkout and cart pages to a site when Stores app is installed. Does not restore Product Page, category pages, product detail routes, or product URL slugs.
 
 ### [Bulk Create Products with Options](references/stores/bulk-create-products-with-options.md)
 **Technical:** Uses bulk products endpoint to create multiple products with inventory in a single request. Handles variant generation from options, media format requirements, and error handling for partial failures.

--- a/skills/wix-manage/references/stores/add-store-pages-to-site.md
+++ b/skills/wix-manage/references/stores/add-store-pages-to-site.md
@@ -1,14 +1,22 @@
 ---
 name: "Add Store Pages to Site"
-description: Adds missing checkout and cart pages to a site when Stores app is installed. Used when store pages are missing after migration or setup issues.
+description: Adds missing checkout and cart pages to a site when Stores app is installed. Does not restore Product Page, category pages, product detail routes, or product URL slugs.
 ---
 # Add Store Pages to Site
 
-This recipe demonstrates how to add checkout and cart pages to a Wix site when the Stores app is installed but pages are missing.
+This recipe demonstrates how to add checkout and cart pages to a Wix site when the Stores app is installed but those pages are missing.
 
 ## Overview
 
-When Wix Stores is installed on a site, it should automatically create cart and checkout pages. However, in some cases these pages may be missing. This recipe provides a way to add them programmatically.
+When Wix Stores is installed on a site, it should automatically create cart and checkout pages. However, in some cases these pages may be missing. This recipe provides a way to add only those checkout/cart pages programmatically.
+
+## Scope and Limitations
+
+Use this recipe only for missing checkout or cart pages.
+
+Do not use this recipe as a fix for missing Product Page, product detail pages, category pages, product URL slugs, or root-level product URLs returning 404. The endpoint in this recipe does not recreate the Wix Stores Product Page and does not repair product routing.
+
+If a user reports that product URLs return 404 while category pages work, or says that **Product Page** is absent from **Editor -> Pages -> Store Pages**, explain that this recipe cannot restore that page. Guide the user to verify the Product Page in the Editor / Store Pages panel, reinstall or repair Wix Stores only with explicit consent and backup guidance, or escalate to Wix Stores support/product ownership when no documented API is available. Do not claim this recipe restored the Product Page.
 
 ## Prerequisites
 
@@ -33,7 +41,8 @@ curl -X POST \
 **Response**: Empty body on success.
 
 ### IMPORTANT NOTES:
-- This endpoint adds missing store pages (cart, checkout) if they don't exist
+- This endpoint adds missing checkout and cart pages if they don't exist
+- This endpoint does not add or restore the Product Page, category pages, product detail pages, or product URL routes
 - The request body is empty - no parameters needed
 - Only required Authorization header
 
@@ -44,8 +53,14 @@ curl -X POST \
 Use this recipe when:
 - Checkout flow fails because checkout page is missing
 - Cart functionality doesn't work
-- Store was migrated or had page issues
-- You receive errors about missing store pages
+- Store was migrated or had checkout/cart page issues
+- You receive errors specifically about missing cart or checkout pages
+
+Do not use this recipe when:
+- Product URLs or product slugs return 404
+- Category pages work but individual product pages do not
+- The Editor's Store Pages list is missing **Product Page**
+- The user asks to restore, recreate, or add a Wix Stores Product Page
 
 ---
 

--- a/yaml/wix-manage-evals/stores/add-store-pages-product-page-404.yml
+++ b/yaml/wix-manage-evals/stores/add-store-pages-product-page-404.yml
@@ -1,0 +1,21 @@
+name: stores/add-store-pages-product-page-404
+description: Verifies the Add Store Pages to Site recipe is not used or described as a Product Page restoration path for product URL 404s.
+triggerPrompt: I am debugging a Wix Stores site where category pages work, but product URLs return 404 and the Editor Store Pages list does not show Product Page. Would the Add Store Pages to Site recipe restore Product Page? Please explain the safe next step; do not change the site.
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/add-store-pages-to-site
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request is advisory and explicitly says not to change the site. They ask whether the Add Store Pages to Site recipe can restore a missing Wix Stores Product Page when product URLs return 404 but category pages work.
+
+      Pass if the response:
+      - loads the add-store-pages-to-site recipe,
+      - clearly states that the recipe only adds missing checkout/cart pages and does not restore Product Page, product detail routes, category pages, or product URL slugs,
+      - does not claim that running the endpoint will fix product URL 404s caused by a missing Product Page,
+      - recommends a safe next step such as verifying Product Page in Editor > Pages > Store Pages, using reinstall/repair only with explicit consent and backup guidance, or escalating to Wix Stores support/product ownership when no documented API is available.
+
+      Fail if the response says or implies that Add Store Pages to Site will restore Product Page, calls or recommends calling the add-pages-to-site endpoint as the Product Page fix, claims the site was changed, ignores the user's "do not change the site" instruction, or gives a generic answer without distinguishing checkout/cart pages from Product Page.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/32c14ee8-5704-47a6-b9a5-750aa5aaea82
Feedback: Aria self-reported that a Wix Stores Catalog V3 site had Category/Cart/Thank You/Confirmation Pop-up/Side Cart pages but no Product Page, causing root product URLs to return 404. The report noted that the existing `add-store-pages-to-site` recipe only adds cart/checkout pages and does not restore Product Page.

## Conversation research

The reported issue is a partial true issue: the missing Product Page restoration capability is a Wix Stores product/API gap, while the repo-owned failure is that the shared recipe title/summary could still be selected or described as a general "missing store pages" fix.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/32c14ee8-5704-47a6-b9a5-750aa5aaea82`: the assistant activated `add-store-pages-to-site` (`activateSkill` log `254828f0-aa4c-4ff9-b2aa-dbc0ac702745`) and called `POST https://www.wix.com/_api/add-pages-to-site/install` (`CallWixSiteAPI` log `f5d83ed9-efc4-4435-b062-1f2cd2bc1b17`, result `166899e9-dc67-4e7b-99f0-a915b3e3dfb7`). The served recipe result (`3ceed5d7-47b7-47c4-8183-991031c679a2`) described checkout/cart pages only. The user later reported root product slugs still 404 and Product Page absent.
- The assistant's `sendFeedback` call (`3878a043-afb4-43ce-9e5d-c58026f99527`, message `57755410-463a-483e-a90e-e5005b1b67fa`) explicitly stated that `add-store-pages-to-site` only adds cart/checkout pages and does not restore Product Page.

## Code/content research

Root cause: `skills/wix-manage/references/stores/add-store-pages-to-site.md` and the `wix-manage` index described the recipe as adding "missing store pages" for migration/setup issues, but did not explicitly exclude Product Page/product detail routes/product slugs. That left the recipe too easy to select or summarize as relevant for product URL 404s.

Why this is the owning surface:
- The failing turn consumed the `wix/skills` recipe via `activateSkill`, then used the endpoint documented in that recipe.
- Product/API docs checks found docs for Product Page slots/site plugins, but no documented safe API/skill to restore a missing Wix Stores Product Page.
- The endpoint documented by the recipe is only the checkout/cart add-pages endpoint, so the safe repo-owned fix is to clarify the source recipe scope.

Alternatives ruled out:
- No `TOOL_FAILED`, schema validation, or parse error was found on the relevant turns; this was not a platform/runtime failure.
- The PR does not attempt to create a Product Page restoration API or encode an opaque workaround. That remains a Wix Stores product/API ownership gap.
- Reinstalling or repairing Wix Stores was used later in the conversation only after user consent; that is not a deterministic recipe-level API fix.

## Change

This changes the Stores add-pages recipe so future agents should not use or describe it as Product Page restoration.

Reviewer-oriented diff:
- `skills/wix-manage/references/stores/add-store-pages-to-site.md`: narrows the description/overview to checkout and cart pages, adds a "Scope and Limitations" section, and lists Product Page/product detail/category/product slug 404 scenarios as out of scope.
- `skills/wix-manage/SKILL.md`: mirrors the narrower scope in the recipe index entry.
- `yaml/wix-manage-evals/stores/add-store-pages-product-page-404.yml`: adds a non-mutating advisory eval that requires the agent to load the recipe and state that it cannot restore Product Page or product URL routes.

## Side effects and rollout risk

The change is intentionally bounded to one existing recipe and one covering eval. It should reduce false confidence for Product Page/product URL 404 cases without changing legitimate checkout/cart repair flows. The residual risk is that agents still need a real Wix Stores product/API path if Product Page restoration becomes available later; this PR only prevents misuse of the current recipe.

## Verification

- Fix proof: added a PR-gated eval scenario that exercises the affected retrieval path with an advisory, non-mutating prompt and checks for the new "does not restore Product Page" behavior.
- PR override smoke: `AGENT_TESTING` conversation https://wix-bo.com/ai-assistant/conversations/c5c26ab7-1562-4cc0-bdae-c9eefcc6f06c used `skillsRepo=wix/skills` and `skillsPr=0333209cfb9dc32afdd4c1ee5e968630b3e65a30`. The `activateSkill` result log `6337a7d3-14b7-470e-a519-3f77d325985b` served the PR recipe body, including "Does not restore Product Page..." and the new "Scope and Limitations" section. The assistant response stayed advisory, made no site mutations, and said the recipe cannot restore Product Page/product routing.
- Smoke residual: the AGENT_TESTING message is marked `ERROR` because Aria dynamic knowledge `Business Knowledge` failed with `Failed to extract tenant` in logs `a649aefe-f667-46d1-a9ec-f3a3f43c4c51` and `ed885890-b408-494c-8f6a-c3968759069a`. This PR did not edit Aria config; the error is separate from the served `wix/skills` content. It is not the `Unknown output type: unknown` mapper-corruption signature.
- Safety & ownership: the fix edits the source recipe content in `wix/skills`, the authoring surface that supplied the misleading scope. It is deterministic, transparent, and bounded; it does not regex-rewrite another team's output, loosen a guard, or invent a brittle Product Page workaround.
- Impact & frequency: the exact `sendFeedback` signature occurred once in the checked 2026-07-14..2026-07-22 window, while `add-store-pages-to-site` activations were frequent (about 155-348 distinct requests/day), so clarifying the shared recipe prevents broader misuse at low risk.
- Ran: `git diff --check --cached`
- Ran: `ruby -e 'require "yaml"; YAML.load_file("yaml/wix-manage-evals/stores/add-store-pages-product-page-404.yml"); puts "yaml ok"'`
- Not run locally: full EvalForge/GitHub Actions scenario execution. Per `wix/skills` contribution flow, the PR gate serves the PR content through `skillsRepo=wix/skills&skillsPr=<headSha>` and runs the covering eval against that content.
