### PR TITLE
docs(wix-headless): make the feedback offer a default checkpoint

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -91,7 +91,12 @@ If the credentials are absent, the Wix backend isn't reachable — **stop with a
 4. **Handoff** (`references/SDK_HANDOFF.md`) — after Setup and Seed, **emit** the integration guide: SDK bootstrap, per-capability call shapes, the **seeded IDs**, and the `@wix/*` package list.
 5. **Finalize deployment** (`<TYPE_DIR>/DEPLOYMENT.md`) — run the project-type's finalize steps.
 
-**Throughout any run** — if the user asks to send feedback to Wix, complains/gets frustrated, or the run hits substantial friction (repeated API/doc/tooling failures), you may **offer** to relay it to Wix per `references/FEEDBACK.md`. Send only after an explicit yes — never automatically.
+**Throughout any run** — if the user asks to send feedback to Wix, complains/gets frustrated, or the
+run hits any real friction (a confusing error, a doc gap, a tooling dead end, a workaround you had to
+invent — it doesn't need to repeat), **offer** to relay it to Wix per `references/FEEDBACK.md`. Default
+to offering rather than waiting to be asked. Every flow's finalize step (`<TYPE_DIR>/DEPLOYMENT.md` /
+`managed/CREATE.md` / `managed/CONNECT.md`) ends with the same checkpoint — treat it as a required
+self-check, not optional. Send only after an explicit yes — never automatically.
 
 **Managed create / connect / iterate** — after Discovery, hand the whole run to the managed flow:
 - **create** → **`references/managed/CREATE.md`** (scaffold → Setup → Seed → build the frontend → release).

--- a/skills/wix-headless/references/FEEDBACK.md
+++ b/skills/wix-headless/references/FEEDBACK.md
@@ -10,16 +10,27 @@ This is **not** support, and not for the user's own site content. It is meta-fee
 
 ## When to offer it (user-approved only — never auto-send)
 
