### PR TITLE
fix(docs): stop <script> placeholder from breaking README/CONTRIBUTING markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,10 +199,10 @@ commit the consuming action's `dist`:
 (cd .github/actions/evalforge-yaml-gate && yarn build)
 ```
 
-Use the `(cd <dir> && yarn <script>)` subshell form, not `yarn --cwd <dir>
-<script>` — under Corepack, `--cwd` resolves the yarn version from the real
-process cwd, so invoking it from the repo root can silently run the wrong
-yarn. See `packages/evalforge-core/README.md` for details.
+Use the `(cd DIR && yarn SCRIPT)` subshell form, not `yarn --cwd DIR SCRIPT` —
+under Corepack, `--cwd` resolves the yarn version from the real process cwd, so
+invoking it from the repo root can silently run the wrong yarn. See
+`packages/evalforge-core/README.md` for details.
 
 ## PR Checklist
 

--- a/packages/evalforge-core/README.md
+++ b/packages/evalforge-core/README.md
@@ -48,9 +48,9 @@ Run these via a subshell, not `yarn --cwd`:
 Corepack, `--cwd` changes the target directory but still resolves the *yarn
 version* from the real process cwd. Run from the repo root, `--cwd` silently
 picks up the wrong yarn instead of the `yarn@4.10.0` this package vendors via
-`.yarnrc.yml` (`yarnPath` + `nodeLinker: node-modules`). The `(cd <dir> && yarn
-<script>)` subshell form makes the target directory the real cwd, so Corepack
-resolves the correct pinned yarn.
+`.yarnrc.yml` (`yarnPath` + `nodeLinker: node-modules`). The `(cd DIR && yarn SCRIPT)`
+subshell form makes the target directory the real cwd, so Corepack resolves the
+correct pinned yarn.
 
 ## Build order when changing shared code
 


### PR DESCRIPTION
## Problem
The `packages/evalforge-core/README.md` (and the matching CONTRIBUTING note) from #676 rendered as a single run-on blob from the "Build order" section onward — headings and lists showed as literal text.

## Cause
The inline example `` `(cd <dir> && yarn <script>)` `` wraps across two lines, so a line **begins with `<script>`**. In CommonMark, a line starting with `<script>` opens a **type-1 raw-HTML block** that continues until a line containing `</script>` — which never appears — so the parser swallowed the rest of the document as raw HTML. Block-structure parsing happens before inline code-span parsing, so the backticks don't prevent it. (`file README.md` even reported it as "HTML document text".)

## Fix
Replace the `<dir>`/`<script>` angle-bracket placeholders with plain `DIR`/`SCRIPT` in both the README and the CONTRIBUTING subshell note. No prose meaning changes.

Verified: `file` now reports plain UTF-8 text; no line starts with `<script>`/`<pre>`/`<style>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
