### PR TITLE
🦞 igor-claw: document init partial-failure recovery + release CWD requirement

### DIFF
--- a/skills/wix-headless/references/managed/CONNECT.md
+++ b/skills/wix-headless/references/managed/CONNECT.md
@@ -31,6 +31,25 @@ place it into CWD **first** — unzip/copy/fetch the design's files into the wor
 project on disk — **then** `init`. An empty CWD plus a brought-in design is still `connect`, not create:
 land the design, then attach Wix to it.
 
+**If `init` half-fails** (a step after the business is created throws — e.g. "Failed to update your
+oauth app in Wix" on a transient 504/timeout): the metasite is already created server-side, but no
+`wix.config.json` was written, so the project looks unconnected while the site already exists.
+**Do not re-run `init`** — it has no idea a business already exists and will create a *second* one.
+Recover instead:
+1. The failing command's error output / `wix-error.log` (CWD or `~/.wix/`) has the `siteId` (metasite
+   id) and OAuth app id — the app id **is** the `id` in the failed `UpdateOAuthApp`/`CreateOAuthApp`
+   request, and is also the `appId`/`clientId` you need (app id === client id for headless).
+2. Confirm ownership: `npx @wix/cli@latest token --site <siteId>` must succeed (only works for sites
+   this account owns), then the Dynamic Context call in `DISCOVERY.md` §1 against that `siteId` should
+   return.
+3. Hand-write `wix.config.json` in the project root with the shape `init` would have written:
+   ```json
+   { "projectType": "Site", "appId": "<oauthAppId>", "siteId": "<metasiteId>", "site": { "outputDirectory": "./dist" } }
+   ```
+4. Continue from §2 below as if `init` had succeeded. If a step *other* than the OAuth app update is
+   what failed, the same recovery applies — the business and its companion app already exist; only the
+   local config is missing.
+
 ## 2 · Authenticate
 
 Per `references/managed/AUTHENTICATION.md` — `whoami`/login if needed, then mint the site token

--- a/skills/wix-headless/references/managed/DEPLOYMENT.md
+++ b/skills/wix-headless/references/managed/DEPLOYMENT.md
@@ -13,6 +13,7 @@ CI=1 npx @wix/cli@latest release
 - Publishes whatever the managed project is configured to deploy to Wix's hosting/CDN, and brings the live site up.
 - The deployed origin is registered on the OAuth app automatically — the frontend's visitor SDK calls are accepted from the live URL with no extra step.
 - The published URL is printed on stdout (`Site published on <url>`).
+- **CWD must be the exact project root** — `release` (like every `wix.config.json`-driven command) looks for the file only in CWD, with no upward directory search and no `--dir`/`--cwd` flag. Running it from a parent or sibling directory fails with `Project type could not be determined due to a missing configuration file "wix.config.json"`, which reads like a missing/corrupt config rather than a wrong-CWD issue. `cd` into the project root (the directory holding `wix.config.json`) before running `release` or any other `wix`/`npx @wix/cli` command.
 
 ## Give the user both links — the live site **and** the dashboard
 


### PR DESCRIPTION
## Summary
- **CONNECT.md §1**: `npm create @wix/new@latest init` can half-succeed (business/metasite created, then a later call like `UpdateOAuthApp` fails) leaving no local `wix.config.json` — the project looks unconnected while the site already exists remotely. Re-running `init` blindly creates a second business. Documents the recovery path an agent should follow instead (recover `siteId`/`appId` from the error output, verify ownership, hand-write `wix.config.json`).
- **DEPLOYMENT.md**: `wix release` (and other `wix.config.json`-driven commands) only look for the config in the exact CWD — no upward search, no `--dir`/`--cwd` flag. Running from a parent directory throws a "missing configuration file" error that reads like a corrupt/missing config rather than a CWD problem. Documents that CWD must be the project root.

Both gaps were confirmed against a real headless-connect feedback report and reproduced directly against the current CLI.

Related CLI-side fixes opened in `wix-private/wix-cli`:
- https://github.com/wix-private/wix-cli/pull/4862 (retry `updateOAuthApp` on transient failures — reduces how often the init recovery path is needed)
- The CWD requirement itself is left as a docs-only fix here since resolving it in the CLI (upward directory search vs. a `--cwd` flag) is a product decision, not covered by this PR.

## Context
Opened automatically by an AI agent acting on behalf of Ayal (ayalg@wix.com) — not written by them personally.

Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1785144476794219