### PR TITLE
fix(wix-app): give OBJECT data-collection fields a copyable TS example to stop TS2741

### DIFF
--- a/skills/wix-app/references/DATA_COLLECTION.md
+++ b/skills/wix-app/references/DATA_COLLECTION.md
@@ -321,7 +321,6 @@ export default {
   fields: [
     { key: 'title', displayName: 'Fee Title', type: 'TEXT' },
     { key: 'amount', displayName: 'Fee Amount', type: 'NUMBER' },
-    // OBJECT fields MUST carry objectOptions.fields — an empty array still accepts arbitrary JSON
     { key: 'metadata', displayName: 'Metadata', type: 'OBJECT', objectOptions: { fields: [] } },
   ],
   dataPermissions: {

--- a/skills/wix-app/references/DATA_COLLECTION.md
+++ b/skills/wix-app/references/DATA_COLLECTION.md
@@ -74,43 +74,40 @@ export default {
 | `URL`             | URL validation                   | Links                  |
 | `PAGE_LINK`       | Link to Wix page                 | Internal navigation    |
 | `LANGUAGE`        | Language code                    | Multi-language content |
-| `OBJECT`          | JSON object                      | Flexible data          |
+| `OBJECT`          | JSON object — requires `objectOptions: { fields: [] }` | Flexible data |
 | `ARRAY`           | Array of values                  | Generic arrays         |
 | `ARRAY_STRING`    | Array of strings                 | Tags list              |
 | `ARRAY_DOCUMENT`  | Array of documents               | File collections       |
 | `ANY`             | Any type                         | Most flexible          |
 
-**CRITICAL: OBJECT fields require `objectOptions` with a `fields` array.** When using `type: "OBJECT"`, you MUST include `objectOptions: { fields: [] }` — the API will reject OBJECT fields without it. Use an empty `fields` array if you don't need a fixed schema (the object will still accept arbitrary JSON):
+**CRITICAL: OBJECT fields require `objectOptions` with a `fields` array.** When using `type: 'OBJECT'`, you MUST include `objectOptions: { fields: [] }`. Use an empty `fields` array if you don't need a fixed schema (the object still accepts arbitrary JSON):
 
-```json
-{
-  "key": "settings",
-  "displayName": "Settings",
-  "type": "OBJECT",
-  "objectOptions": { "fields": [] }
-}
+| ❌ WRONG                                                        | ✅ CORRECT                                                                    |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `{ key: 'settings', type: 'OBJECT', objectOptions: {} }`       | `{ key: 'settings', type: 'OBJECT', objectOptions: { fields: [] } }`         |
+
+> ⚠️ `objectOptions: {}` (without the `fields` key) does **not** type-check — `fields` is required on `DevCenterDataCollectionObjectOptions`, so the build fails with `TS2741: Property 'fields' is missing`. Always include `fields`, even as an empty array.
+
+Written as a full field, in the same TypeScript syntax as the rest of the collection file:
+
+```ts
+{ key: 'settings', displayName: 'Settings', type: 'OBJECT', objectOptions: { fields: [] } }
 ```
-
-> ⚠️ `objectOptions: {}` (without the `fields` key) is **not valid** and will cause a runtime error. Always include `fields`, even as an empty array.
 
 For structured objects with a defined schema, list the nested fields inside `objectOptions.fields`:
 
-```json
+```ts
 {
-  "key": "triggerRules",
-  "displayName": "Trigger Rules",
-  "type": "OBJECT",
-  "objectOptions": {
-    "fields": [
-      { "key": "url", "displayName": "URL Condition", "type": "TEXT" },
-      {
-        "key": "scrollDepth",
-        "displayName": "Scroll Depth %",
-        "type": "NUMBER"
-      },
-      { "key": "dateStart", "displayName": "Start Date", "type": "DATE" }
-    ]
-  }
+  key: 'triggerRules',
+  displayName: 'Trigger Rules',
+  type: 'OBJECT',
+  objectOptions: {
+    fields: [
+      { key: 'url', displayName: 'URL Condition', type: 'TEXT' },
+      { key: 'scrollDepth', displayName: 'Scroll Depth %', type: 'NUMBER' },
+      { key: 'dateStart', displayName: 'Start Date', type: 'DATE' },
+    ],
+  },
 }
 ```
 
@@ -324,6 +321,8 @@ export default {
   fields: [
     { key: 'title', displayName: 'Fee Title', type: 'TEXT' },
     { key: 'amount', displayName: 'Fee Amount', type: 'NUMBER' },
+    // OBJECT fields MUST carry objectOptions.fields — an empty array still accepts arbitrary JSON
+    { key: 'metadata', displayName: 'Metadata', type: 'OBJECT', objectOptions: { fields: [] } },
   ],
   dataPermissions: {
     itemRead: 'ANYONE',


### PR DESCRIPTION
## Problem

Codegen keeps writing `objectOptions: {}` for OBJECT-type data collection fields instead of `objectOptions: { fields: [] }`, failing type-check with TS2741 — **21 jobs in 2 weeks**.

`DATA_COLLECTION.md` already warned against this, so it was present-but-ignored. Root cause: the model copies **examples**, and every complete `satisfies DataCollection` example used TEXT/NUMBER/REFERENCE — no OBJECT field to copy. The only OBJECT examples were JSON in a distant section, so the model improvised the loose `{}` default.

## Fix (one file, `skills/wix-app/references/DATA_COLLECTION.md`)

- Add an OBJECT field to the copyable TS worked example — the missing anchor.
- Convert the inline OBJECT examples from JSON to TS, with a `❌ WRONG / ✅ CORRECT` contrast.
- Annotate the `OBJECT` row in the Field Types table.
- Reframe the callout to the real compile-time error (TS2741).

🤖 Generated with [Claude Code](https://claude.com/claude-code)