### PR TITLE
feat(discovery): read an existing site's installed capabilities instead of guessing the vertical

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -118,6 +118,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 |---|---|
 | Vertical index (intent matching + per-vertical site spec) | `<SKILL_ROOT>/references/CAPABILITIES.md` |
 | Discovery (infer capabilities + brand + intent) | `<SKILL_ROOT>/references/DISCOVERY.md` |
+| Site discovery script (existing site → installed apps + site props) | `<SKILL_ROOT>/references/discover-site.mjs` |
 | Setup (install apps) | `<SKILL_ROOT>/references/SETUP.md` |
 | Seed (create backend content) | `<SKILL_ROOT>/references/SEED.md` |
 | SDK-integration handoff (emitted, or applied by create/connect) | `<SKILL_ROOT>/references/SDK_HANDOFF.md` |

--- a/skills/wix-headless/references/DISCOVERY.md
+++ b/skills/wix-headless/references/DISCOVERY.md
@@ -6,6 +6,24 @@ Discovery is pure inference — it needs **no authentication** and is **agnostic
 
 ## 1 · Resolve the capability set
 
+> **Targeting an existing site with an ambiguous brief? Read the site — don't guess.** When the
+> run points at a site that already exists (connect/iterate, a funnel-created site, "build a
+> frontend for my business" with no vertical named) and an elevated credential is already
+> available, the site itself is the ground truth of what the business is:
+>
+> ```bash
+> WIX_TOKEN=$TOKEN node <SKILL_ROOT>/references/discover-site.mjs $SITE_ID
+> ```
+>
+> The installed apps it reports (plus non-empty `cmsCollections` → cms) map to the vertical
+> set and seed `verticals[]` directly; inference below then only fills what the site can't
+> answer (brand, per-capability intent).
+> Several verticals installed → prioritize by the user's words and by which holds real
+> (non-sample) content. Nothing installed → **ask the user one short question** ("what do you
+> offer — products, appointments, posts, events?") rather than defaulting to a store. This is
+> the one case where Discovery may use the authentication mechanism early; with no credential
+> at hand yet, skip it and infer from the words as below.
+
 Read the **user intent** (+ optional project signals: `package.json` name, README, visible copy) against the vertical index in `references/CAPABILITIES.md` — each entry there carries the intent signals that point to it. Pick every vertical that genuinely fits → `verticals[]`. Multiple signals → multiple capabilities. On ambiguity, prefer the more specific vertical; if nothing dynamic is named, fall to the **forms** floor (a contact form). **Never return an empty set.**
 
 Resolve to the skill's operational set — **stores · blog · cms · forms · events · bookings · pricing-plans · restaurants · portfolio** (`CAPABILITIES.md` § "Built verticals"). If intent points squarely at a vertical outside that set, note it plainly as not-yet-wired (per the index) and resolve the rest; don't force an unrelated capability in its place.

--- a/skills/wix-headless/references/discover-site.mjs
+++ b/skills/wix-headless/references/discover-site.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * discover-site.mjs — read what an existing Wix site already is: which Wix
+ * business apps are installed on it, plus basic site properties.
+ *
+ * Use it when a run targets an EXISTING site and the words alone don't say
+ * what to build — an ambiguous brief ("build a frontend for my business"), a
+ * connect/iterate pass over a site that may already be set up. The site is
+ * the ground truth of what the business is; read it instead of guessing.
+ *
+ * Usage:
+ *   WIX_TOKEN=<elevated credential> node discover-site.mjs <metaSiteId>
+ *
+ * WIX_TOKEN is an elevated credential from the run's authentication mechanism
+ * (see <TYPE_DIR>/AUTHENTICATION.md) — a CLI-minted token, a platform
+ * Wix-connector access token, or a Wix API key. The public client id and
+ * visitor tokens are rejected by these APIs.
+ *
+ * Output — one JSON object of plain data (interpretation stays with the
+ * caller and the flow docs):
+ *   site           — id, displayName, url, namespace ("HEADLESS" = headless
+ *                    project), editorType, published, premium, veloEnabled,
+ *                    createdDate/updatedDate, language, currency, timeZone
+ *   installedApps  — the known Wix business apps installed on the site:
+ *                    { name, appId, ...extras }, resolved against KNOWN_APPS
+ *                    below. Any extra field the API reports on an app (e.g.
+ *                    stores' catalogVersion) rides along untouched. Note that
+ *                    ecom is installed alongside ANY selling app (bookings,
+ *                    events, …), not only stores.
+ *   cmsCollections — native CMS collections (id + non-system field keys).
+ *                    Wix Data is core, so there is no app to detect — a
+ *                    non-empty list is the signal that CMS is in use.
+ */
+
+const WIX_API_BASE = "https://www.wixapis.com";
+
+// appDefId → app name, for the apps this skill can build on. Keep in sync
+// with SETUP.md §2 (the install table) — these are the same appDefId
+// constants. The full "Apps Created by Wix" appDefId list lives in the docs:
+// https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/platform/about-apps-created-by-wix.md
+const KNOWN_APPS = {
+  "215238eb-22a5-4c36-9e7b-e7c08025e04e": "stores",
+  "14bcded7-0066-7c35-14d7-466cb3f09103": "blog",
+  "225dd912-7dea-4738-8688-4b8c6955ffc2": "forms",
+  "140603ad-af8d-84a5-2c80-a0f60cb47351": "events",
+  "13d21c63-b5ec-5912-8397-c3a5ddb27a97": "bookings",
+  "1522827f-c56c-a5c9-2ac9-00f9e6ae12d3": "pricing-plans",
+  "b278a256-2757-4f19-9313-c05c783bec92": "restaurants menus",
+  "9a5d83fd-8570-482e-81ab-cfa88942ee60": "restaurants online ordering",
+  "f9c07de2-5341-40c6-b096-8eb39de391fb": "restaurants table reservations",
+  "d90652a2-f5a1-4c7c-84c4-d4cdcc41f130": "portfolio",
+  "1380b703-ce81-ff05-f115-39571d94dfcd": "ecom (checkout layer)",
+  "14cc59bc-f0b7-15b8-e1c7-89ce41d0e0c9": "members area (profile)",
+  "a95a5fce-e370-4402-9ce4-96956acc747d": "reviews",
+};
+
+const siteId = process.argv[2];
+const token = process.env.WIX_TOKEN;
+if (!siteId || !token) {
+  console.error("Usage: WIX_TOKEN=<elevated credential> node discover-site.mjs <metaSiteId>");
+  process.exit(1);
+}
+// Wix API keys ("IST.…") are sent raw; OAuth access tokens take a Bearer prefix.
+const authHeader = token.startsWith("IST.") ? token : `Bearer ${token}`;
+
+async function wixFetch(path, { method = "GET", body } = {}) {
+  const res = await fetch(`${WIX_API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: authHeader,
+      "wix-site-id": siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error(`${path} -> HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return res.json();
+}
+
+// Dynamic Context — one call returns the installed apps plus site metadata
+// and CMS collection schemas.
+const data = await wixFetch("/_api/dynamic-context/v1/dynamic-context", {
+  method: "POST",
+  body: { siteId },
+});
+const site = data.sites?.[0];
+if (!site) throw new Error("dynamic-context returned no site for this siteId");
+
+// Resolve against KNOWN_APPS — NEVER read the raw app list as a verdict: it
+// holds 50+ infra entries and non-GUID legacy ids ("HtmlAnywhere").
+const installedApps = (site.installedApps ?? []).flatMap((app) =>
+  KNOWN_APPS[app.appId] ? [{ name: KNOWN_APPS[app.appId], ...app }] : []
+);
+
+console.log(
+  JSON.stringify(
+    {
+      site: {
+        id: site.id,
+        displayName: site.displayName,
+        url: site.url,
+        namespace: site.namespace,
+        editorType: site.editorType,
+        published: site.published,
+        premium: site.premium,
+        veloEnabled: site.veloEnabled,
+        createdDate: site.createdDate,
+        updatedDate: site.updatedDate,
+        language: site.properties?.language,
+        currency: site.properties?.paymentCurrency,
+        timeZone: site.properties?.timeZone,
+      },
+      installedApps,
+      cmsCollections: (site.cmsCollections ?? []).map((c) => ({
+        id: c.id,
+        fields: (c.fields ?? []).filter((f) => !f.systemField).map((f) => f.key),
+      })),
+    },
+    null,
+    2
+  )
+);

--- a/skills/wix-headless/references/managed/CONNECT.md
+++ b/skills/wix-headless/references/managed/CONNECT.md
@@ -14,7 +14,7 @@ Run these in order:
 
 **If a `wix.config.json` (or `.wix/`) is already present, the project is already connected to Wix — this is the *iterate* case.** Do **not** run `init` again (it's for attaching a *new* Wix project). Read `./wix.config.json` → hold `SITE_ID` in scratch, and skip to §2.
 
-> **Iterate is incremental.** An already-connected project may already be set up and/or seeded from a prior run. In §3–§4, **check current state before acting** — query installed apps before installing, check for already-seeded content before seeding (re-seeding duplicates it), and inspect existing wiring before adding. Do only the delta the new intent requires; leave the rest untouched.
+> **Iterate is incremental.** An already-connected project may already be set up and/or seeded from a prior run. In §3–§4, **check current state before acting** — query installed apps before installing (`WIX_TOKEN=$TOKEN node <SKILL_ROOT>/references/discover-site.mjs $SITE_ID` reports them in one call), check for already-seeded content before seeding (re-seeding duplicates it), and inspect existing wiring before adding. Do only the delta the new intent requires; leave the rest untouched.
 
 Otherwise, attach Wix in place:
 

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -123,11 +123,31 @@ with a blog, or a store with pricing plans).
 | Plans & pricing: memberships/subscriptions, subscribe, my plans | **pricing-plans** | `references/pricing-plans/INSTRUCTIONS.md` | `references/pricing-plans/wix-pricing-plans.js` |
 | Member accounts: custom login/sign-up (email+password, Google/Facebook, SSO), account area, gated content | **members** | `references/members/INSTRUCTIONS.md` | `references/members/wix-members-auth.js` |
 
+### When the request doesn't name a vertical — read the site or ask, never guess
+
+Don't infer a vertical from a vague brief. In order of preference:
+
+1. **Read the site.** With an admin-grade Wix credential — the platform's Wix connector or a
+   user-provided API key (the public `WIX_CLIENT_ID` is **not** enough) — run the
+   `wix-headless` skill's discovery script (`../wix-headless/references/discover-site.mjs`
+   when co-installed):
+
+   ```bash
+   WIX_TOKEN=<admin token or API key> node ../wix-headless/references/discover-site.mjs <metaSiteId>
+   ```
+
+   Build for the verticals matching the installed apps it reports; several → prioritize by
+   the user's words and by which holds real (non-sample) content.
+2. **Ask.** No admin credential — or the script failed, reported nothing, or doesn't apply?
+   Ask one short question — what do they offer (products? appointments? posts? events?).
+
 ## The run
 
 1. **Get `WIX_CLIENT_ID`.** It comes from the user (the handoff prompt from their Wix/vibe
    platform carries it). If it's missing, ask for it before wiring — nothing works without it.
-2. **Pick the vertical(s)** from the routing table and open each one's `INSTRUCTIONS.md`.
+2. **Pick the vertical(s)** from the routing table — and when the request doesn't name any,
+   **read the site or ask** (see above) instead of guessing. Open each picked vertical's
+   `INSTRUCTIONS.md`.
 3. **Copy the two files per vertical** — `shared/wix-client.js` (once) + the vertical helper —
    into the app's `src/rest/` (adjust only the import path if the app uses a different folder),
    and set `WIX_CLIENT_ID`.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -10,17 +10,18 @@ the Wix client setup.
 
 Follow the steps below exactly.
 
-## STEP 0 — Install the Wix skills locally
+## STEP 1 — Install the Wix skills locally
 
 Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
-  APIs. This is your main source of truth (STEP 1).
+  APIs. This is your main source of truth (STEP 3).
 - **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
-  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 2. **Ignore
+  of which does not apply to how you build here**. Use it **only** as a seeding/admin reference —
+  its `references/SEED.md` and `references/inline-recipes/` for STEP 4, and its
+  `references/discover-site.mjs` discovery script for STEP 2. **Ignore
   everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
   "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
-  That is **not** how auth works here — auth is handled per STEP 2 below.
+  That is **not** how auth works here — auth is handled per STEP 4 below.
 - **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
   the seeding recipes above don't cover.
 
@@ -72,14 +73,28 @@ on the tool:
 - **exec_tool / shell** (only if you must): use the absolute path
   `/app/.agents/skills/wix-vibe-headless/SKILL.md`.
 
-## STEP 1 — Build the client
+## STEP 2 (optional) — Brief doesn't say what to build? Read the site
+
+Only needed when the business description in your prompt is vague or missing — otherwise skip
+to STEP 3. Don't guess a vertical: the site's installed apps are the ground truth. Get the
+connector access token (STEP 4 snippet) and run:
+
+```bash
+WIX_TOKEN=<connector access token> node .agents/skills/wix-headless/references/discover-site.mjs <metasite id>
+```
+
+Build for the verticals matching the installed apps it reports (several → prioritize by the
+user's words and by which holds real, non-sample content); the same output drives STEP 4's
+seeding. If it fails or reports nothing, ask the user what they offer.
+
+## STEP 3 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — it is the single
 source of truth for how the client app is built. To save time, prefer copying ready-made files
 the `wix-vibe-headless` skill provides (e.g. the Wix client setup) and adapting them over
 re-generating them from scratch.
 
-## STEP 2 — Manage and seed the business
+## STEP 4 — Manage and seed the business
 
 Seed the site with real content by following the **`wix-headless` skill**'s
 `references/SEED.md` (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes
@@ -110,17 +125,17 @@ that pattern is only for standalone `.js` skill files, and inline it throws *"Id
 'base44' has already been declared."*
 
 **IMPORTANT:** the Wix connector and the `wix-headless` skill's seeding instructions are for
-management/admin operations only (STEP 2) — they are **NOT** part of the client. The client is
+management/admin operations only (STEP 4) — they are **NOT** part of the client. The client is
 built solely per the `wix-vibe-headless` skill.
 
 ## Parallelism
 
-If possible, run STEP 1 and STEP 2 in parallel — building the client and seeding the business
+If possible, run STEP 3 and STEP 4 in parallel — building the client and seeding the business
 are independent, so don't wait for one to start the other. Within each step, also work in
 parallel where possible (e.g. independent API calls, seeding multiple entities) instead of
 one-by-one, to finish faster.
 
-## STEP 3 — Wrap up
+## STEP 5 — Wrap up
 
 Once the site is built and seeded:
 
@@ -136,7 +151,7 @@ Once the site is built and seeded:
 
 ## Later admin requests
 
-For any later admin/management request the user makes, work the same way as STEP 2: check the
+For any later admin/management request the user makes, work the same way as STEP 4: check the
 `wix-headless` skill's inline recipes first (`.agents/skills/wix-headless/references/inline-recipes/`)
 and, where the operation isn't documented there, fall back to the `wix-docs` skill to search the
 Wix API docs — all over the Wix connector.

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -3,17 +3,18 @@
 You are building a **Wix Managed** headless site. The business to build, and your Wix client id
 and metasite id, are given in your initial prompt. Follow the steps below.
 
-## STEP 0 — Install the Wix skills locally
+## STEP 1 — Install the Wix skills locally
 
 Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
-  APIs. This is your main source of truth (STEP 1).
+  APIs. This is your main source of truth (STEP 3).
 - **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
-  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 2. **Ignore
+  of which does not apply to how you build here**. Use it **only** as a seeding/admin reference —
+  its `references/SEED.md` and `references/inline-recipes/` for STEP 4, and its
+  `references/discover-site.mjs` discovery script for STEP 2. **Ignore
   everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
   "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
-  That is **not** how auth works here — auth is handled per STEP 2 below.
+  That is **not** how auth works here — auth is handled per STEP 4 below.
 - **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
   the seeding recipes above don't cover.
 
@@ -36,7 +37,22 @@ for s in headless vibe-headless docs; do
 done
 ```
 
-## STEP 1 — Build the client
+## STEP 2 (optional) — Brief doesn't say what to build? Ask, or read the site
+
+Only needed when the business description in your prompt is vague or missing — otherwise skip
+to STEP 3. Don't guess a vertical. Either **ask the user** one short question (what do they
+offer?), or — if you have an admin-grade Wix credential (connector token or API key, per
+STEP 4; the public `WIX_CLIENT_ID` is not enough) — **read the site**:
+
+```bash
+WIX_TOKEN=<admin token or API key> node .agents/skills/wix-headless/references/discover-site.mjs <metasite id>
+```
+
+Build for the verticals matching the installed apps it reports (several → prioritize by the
+user's words and by which holds real, non-sample content); the same set drives STEP 4's
+seeding — never seed guessed verticals.
+
+## STEP 3 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **exactly** — it is the single
 source of truth for how the client app is built against the Wix APIs (over the public
@@ -44,7 +60,7 @@ source of truth for how the client app is built against the Wix APIs (over the p
 prefer copying the ready-made files the `wix-vibe-headless` skill provides (e.g. the Wix client
 setup) and adapting them over re-generating them from scratch.
 
-## STEP 2 — Seed and manage the business
+## STEP 4 — Seed and manage the business
 
 Seed the site with real content by following the `wix-headless` skill's `references/SEED.md`
 (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes don't cover what you
@@ -71,13 +87,13 @@ CLI (`@wix/cli`), do a device-login, or follow `wix-headless`'s `references/mana
 Management/admin operations (seeding, `wix-headless`, `wix-docs`) are **separate from the
 client** — the client is built solely per the `wix-vibe-headless` skill.
 
-If possible, run STEP 1 and STEP 2 in parallel — building the client and seeding the business
+If possible, run STEP 3 and STEP 4 in parallel — building the client and seeding the business
 are independent. Within each, also parallelize independent work (API calls, seeding multiple
 entities) to finish faster.
 
 ## Later admin requests
 
-For any later admin/management request, work the same way as STEP 2: check the `wix-headless`
+For any later admin/management request, work the same way as STEP 4: check the `wix-headless`
 skill's inline recipes first (`.agents/skills/wix-headless/references/inline-recipes/`) and fall
 back to the `wix-docs` skill where the operation isn't documented there.
 


### PR DESCRIPTION
## Problem

Reported from the field: when the vibe flow runs with a vague brief — the user names no store/bookings/blog/… — the agent always pattern-matches to a **store or bookings site** without attempting to understand what the site actually is. Neither `SKILL.md`'s routing nor the platform handoffs had any discovery step, and the site — created with specific business apps installed — is the ground truth the agent never consults.

## Design

Discovery belongs to `wix-headless` (which owns the admin/manage axis and the connect/iterate path); `wix-vibe-headless` just points at it.

**`wix-headless` — new `references/discover-site.mjs`** (dependency-free, copy-as-is like the other shipped helpers):

```bash
WIX_TOKEN=<elevated credential> node references/discover-site.mjs <metaSiteId>
```

One dynamic-context call, output is **plain data mirroring what the dynamic-context enricher exposes** — interpretation stays with the flow docs:

- `site` — id, displayName, url, `namespace` (`HEADLESS` for funnel sites), editorType, published/premium, veloEnabled, dates, language, currency, timeZone.
- `installedApps` — the known Wix business apps on the site (`{ name, appId, ...extras }`), resolved against the same appDefId constants as `SETUP.md` §2 (never by reading the raw ~50-entry list, which is mostly infra plus non-GUID legacy ids). Extra per-app fields ride along generically — e.g. stores' `catalogVersion`, which gates the V3-only frontend recipes. `ecom (checkout layer)` is named as what it is, since it installs alongside *any* selling app — counting it as "store" is exactly the reported bias.
- `cmsCollections` — native collections with field keys (Wix Data is core; a non-empty list is the CMS signal).
- Accepts connector/CLI OAuth tokens (`Bearer`) and Wix API keys (`IST.…`, raw). Visitor tokens / the public client id are rejected by the API — evaluated and ruled out as a discovery credential.

Wired into the flow docs: `DISCOVERY.md` §1 (existing site + ambiguous brief + credential at hand → run the script; the apps it reports seed `verticals[]`; nothing installed → ask one short question, never default to a store) and `CONNECT.md`'s iterate state check.

**`wix-vibe-headless` — "read the site or ask, never guess":**

- `SKILL.md` routing: with an admin-grade credential, run the co-installed script and build for the verticals matching the apps it reports (several → prioritize by the user's words and by which holds real, non-sample content); otherwise — or if the script fails or reports nothing — ask the user one short question.
- `platforms/base44.md` / `platforms/generic.md`: steps renumbered to a plain 1..N sequence, with a new **optional STEP 2** ("only needed when the brief is vague") — base44 runs the script over the already-configured connector; generic offers ask-the-user or the same script over a connector token / API key. The same output drives STEP 4's seeding.

## Verification

Script tested against 70 real account sites (10-way parallel batch included; ~1s/site): a bookings-only spa resolves to bookings (no invented store), store sites to stores with `catalogVersion` (including one V1-catalog site the V3-only recipes would break on), a six-app funnel site lists all six, and plain editor sites with no business apps return an empty list. Verdicts cross-checked three ways (per-vertical content reads over the public client id, admin `app-instances`, and the site-domain dynamic model) — 100% agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)