### PR TITLE
fix(wix-app): document singular service plugin types 

### DIFF
--- a/skills/wix-app/references/SERVICE_PLUGIN.md
+++ b/skills/wix-app/references/SERVICE_PLUGIN.md
@@ -7,16 +7,18 @@ Service plugins are a set of APIs defined by Wix that let you inject custom logi
 
 Use `wix generate --params` with `extensionType: SERVICE_PLUGIN`. `pluginType` is one of:
 
-| Value | SPI |
-| --- | --- |
-| `ECOM_ADDITIONAL_FEES` | Additional Fees |
-| `ECOM_SHIPPING_RATES` | Shipping Rates |
-| `ECOM_DISCOUNTS_TRIGGER` | Discount Triggers |
-| `ECOM_VALIDATIONS` | Validations |
-| `ECOM_PAYMENT_SETTINGS` | Payment Settings |
-| `GIFT_CARDS_PROVIDER` | Gift Cards Provider |
-| `STAFF_SORTING_PROVIDER` | Bookings Staff Sorting |
-| `REALTIME_PERMISSIONS_PROVIDER` | Realtime Permissions Provider |
+| Value | SPI | Singular |
+| --- | --- | --- |
+| `ECOM_ADDITIONAL_FEES` | Additional Fees | No |
+| `ECOM_SHIPPING_RATES` | Shipping Rates | **Yes** |
+| `ECOM_DISCOUNTS_TRIGGER` | Discount Triggers | **Yes** |
+| `ECOM_VALIDATIONS` | Validations | No |
+| `ECOM_PAYMENT_SETTINGS` | Payment Settings | No |
+| `GIFT_CARDS_PROVIDER` | Gift Cards Provider | **Yes** |
+| `STAFF_SORTING_PROVIDER` | Bookings Staff Sorting | No |
+| `REALTIME_PERMISSIONS_PROVIDER` | Realtime Permissions Provider | No |
+
+> **Singular types** — `ECOM_SHIPPING_RATES`, `ECOM_DISCOUNTS_TRIGGER`, and `GIFT_CARDS_PROVIDER` are **singular**: only one component of each type is allowed per app. Never scaffold or include two components of the same singular type in the same app payload.
 
 `name` must be lowercase alphanumeric + hyphens, max 19 characters. The CLI generates the folder, `plugin.ts`, the builder file, the UUID, and the `src/extensions.ts` registration with the appropriate builder method for the SPI type. Some SPI types (e.g., `ECOM_SHIPPING_RATES`) get a `description` placeholder field in the generated builder — replace it with your real copy.
 

--- a/skills/wix-app/references/service-plugin/DISCOUNT-TRIGGERS.md
+++ b/skills/wix-app/references/service-plugin/DISCOUNT-TRIGGERS.md
@@ -69,6 +69,10 @@ customTriggers.provideHandlers({
 });
 ```
 
+## Singular Constraint
+
+`ECOM_DISCOUNTS_TRIGGER` is **singular** — only one component of this type is allowed per app. Do not scaffold or include two Discount Triggers service plugins in the same app.
+
 ## Key Implementation Notes
 
 1. **Trigger IDs must match** - The `customTriggerId` in `getEligibleTriggers` must match an `_id` from `listTriggers`

--- a/skills/wix-app/references/service-plugin/GIFT-CARDS.md
+++ b/skills/wix-app/references/service-plugin/GIFT-CARDS.md
@@ -67,6 +67,10 @@ giftVouchersProvider.provideHandlers({
 });
 ```
 
+## Singular Constraint
+
+`GIFT_CARDS_PROVIDER` is **singular** — only one component of this type is allowed per app. Do not scaffold or include two Gift Cards service plugins in the same app.
+
 ## Key Implementation Notes
 
 1. **All three handlers required** - You must implement `redeem`, `getBalance`, and `_void`

--- a/skills/wix-app/references/service-plugin/SHIPPING-RATES.md
+++ b/skills/wix-app/references/service-plugin/SHIPPING-RATES.md
@@ -53,6 +53,10 @@ shippingRates.provideHandlers({
 });
 ```
 
+## Singular Constraint
+
+`ECOM_SHIPPING_RATES` is **singular** — only one component of this type is allowed per app. Do not scaffold or include two Shipping Rates service plugins in the same app.
+
 ## Key Implementation Notes
 
 1. **Price as string** - All price values must be strings, not numbers


### PR DESCRIPTION
## Summary

- Adds a `Singular` column to the scaffold table in `SERVICE_PLUGIN.md` showing which plugin types are one-per-app
- Adds a callout warning in `SERVICE_PLUGIN.md` naming all 3 singular types explicitly
- Adds a `## Singular Constraint` section to `SHIPPING-RATES.md`, `DISCOUNT-TRIGGERS.md`, and `GIFT-CARDS.md`

**Singular types** (verified against the live Wix component catalog API):
- `ECOM_SHIPPING_RATES` — Shipping Rates
- `ECOM_DISCOUNTS_TRIGGER` — Discount Triggers
- `GIFT_CARDS_PROVIDER` — Gift Cards Provider

**Non-singular:** `ECOM_ADDITIONAL_FEES`, `ECOM_VALIDATIONS`, `ECOM_PAYMENT_SETTINGS`, `STAFF_SORTING_PROVIDER`, `REALTIME_PERMISSIONS_PROVIDER`

## Test plan

- [ ] Verify `SERVICE_PLUGIN.md` scaffold table renders correctly with the new Singular column
- [ ] Confirm the warning callout is visible above the `name` constraints paragraph
- [ ] Confirm each of the 3 affected reference files has the `Singular Constraint` section before `Key Implementation Notes`

Fixes [CODEAI-921](https://wix.atlassian.net/browse/CODEAI-921)

🤖 Generated with [Claude Code](https://claude.com/claude-code)