### PR TITLE
feat(wix-headless): add DESIGN.md + CONTENT.md — fallback design and copy quality bars for managed create

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -122,6 +122,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | Seed (create backend content) | `<SKILL_ROOT>/references/SEED.md` |
 | SDK-integration handoff (emitted, or applied by create/connect) | `<SKILL_ROOT>/references/SDK_HANDOFF.md` |
 | Image generation (opt-in; agnostic) | `<SKILL_ROOT>/references/IMAGE_GENERATION.md` |
+| Design — visual quality bar for the built frontend (managed **create** only) | `<SKILL_ROOT>/references/DESIGN.md` |
 | AI features — text/chat + embeddings (opt-in; agnostic) | `<SKILL_ROOT>/references/AI_FEATURES.md` |
 | Feedback — relay the user's headless-experience feedback to Wix (opt-in; user-approved) | `<SKILL_ROOT>/references/FEEDBACK.md` |
 | **Authentication** — obtain `$TOKEN`/`$SITE_ID`/`clientId` (project-type-specific) | `<TYPE_DIR>/AUTHENTICATION.md` |

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -123,6 +123,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | SDK-integration handoff (emitted, or applied by create/connect) | `<SKILL_ROOT>/references/SDK_HANDOFF.md` |
 | Image generation (opt-in; agnostic) | `<SKILL_ROOT>/references/IMAGE_GENERATION.md` |
 | Design — fallback visual quality bar for the built frontend, when the user gave no design direction of their own (managed **create** only) | `<SKILL_ROOT>/references/DESIGN.md` |
+| Content — fallback copy quality bar for the built frontend, when the user gave no copy/voice direction of their own (managed **create** only) | `<SKILL_ROOT>/references/CONTENT.md` |
 | AI features — text/chat + embeddings (opt-in; agnostic) | `<SKILL_ROOT>/references/AI_FEATURES.md` |
 | Feedback — relay the user's headless-experience feedback to Wix (opt-in; user-approved) | `<SKILL_ROOT>/references/FEEDBACK.md` |
 | **Authentication** — obtain `$TOKEN`/`$SITE_ID`/`clientId` (project-type-specific) | `<TYPE_DIR>/AUTHENTICATION.md` |

