### PR TITLE
🦞 igor-claw: bootstrap.mjs - surface spawn errors instead of an empty detail

### DIFF
--- a/skills/wix-headless/entry/bootstrap.mjs
+++ b/skills/wix-headless/entry/bootstrap.mjs
@@ -33,7 +33,13 @@ function capture(cmd, args, opts = {}) {
 // ── 1. CLI reachable (via npx — no install) ──────────────────────────────────
 function checkCli() {
   const r = capture(WIX[0], [...WIX.slice(1), '--version']);
-  if (r.status !== 0) fail('cli_unreachable', { detail: r.out.trim().slice(0, 400) });
+  // r.out is empty whenever the child never ran at all (ENOENT, EINVAL, a
+  // sandboxed spawn denial, ...) — fall back to r.error so the failure is
+  // still diagnosable instead of shipping an empty detail string.
+  if (r.status !== 0)
+    fail('cli_unreachable', {
+      detail: (r.out.trim() || r.error?.message || '').slice(0, 400),
+    });
   // npx interleaves "npm notice …" lines with the version, so don't just take the
   // last line — pick the first semver-looking token, falling back to the last line.
   const version = (r.out.match(/\d+\.\d+\.\d+[^\s]*/) || [])[0] || r.out.trim().split('\n').pop();


### PR DESCRIPTION
## What's broken

`capture()` in `skills/wix-headless/entry/bootstrap.mjs` already collects spawnSync's `r.error`, but `checkCli()`'s `cli_unreachable` failure path only reads `r.out`:

```js
if (r.status !== 0) fail('cli_unreachable', { detail: r.out.trim().slice(0, 400) });
```

Any spawn that never runs at all (ENOENT, EINVAL, a sandboxed spawn denial, permissions error, …) produces no stdout/stderr, so this reports `{"event":"cli_unreachable","ok":false,"detail":""}` — an empty string with no way to diagnose the real cause.

Verified locally: `spawnSync('/nonexistent/binary', ['--version'], {encoding:'utf8'})` returns `status: null`, empty `out`, and `error.message` = `"spawnSync /nonexistent/binary ENOENT"` — exactly the case this silently drops today.

This is independent of, and survived, the earlier `shell: isWin` Windows/`.cmd` fix (#571) to this same file — that patch fixed the Windows `spawnSync .cmd` failure itself, but the resulting error still reports with an empty `detail`.

## Fix

Fall back to `r.error?.message` when `r.out` is empty, so a spawn failure with no output still surfaces a diagnosable message instead of `""`.

## Context

Filed from Wix headless user feedback. This PR was opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com) — not written by Ayal directly.
Thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1785094614594749