### PR TITLE
docs(wix-app): register ANIMATED-COMPONENTS and COMPONENT-PREVIEW in reference indexes

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -87,6 +87,8 @@ Topic-focused references (rules + patterns + common mistakes in one place):
 - [`editor-react-component/PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
 - [`editor-react-component/REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, remaining common mistakes
+- [`editor-react-component/ANIMATED-COMPONENTS.md`](editor-react-component/ANIMATED-COMPONENTS.md) — Play/pause controls for animated components (Lottie, GIF, autoPlay props)
+- [`editor-react-component/COMPONENT-PREVIEW.md`](editor-react-component/COMPONENT-PREVIEW.md) — `component.preview.tsx` patterns and `useIsEditMode()` usage
 
 ## CSS guidelines
 

--- a/skills/wix-app/references/editor-react-component/REACT-GUIDELINES.md
+++ b/skills/wix-app/references/editor-react-component/REACT-GUIDELINES.md
@@ -10,6 +10,7 @@ This guide defines rules and guidance on **how to implement** production-quality
 - [`PROPS-VS-CSS.md`](PROPS-VS-CSS.md) — What should be a React prop vs CSS
 - [`COMPONENT-API.md`](COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
 - [`ANIMATED-COMPONENTS.md`](ANIMATED-COMPONENTS.md) — Play/pause control and autoplay for animated/playable components
+- [`COMPONENT-PREVIEW.md`](COMPONENT-PREVIEW.md) — `component.preview.tsx` patterns and `useIsEditMode()` usage
 - [`REACT-PATTERNS.md`](REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, common mistakes
 
 ## React 18 features are not supported


### PR DESCRIPTION
Add both new reference files to the topic lists in EDITOR_REACT_COMPONENT.md and REACT-GUIDELINES.md so they are discoverable from the skill entry points.