--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -122,7 +122,7 @@ Compute `<SKILL_ROOT>` from this file (`<SKILL_ROOT>/SKILL.md` — strip `/SKILL
 | Seed (create backend content) | `<SKILL_ROOT>/references/SEED.md` |
 | SDK-integration handoff (emitted, or applied by create/connect) | `<SKILL_ROOT>/references/SDK_HANDOFF.md` |
 | Image generation (opt-in; agnostic) | `<SKILL_ROOT>/references/IMAGE_GENERATION.md` |
-| Design — visual quality bar for the built frontend (managed **create** only) | `<SKILL_ROOT>/references/DESIGN.md` |
+| Design — fallback visual quality bar for the built frontend, when the user gave no design direction of their own (managed **create** only) | `<SKILL_ROOT>/references/DESIGN.md` |
 | AI features — text/chat + embeddings (opt-in; agnostic) | `<SKILL_ROOT>/references/AI_FEATURES.md` |
 | Feedback — relay the user's headless-experience feedback to Wix (opt-in; user-approved) | `<SKILL_ROOT>/references/FEEDBACK.md` |
 | **Authentication** — obtain `$TOKEN`/`$SITE_ID`/`clientId` (project-type-specific) | `<TYPE_DIR>/AUTHENTICATION.md` |

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -70,6 +70,19 @@ CI=1 npx skills@latest add wix/skills --yes
 
 The skills land in `.agents/skills/`.
 
+**Testing an unreleased branch or PR?** Only if the person running this explicitly asked to test a
+specific branch/PR rather than the published skill, replace the command above with:
+
+```bash
+CI=1 npx skills@latest add "https://github.com/wix/skills.git#<branch-name>" --yes
+```
+
+using the **PR's source branch name** (not a PR number — GitHub doesn't expose PR refs as an
+installable tree). Use the `repo.git#branch` form shown above, not a `/tree/<branch>/...` URL — the
+latter breaks whenever the branch name itself contains a `/` (e.g. `feat/xxx`), since it naively splits
+on the first slash and tries to fetch a branch called just `feat`. Everything else in this entry is
+unchanged.
+
 Then **open `wix-headless/SKILL.md` and follow it.** That skill owns the rest of the run — it resolves the **project type** (`managed` / `self-managed` / `stripe`) and, for managed, the **operation** (create / connect), then runs Discovery → Setup → Seed → the SDK handoff, and for managed create/connect it also scaffolds, builds, and releases.
 
 - **Don't** scaffold, install apps, or release by hand here — the skill does all of that (`SETUP.md`, `references/managed/CREATE.md`, etc.). This entry stops at *logged in*.

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -70,19 +70,6 @@ CI=1 npx skills@latest add wix/skills --yes
 
 The skills land in `.agents/skills/`.
 
-**Testing an unreleased branch or PR?** Only if the person running this explicitly asked to test a
-specific branch/PR rather than the published skill, replace the command above with:
-
-```bash
-CI=1 npx skills@latest add "https://github.com/wix/skills.git#<branch-name>" --yes
-```
-
-using the **PR's source branch name** (not a PR number — GitHub doesn't expose PR refs as an
-installable tree). Use the `repo.git#branch` form shown above, not a `/tree/<branch>/...` URL — the
-latter breaks whenever the branch name itself contains a `/` (e.g. `feat/xxx`), since it naively splits
-on the first slash and tries to fetch a branch called just `feat`. Everything else in this entry is
-unchanged.
-
 Then **open `wix-headless/SKILL.md` and follow it.** That skill owns the rest of the run — it resolves the **project type** (`managed` / `self-managed` / `stripe`) and, for managed, the **operation** (create / connect), then runs Discovery → Setup → Seed → the SDK handoff, and for managed create/connect it also scaffolds, builds, and releases.
 
 - **Don't** scaffold, install apps, or release by hand here — the skill does all of that (`SETUP.md`, `references/managed/CREATE.md`, etc.). This entry stops at *logged in*.

