### PR TITLE
fix(wix-vibe-headless): simplify vague-brief discovery — ask, or check via the skill's own query APIs

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -123,30 +123,24 @@ with a blog, or a store with pricing plans).
 | Plans & pricing: memberships/subscriptions, subscribe, my plans | **pricing-plans** | `references/pricing-plans/INSTRUCTIONS.md` | `references/pricing-plans/wix-pricing-plans.js` |
 | Member accounts: custom login/sign-up (email+password, Google/Facebook, SSO), account area, gated content | **members** | `references/members/INSTRUCTIONS.md` | `references/members/wix-members-auth.js` |
 
-### When the request doesn't name a vertical — read the site or ask, never guess
+### When the request doesn't name a Wix Business Solution — ask, or check the site
 
-Don't infer a vertical from a vague brief. In order of preference:
-
-1. **Read the site.** With an admin-grade Wix credential — the platform's Wix connector or a
-   user-provided API key (the public `WIX_CLIENT_ID` is **not** enough) — run the
-   `wix-headless` skill's discovery script (`../wix-headless/references/discover-site.mjs`
-   when co-installed):
-
-   ```bash
-   WIX_TOKEN=<admin token or API key> node ../wix-headless/references/discover-site.mjs <metaSiteId>
-   ```
-
-   Build for the verticals matching the installed apps it reports; several → prioritize by
-   the user's words and by which holds real (non-sample) content.
-2. **Ask.** No admin credential — or the script failed, reported nothing, or doesn't apply?
-   Ask one short question — what do they offer (products? appointments? posts? events?).
+Don't infer which Wix Business Solution to build (stores, bookings, blog, events, portfolio,
+restaurants, CMS, pricing plans, members, etc..) from a vague brief. **Ask the user** one short
+question — what do they offer (products? appointments? posts? events?) — or **check what the
+site actually has**: call a cheap read from each likely solution's helper (`queryProducts`,
+`queryServices`, `queryPosts`, `queryEvents`, …) — authenticated with a visitor token minted
+from the `WIX_CLIENT_ID`, or with an admin token if you have one — and build for the solutions
+that return real content. A `428` "app not installed" (blog: `401`) means
+that solution isn't on the site; sample-looking content ("Sample product 3") proves the app is
+installed, not what the business is about. Never default to store/bookings on silence.
 
 ## The run
 
 1. **Get `WIX_CLIENT_ID`.** It comes from the user (the handoff prompt from their Wix/vibe
    platform carries it). If it's missing, ask for it before wiring — nothing works without it.
 2. **Pick the vertical(s)** from the routing table — and when the request doesn't name any,
-   **read the site or ask** (see above) instead of guessing. Open each picked vertical's
+   **ask or check the site** (see above) instead of guessing. Open each picked vertical's
    `INSTRUCTIONS.md`.
 3. **Copy the two files per vertical** — `shared/wix-client.js` (once) + the vertical helper —
    into the app's `src/rest/` (adjust only the import path if the app uses a different folder),

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -8,7 +8,13 @@ Your Wix client id is given in your prompt. It's a public, buyer/visitor-facing 
 only mints anonymous visitor tokens), so it's safe in the frontend — use that value directly for
 the Wix client setup.
 
-Follow the steps below exactly.
+Follow the steps below exactly:
+
+1. **Install the Wix skills locally**
+2. **(optional) Brief doesn't say what to build? Ask, or check the site**
+3. **Build the client**
+4. **Manage and seed the business** (run in parallel with 3)
+5. **Wrap up**
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -16,9 +22,8 @@ Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
   APIs. This is your main source of truth (STEP 3).
 - **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only** as a seeding/admin reference —
-  its `references/SEED.md` and `references/inline-recipes/` for STEP 4, and its
-  `references/discover-site.mjs` discovery script for STEP 2. **Ignore
+  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
+  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 4. **Ignore
   everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
   "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
   That is **not** how auth works here — auth is handled per STEP 4 below.
@@ -73,19 +78,32 @@ on the tool:
 - **exec_tool / shell** (only if you must): use the absolute path
   `/app/.agents/skills/wix-vibe-headless/SKILL.md`.
 
-## STEP 2 (optional) — Brief doesn't say what to build? Read the site
+## STEP 2 (optional) — Brief doesn't say what to build? Ask, or check the site
 
 Only needed when the business description in your prompt is vague or missing — otherwise skip
-to STEP 3. Don't guess a vertical: the site's installed apps are the ground truth. Get the
-connector access token (STEP 4 snippet) and run:
+to STEP 3. Don't guess which Wix Business Solution to build (stores, bookings, blog, events,
+portfolio, restaurants, CMS, pricing plans, members, etc..): **ask the user** one short question
+(what do they offer?), or **check what the site actually has** using the `wix-vibe-headless`
+skill's query APIs (`queryProducts`, `queryServices`, `queryPosts`, …) — with a visitor token
+minted from the client id, or with an admin token if you have one (the connector) — and build
+for the solutions that return content (a `428` "app not installed" means that solution isn't
+on the site). The resolved solutions also drive STEP 4's seeding — never seed guessed
+ones.
 
