### PR TITLE
fix(wix-manage): omit field from catalog count aggregate

### DIFF
--- a/skills/wix-manage/references/ecommerce/ecom-load-context.md
+++ b/skills/wix-manage/references/ecommerce/ecom-load-context.md
@@ -75,7 +75,7 @@ CallWixSiteAPI(
   method: "POST",
   body: {
     "aggregates": [
-      {"op":"count","field":"price"},
+      {"op":"count"},
       {"op":"min","field":"price"},
       {"op":"max","field":"price"},
       {"op":"avg","field":"profitMargin"},
@@ -87,6 +87,8 @@ CallWixSiteAPI(
   }
 )
 ```
+
+For `count`, omit `field` so the service generates `count()`, not `count(<field>)`.
 
 Save the full `categoryGroups` array as `siteData.catalogAnalytics`. From the "All Products" group extract:
 - `siteData.catalogProductCount` = `count()` value (0 if missing or call fails)

--- a/yaml/wix-manage-evals/ecommerce/ecom-load-context.yml
+++ b/yaml/wix-manage-evals/ecommerce/ecom-load-context.yml
@@ -10,8 +10,9 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: |
-      Score 9-10: Agent called ReadFullDocsArticle on the eCommerce Load Context recipe, used the wix-profile-client metasite endpoint, and reported all fields: siteId, country, currency, industry, visitors30d, orders30d, GPV.
+      Score 9-10: Agent called ReadFullDocsArticle on the eCommerce Load Context recipe, used the wix-profile-client metasite endpoint, loaded catalog analytics with a fieldless count aggregate (`{"op":"count"}`), and reported all fields: siteId, country, currency, industry, visitors30d, orders30d, GPV.
       Score 7-8: Agent attempted to load the recipe (even if it returned 404), AND correctly reported all required fields (siteId, country, currency, industry, visitors30d, orders30d, GPV) via any endpoint combination.
       Score 4-6: All fields reported but recipe was never attempted.
       Score 1-3: Missing visitor count, order count, or GPV; or field values were invented without API calls.
+      Fail if the agent sends a catalog analytics count aggregate with any field, such as `{"op":"count","field":"price"}`, because that generates invalid `count(price)` output.
       Do NOT penalize solely for using a non-metasite endpoint when the recipe returned 404 — a 404 is a content-availability issue, not an agent error.


### PR DESCRIPTION
# Feedback

Conversation(s): https://wix-bo.com/ai-assistant/conversations/6388149f-8d45-4e1a-8a6e-d83faec6a13f
Feedback: Wix MCP `get-catalog-analytics-tool` returned 500 while loading catalog analytics.

## Conversation research

The reported issue is a true recurring tool failure, with self-recovery in the sampled turn. In message `f15f5d2b-b6e7-4d10-b35f-28ad0ebbaee1`, `CallWixSiteAPI` failed twice against `POST https://manage.wix.com/recommendations/v1/recommendations/get-catalog-analytics-tool` (`TOOL_FAILED` logs `2c842182-158d-44cb-823a-8b893eb0844d` and `0c113d45-b9fa-4041-9a2e-9686edc4d02d`). The final assistant message completed, but the turn burned extra tool calls/iterations and reported the failure through `sendFeedback`.

Sample broken conversation(s):
- `https://wix-bo.com/ai-assistant/conversations/6388149f-8d45-4e1a-8a6e-d83faec6a13f`: eCommerce/shipping recommendation flow activated `e-commerce-load-context`, then called catalog analytics with `{"op":"count","field":"price"}`. Downstream logs for `com.wixpress.ecom.discounts.recommendations` showed `GetCatalogAnalyticsTool: Failed to get catalog data from VSearch` and VSearch rejected the generated grouping containing `output(count(price))`.

Impact and frequency: the same downstream signature occurred 84 distinct failed request IDs in the 2026-07-15 to 2026-07-22 window, with daily counts 24, 13, 9, 8, 8, 13, 9. Access logs for the endpoint in the same window showed 84 distinct 500s and 45 distinct 200s. Per occurrence cost is wasted latency/iterations/tokens and a noisy tool failure in otherwise recoverable conversations.

## Code/content research

Root cause: the Wix Manage eCommerce recipe examples request a `count` aggregate with a `field`. The recommendations service turns that into `count(price)`, while the response shape and adjacent working examples expect fieldless `count()`.

Why this is the owning surface:
- The failing request body exactly matches `skills/wix-manage/references/ecommerce/ecom-load-context.md`.
- `wix/skills` is the canonical source for these Wix MCP recipes; local generated/mirrored copies were not edited.

Alternatives ruled out:
- Not auth/permission/host allowlist: the call reached the recommendations service and returned an upstream 500.
- Not Genie platform execution: `CallWixSiteAPI` executed the request the recipe instructed.
- Not a safe downstream-service patch: changing or masking the service error would leave the agent-authored bad aggregate shape intact. The safe owner is the recipe content that produced the value.

## Change

This changes catalog analytics count aggregate guidance so agents request `{"op":"count"}` and the service generates `count()`.

Reviewer-oriented diff:
- `skills/wix-manage/references/ecommerce/ecom-load-context.md`: changes the loader's first aggregate from `{"op":"count","field":"price"}` to `{"op":"count"}` and adds an explicit note that `count` must omit `field`.
- `yaml/wix-manage-evals/ecommerce/ecom-load-context.yml`: makes fieldless catalog analytics count part of the top score and fails fielded counts.

## Side effects and rollout risk

The change is bounded to catalog analytics examples for the existing `count` aggregate. Other aggregate operations still include `field`; `quantiles` still includes `q`. The docs already instruct readers to read `count()` from the response, so this aligns the request examples with the documented response contract rather than changing the recommendation flow.

Adjacent note: `recommend-ecommerce-strategy.md` has similar fielded count examples, but its required eval scenario is currently held by another open PR (`wix/skills#467`). This PR stays scoped to the confirmed failing loader source so the fix can pass the gate; the strategy examples should be aligned once that scenario lock clears.

## Verification

- Fix proof: AGENT_TESTING conversation https://wix-bo.com/ai-assistant/conversations/4d6c3b6b-1bc4-4180-baf7-55710977acc0 used the `skillsRepo=wix/skills` + `skillsPr=679b9fb48e19796e21fa0c90d4d0524cc34663f2` override. The `activateSkill` result log `d934e88f-6134-4920-8aa6-640fca245300` served `e-commerce-load-context` from the PR with `{"op":"count"}` and the corrected rule: `For count, omit field so the service generates count(), not count(<field>)`.
- Safety & ownership: the sampled turn self-recovered, but the measured frequency is high enough to fix the source. The mechanism is deterministic and transparent: update the canonical `wix/skills` authoring content that produced the invalid request, not a brittle consumer-side rewrite or a downstream error mask.
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("yaml/wix-manage-evals/ecommerce/ecom-load-context.yml"); puts "OK yaml/wix-manage-evals/ecommerce/ecom-load-context.yml"'`
- `node .yarn/releases/yarn-4.10.0.cjs install --immutable` in `.github/actions/evalforge-yaml-gate`
- `node .yarn/releases/yarn-4.10.0.cjs test` in `.github/actions/evalforge-yaml-gate` (180 tests passed)
- `node .yarn/releases/yarn-4.10.0.cjs typecheck` in `.github/actions/evalforge-yaml-gate`
- Residual: the AGENT_TESTING message has two dynamic-knowledge errors because the test context had no active tenant/site (`Business Knowledge` failed with `Failed to extract tenant`). No site mutations were attempted; the run stopped after `listSites` could not find `Gracia` in the test account. The successful proof for this PR is the served `activateSkill` content. The repo's PR eval workflow is expected to run the faithful skills override using this PR head SHA.
- Not run locally: live `get-catalog-analytics-tool` against a seeded ecommerce site.