-Sending is always the user's call. Offer once, in plain prose, in any of these situations; send only
-after an explicit yes:
+Sending is always the user's call, but **offering is not** — default to offering, don't wait to be
+asked or for the user to complain first. Offer once, in plain prose, in any of these situations; send
+only after an explicit yes:
 
 - The user **explicitly asks** to send feedback / report something to Wix ("tell Wix that…", "report
   this", "send feedback"). Then just confirm the wording and send.
 - The user **complains, is frustrated, or reports a Wix bug** in the course of the work ("this API is
   broken", "the docs are wrong", "why is this so hard"). Acknowledge, then offer to pass it on.
-- **The run hit substantial friction** — repeated API failures, wrong/missing docs, a tooling dead
-  end, or a workaround you had to invent. When you notice the pattern, offer: *"This tripped us up a
-  few times — want me to send it to Wix as feedback?"*
+- **The run hit any real friction** — not just repeated failures. A single confusing error, a doc
+  that was wrong/stale/missing, an extra round trip you had to make, a workaround you had to invent,
+  or anything that cost more turns than it should have all qualify — it doesn't need to have happened
+  more than once. When you notice it, offer in the moment: *"That [error/doc gap] tripped us up —
+  want me to send it to Wix as feedback?"*
+- **At the natural end of every run** (deployment/handoff, or wherever the skill's flow closes out),
+  do a deliberate self-check over the whole session even if nothing felt dramatic at the time — friction
+  you shrugged off or silently retried past is still signal. If the self-check turns up anything,
+  offer before you sign off rather than letting the run end without asking.
+
+Bias toward offering over staying quiet: a redundant offer costs the user one "no thanks"; a friction
+point that goes unreported is a signal Wix never gets. Only skip the offer when the run was genuinely
+clean end to end.
 
 When you offer, invite the user to add anything in their own words — whatever they give you goes
 into the message verbatim, in its own "In the user's words" section.

--- a/skills/wix-headless/references/managed/CONNECT.md
+++ b/skills/wix-headless/references/managed/CONNECT.md
@@ -71,4 +71,4 @@ static-hosting fixes in **`references/managed/DEPLOYMENT.md`** — the entry fil
 `index.html`, and `outputDirectory` must point at the directory holding it (init's `./dist` default is
 wrong for static). Then finalize per **`references/managed/DEPLOYMENT.md`** (`npx @wix/cli@latest release` — Wix
 publishes + registers the origin OOTB). Close with a short summary (apps installed, content seeded, what
-was wired) and **both links — the live site URL and the site dashboard `https://manage.wix.com/dashboard/<SITE_ID>`** (see `managed/DEPLOYMENT.md` § "Give the user both links"; `<SITE_ID>` is the `siteId` in scratch).
+was wired) and **both links — the live site URL and the site dashboard `https://manage.wix.com/dashboard/<SITE_ID>`** (see `managed/DEPLOYMENT.md` § "Give the user both links"; `<SITE_ID>` is the `siteId` in scratch), then run the feedback checkpoint (`managed/DEPLOYMENT.md` § "Before you sign off").

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -127,4 +127,4 @@ depends on `frontendFramework` (§0):
 - **Non-Astro** → the framework's own build (e.g. `npm run build`); a static (no-build) site skips this.
   `release` publishes whatever `site.outputDirectory` points at (default `./dist`).
 
-Close with a short summary (apps installed, content seeded, pages built) and **both links — the live site URL and the site dashboard `https://manage.wix.com/dashboard/<SITE_ID>`** (see `managed/DEPLOYMENT.md` § "Give the user both links"; `<SITE_ID>` is the `siteId` in scratch).
+Close with a short summary (apps installed, content seeded, pages built) and **both links — the live site URL and the site dashboard `https://manage.wix.com/dashboard/<SITE_ID>`** (see `managed/DEPLOYMENT.md` § "Give the user both links"; `<SITE_ID>` is the `siteId` in scratch), then run the feedback checkpoint (`managed/DEPLOYMENT.md` § "Before you sign off").

--- a/skills/wix-headless/references/managed/DEPLOYMENT.md
+++ b/skills/wix-headless/references/managed/DEPLOYMENT.md
@@ -28,6 +28,14 @@ Live site:  <published-url>
 Dashboard:  https://manage.wix.com/dashboard/<SITE_ID>
 ```
 
+## Before you sign off — feedback checkpoint
+
+This is the last step of the run — the natural point to check `../FEEDBACK.md`. Don't wait for the
+user to complain: run a quick self-check over the whole session (not just this final step) — a
+confusing API response, a doc that was wrong/missing, an extra retry, a workaround you had to invent,
+anything that cost more turns than it should have. If anything qualifies, **offer** to relay it to Wix
+as you deliver the links above; send only after an explicit yes.
+
 ## Member login on a **non-Astro** frontend — register the callback URI (post-release)
 
 **Only when the run has member login on a non-Astro SPA/static frontend using the Wix login page** (`inline-recipes/how-to-code-members-non-astro.md` — the `getAuthUrl` → `/callback` handshake). Astro's built-in `/api/auth/*` callback shapes are auto-registered; a **non-Astro SPA's own callback path is not** — and **login stays dead (4xx on the login redirect) until you register it**. This is a genuine gap `wix release` does *not* close for you.

--- a/skills/wix-headless/references/self-managed/DEPLOYMENT.md
+++ b/skills/wix-headless/references/self-managed/DEPLOYMENT.md
@@ -5,3 +5,11 @@ For a **self-managed** project, the deploy/finalize steps are **not yet decided 
 Because hosting is the user's (not Wix's), this will likely mirror the self-hosted finalize pattern — **publish the metasite** and **register the deployed origin** on the OAuth app once the live URL is known (see `../stripe/DEPLOYMENT.md` for that shape) — but the exact mechanism, and how credentials/URL are supplied, are TBD.
 
 > **TBD.** Until this is defined, tell the user that `self-managed` deployment isn't wired yet, and that the frontend's visitor calls will be rejected until its origin is registered on the OAuth app.
+
+## Before you sign off — feedback checkpoint
+
+This is the last step of the run — the natural point to check `../FEEDBACK.md`. Don't wait for the
+user to complain: run a quick self-check over the whole session — a confusing API response, a doc
+that was wrong/missing, an extra retry, a workaround you had to invent, anything that cost more turns
+than it should have. If anything qualifies, **offer** to relay it to Wix before you close out; send
+only after an explicit yes.

--- a/skills/wix-headless/references/stripe/DEPLOYMENT.md
+++ b/skills/wix-headless/references/stripe/DEPLOYMENT.md
@@ -61,3 +61,11 @@ curl -sS -w "\nHTTP_STATUS:%{http_code}" -X PATCH \
 If the agent isn't the one deploying — the user will deploy the site themselves — the skill **cannot know the deployed URL**, so it cannot register the origin. (It can still publish the site — step 1 doesn't need the URL.) **Flag the origin step to the user clearly**, e.g.:
 
 > *"One required step remains before the frontend can talk to Wix: once your site is live, its URL must be registered on the Wix OAuth app (allowed domains). Give me the deployed URL — or re-run this skill with it — and I'll register it. Until then, Wix SDK calls from the live site will be rejected."*
+
+## Before you sign off — feedback checkpoint
+
+This is the last step of the run — the natural point to check `../FEEDBACK.md`. Don't wait for the
+user to complain: run a quick self-check over the whole session (not just this final step) — a
+confusing API response, a doc that was wrong/missing, an extra retry, a workaround you had to invent,
+anything that cost more turns than it should have. If anything qualifies, **offer** to relay it to Wix
+before you close out; send only after an explicit yes.


### PR DESCRIPTION
## Summary
- The FEEDBACK.md capability (relay building-with-Wix friction to Wix, opt-in) existed but rarely fired — it lived as a single buried "you may offer" line in SKILL.md with a high friction bar (repeated failures only).
- Lowered the trigger bar in `FEEDBACK.md` to any real friction (a single confusing error, a doc gap, an invented workaround — not just repeated failures), and added an explicit end-of-run self-check.
- Added a "Before you sign off — feedback checkpoint" section to all three `DEPLOYMENT.md` files (managed/self-managed/stripe) — the point where every flow naturally ends and the agent already composes its closing summary, so this becomes a required step rather than an easily-skipped footnote.
- `managed/CREATE.md` and `managed/CONNECT.md` now point to that checkpoint from their own closing-summary line.
- `SKILL.md` reworded from passive "you may offer" to point at the reinforced checkpoints.
- The hard rule is unchanged: sending still requires an explicit user "yes" — only the *offering* became proactive/default.

## Test plan
- [ ] Skim each edited file to confirm the checkpoint reads naturally at its insertion point
- [ ] Run a wix-headless flow end-to-end and confirm the agent now surfaces the feedback offer at close-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)