### PR TITLE
🦞 igor-claw: document Update Product SEO-keywords missing-hierarchies gotcha

### DIFF
--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -296,6 +296,32 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
   }'
 ```
 
+### Set SEO Focus Keywords
+
+If the product has never had `seoData.settings` set before (most products, unless SEO was configured earlier), a PATCH that sets **only** `seoData.settings.keywords` fails with `400 INVALID_PATCH: "Invalid patch. Patch failed due to missing hierarchies"`. Always include `preventAutoRedirect` alongside `keywords` the first time you write to `seoData.settings` on a product to avoid this:
+
+```bash
+curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <AUTH>" \
+  -d '{
+    "product": {
+      "id": "{productId}",
+      "revision": "{currentRevision}",
+      "seoData": {
+        "settings": {
+          "preventAutoRedirect": false,
+          "keywords": [
+            { "term": "focus keyword", "isMain": true }
+          ]
+        }
+      }
+    }
+  }'
+```
+
+Once `seoData.settings` exists on the product (confirm via [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product)), subsequent PATCHes to `seoData.settings.keywords` alone work fine.
+
 ## Important Notes
 
 - To update array fields like `options`, `modifiers`, `variantsInfo.variants`, and any others, pass the entire existing array. Passing only the changed item overwrites the whole array.
@@ -315,4 +341,5 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 | `choicesSettings must not be empty` | Missing choices array | Include full `choicesSettings.choices` array |
 | `Missing product option choices` | Variant references non-existent option | Use `optionChoiceNames` with exact option and choice names |
 | `price must not be empty` | A variant was created or replaced without a price | Include `price.actualPrice.amount` on every new variant |
+| `Invalid patch. Patch failed due to missing hierarchies` (`INVALID_PATCH`) | Patched `seoData.settings.keywords` alone on a product with no `seoData.settings` yet | Include `seoData.settings.preventAutoRedirect` in the same PATCH the first time you write to `seoData.settings` |
 | `Missing option choices` or `INVALID_DEFAULT_VARIANT` | Product has options but at least one variant has no matching choices | Rebuild `variantsInfo.variants` so every variant includes choices for all product options |


### PR DESCRIPTION
## What's wrong

`PATCH /stores/v3/products/{id}` (Update Product, Catalog V3) fails with an undocumented `400 INVALID_PATCH: "Invalid patch. Patch failed due to missing hierarchies"` when a request writes **only** `seoData.settings.keywords` on a product that has never had `seoData.settings` populated before — a very common first-time "set SEO focus keywords" request.

## Root cause

`seoData.settings.preventAutoRedirect` is non-optional in the backend domain model (`SettingsDomain.preventAutoRedirect: Boolean`), so SDL can't auto-create the `seoData.settings` object from a patch that supplies only `keywords`. Filed and root-caused with a proposed API fix here: wix-private/ecom#53272.

## This PR

Until the API fix ships, document the workaround in the existing `skills/wix-manage/references/stores/update-product-with-options.md` recipe (the recipe an agent already uses for product PATCH requests):
- A new "Set SEO Focus Keywords" example showing `preventAutoRedirect` included alongside `keywords`.
- A new row in the recipe's "Error Message Reference" table for the `INVALID_PATCH` / missing-hierarchies error.

Verified live: the same PATCH without `preventAutoRedirect` fails with the error above on a fresh product with no prior `seoData`; including `preventAutoRedirect` in the same request succeeds.

## Context

Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching feedback reported through the Wix MCP. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1784691981551539