### PR TITLE
🦞 igor-claw: warn init/create can hit the same login wait as `login`

### DIFF
--- a/skills/wix-headless/references/managed/CONNECT.md
+++ b/skills/wix-headless/references/managed/CONNECT.md
@@ -26,6 +26,14 @@ Run from the project directory. It creates `wix.config.json` (with the `siteId` 
 OAuth app) and registers the project's origin on that app. Read `./wix.config.json` → hold `SITE_ID`
 in scratch.
 
+**If the CLI session isn't already authenticated, `init` embeds the same device-code login wait as
+`login` does** — it blocks on an `{"event":"awaiting_user",...}` line before continuing. Run it the
+same way `AUTHENTICATION.md` §1 prescribes for `login`: **`run_in_background: true`, no pipe/redirect
+of your own**. In particular, never pipe it through `tail -N` (without `-f`) — `tail` can't know which
+lines are "the last N" on a non-seekable pipe until the input ends, so it shows **nothing at all**
+until the process exits, making an actively-working login wait indistinguishable from a hang. Poll the
+captured output for the `awaiting_user` line and relay it per `AUTHENTICATION.md` §1.
+
 **If the design was brought in from elsewhere** (a `.zip`/folder/file, or a fetched design-file URL),
 place it into CWD **first** — unzip/copy/fetch the design's files into the working directory so it's the
 project on disk — **then** `init`. An empty CWD plus a brought-in design is still `connect`, not create:

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -39,8 +39,14 @@ CI=1 npm create @wix/new@latest -- headless \
 - The `--` separator is required. Bare `--site-template` (no value) keeps it on the **blank** starter —
   the model owns design, so don't adopt a business template; a value, or omitting the flag, would
   prompt and abort in a non-interactive shell.
-- The command provisions the Wix site + private app and writes `wix.config.json`. It requires a
-  logged-in CLI session (step 2 handles login if needed).
+- The command provisions the Wix site + private app and writes `wix.config.json`. **If the CLI session
+  isn't already authenticated, it embeds the same device-code login wait as `login`** — it blocks on an
+  `{"event":"awaiting_user",...}` line before continuing. Run it the way `AUTHENTICATION.md` §1
+  prescribes for `login`: **`run_in_background: true`, no pipe/redirect of your own** — in particular,
+  never pipe it through `tail -N` (without `-f`), which shows **nothing at all** until the process
+  exits (it can't know "the last N lines" of a non-seekable pipe until EOF), making an actively-working
+  login wait indistinguishable from a hang. Poll the captured output for the `awaiting_user` line and
+  relay it per `AUTHENTICATION.md` §1.
 - It creates the project in a **subdirectory named `<folder-name>`** — there is no in-place option, so
   **`cd <folder-name>`** and run the rest of the flow from inside it (it's the project root, with the
   single `.wix/`).
@@ -66,7 +72,8 @@ CI=1 npm create @wix/new@latest init
 - `npm create @wix/new@latest init` runs **in place** (no new subdirectory, no Astro files added): it
   signs you in, provisions the Wix site + private app, and writes `wix.config.json`
   (`siteId`, `appId`, `site.outputDirectory: "./dist"`). It takes no flags. Run it **from inside**
-  `<folder-name>` *after* the framework scaffold exists.
+  `<folder-name>` *after* the framework scaffold exists. **Same login-wait caveat as the Astro command
+  above** — `run_in_background: true`, no pipe/redirect of your own (never `| tail -N`).
 - A static (no-build) frontend builds to no `dist` — fix `site.outputDirectory` per
   `managed/DEPLOYMENT.md` ("Static frontends") before release.
 


### PR DESCRIPTION
## Summary
- `npm create @wix/new@latest init` (used by `CONNECT.md` §1 and `CREATE.md` §1) embeds the same device-code login wait as the standalone `login` command when the CLI session isn't already authenticated — it blocks on `{"event":"awaiting_user",...}`. Only `AUTHENTICATION.md` §1 warned agents to run `login` in the background with no self-directed pipe/redirect; `CONNECT.md`/`CREATE.md` showed `init`/the Astro scaffold as bare foreground commands with no such guidance.
- Root-caused a real reported incident: an agent piped `init`'s output through `| tail -60` and saw **zero stdout for ~7 minutes** while the process was actually waiting on the login step — indistinguishable from a hang, causing the login code to expire unused. Reproduced directly: a plain `console.log` on a piped, non-TTY stdout flushes immediately (confirmed via `cat`), but `tail -N` (without `-f`) shows **nothing** until the process exits, because it can't know "the last N lines" of a non-seekable pipe until EOF. So this isn't CLI-side stdout buffering — it's the invocation pattern the skill told agents to use.
- Fix: point `CONNECT.md`/`CREATE.md` at the same `run_in_background: true` + no-redirect-of-your-own pattern `AUTHENTICATION.md` already prescribes for `login`, and explicitly call out `tail -N` as the trap.

## Context
This was opened automatically by an AI agent (Claude, via an igor-claw research run) on behalf of Ayal (`ayalg@wix.com`) — not written by Ayal directly. Source report thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1785012861103909

## Test plan
- [x] Reproduced the `console.log`-on-pipe-via-`cat` (immediate) vs. `console.log`-on-pipe-via-`tail -60` (silent until EOF) behavior directly against Node.
- [x] Confirmed `init`/create's login path (`@wix/create-new` → `loginMode: agent` → `runAgentLoginFlow` → plain `console.log`) in `wix-private/wix-cli`.
- Docs-only change; no code to test.