### PR TITLE
feat(wix-vibe-headless): vague-brief discovery is now one Dynamic Context call in the platform flows

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -11,7 +11,7 @@ the Wix client setup.
 Follow the steps below exactly:
 
 1. **Install the Wix skills locally**
-2. **(optional) Brief doesn't say what to build? Ask, or check the site**
+2. **(optional) Brief doesn't say what to build? Read the site**
 3. **Build the client**
 4. **Manage and seed the business** (run in parallel with 3)
 5. **Wrap up**
@@ -78,32 +78,29 @@ on the tool:
 - **exec_tool / shell** (only if you must): use the absolute path
   `/app/.agents/skills/wix-vibe-headless/SKILL.md`.
 
-## STEP 2 (optional) — Brief doesn't say what to build? Ask, or check the site
+## STEP 2 (optional) — Brief doesn't say what to build? Read the site
 
 Only needed when the business description in your prompt is vague or missing — otherwise skip
 to STEP 3. Don't guess which Wix Business Solution to build (stores, bookings, blog, events,
-portfolio, restaurants, CMS, pricing plans, members, etc..): **ask the user** one short question
-(what do they offer?), or **check what the site actually has** using the `wix-vibe-headless`
-skill's query APIs (`queryProducts`, `queryServices`, `queryPosts`, …) — with a visitor token
-minted from the client id, or with an admin token if you have one (the connector) — and build
-for the solutions that return content (a `428` "app not installed" means that solution isn't
-on the site). The resolved solutions also drive STEP 4's seeding — never seed guessed
-ones.
-
-The gist, as one exec_tool call:
+portfolio, restaurants, CMS, pricing plans, members, etc..) — **read the site in one call**
+via the connector (exec_tool):
 
 ```js
-// token = visitor token (minted from the client id) or the connector's admin token
-// one cheap first-page read per solution (endpoints = each helper's first query)
-// stores:   POST /stores/v3/products/query   { query: { cursorPaging: { limit: 3 } } }
-// bookings: POST /bookings/v2/services/query { query: { paging: { limit: 3 } } }
-// blog: /v3/posts/query · events: /events/v3/events/query · portfolio, restaurants, pricing-plans: …
-// fetch each with { Authorization: token }, then per solution:
-//   !res.ok (428 / blog 401)          -> not installed
-//   items with real names             -> build for it
-//   empty, or "Sample product 3" names -> installed, but says little about the business
-return { stores: "...", bookings: "...", /* ... */ };
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const res = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ siteId: "<metasite id from your prompt>" }),
+});
+return (await res.json()).markdown;
 ```
+
+It returns a markdown report of the site — installed apps (by name), status, URL, locale, and
+CMS collections
+([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md)).
+Build for the solutions whose apps are installed (several → prioritize by the user's words and
+by which holds real, non-sample content); the same output drives STEP 4's seeding — never seed
+guessed ones. If the call fails or reports nothing relevant, ask the user what they offer.
 
 ## STEP 3 — Build the client
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -4,7 +4,7 @@ You are building a **Wix Managed** headless site. The business to build, and you
 and metasite id, are given in your initial prompt. Follow the steps below:
 
 1. **Install the Wix skills locally**
-2. **(optional) Brief doesn't say what to build? Ask, or check the site**
+2. **(optional) Brief doesn't say what to build? Ask, or read the site**
 3. **Build the client**
 4. **Seed and manage the business** (run in parallel with 3)
 
@@ -41,32 +41,26 @@ for s in headless vibe-headless docs; do
 done
 ```
 
-## STEP 2 (optional) — Brief doesn't say what to build? Ask, or check the site
+## STEP 2 (optional) — Brief doesn't say what to build? Ask, or read the site
 
 Only needed when the business description in your prompt is vague or missing — otherwise skip
 to STEP 3. Don't guess which Wix Business Solution to build (stores, bookings, blog, events,
-portfolio, restaurants, CMS, pricing plans, members, etc..): **ask the user** one short question
-(what do they offer?), or **check what the site actually has** using the `wix-vibe-headless`
-skill's query APIs (`queryProducts`, `queryServices`, `queryPosts`, …) — with a visitor token
-minted from the client id, or with an admin token if you have one (connector / API key) — and
-build for the solutions that return content (a `428` "app not installed" means that solution
-isn't on the site). The resolved solutions also drive STEP 4's seeding — never seed guessed
-ones.
+portfolio, restaurants, CMS, pricing plans, members, etc..): **ask the user** one short
+question (what do they offer?), or — with an admin-grade Wix credential (connector token or
+API key, per STEP 4; the public `WIX_CLIENT_ID` is not enough) — **read the site in one call**:
 
-The gist, as a one-shot script (run however your platform runs code):
-
-```js
-// token = visitor token (minted from the client id) or your admin token
-// one cheap first-page read per solution (endpoints = each helper's first query)
-// stores:   POST /stores/v3/products/query   { query: { cursorPaging: { limit: 3 } } }
-// bookings: POST /bookings/v2/services/query { query: { paging: { limit: 3 } } }
-// blog: /v3/posts/query · events: /events/v3/events/query · portfolio, restaurants, pricing-plans: …
-// fetch each with { Authorization: token }, then per solution:
-//   !res.ok (428 / blog 401)          -> not installed
-//   items with real names             -> build for it
-//   empty, or "Sample product 3" names -> installed, but says little about the business
-console.log({ stores: "...", bookings: "...", /* ... */ });
+```bash
+curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H 'Authorization: Bearer <admin token>' -H 'Content-Type: application/json' \
+  -d '{"siteId": "<metasite id from your prompt>"}'
 ```
+
+It returns a markdown report of the site — installed apps (by name), status, URL, locale, and
+CMS collections
+([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md);
+with an API key send it raw as the `Authorization` value, no `Bearer`). Build for the solutions
+whose apps are installed (several → prioritize by the user's words and by which holds real,
+non-sample content); the same set drives STEP 4's seeding — never seed guessed ones.
 
 ## STEP 3 — Build the client
 


### PR DESCRIPTION
## What

Follow-up to #707: now that the [Dynamic Context markdown endpoint](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown) is documented, STEP 2 in `base44.md` and `generic.md` replaces the per-solution query probing with **one call** that returns the site's context — installed apps by name (incl. Stores catalog version), status, URL, locale, CMS collections — as an agent-ready markdown report (byte-identical to what the Wix MCP serves).

- **base44.md** — STEP 2 gist is an 8-line exec_tool call: connector token → POST the markdown endpoint → return `.markdown`. Ask-the-user stays as the fallback when the call fails or reports nothing relevant.
- **generic.md** — STEP 2 stays "ask, or read the site": one curl with the connector token / API key (raw `Authorization` for API keys, no `Bearer`).
- Step indexes updated to match; the resolved solutions still drive STEP 4's seeding — never seed guessed ones.

Endpoint verified live in #707 (200 with full report on real sites; visitor tokens rejected — hence the admin-credential requirement).

## Note

Worth verifying in a real Base44 run that the connector token passes the endpoint's permission check — if it doesn't, the ask fallback keeps the flow safe, but we'd want to know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)