-```bash
-WIX_TOKEN=<connector access token> node .agents/skills/wix-headless/references/discover-site.mjs <metasite id>
+The gist, as one exec_tool call:
+
+```js
+// token = visitor token (minted from the client id) or the connector's admin token
+// one cheap first-page read per solution (endpoints = each helper's first query)
+// stores:   POST /stores/v3/products/query   { query: { cursorPaging: { limit: 3 } } }
+// bookings: POST /bookings/v2/services/query { query: { paging: { limit: 3 } } }
+// blog: /v3/posts/query · events: /events/v3/events/query · portfolio, restaurants, pricing-plans: …
+// fetch each with { Authorization: token }, then per solution:
+//   !res.ok (428 / blog 401)          -> not installed
+//   items with real names             -> build for it
+//   empty, or "Sample product 3" names -> installed, but says little about the business
+return { stores: "...", bookings: "...", /* ... */ };
 ```
-
-Build for the verticals matching the installed apps it reports (several → prioritize by the
-user's words and by which holds real, non-sample content); the same output drives STEP 4's
-seeding. If it fails or reports nothing, ask the user what they offer.
 
 ## STEP 3 — Build the client
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -1,7 +1,12 @@
 # Wix Managed Headless — build instructions
 
 You are building a **Wix Managed** headless site. The business to build, and your Wix client id
-and metasite id, are given in your initial prompt. Follow the steps below.
+and metasite id, are given in your initial prompt. Follow the steps below:
+
+1. **Install the Wix skills locally**
+2. **(optional) Brief doesn't say what to build? Ask, or check the site**
+3. **Build the client**
+4. **Seed and manage the business** (run in parallel with 3)
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -9,9 +14,8 @@ Install three skills — they land under `.agents/skills/` as:
 - **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
   APIs. This is your main source of truth (STEP 3).
 - **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only** as a seeding/admin reference —
-  its `references/SEED.md` and `references/inline-recipes/` for STEP 4, and its
-  `references/discover-site.mjs` discovery script for STEP 2. **Ignore
+  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
+  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 4. **Ignore
   everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
   "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
   That is **not** how auth works here — auth is handled per STEP 4 below.
@@ -37,20 +41,32 @@ for s in headless vibe-headless docs; do
 done
 ```
 
-## STEP 2 (optional) — Brief doesn't say what to build? Ask, or read the site
+## STEP 2 (optional) — Brief doesn't say what to build? Ask, or check the site
 
 Only needed when the business description in your prompt is vague or missing — otherwise skip
-to STEP 3. Don't guess a vertical. Either **ask the user** one short question (what do they
-offer?), or — if you have an admin-grade Wix credential (connector token or API key, per
-STEP 4; the public `WIX_CLIENT_ID` is not enough) — **read the site**:
+to STEP 3. Don't guess which Wix Business Solution to build (stores, bookings, blog, events,
+portfolio, restaurants, CMS, pricing plans, members, etc..): **ask the user** one short question
+(what do they offer?), or **check what the site actually has** using the `wix-vibe-headless`
+skill's query APIs (`queryProducts`, `queryServices`, `queryPosts`, …) — with a visitor token
+minted from the client id, or with an admin token if you have one (connector / API key) — and
+build for the solutions that return content (a `428` "app not installed" means that solution
+isn't on the site). The resolved solutions also drive STEP 4's seeding — never seed guessed
+ones.
 
-```bash
-WIX_TOKEN=<admin token or API key> node .agents/skills/wix-headless/references/discover-site.mjs <metasite id>
+The gist, as a one-shot script (run however your platform runs code):
+
+```js
+// token = visitor token (minted from the client id) or your admin token
+// one cheap first-page read per solution (endpoints = each helper's first query)
+// stores:   POST /stores/v3/products/query   { query: { cursorPaging: { limit: 3 } } }
+// bookings: POST /bookings/v2/services/query { query: { paging: { limit: 3 } } }
+// blog: /v3/posts/query · events: /events/v3/events/query · portfolio, restaurants, pricing-plans: …
+// fetch each with { Authorization: token }, then per solution:
+//   !res.ok (428 / blog 401)          -> not installed
+//   items with real names             -> build for it
+//   empty, or "Sample product 3" names -> installed, but says little about the business
+console.log({ stores: "...", bookings: "...", /* ... */ });
 ```
-
-Build for the verticals matching the installed apps it reports (several → prioritize by the
-user's words and by which holds real, non-sample content); the same set drives STEP 4's
-seeding — never seed guessed verticals.
 
 ## STEP 3 — Build the client
 


### PR DESCRIPTION
## What

Simplifies the vague-brief discovery step in the vibe flow (follow-up to #704): `base44.md`, `generic.md`, and `SKILL.md` no longer reference `wix-headless`'s `discover-site.mjs`. Instead, STEP 2 / the routing note now offer two plain moves:

- **Ask the user** one short question (what do they offer?), or
- **Check the site** with the query APIs the skill already ships, over the public client id — `queryProducts`, `queryServices`, `queryPosts`, … A `428` "app not installed" (blog: `401`) rules a vertical out; returned content says what to build, and the resolved verticals drive STEP 4's seeding. Sample-looking content ("Sample product 3") proves the app is installed, not what the business is about (SKILL.md carries that caveat).

Never default to store/bookings on silence — unchanged.

## Why

Keep the platform prompts self-contained on the client-id credential they already hold: no dependency on the connector/API key being ready at discovery time, no cross-skill script invocation in the vibe path. `discover-site.mjs` stays in `wix-headless` for the connect/iterate flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)