--- a/skills/wix-headless/references/CONTENT.md
+++ b/skills/wix-headless/references/CONTENT.md
@@ -1,0 +1,36 @@
+# Content — default copy quality bar for the built frontend (managed create)
+
+**Applies when this skill writes frontend page copy from scratch** (managed `create`, `CREATE.md` §4) — hero/section headlines, subtitles, kickers, CTA labels, and any image captions the pages include. Same scope as `DESIGN.md`: not `connect`/`iterate` (the copy already exists there).
+
+**Same precedence rule as `DESIGN.md`: fallback, not override.** If the user supplied their own copy, brand voice, or tone direction, use theirs — don't overwrite it to match the conventions below. The one exception is **§1** — a comprehension floor, not a style preference: whatever the voice, a first-time visitor must still be able to tell what the business *is* from the hero.
+
+## 1 · Say what the business is — explicitly, above the fold
+
+- A first-time visitor must know what the site *is* and what they can *do*, straight from the hero — never left to infer from mood or voice alone.
+- The **business category** (e.g. "yoga studio", "restaurant", "construction services") must appear **literally** in at least one of: the H1, a kicker above the H1, or the **first clause of the subtitle**. A witty H1 alone is not enough.
+- The **subtitle leads with the offer**, in plain language, before any flavor — put the verb the visitor actually cares about early ("Book…", "Order…", "Learn…", "Hire…").
+- Voice-driven, evocative H1s are welcome — but only when the category sits explicitly right beside them (kicker or subtitle). When in doubt, name the category in the kicker.
+
+## 2 · Kickers (micro-copy above titles)
+
+- **Cut a kicker that only restates the title** (e.g. "The Courses" above a Courses heading) — it adds nothing.
+- **Keep a kicker that carries real information**: category + location ("Yoga Studio · Downtown"), a feature's proper name, event details, dates, price framing.
+- A kicker is the right place to satisfy §1 when the H1 itself is voice-led rather than literal.
+
+## 3 · Titles, subtitles, paragraphs, CTAs
+
+- **Titles and subtitles end without a period.** Paragraphs (full running sentences) keep theirs.
+- No fluff — every line should move the visitor's understanding forward, the H1 and subtitle most of all.
+- **CTA labels are short and avoid all-caps** unless a specific reason demands it (readability). Word them to the actual action (ties to `DESIGN.md` §2's "one primary CTA, worded to the action" rule) — not generic verbs.
+
+## 4 · Images — the real subject comes first
+
+- **At least one image on the page must show the real story of the business** — the actual thing, not just abstract graphics, dashboards, or decorative art. A climbing outfitter shows mountains and climbers; a clinic shows the room; a workshop shows the tools and hands at work.
+- **Decorative/supporting visuals (illustrations, icons, patterns, textures) layer in *addition to* the real subject, never *instead of* it.** They earn their place by reinforcing the story and mood once the business is genuinely shown — not by standing in for it.
+- Imagery (real or decorative) matches the tone, voice, and era of the business.
+- When the user must supply their own real photos (the business has a specific, particular space/product/person that generated imagery can't stand in for), use a **fillable image slot with a descriptive placeholder** naming exactly what belongs there — not a generic stock image presented as final.
+
+## 5 · Image captions
+
+- A caption describes what is **actually seen** in its image. Tone can vary (serious, playful, informative) but must stay aligned with the image's real content.
+- **No meaningless captions, and no caption that ignores the image.** A slogan or pull-quote overlaid on a photo is not a caption — if a true caption is wanted, write one that describes the scene once the real image is in place.

--- a/skills/wix-headless/references/DESIGN.md
+++ b/skills/wix-headless/references/DESIGN.md
@@ -1,0 +1,54 @@
+# Design — visual quality bar for the built frontend (managed create)
+
+**Applies when this skill builds the frontend from scratch** (managed `create`, `CREATE.md` §4). It does **not** apply to `connect`/`iterate` — there the design already exists (brought in by the user), and the job is wiring, not designing (`CONNECT.md` §4).
+
+This is the **agent's own design-tokens contract** — it's the thing `IMAGE_GENERATION.md` and `DISCOVERY.md` §4 already assume exists when they say a themed-block fallback "follows the site's own design tokens (palette, radius, spacing)". Decide the tokens below *before* writing the first component; every page and fallback then draws from that one decision instead of improvising per-component.
+
+*Provenance note: this distills — not ports — Base44's internal beautification prompts (`base44-dev/apper`: `design_enhancement_system.md`, `design_guidelines_apps_*.md`). Those are meta-prompts for a single isolated Gemini call that outputs a prose design brief for a second generation stage; only the checkable, code-facing rules below carry over. Their persona-priming ("Visionary Creative Designer", "industry-defining benchmark") and prescribed brief-output format don't apply to an agent writing files directly — skip that framing entirely.*
+
+## 1 · Decide the design tokens once, before any component
+
+A short, explicit decision — a few lines, not a document — derived from `brand.description`/`brand.vibe` (`DISCOVERY.md` §2):
+
+- **Theme polarity** — light, dark, or vivid/tinted. Argue it from the business, never default to dark for "premium" (a light, high-key theme can be just as strong — e.g. healthcare/wellness usually reads better light).
+- **Palette** — 2–4 hex colors, one dominant + accents drawn from **analogous hues** (adjacent on the color wheel, ~30° arc) — not complementary jumps. Functional colors (error/success/warning) sit outside this count.
+- **Type scale** — one heading scale + one body size. Body text floor: **16px, 1.5 line-height** (§3 is non-negotiable, this is where you set it).
+- **Radius + spacing** — pick once (e.g. "12px radius, 24px section padding") and reuse everywhere; don't let each component invent its own.
+
+Hold these as the run's design tokens. Reuse them literally in the themed-block fallback (`IMAGE_GENERATION.md`) and every page — don't re-derive per page.
+
+**Vary this across projects.** Don't reach for the same palette/theme/layout on every build — derive it from *this* brand's vibe each time. Repeating the same look across unrelated projects is a failure mode, not a shortcut.
+
+## 2 · Layout (hard rules)
+
+- **Full-bleed, not boxed.** Don't wrap the page in a narrow centered container (no `max-w-4xl mx-auto` outer shell). Design for the full viewport; use the peripheral space intentionally.
+- **One primary CTA per page**, worded to the page's actual action — `Book a Table`, `Add to Cart`, `Reserve Your Spot`, not generic verbs ("Submit", "Click here", "Go").
+- **Icons never sit on a filled/tinted background shell** — no circle/square/pill behind a nav or card icon. The glyph renders directly on the surface.
+- **Identify the site's 3–4 core pages/sections from its resolved vertical** (`verticals[]`, `DISCOVERY.md` §1) before laying out anything, and design each to its own intent:
+
+  | Vertical | Core pages/sections to get right |
+  |---|---|
+  | stores | Home hero, product grid, product detail, cart |
+  | blog | Post list, post detail |
+  | cms | Collection list, item detail |
+  | forms | The form itself — clear single-column, one obvious submit |
+  | events | Event list, event detail + RSVP |
+  | bookings | Service list, booking widget/flow |
+  | pricing-plans | Plan comparison, checkout/signup |
+  | restaurants | Menu, reservation/ordering flow |
+  | portfolio | Project grid, case-study/project detail |
+
+## 3 · Accessibility (hard rules, no exceptions)
+
+- **WCAG 2.2 AA contrast** — every chosen background/foreground pair must hit **4.5:1** for body text, **3:1** for large text (≥24px or ≥19px bold). Check the actual hex pair against the ratio — don't assume a palette is accessible because it "looks fine."
+- **16px minimum body font**, **1.5 minimum line-height** for body copy.
+
+## 4 · Content & imagery hygiene
+
+- **No emojis** in UI copy, headings, or empty states.
+- **No stock-photo clichés** — generic handshake/lightbulb/laptop-on-desk imagery reads as filler, not a real page.
+- Generated imagery already carries its own purity rule (no text/logos/watermarks/UI-mockups — `IMAGE_GENERATION.md` § Prompts, "no text, no watermarks"); nothing additional to do here beyond following that section as written.
+
+## What this doesn't cover
+
+This is a floor, not a template library — it constrains the *how* (contrast, layout shape, token discipline), not the *what* (that's `verticals[]` + `brand` from Discovery, and the user's intent). Two builds with the same vertical and different brand vibes should still look nothing alike.

--- a/skills/wix-headless/references/DESIGN.md
+++ b/skills/wix-headless/references/DESIGN.md
@@ -1,10 +1,10 @@
-# Design — visual quality bar for the built frontend (managed create)
+# Design — default visual quality bar for the built frontend (managed create)
 
 **Applies when this skill builds the frontend from scratch** (managed `create`, `CREATE.md` §4). It does **not** apply to `connect`/`iterate` — there the design already exists (brought in by the user), and the job is wiring, not designing (`CONNECT.md` §4).
 
-This is the **agent's own design-tokens contract** — it's the thing `IMAGE_GENERATION.md` and `DISCOVERY.md` §4 already assume exists when they say a themed-block fallback "follows the site's own design tokens (palette, radius, spacing)". Decide the tokens below *before* writing the first component; every page and fallback then draws from that one decision instead of improvising per-component.
+**This is a fallback, not an override.** It fills the gap **only when the user gave no design direction of their own** — no palette, no "make it dark/minimal/playful," no reference site or screenshot, no brand guidelines. The moment the user specifies *any* of that, their explicit intent wins outright — don't apply a rule below just because it's here if it contradicts what they asked for. Two exceptions that hold regardless of what's requested: **§3 (accessibility)** is a hard floor — if a user-requested palette fails contrast, fix the specific pair to comply, don't ship a violation — and the **anti-genericism intent** of §1 (derive tokens from *this* brand, don't reuse the last project's look) still applies even when the user supplied their own palette/theme, since it's about not being lazy with *their* inputs, not about overriding them.
 
-*Provenance note: this distills — not ports — Base44's internal beautification prompts (`base44-dev/apper`: `design_enhancement_system.md`, `design_guidelines_apps_*.md`). Those are meta-prompts for a single isolated Gemini call that outputs a prose design brief for a second generation stage; only the checkable, code-facing rules below carry over. Their persona-priming ("Visionary Creative Designer", "industry-defining benchmark") and prescribed brief-output format don't apply to an agent writing files directly — skip that framing entirely.*
+This is the **agent's own design-tokens contract** — it's the thing `IMAGE_GENERATION.md` and `DISCOVERY.md` §4 already assume exists when they say a themed-block fallback "follows the site's own design tokens (palette, radius, spacing)". Decide the tokens below *before* writing the first component; every page and fallback then draws from that one decision instead of improvising per-component.
 
 ## 1 · Decide the design tokens once, before any component
 

--- a/skills/wix-headless/references/IMAGE_GENERATION.md
+++ b/skills/wix-headless/references/IMAGE_GENERATION.md
@@ -57,6 +57,8 @@ The pass-2 **write shape is per-entity earned knowledge and lives in each capabi
 
 Brand-contextual, never generic. Include: subject; the brand aesthetic/mood; the palette (real tones, e.g. "warm cream and forest green"); style/lighting; and always **"no text, no watermarks"** (AI-rendered text is garbled). Pull context from the brand + the entity (product name/description, post topic, page purpose).
 
+**At least one image per page must show the real subject of the business** — the actual service/product/space, not just abstract or decorative art; decorative visuals layer in *addition* to that, never *instead of* it (`CONTENT.md` § Images has the full rule + the fillable-slot fallback for when only the user's own real photos will do).
+
 ## Credits, cost & the not-generating fallback
 
 Each generated image costs **1 Wix AI credit**, billed at the account level regardless of project type (the account behind the metasite must have credits). Volume is bounded in `DISCOVERY.md` §4 — carry those two values through:

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -102,6 +102,11 @@ enforce over an explicit ask. Either way, `DESIGN.md` §3's accessibility floor 
 16px/1.5 body type) always applies — a page that fails it isn't done yet, regardless of whose palette
 it's using.
 
+**Same for page copy**: if the user didn't supply their own copy or voice direction, write hero/section
+headlines, kickers, subtitles, and CTA labels per **`references/CONTENT.md`** — otherwise use theirs.
+Either way, `CONTENT.md` §1 (the business's category must read literally above the fold) always holds —
+a page a first-time visitor can't identify isn't done yet, regardless of voice.
+
 Then build the pages the user's intent calls for, **wired to the live backend**, using
 **`references/SDK_HANDOFF.md`** for the per-capability packages, the SDK docs, and the seeded schema to
 bind (collection/form names + field keys; all other content is queried live). Install the SDK packages the loaded verticals need, author the pages/components directly in the

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -93,11 +93,14 @@ Run the agnostic flow against the scaffolded site:
   (`createClient({ modules, auth: OAuthStrategy({ clientId }) })`), where `clientId` is the public
   `appId` from the `wix.config.json` written by `init` (§1).
 
-**Before writing any component, decide the run's design tokens per `references/DESIGN.md`** — theme
-polarity, a 2–4 color palette, type scale, radius/spacing — and hold them for reuse across every page and
-the themed-block fallback (`IMAGE_GENERATION.md`). `DESIGN.md` also pins the hard layout/accessibility
-rules (full-bleed, one primary CTA per page, WCAG 2.2 AA contrast, 16px/1.5 body type) — a page that
-violates one of those isn't done yet, regardless of how the backend wiring looks.
+**If the user didn't specify their own design direction** (no palette, no theme/style words, no
+reference site, no brand guidelines), **decide the run's design tokens per `references/DESIGN.md`**
+before writing any component — theme polarity, a 2–4 color palette, type scale, radius/spacing — and
+hold them for reuse across every page and the themed-block fallback (`IMAGE_GENERATION.md`). If the
+user *did* specify a direction, use theirs instead — `DESIGN.md` is a fallback, not a checklist to
+enforce over an explicit ask. Either way, `DESIGN.md` §3's accessibility floor (WCAG 2.2 AA contrast,
+16px/1.5 body type) always applies — a page that fails it isn't done yet, regardless of whose palette
+it's using.
 
 Then build the pages the user's intent calls for, **wired to the live backend**, using
 **`references/SDK_HANDOFF.md`** for the per-capability packages, the SDK docs, and the seeded schema to

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -102,7 +102,7 @@ enforce over an explicit ask. Either way, `DESIGN.md` §3's accessibility floor 
 16px/1.5 body type) always applies — a page that fails it isn't done yet, regardless of whose palette
 it's using.
 
