### PR TITLE
🦞 igor-claw: document the STATIC_ONLY-misclassification release bug and its workaround

### DIFF
--- a/skills/wix-headless/references/managed/DEPLOYMENT.md
+++ b/skills/wix-headless/references/managed/DEPLOYMENT.md
@@ -76,4 +76,12 @@ These two fixes are **Wix-hosting facts** — they apply to a connected **static
 
 A release can hit transient infrastructure errors (`ECONNRESET`, `ETIMEDOUT`, `STATE_MISMATCH`, "try again shortly"). Retry the release serially up to **3×** with a short backoff. **Build failures are not retryable** — they're code bugs; fix the code, not the retry.
 
+## Site works in `wix preview` but 404s everywhere after `wix release`
+
+If **every** route 404s in production (including `/` and `/_wix/pages.json`) right after a `wix release`, while the same build works under `wix preview`, this is a known server-side deployment classification bug, not a build or config problem in the project — don't chase entry-file/output-directory fixes (those are for the *static-frontend* case above) or re-check `astro.config`/adapter settings. Re-running `release` (even with a cache-busted rebuild, or with the suspect commit reverted) does **not** self-recover; it re-triggers the same classification and comes back 404.
+
+- **Diagnose:** confirm the report shape matches (works in `preview`, 404s in `release`) — that difference is the signature of this bug, since `preview` never calls the release/publish step. Check `.wix/debug.log` for the release request if you need to confirm.
+- **Recover:** the only fix is a **dashboard Site History republish** of a previous working deployment — open the site's dashboard (Business Manager) → Site History, and republish the last release that worked. This discards the new build, so if the new build has real changes, republish first to restore the live site, then re-release the new build once the underlying bug is fixed (tracked in wix-private/wix-code#8153).
+- Don't tell the user to keep re-releasing — it won't help, and it burns their time.
+
 That's the whole of finalize for `managed` — no `site-publisher` call, and no `oauth-app` **origin** PATCH (the origin is auto-registered). The **one** exception is the member-login callback on a non-Astro frontend above — that `allowedRedirectUris` PATCH is manual and required.


### PR DESCRIPTION
## Summary

Adds a troubleshooting entry to `skills/wix-headless/references/managed/DEPLOYMENT.md` for the case where `wix release` publishes a build that 404s on **every** route in production (including `/` and `/_wix/pages.json`), while the identical build works fine under `wix preview`.

## Why

This is a known server-side deployment-classification bug (`deploymentInfo.pageModel` wrongly resolved to `STATIC_ONLY` for SSR Astro projects that also ship static assets — essentially all of them), root-caused and fixed server-side in wix-private/wix-code#8153. Without a troubleshooting note, an agent following this recipe has no way to recognize the symptom and will likely:
- Chase the *static-frontend* fixes already documented just above this section (entry-file naming, `outputDirectory`) — those don't apply here, the project is fine.
- Keep re-running `release`, which does not self-recover (confirmed via 9 consecutive reproductions in the originating report) and wastes the user's time.

The only current recovery is a dashboard Site History republish of a previously-working deployment, which isn't documented anywhere in this skill today.

## Context

Filed from Wix MCP user feedback. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1784801330746899

This PR was opened automatically by an AI agent acting on behalf of Ayal (`ayalg@wix.com`), as part of investigating that feedback report. Not written or reviewed by a human before opening - please review accordingly.

## Test plan
- [ ] Read-through for tone/placement consistency with the rest of `DEPLOYMENT.md`
- [ ] Update/remove this note once wix-private/wix-code#8153 (or equivalent) is merged and rolled out, if the bug is confirmed gone