### PR TITLE
🦞 igor-claw: settle Stores catalog version before product calls in setup-online-store

### DIFF
--- a/skills/wix-headless/references/SETUP.md
+++ b/skills/wix-headless/references/SETUP.md
@@ -18,7 +18,7 @@ Content-Type: application/json
 
 For each capability in `verticals[]`, install its app by `appDefId` (these are the constants the install call needs):
 
-- **stores** → `215238eb-22a5-4c36-9e7b-e7c08025e04e`
+- **stores** → `215238eb-22a5-4c36-9e7b-e7c08025e04e`. **A 200 here does not mean the catalog version has settled** — `setup-online-store.md` STEP 0 checks and settles it before any product call; don't query/delete products until that step passes.
 - **blog** → `14bcded7-0066-7c35-14d7-466cb3f09103`
 - **forms** → `225dd912-7dea-4738-8688-4b8c6955ffc2`
 - **events** → `140603ad-af8d-84a5-2c80-a0f60cb47351`

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -16,9 +16,18 @@ A concise checklist for preparing any new Wix site that uses the Online Stores a
 ---
 
 ## Article: Steps for Setting Up a Wix Online Store
-**YOU MUST** complete the following steps **in the given order** (1-4) and **without requiring additional user input**. One conditional: **the category steps (3-4) run only when the request names categories** — if `intent.stores.categoriesNamed` is empty, **create none** (skill policy, per `SEED.md` § "What to seed per capability") and skip the category steps. Products (steps 1-2) always run; the **Attach images** step runs last, only when `imagery` is on.
+**YOU MUST** complete the following steps **in the given order** (0-4) and **without requiring additional user input**. One conditional: **the category steps (3-4) run only when the request names categories** — if `intent.stores.categoriesNamed` is empty, **create none** (skill policy, per `SEED.md` § "What to seed per capability") and skip the category steps. Products (steps 1-2) always run; the **Attach images** step runs last, only when `imagery` is on.
 
 **⚠️ CRITICAL ORDER REQUIREMENT: Do the product operations FIRST (clean + create, Steps 1-2), then categories (Steps 3-4). Categories API might take some time to be fully available after Stores installation, so always finish products before attempting category operations.**
+
+### STEP 0: Confirm the catalog version — don't discover it by trial and error
+
+**Immediately after installing Stores, the catalog version is still settling — don't assume V3 and don't discover the version by calling a product endpoint and branching on a `428`.** Reproduced behavior on a freshly-installed site: the version-check endpoint itself reports `V1_CATALOG` for several seconds post-install, then hits a brief window where product *enforcement* has already switched to V3 while the version-check call still reports the stale `V1_CATALOG` value, before both agree. Querying/deleting reactively during this window is exactly what produces alternating `428 CATALOG_V1_SITE_CALLING_CATALOG_V3_API` / `428 CATALOG_V3_CALLING_CATALOG_V1_API` errors on the same site seconds apart.
+
+1. **Check the version once** — `GET https://www.wixapis.com/stores/v3/provision/version` → `{"catalogVersion": "V1_CATALOG" | "V3_CATALOG"}`.
+2. **Settle it** — re-check after ~3s; if the two reads disagree, wait ~3s more and take a third read. Cap the whole settle at ~15s total and go with the last reading — don't poll indefinitely.
+3. **Commit to that version for the rest of this run.** Every call in Steps 1-2 below is V3 (this recipe's format is V3-only). If a settled `V3_CATALOG` read is still followed by a `428` on a Steps 1-2 call, treat it as a genuine, rare mid-run version change: re-run this STEP 0 once, then retry — don't silently swap to the V1 endpoint family to "make it work."
+4. **If it settles to `V1_CATALOG`** — this recipe doesn't cover V1 (its product write shape in Step 2 is V3-only). This should not happen on a freshly-provisioned managed-headless site; if it does (e.g. an existing/connected site on the legacy catalog), stop and surface it rather than mixing V1 and V3 product calls — V1 request/response shapes differ (lower-case `productType`, `priceData.price`, no `visible` gate, etc.) from everything below.
 
 ### STEP 1: Clean the store — remove the default sample products
 


### PR DESCRIPTION
## Summary
- `setup-online-store.md` assumed Catalog V3 immediately after installing Stores. Reproduced on a freshly-provisioned managed-headless site: for several seconds post-install `GET /stores/v3/provision/version` reports `V1_CATALOG`, then there's a ~1-2s window where product *enforcement* has already switched to V3 while the version-check endpoint itself still reports the stale `V1_CATALOG` value, before both agree (fully stable ~8s after install in testing).
- An agent that discovers the version by calling a product endpoint and branching on `428` (as this recipe implicitly encouraged by assuming V3) gets alternating `428 CATALOG_V1_SITE_CALLING_CATALOG_V3_API` / `428 CATALOG_V3_CALLING_CATALOG_V1_API` on the same site seconds apart — exactly the friction reported by a user building a Wix Headless pet-supply store.
- Adds **STEP 0**: check `/stores/v3/provision/version`, settle it with a short bounded re-check (since the check endpoint itself can lag), then commit to that version for the whole recipe — no reactive endpoint-family flipping on 428. Also cross-references this from `SETUP.md`'s stores install step.
- `wix-manage`'s sibling recipe (`setup-online-store-catalog-v3.md`) already checks the version once via this same endpoint; this brings `wix-headless` to parity and hardens the check against the observed settle window.

This PR was opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching headless-platform feedback.
Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1784735372076189

## Test plan
- [x] Reproduced the version-settle race against two freshly-provisioned throwaway sites (Stores install → poll `provision/version` + V1/V3 product query every ~1.3s) — confirmed the V1→transitional→V3 sequence described above.
- [x] Confirmed `GET /stores/v3/provision/version` is a valid, working endpoint on a live site.
- [ ] Not run against a live agent session (docs-only change, no code to execute).