-**Same for page copy**: if the user didn't supply their own copy or voice direction, write hero/section
+**For page copy:** if the user didn't supply their own copy or voice direction, write hero/section
 headlines, kickers, subtitles, and CTA labels per **`references/CONTENT.md`** — otherwise use theirs.
 Either way, `CONTENT.md` §1 (the business's category must read literally above the fold) always holds —
 a page a first-time visitor can't identify isn't done yet, regardless of voice.

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -93,6 +93,12 @@ Run the agnostic flow against the scaffolded site:
   (`createClient({ modules, auth: OAuthStrategy({ clientId }) })`), where `clientId` is the public
   `appId` from the `wix.config.json` written by `init` (§1).
 
+**Before writing any component, decide the run's design tokens per `references/DESIGN.md`** — theme
+polarity, a 2–4 color palette, type scale, radius/spacing — and hold them for reuse across every page and
+the themed-block fallback (`IMAGE_GENERATION.md`). `DESIGN.md` also pins the hard layout/accessibility
+rules (full-bleed, one primary CTA per page, WCAG 2.2 AA contrast, 16px/1.5 body type) — a page that
+violates one of those isn't done yet, regardless of how the backend wiring looks.
+
 Then build the pages the user's intent calls for, **wired to the live backend**, using
 **`references/SDK_HANDOFF.md`** for the per-capability packages, the SDK docs, and the seeded schema to
 bind (collection/form names + field keys; all other content is queried live). Install the SDK packages the loaded verticals need, author the pages/components directly in the


### PR DESCRIPTION
## Summary
- Adds `skills/wix-headless/references/DESIGN.md`: a fallback design-tokens/layout/accessibility rule set for the frontend this skill builds from scratch (managed `create` only) — used only when the user gave no design direction of their own.
- Adds `skills/wix-headless/references/CONTENT.md`: same shape, for copy — hero/kicker/CTA writing rules and image-storytelling rules (at least one image must show the real business, not just decorative art), used only when the user gave no copy/voice direction of their own.
- Both wire into `CREATE.md` §4 as required pre-component steps when their fallback applies. Each has one exception that holds regardless of user direction: `DESIGN.md` §3 (WCAG 2.2 AA accessibility) and `CONTENT.md` §1 (the business category must read literally above the fold) — comprehension/compliance floors, not style preferences.
- Cross-links a "real subject over decorative" imagery rule into `IMAGE_GENERATION.md`'s existing Prompts section.
- `CONNECT.md`/`iterate` untouched — a brought-in design/copy already has its own look and voice; that flow is wiring, not authoring.

## Test plan
- [ ] Run a managed `create` end-to-end with no design/copy direction given and confirm the built frontend follows both rule sets
- [ ] Run a managed `create` with an explicit user design/copy direction and confirm it's honored over the defaults, except the accessibility/category floors
- [ ] Confirm `CONNECT.md`/iterate behavior is unaffected