### PR TITLE
feat(wix-app): document extending a vertical in the editor — site plu…

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-app
-description: "Build and review Wix CLI app extensions — dashboard pages, modals, plugins, menu plugins, custom element widgets, Editor React components, site plugins, embedded scripts, backend APIs, backend events, service plugins, data collections, and App Market readiness. Use when building ANY feature or extension for a Wix CLI app or preparing a Wix app for App Market review. Triggers on: add, build, create, implement, help me, dashboard, widget, plugin, backend, API, event, collection, embedded script, service plugin, Editor React component, checkout, shipping, tax, discount, SPI, CMS, schema, tracking, popup, admin panel, menu item, modal, validate, test, verify, register extension, App Market, app review, submission readiness."
+description: "Build and review Wix CLI app extensions — dashboard pages, modals, plugins, menu plugins, custom element widgets, Editor React components, site plugins, embedded scripts, backend APIs, backend events, service plugins, data collections, and App Market readiness. Use when building ANY feature or extension for a Wix CLI app or preparing a Wix app for App Market review. Triggers on: add, build, create, implement, help me, dashboard, widget, plugin, backend, API, event, collection, embedded script, service plugin, Editor React component, extend a vertical, business solution page, product page, service page, event page, vertical context, context provider, checkout, shipping, tax, discount, SPI, CMS, schema, tracking, popup, admin panel, menu item, modal, validate, test, verify, register extension, App Market, app review, submission readiness."
 compatibility: requires `@wix/cli` >= 1.1.192.
 ---
 
@@ -75,7 +75,8 @@ Helps build extensions for Wix CLI applications. Covers all extension types: das
    - Existing Wix app dashboard (menu item) → Dashboard Menu Plugin
    - Anywhere on site → custom element widget
    - Anywhere on site (with editor manifest) → Editor React component
-   - Wix business solution page → Site Plugin
+   - Wix business solution **site page** → [Extending a Vertical](references/EXTENDING_A_VERTICAL.md) (needs **both** a Site Plugin and an Editor React component)
+   - Wix business solution **dashboard** → Dashboard Plugin / Dashboard Menu Plugin
    - During business flow → Service Plugin
    - After event occurs → Backend Event Extension
 
@@ -83,7 +84,7 @@ Helps build extensions for Wix CLI applications. Covers all extension types: das
 
 - **Admin:** Single-collection CRUD admin page? → **Auto Patterns Dashboard (DEFAULT)**. Custom React page (multi-collection / custom logic / embedded scripts / external APIs / explicit user request)? → Dashboard Page. Need popup/form? → Dashboard Modal. Extending Wix app dashboard with a visual widget? → Dashboard Plugin. Adding a menu item to a Wix app dashboard's more-actions or bulk-actions menu? → Dashboard Menu Plugin. **Modal constraint:** Dashboard Pages cannot use `<Modal />`; use a separate Dashboard Modal extension and `dashboard.openModal()`.
 - **Backend:** During business flow (checkout/shipping/tax)? → Service Plugin. After event (webhooks/sync)? → Backend Event Extension. Custom HTTP endpoints? → Backend API. Need CMS collections for app data? → Data Collection.
-- **Site:** User places anywhere (standalone)? → custom element widget. Editor React component with editor manifest (styling, content, elements)? → Editor React component. Fixed slot on Wix app page? → Site Plugin. Scripts/analytics only? → Embedded Script.
+- **Site:** User places anywhere (standalone)? → custom element widget. Editor React component with editor manifest (styling, content, elements)? → Editor React component. Extending a Wix business solution's site page? → **[EXTENDING_A_VERTICAL.md](references/EXTENDING_A_VERTICAL.md) first** — no single extension type covers all editors, so this needs a Site Plugin (Wix Editor/Studio) **and** an Editor React component (Harmony). Scripts/analytics only? → Embedded Script.
 
 ---
 
@@ -126,6 +127,7 @@ Helps build extensions for Wix CLI applications. Covers all extension types: das
 | App Validation | [APP_VALIDATION.md](references/APP_VALIDATION.md) |
 | App Market Review | [APP_MARKET_REVIEW.md](references/APP_MARKET_REVIEW.md) |
 | App Identifiers (Namespace, Code ID) | [APP_IDENTIFIERS.md](references/APP_IDENTIFIERS.md) |
+| Extending a Vertical in the Editor (Site Plugin + Editor React component) | [EXTENDING_A_VERTICAL.md](references/EXTENDING_A_VERTICAL.md) |
 | Wix Stores Versioning (V1/V3) | [STORES_VERSIONING.md](references/STORES_VERSIONING.md) |
 | Official Documentation Links | [DOCUMENTATION.md](references/DOCUMENTATION.md) |
 | Auto-patterns Dashboard Pages | [AUTO_PATTERNS_DASHBOARD.md](references/AUTO_PATTERNS_DASHBOARD.md) |

--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -1,6 +1,6 @@
 # Wix Editor React Component Builder
 
-Creates production-quality Editor React components that would be used in Harmony Editor for Wix CLI applications. Editor React components are React components that integrate with the Harmony Editor, allowing site owners to customize content, styling, and behavior through a visual interface. **Note: Editor React components are not available in Wix Editor (Classic) or Wix Studio.** The public docs scope them to Harmony; the internal Builder architecture guide scopes them to "Studio 2 & Harmony" — verify against the target site when it affects a decision.
+Creates production-quality Editor React components that would be used in Harmony Editor for Wix CLI applications. Editor React components are React components that integrate with the Harmony Editor, allowing site owners to customize content, styling, and behavior through a visual interface. **Note: Editor React components are not available in Wix Editor (Classic) or Wix Studio.** The public docs scope them to Harmony; Studio 2 is also a Builder-architecture editor — treat Harmony as the supported target and verify against the actual site when the difference affects a decision.
 
 > **Extending a Wix business solution's page?** An Editor React component covers only the Harmony side. See [`EXTENDING_A_VERTICAL.md`](EXTENDING_A_VERTICAL.md) for the two-surface requirement and [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) for reading vertical data.
 

--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -1,6 +1,8 @@
 # Wix Editor React Component Builder
 
-Creates production-quality Editor React components that would be used in Harmony Editor for Wix CLI applications. Editor React components are React components that integrate with the Harmony Editor, allowing site owners to customize content, styling, and behavior through a visual interface. **Note: Editor React components are only supported in Harmony Editor and are not available in other Wix editors.**
+Creates production-quality Editor React components that would be used in Harmony Editor for Wix CLI applications. Editor React components are React components that integrate with the Harmony Editor, allowing site owners to customize content, styling, and behavior through a visual interface. **Note: Editor React components are not available in Wix Editor (Classic) or Wix Studio.** The public docs scope them to Harmony; the internal Builder architecture guide scopes them to "Studio 2 & Harmony" — verify against the target site when it affects a decision.
+
+> **Extending a Wix business solution's page?** An Editor React component covers only the Harmony side. See [`EXTENDING_A_VERTICAL.md`](EXTENDING_A_VERTICAL.md) for the two-surface requirement and [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) for reading vertical data.
 
 > **Prerequisite — verify first:** this skill applies only to an `@wix/astro` app. Confirm the target package's `package.json` lists `@wix/astro` as a dependency (`grep '"@wix/astro"' package.json`). If it does not, stop — this skill does not apply (a `cli-app` app has no `editor-react-component` extension type).
 
@@ -89,6 +91,7 @@ Topic-focused references (rules + patterns + common mistakes in one place):
 - [`editor-react-component/REACT-PATTERNS.md`](editor-react-component/REACT-PATTERNS.md) — SSR-safe patterns, CSS rules, remaining common mistakes
 - [`editor-react-component/ANIMATED-COMPONENTS.md`](editor-react-component/ANIMATED-COMPONENTS.md) — Play/pause controls for animated components (Lottie, GIF, autoPlay props)
 - [`editor-react-component/COMPONENT-PREVIEW.md`](editor-react-component/COMPONENT-PREVIEW.md) — `component.preview.tsx` patterns and `useIsEditMode()` usage
+- [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) — Reading a Wix vertical's data (Stores/Bookings/Events context providers), `contextDependencies`, per-vertical catalog
 
 ## CSS guidelines
 

--- a/skills/wix-app/references/EXTENDING_A_VERTICAL.md
+++ b/skills/wix-app/references/EXTENDING_A_VERTICAL.md
@@ -52,7 +52,7 @@ Before calling an editor-side vertical extension "done":
 - [ ] A **Site Plugin** exists, with `placements` for every relevant slot — including **both** Stores product-page versions where applicable (see [`site-plugin/SLOTS.md`](site-plugin/SLOTS.md)).
 - [ ] An **Editor React Component** exists that reads the same data from the vertical's context (see [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md)) — **or** the vertical has no context provider yet, in which case this half is blocked, not optional: say so explicitly rather than shipping silently half-covered.
 - [ ] Both surfaces produce the **same** user-visible behaviour from the same underlying data.
-- [ ] The ERC survives being placed **outside** the vertical's page — the context hook throws when no provider is present, so this needs an error boundary or a guaranteed provider, not a null check. See [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) Rule 4.
+- [ ] You know where the ERC can be placed. Its context hook **throws** when no provider is present, and shipping vertical components call the hook unguarded rather than defending against that — so the guarantee comes from placement, not from the component. See [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) Rules 4–5.
 - [ ] The user has been told, under "🔧 Manual Steps Required", that two extensions ship for one feature and why.
 
 ---

--- a/skills/wix-app/references/EXTENDING_A_VERTICAL.md
+++ b/skills/wix-app/references/EXTENDING_A_VERTICAL.md
@@ -1,0 +1,110 @@
+
+# Extending a Wix Vertical in the Editor
+
+Start here whenever the goal is to **add functionality to a site page owned by a Wix business solution** (Wix Stores, Bookings, Events, Blog, eCommerce) — a badge on the product page, a note on the service page, an upsell in checkout.
+
+## First: which surface of the vertical?
+
+"Extend Wix Stores" is ambiguous. Route by **where the extension appears**, not by which vertical it touches:
+
+| The extension appears on | Surface | Go to |
+| --- | --- | --- |
+| A vertical's **site page**, seen by site visitors | Editor / site | **This file** |
+| A vertical's **dashboard page**, seen by the site owner | Dashboard | [`DASHBOARD_PLUGIN.md`](DASHBOARD_PLUGIN.md) |
+| A vertical's dashboard **more-actions / bulk-actions menu** | Dashboard | [`DASHBOARD_MENU_PLUGIN.md`](DASHBOARD_MENU_PLUGIN.md) |
+
+Only the site/editor surface has the two-architecture problem below. Dashboard plugins are a single extension type across all editors — there is no dual-build requirement there, and they get host data through `observeState()` and typed host props instead of contexts or slot props.
+
+The rest of this file is **editor/site only**. Per-extension mechanics live in [`SITE_PLUGIN.md`](SITE_PLUGIN.md) and [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md).
+
+---
+
+## The two-surface rule
+
+Within the editor, there is no single extension type that extends a vertical across all Wix editors. The two page architectures are disjoint:
+
+| Editor | Vertical page architecture | Extension type to build |
+| --- | --- | --- |
+| Wix Editor (Classic), Wix Studio | OOI widgets with **slots** | **Site Plugin** |
+| Wix Harmony (and Studio 2 as it rolls out) | Builder: **Context Providers + Editor React Components** | **Editor React Component** |
+
+**You must build both to cover all editors.** This is not a style preference — the platform offers no runtime fallback:
+
+> "Editor React Component extensions are built for Wix Harmony... They're not supported on Wix Editor or Wix Studio sites, and **there's no way to conditionally switch between extension types based on the editor**."
+> — [Editor React Component Extension Files and Code](https://dev.wix.com/docs/build-apps/develop-your-app/develop-an-app-with-the-cli/supported-extensions/site/editor-react-components/editor-react-component-extension-files-and-code)
+
+Co-existence is a known open problem on the platform side. The current approach is dev-center **specs that show/hide extensions per editor group**, which is not self-serve — raise it in `#editor-platform-dev` before assuming a single app version can ship both cleanly.
+
+**Precedent for this shape of requirement:** [`STORES_VERSIONING.md`](STORES_VERSIONING.md) — an app must support both Stores V1 and V3 for the same reason (single-version apps break on some sites). Editor-side vertical extension has the same "cover both or be silently broken" property, one axis up.
+
+### Editor-support discrepancy — state it, don't resolve it
+
+The public docs say Harmony **only**. The internal Builder guide scopes the Builder architecture to "**Studio 2 & Harmony**." Both are cited above; when it matters for a decision, verify against the target site rather than picking one.
+
+---
+
+## Coverage checklist
+
+Before calling an editor-side vertical extension "done":
+
+- [ ] A **Site Plugin** exists, with `placements` for every relevant slot — including **both** Stores product-page versions where applicable (see [`site-plugin/SLOTS.md`](site-plugin/SLOTS.md)).
+- [ ] An **Editor React Component** exists that reads the same data from the vertical's context (see [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md)).
+- [ ] Both surfaces produce the **same** user-visible behaviour from the same underlying data.
+- [ ] The ERC degrades to a deterministic empty/placeholder render when its context is absent — it will be placeable outside the vertical's page.
+- [ ] The user has been told, under "🔧 Manual Steps Required", that two extensions ship for one feature and why.
+
+---
+
+## What to share, what to keep per-surface
+
+Factor into a shared module (e.g. `src/lib/<feature>/`):
+
+- Data shaping and derivation — "is this product a best seller?", price formatting, date formatting.
+- TypeScript types for the feature's own domain.
+- Backend calls, and the copy/i18n strings.
+
+Keep separate, because the two hosts are genuinely different:
+
+| Concern | Site Plugin | Editor React Component |
+| --- | --- | --- |
+| Where it renders | `slotId` in the extension config | Context attached to page/section; user places the component |
+| How it gets vertical data | Slot props (`productId`, `eventId`, …) | Context hook (`useProductContext()`, …) |
+| Settings UI | Hand-written `.panel.tsx` | Generated auto-panels from the manifest |
+| Styling | Custom element / panel fields | CSS Modules + manifest CSS properties |
+
+The data channel is the part that cannot be shared — write a thin per-surface adapter that pulls the host's identifiers, then hand off to the shared module.
+
+---
+
+## Escape hatch: an ERC plugin inside a not-yet-migrated OOI host
+
+If the host vertical has **not** migrated to Builder but you want to ship ERC-based UI into its OOI slot, there is a legacy adapter that wraps a slot placeholder in a context provider:
+
+```tsx
+function OOIWidget({ someContainer1, someContainer2 }) {
+  const [ProductSlotPlaceholder] = useSlotPlaceholder('product-page-slot-1');
+  return (
+    <ContextProviderFactory
+      moduleName="@wix/stores-smth/product-context"
+      providerProps={{ productVariant, productId }}
+    >
+      <ProductSlotPlaceholder />
+    </ContextProviderFactory>
+  );
+}
+```
+
+**Treat this as a last resort.** Per the Builder guide it is "only meant for ERC-plugin developers who need to remain compatible with non-migrated OOI host apps," is **not SSR-compatible yet**, and is intended only until the hosting app migrates. Do not reach for it as the default path — build the two surfaces above instead.
+
+---
+
+## Routing
+
+| You need to | Go to |
+| --- | --- |
+| Build the classic-editor surface | [`SITE_PLUGIN.md`](SITE_PLUGIN.md) |
+| Know which slots a vertical offers | [`site-plugin/SLOTS.md`](site-plugin/SLOTS.md) |
+| Build the Harmony surface | [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) |
+| Know what data a vertical's context exposes | [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) — per-vertical catalog |
+| General ERC authoring rules | [`EDITOR_REACT_COMPONENT.md`](EDITOR_REACT_COMPONENT.md) |
+| Extend a vertical's **dashboard** instead | [`DASHBOARD_PLUGIN.md`](DASHBOARD_PLUGIN.md) / [`DASHBOARD_MENU_PLUGIN.md`](DASHBOARD_MENU_PLUGIN.md) |

--- a/skills/wix-app/references/EXTENDING_A_VERTICAL.md
+++ b/skills/wix-app/references/EXTENDING_A_VERTICAL.md
@@ -33,7 +33,7 @@ Within the editor, there is no single extension type that extends a vertical acr
 > "Editor React Component extensions are built for Wix Harmony... They're not supported on Wix Editor or Wix Studio sites, and **there's no way to conditionally switch between extension types based on the editor**."
 > — [Editor React Component Extension Files and Code](https://dev.wix.com/docs/build-apps/develop-your-app/develop-an-app-with-the-cli/supported-extensions/site/editor-react-components/editor-react-component-extension-files-and-code)
 
-Co-existence is a known open problem on the platform side. The current approach is dev-center **specs that show/hide extensions per editor group**, which is not self-serve — raise it in `#editor-platform-dev` before assuming a single app version can ship both cleanly.
+Co-existence is a known open problem on the platform side. The current approach is dev-center **specs that show/hide extensions per editor group**, which is not self-serve — check with Wix developer support before assuming one app version can ship both surfaces cleanly.
 
 **The ERC half depends on the vertical.** An ERC reads vertical data from a Context Provider the vertical publishes, so if the target vertical hasn't shipped one, that half cannot be built at all — Wix Blog and Wix Restaurants are in this position today. Check the catalog in [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) before promising both surfaces.
 
@@ -41,7 +41,7 @@ Same shape as [`STORES_VERSIONING.md`](STORES_VERSIONING.md), where an app must 
 
 ### Which editors support Editor React Components
 
-The public docs (quoted above) say Harmony **only**. Wix's internal Builder architecture guide scopes it to "Studio 2 & Harmony." Verify against the target site when the difference affects a decision, rather than assuming either.
+The public docs (quoted above) say Harmony **only**, while Wix's Builder architecture is described elsewhere as covering Studio 2 as well. Treat Harmony as the supported target and verify against the actual site when the difference affects a decision.
 
 ---
 

--- a/skills/wix-app/references/EXTENDING_A_VERTICAL.md
+++ b/skills/wix-app/references/EXTENDING_A_VERTICAL.md
@@ -80,21 +80,26 @@ The data channel is the part that cannot be shared — write a thin per-surface 
 
 ## Escape hatch: an ERC plugin inside a not-yet-migrated OOI host
 
-If the host vertical has **not** migrated to Builder but you want to ship ERC-based UI into its OOI slot, there is a legacy adapter that wraps a slot placeholder in a context provider:
+If the host vertical has **not** migrated to Builder but you want to ship ERC-based UI into its OOI slot, a legacy adapter wraps a slot placeholder in a context provider. **This code lives in an OOI widget, not in the ERC** — so it only applies if you own an OOI widget on that page:
 
 ```tsx
-function OOIWidget({ someContainer1, someContainer2 }) {
-  const [ProductSlotPlaceholder] = useSlotPlaceholder('product-page-slot-1');
+import { useSlotPlaceholder } from '@wix/widget-plugins-ooi';
+import { ContextProviderFactory } from '@wix/context-provider-import-ooi';
+
+const Widget = () => {
+  const [SlotPlaceholder] = useSlotPlaceholder('slot1');
   return (
     <ContextProviderFactory
-      moduleName="@wix/stores-smth/product-context"
-      providerProps={{ productVariant, productId }}
+      moduleName="@wix/vertical-example-cli-app/product-context-provider"
+      providerProps={{ productVariantFromOOIWidget: variant }}
     >
-      <ProductSlotPlaceholder />
+      <SlotPlaceholder />
     </ContextProviderFactory>
   );
-}
+};
 ```
+
+`moduleName` is the provider's `moduleSpecifier`; `providerProps` are the values the provider needs, supplied by the host instead of being fetched. Both packages are on public npm.
 
 **Treat this as a last resort.** Per the Builder guide it is "only meant for ERC-plugin developers who need to remain compatible with non-migrated OOI host apps," is **not SSR-compatible yet**, and is intended only until the hosting app migrates. Do not reach for it as the default path — build the two surfaces above instead.
 

--- a/skills/wix-app/references/EXTENDING_A_VERTICAL.md
+++ b/skills/wix-app/references/EXTENDING_A_VERTICAL.md
@@ -35,11 +35,11 @@ Within the editor, there is no single extension type that extends a vertical acr
 
 Co-existence is a known open problem on the platform side. The current approach is dev-center **specs that show/hide extensions per editor group**, which is not self-serve — raise it in `#editor-platform-dev` before assuming a single app version can ship both cleanly.
 
-**Precedent for this shape of requirement:** [`STORES_VERSIONING.md`](STORES_VERSIONING.md) — an app must support both Stores V1 and V3 for the same reason (single-version apps break on some sites). Editor-side vertical extension has the same "cover both or be silently broken" property, one axis up.
+Same shape as [`STORES_VERSIONING.md`](STORES_VERSIONING.md), where an app must support both Stores V1 and V3 or break on some sites.
 
-### Editor-support discrepancy — state it, don't resolve it
+### Which editors support Editor React Components
 
-The public docs say Harmony **only**. The internal Builder guide scopes the Builder architecture to "**Studio 2 & Harmony**." Both are cited above; when it matters for a decision, verify against the target site rather than picking one.
+The public docs (quoted above) say Harmony **only**. Wix's internal Builder architecture guide scopes it to "Studio 2 & Harmony." Verify against the target site when the difference affects a decision, rather than assuming either.
 
 ---
 
@@ -50,7 +50,7 @@ Before calling an editor-side vertical extension "done":
 - [ ] A **Site Plugin** exists, with `placements` for every relevant slot — including **both** Stores product-page versions where applicable (see [`site-plugin/SLOTS.md`](site-plugin/SLOTS.md)).
 - [ ] An **Editor React Component** exists that reads the same data from the vertical's context (see [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md)).
 - [ ] Both surfaces produce the **same** user-visible behaviour from the same underlying data.
-- [ ] The ERC degrades to a deterministic empty/placeholder render when its context is absent — it will be placeable outside the vertical's page.
+- [ ] The ERC survives being placed **outside** the vertical's page — the context hook throws when no provider is present, so this needs an error boundary or a guaranteed provider, not a null check. See [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) Rule 4.
 - [ ] The user has been told, under "🔧 Manual Steps Required", that two extensions ship for one feature and why.
 
 ---

--- a/skills/wix-app/references/EXTENDING_A_VERTICAL.md
+++ b/skills/wix-app/references/EXTENDING_A_VERTICAL.md
@@ -35,6 +35,8 @@ Within the editor, there is no single extension type that extends a vertical acr
 
 Co-existence is a known open problem on the platform side. The current approach is dev-center **specs that show/hide extensions per editor group**, which is not self-serve — raise it in `#editor-platform-dev` before assuming a single app version can ship both cleanly.
 
+**The ERC half depends on the vertical.** An ERC reads vertical data from a Context Provider the vertical publishes, so if the target vertical hasn't shipped one, that half cannot be built at all — Wix Blog and Wix Restaurants are in this position today. Check the catalog in [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) before promising both surfaces.
+
 Same shape as [`STORES_VERSIONING.md`](STORES_VERSIONING.md), where an app must support both Stores V1 and V3 or break on some sites.
 
 ### Which editors support Editor React Components
@@ -48,7 +50,7 @@ The public docs (quoted above) say Harmony **only**. Wix's internal Builder arch
 Before calling an editor-side vertical extension "done":
 
 - [ ] A **Site Plugin** exists, with `placements` for every relevant slot — including **both** Stores product-page versions where applicable (see [`site-plugin/SLOTS.md`](site-plugin/SLOTS.md)).
-- [ ] An **Editor React Component** exists that reads the same data from the vertical's context (see [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md)).
+- [ ] An **Editor React Component** exists that reads the same data from the vertical's context (see [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md)) — **or** the vertical has no context provider yet, in which case this half is blocked, not optional: say so explicitly rather than shipping silently half-covered.
 - [ ] Both surfaces produce the **same** user-visible behaviour from the same underlying data.
 - [ ] The ERC survives being placed **outside** the vertical's page — the context hook throws when no provider is present, so this needs an error boundary or a guaranteed provider, not a null check. See [`editor-react-component/CONSUMING-A-VERTICAL.md`](editor-react-component/CONSUMING-A-VERTICAL.md) Rule 4.
 - [ ] The user has been told, under "🔧 Manual Steps Required", that two extensions ship for one feature and why.

--- a/skills/wix-app/references/SITE_PLUGIN.md
+++ b/skills/wix-app/references/SITE_PLUGIN.md
@@ -3,6 +3,8 @@
 
 Site plugins are custom elements that integrate into predefined **slots** within Wix business solutions (Wix Stores, Wix Bookings, Wix eCommerce, etc.), extending their functionality and user experience. Site owners place site plugins into UI slots using the plugin explorer in Wix editors.
 
+> **A site plugin only covers Wix Editor and Wix Studio.** Harmony vertical pages use Context Providers + Editor React Components instead, and there is no runtime fallback between the two — covering all editors needs both extensions. Read [`EXTENDING_A_VERTICAL.md`](EXTENDING_A_VERTICAL.md) before building only this half.
+
 ## Scaffold
 
 Use `wix generate --params` with `extensionType: SITE_PLUGIN`. `slotId` is `<componentId>:<slotId>` — the colon-joined widget component ID and slot ID. Run `wix schema generate --type SITE_PLUGIN` to list the available `slotId` values (each `anyOf` entry has the slot's human-readable title). The CLI generates the folder, the plugin `.tsx`, the settings panel `.tsx`, the builder file, the UUID, the logo SVG, and the `src/extensions.ts` registration.

--- a/skills/wix-app/references/editor-react-component/COMPONENT-API.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-API.md
@@ -200,6 +200,13 @@ Allowed image hosts: `static.wixstatic.com` (and other `*.wixstatic.com`
 subdomains). Allowed data: values supplied through props (populated by the
 editor) or imported local assets bundled with the component.
 
+**Platform-supplied data is not an external resource.** Values that arrive
+through the platform — `a11y` props, `EnvironmentDefinition` (see
+[`DIRECTIONALITY.md`](DIRECTIONALITY.md)), and a Wix vertical's context via a
+declared `contextDependencies` hook (see
+[`CONSUMING-A-VERTICAL.md`](CONSUMING-A-VERTICAL.md)) — are allowed. This rule
+bans reaching out to non-Wix hosts, not reading data the platform hands you.
+
 ### Default values for `Image` props
 
 Image defaults belong in the `<componentName>.props.ts` file's exported

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -8,7 +8,7 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
 > **🚧 TODO — package names are internal.** The `moduleSpecifier` values in the catalog below are the real identifiers the verticals ship today, taken verbatim from their manifests, but the packages are **not on public npm** (`npm view @wix/bookings-uou` → E404; same for `@wix/stores-product-page` and `@wix/events-contexts-poc`). Replace with the public package names once they are published. Until then a third-party app cannot install these — verify with `npm view <pkg> version` before writing code against a row.
 
-> **Alpha.** Editor React Components are alpha. The Events contexts are an explicit POC (`events-contexts-poc`). Context manifests **cannot take breaking changes once released**, so treat a context's shape as frozen only after it ships.
+> **Alpha.** Editor React Components are alpha, and the Events contexts are an explicit POC (`events-contexts-poc`). A context's shape can still change before it is released; once released it is frozen, because context manifests **cannot take breaking changes**.
 
 ---
 
@@ -67,9 +67,9 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
    if (!serviceName) return null;
    ```
 
-6. **Split smart from dumb.** Exactly one component calls the hook; presentation components take props. See [Patterns](#patterns).
+6. **Split smart from dumb.** Within one component, the hook is called once at the top and the values flow down as props — presentation components never call it themselves. (Across the page, any number of separate components may each consume the same context; the rule is about one component's internals, not a page-wide limit.) See [Patterns](#patterns).
 
-7. **Any backend call of your own must be platformized.** Exported sites run off Wix domains, so calls must go through public `wixapis.com`-mapped APIs. Fetch with the `use`/`usePromise` utility (a React-18 implementation of React 19's `use`) so Suspense works during SSR — never `useEffect` + `setState` for first-render data.
+7. **Any backend call of your own must be platformized.** Exported sites run off Wix domains, so calls must go through public `wixapis.com`-mapped APIs. Fetch with the `use` utility so Suspense works during SSR — never `useEffect` + `setState` for first-render data. See [Fetching your own data](#fetching-your-own-data).
 
 ---
 
@@ -77,9 +77,9 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
 `type` is the provider's dev-center component type. `Hook` + `moduleSpecifier` are what you write in code. `Requires` lists other contexts the provider itself depends on — those must also be present on the page.
 
-> **The field lists below are the manifest's `context.items` — the editor-**bindable** subset, not the hook's full return type.** The hook usually returns **more**: raw entity objects and extra actions that were deliberately left undeclared because they are smart-component API rather than editor-bindable values. Two confirmed examples: Bookings `ServiceContextValue` also carries `service`, `selection`, `setVariant`, `toggleAddOn`, `setAddOnQuantity`, `setSlot`, `clearSlot`; Bookings time-slots also carries `selectTimeSlot` and `navigateToBookingForm`. Stores composes its value by spreading several internal hooks (info, price, inventory, selected media, cart actions, back-in-stock), so its runtime surface is considerably wider than the five bindable items listed.
+> **These field lists are the manifest's `context.items` — the editor-bindable subset, not the hook's return type.** The hook returns more: raw entity objects and actions left undeclared because they are smart-component API rather than bindable values. Bookings `ServiceContextValue`, for example, also carries `service`, `selection`, `setVariant`, `toggleAddOn`, `setAddOnQuantity`, `setSlot`, and `clearSlot`; Stores builds its value by spreading six internal hooks behind five bindable items.
 >
-> Use the lists below to answer "what can the editor bind?" and to know a context is the right one. For the authoritative runtime shape, read the exported type — `ProductContextValue`, `ServiceContextValue`, etc. — from the provider package.
+> Use these lists to pick the right context and to know what the editor can bind. For the runtime shape, read the exported `ProductContextValue` / `ServiceContextValue` type from the provider package.
 
 | Vertical | `type` | Hook | `moduleSpecifier` | Requires |
 | --- | --- | --- | --- | --- |
@@ -97,14 +97,14 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
 ### Wix Stores — product context
 
-Product page. `description` is a Ricos document; everything else here is pre-formatted text.
+Product page.
 
 - `name`, `sku`
 - `description` — Ricos document
 - `prices` → `currentSellingPrice`, `originalPrice`, `pricePerUnit`
 - `productPriceRange` → `minCurrentSellingPrice`, `maxCurrentSellingPrice`, `minOriginalPrice`, `maxOriginalPrice`, `minPricePerUnit`, `maxPricePerUnit`
 
-Prices arrive **formatted for display** — do not re-format or do currency math on them.
+Every price is a **display-formatted string**, not a number — don't parse it back for currency math.
 
 ### Wix Events
 
@@ -121,11 +121,9 @@ Prices arrive **formatted for display** — do not re-format or do currency math
 **Membership offers** — `plans` → `name`
 **Seating plan** — `seatingPlan` → `title`
 
-The three above are thin by design in the POC; expect them to grow.
-
 ### Wix Bookings
 
-**Service context** — service page. The richest context of the three verticals:
+**Service context** — service page:
 
 - Identity — `serviceId`, `serviceSlug`, `serviceName`, `serviceDescription`, `serviceTagLine`, `serviceType`, `serviceCtaState`
 - Price — `servicePrice` → `rateType`, `price`, `priceAfterDiscount`, `discountName`, `calculatedAtCheckout`
@@ -143,7 +141,7 @@ The three above are thin by design in the POC; expect them to grow.
 
 **Sessions context** — requires Service. `sessions[]` → `id`, `title`, `startDate`, `endDate`, `durationMinutes`, `staff[]` (`staffMemberId`, `name`), `totalCapacity`, `spotsLeft`, `isFullyBooked`, `isConfirmed`, `isCancelled`, `isAllDay`; plus `timeZone`, `hasMore`, `loadMoreSessions()` (async).
 
-Plural — pair with a repeater to render one row per session.
+This context is plural — it exposes the whole array, so pair it with a repeater to render one row per session.
 
 **Time slots context** — requires Service. `timeSlots` and `nextAvailableSlots`, each slot → `slotId`, `startTime`, `endTime`, `bookable`, `totalCapacity`, `remainingCapacity`, `bookableCapacity`, `eventId`, `eventTitle`, `waitlistCapacity`, `locationId`, `locationName`. Plus `loading`, `error`, `timeZone`, `nextAvailableSlotsCount`, `selectedResourceId`, `selectedTimeSlot` (`slotStartTime`, `slotEndTime`, `bookable`, `eventId`), `staffFromSlots`, `setDateRange(start, end)`, `setSelectedResource(resourceId)`.
 
@@ -172,39 +170,16 @@ export default function BestSellerBadge({ className, id, label }: BestSellerBadg
 }
 ```
 
-Two distinct failure modes, and they need different handling:
-
-| Situation | Symptom | Handling |
-| --- | --- | --- |
-| No provider on the page | Hook **throws** | Error boundary, or don't render the consumer at all |
-| Provider present, data not resolved / not applicable | Field is `null` | Per-field guard, as above |
-
-Conflating them — `useProductContext() ?? {}` — produces code that looks defensive and isn't.
-
-### The root node must stay selectable
-
-The editor can only select the component if its root carries all three:
-
-```tsx
-<div className={`${props.className} ${styles.root}`} id={props.id}>
-```
-
-- `className` from props
-- the class matching the selector declared in the manifest
-- `id` from `props.id`
-
-Dropping any one of them makes the component unselectable in the editor even though it renders correctly on the site.
+The two comments mark the two different failure modes — see Rules 4 and 5. The root element follows the usual ERC pattern ([`CSS-GUIDELINES.md`](CSS-GUIDELINES.md)); consuming a context changes nothing about it.
 
 ### Composition over one large component
 
-Prefer several small context-consuming components (a name, a price, a badge) that the user can add, remove, and rearrange, over one component that owns the whole page layout. Multiple components may consume the same context, and a provider may itself consume a parent context.
-
-Segregate contexts by data purpose: list vs single item, backend data vs UI state (filters, dropdowns), shareable vs specific.
+Prefer several small context-consuming components (a name, a price, a badge) that the user can add, remove, and rearrange, over one component that owns the whole page layout. Any number of components on the page may consume the same context.
 
 ### Fetching your own data
 
 ```tsx
-import { use } from '../usePromise'; // app-local utility — see note below
+import { use } from '../../hooks/use'; // app-local — see note below
 
 function WithData({ promise }) {
   const result = use(promise); // suspends during SSR until resolved
@@ -212,7 +187,7 @@ function WithData({ promise }) {
 }
 ```
 
-`use` is a React-18 backport of React 19's `use` and is **not yet a published package** — the verticals each vendor a local copy (Stores keeps it at `src/hooks/use.ts`). Vendor it in your own app until it ships in a shared lib, and expect to delete it when the platform moves to React 19.
+`use` is a React-18 backport of React 19's `use` and is **not a published package** — each vertical vendors a local copy (Stores keeps it at `src/hooks/use.ts`). Vendor it in your app too, and delete it once the platform moves to React 19.
 
 ---
 
@@ -234,20 +209,19 @@ Components inside that page/section then receive the context.
 
 For production, attachment must happen when the app is installed — this is an Editor Platform dependency, not something the component can arrange for itself. If a context will not attach, raise it in `#editor-platform-dev`.
 
-There are four ways a provider ends up on stage: attached to a page, attached to a section, wrapping ERC containers the developer injects, or the legacy OOI slot adapter (see [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md)).
+Page and section attachment are the two cases you will meet. Two others exist — a developer wrapping ERC containers, and the legacy OOI slot adapter ([`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md)).
 
 ---
 
 ## Common Mistakes
 
 - **Importing the hook without `contextDependencies`.** Builds, then fails at runtime with no context. Both halves are required.
-- **`useXContext() ?? {}`.** Looks defensive, is dead code — the hook throws before returning. See Rule 4.
+- **Guarding a missing provider with `useXContext() ?? {}`.** Dead code — the hook throws before returning. A component users can place anywhere needs an error boundary or a guaranteed provider (Rule 4).
 - **Treating the catalog's field list as the hook's return type.** It is the editor-bindable subset; the runtime type is wider. Read the exported `*ContextValue` type.
-- **Calling a vertical hook unconditionally in a component users can place anywhere.** Crashes off the vertical's page — needs an error boundary or a guaranteed provider.
 - **Expecting the provider to attach itself.** The most common "my component renders nothing" cause. Verify with `s.ds.contexts.list(pointer)`.
 - **Writing code against a catalog row without checking the package resolves.** See the TODO at the top — these packages are not on public npm yet.
 - **Re-formatting pre-formatted values.** Stores prices and Events dates/locations arrive display-ready; parsing them back into numbers or `Date`s loses locale and currency handling.
-- **Fetching in `useEffect` for first-render data.** Breaks SSR. Use `use`/`usePromise`.
+- **Fetching in `useEffect` for first-render data.** Breaks SSR. Use the `use` utility.
 - **Calling a non-platformized backend.** Works on a Wix-hosted site, fails on an exported one.
 - **Shipping only the ERC.** Dead on Wix Editor and Studio — see [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md).
 - **Building a dashboard extension this way.** Vertical dashboard pages use `observeState()` and typed host props, not contexts — see [`../DASHBOARD_PLUGIN.md`](../DASHBOARD_PLUGIN.md).

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -16,13 +16,23 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
 1. **Declare the dependency in the manifest, import the hook in the component.** Both halves are required — the hook import alone will not cause the platform to provide the context.
 
+   `resources` lives in `<componentName>.extension.ts` — add `dependencies` alongside the existing `client`, inside the `extensions.editorReactComponent({ ... })` call the scaffold already generated. Do not introduce a second `resources` block.
+
    ```ts
    // <componentName>.extension.ts
-   resources: {
-     dependencies: {
-       contextDependencies: ['@wix/stores-product-page/product-context-provider'],
+   export default extensions.editorReactComponent({
+     id: '…',
+     type: '…',
+     editorElement,
+     resources: {
+       client: {
+         componentUrl: './extensions/site/components/best-seller-badge/best-seller-badge.tsx',
+       },
+       dependencies: {
+         contextDependencies: ['@wix/stores-product-page/product-context-provider'],
+       },
      },
-   }
+   });
    ```
 
    ```tsx
@@ -32,21 +42,44 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
    The string in `contextDependencies` is the provider's `moduleSpecifier` — the same value you import from. Get both from the catalog below.
 
+   > **`contextDependencies` is not in the public manifest reference.** The [`resources`](https://dev.wix.com/docs/build-apps/develop-your-app/extensions/site-extensions/editor-react-components/manifest-reference/root-properties/resources) page documents no `dependencies` key at all — the field is confirmed only by the internal Builder guide and by the verticals' own manifests. Don't conclude it doesn't exist because the public docs omit it; do expect the shape to move while ERCs are alpha.
+
 2. **Context data is platform-supplied, not an external fetch.** [`COMPONENT-API.md`](COMPONENT-API.md) forbids external resources; a vertical context is not one. It arrives through the platform like `a11y` props or `EnvironmentDefinition` in [`DIRECTIONALITY.md`](DIRECTIONALITY.md). Reading it is allowed and expected.
 
-3. **The context is not attached automatically.** A correct component renders empty until the provider is attached to the page or section. See [Attaching the provider](#attaching-the-provider) — this is the single most common reason a working component shows nothing.
+3. **The context is not attached automatically.** Declaring `contextDependencies` does not put a provider on the page — someone must attach it to the page or section. Until then the hook throws (Rule 4) and the component fails to render. See [Attaching the provider](#attaching-the-provider): this is the single most common reason an otherwise-correct component shows nothing.
 
-4. **Never assume the context is present.** Users can place the component anywhere. Render a deterministic placeholder when the hook returns nothing, and keep first render SSR-safe per [`SSR.md`](SSR.md).
+4. **The hook throws when the provider is absent — it does not return `null`.** Every vertical hook is written as "read context, throw if missing":
 
-5. **Split smart from dumb.** Exactly one component calls the hook; presentation components take props. See [Patterns](#patterns).
+   ```ts
+   export function useServiceContext(): ServiceContextValue {
+     const ctx = useContext(context);
+     if (!ctx) throw new Error('useServiceContext must be used within ServiceContextProvider');
+     return ctx;
+   }
+   ```
 
-6. **Any backend call of your own must be platformized.** Exported sites run off Wix domains, so calls must go through public `wixapis.com`-mapped APIs. Fetch with the `use`/`usePromise` utility (a React-18 implementation of React 19's `use`) so Suspense works during SSR — never `useEffect` + `setState` for first-render data.
+   So `useServiceContext() ?? {}` is dead code — the throw happens first. Defending against a missing provider means **not calling the hook** unless the provider is guaranteed, or wrapping the consumer in an error boundary. Users can place a component anywhere, so an ERC that calls a vertical hook unconditionally will crash when dropped outside the vertical's page.
+
+5. **Missing *data* is expressed as `null` fields, not a null context.** Most fields are `T | null` (e.g. `serviceName: string | null`), so guard per field and keep first render SSR-safe per [`SSR.md`](SSR.md):
+
+   ```tsx
+   const { serviceName } = useServiceContext();
+   if (!serviceName) return null;
+   ```
+
+6. **Split smart from dumb.** Exactly one component calls the hook; presentation components take props. See [Patterns](#patterns).
+
+7. **Any backend call of your own must be platformized.** Exported sites run off Wix domains, so calls must go through public `wixapis.com`-mapped APIs. Fetch with the `use`/`usePromise` utility (a React-18 implementation of React 19's `use`) so Suspense works during SSR — never `useEffect` + `setState` for first-render data.
 
 ---
 
 ## Per-vertical catalog
 
 `type` is the provider's dev-center component type. `Hook` + `moduleSpecifier` are what you write in code. `Requires` lists other contexts the provider itself depends on — those must also be present on the page.
+
+> **The field lists below are the manifest's `context.items` — the editor-**bindable** subset, not the hook's full return type.** The hook usually returns **more**: raw entity objects and extra actions that were deliberately left undeclared because they are smart-component API rather than editor-bindable values. Two confirmed examples: Bookings `ServiceContextValue` also carries `service`, `selection`, `setVariant`, `toggleAddOn`, `setAddOnQuantity`, `setSlot`, `clearSlot`; Bookings time-slots also carries `selectTimeSlot` and `navigateToBookingForm`. Stores composes its value by spreading several internal hooks (info, price, inventory, selected media, cart actions, back-in-stock), so its runtime surface is considerably wider than the five bindable items listed.
+>
+> Use the lists below to answer "what can the editor bind?" and to know a context is the right one. For the authoritative runtime shape, read the exported type — `ProductContextValue`, `ServiceContextValue`, etc. — from the provider package.
 
 | Vertical | `type` | Hook | `moduleSpecifier` | Requires |
 | --- | --- | --- | --- | --- |
@@ -133,13 +166,20 @@ Locations and Categories back their selection with the URL — selecting updates
 import { useProductContext } from '@wix/stores-product-page/product-context-provider';
 
 export default function BestSellerBadge({ className, id, label }: BestSellerBadgeProps) {
-  const { sku } = useProductContext() ?? {};
-  if (!sku) return null; // placed outside a product page, or not resolved yet
+  const { sku } = useProductContext(); // throws if no provider — see Rule 4
+  if (!sku) return null;               // field is nullable even when the provider exists
   return <BadgeUI className={className} id={id} label={label} sku={sku} />;
 }
 ```
 
-`useProductContext() ?? {}` plus the early return is the whole missing-context contract. A component that destructures unconditionally crashes the moment a user drags it onto the home page.
+Two distinct failure modes, and they need different handling:
+
+| Situation | Symptom | Handling |
+| --- | --- | --- |
+| No provider on the page | Hook **throws** | Error boundary, or don't render the consumer at all |
+| Provider present, data not resolved / not applicable | Field is `null` | Per-field guard, as above |
+
+Conflating them — `useProductContext() ?? {}` — produces code that looks defensive and isn't.
 
 ### The root node must stay selectable
 
@@ -164,7 +204,7 @@ Segregate contexts by data purpose: list vs single item, backend data vs UI stat
 ### Fetching your own data
 
 ```tsx
-import { use } from '../usePromise';
+import { use } from '../usePromise'; // app-local utility — see note below
 
 function WithData({ promise }) {
   const result = use(promise); // suspends during SSR until resolved
@@ -172,11 +212,13 @@ function WithData({ promise }) {
 }
 ```
 
+`use` is a React-18 backport of React 19's `use` and is **not yet a published package** — the verticals each vendor a local copy (Stores keeps it at `src/hooks/use.ts`). Vendor it in your own app until it ships in a shared lib, and expect to delete it when the platform moves to React 19.
+
 ---
 
 ## Attaching the provider
 
-A context provider is attached to a **page** or a **section**, not to your component. Until it is, your hook returns nothing.
+A context provider is attached to a **page** or a **section**, not to your component. Until it is, your hook throws — so "nothing renders" and "the hook threw" are the same bug seen from two angles.
 
 To test locally, open the editor with `&experiments=specs.thunderbolt.contextProviders`, select the section, then:
 
@@ -199,7 +241,9 @@ There are four ways a provider ends up on stage: attached to a page, attached to
 ## Common Mistakes
 
 - **Importing the hook without `contextDependencies`.** Builds, then fails at runtime with no context. Both halves are required.
-- **Assuming the context exists.** Destructuring the hook result unconditionally crashes when the component is placed off the vertical's page.
+- **`useXContext() ?? {}`.** Looks defensive, is dead code — the hook throws before returning. See Rule 4.
+- **Treating the catalog's field list as the hook's return type.** It is the editor-bindable subset; the runtime type is wider. Read the exported `*ContextValue` type.
+- **Calling a vertical hook unconditionally in a component users can place anywhere.** Crashes off the vertical's page — needs an error boundary or a guaranteed provider.
 - **Expecting the provider to attach itself.** The most common "my component renders nothing" cause. Verify with `s.ds.contexts.list(pointer)`.
 - **Writing code against a catalog row without checking the package resolves.** See the TODO at the top — these packages are not on public npm yet.
 - **Re-formatting pre-formatted values.** Stores prices and Events dates/locations arrive display-ready; parsing them back into numbers or `Date`s loses locale and currency handling.

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -42,9 +42,24 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
    The string in `contextDependencies` is the provider's `moduleSpecifier` — the same value you import from. Get both from the catalog below. The array takes more than one entry: a component may consume several contexts.
 
-   > **⚠️ `dependencies` placement is genuinely ambiguous — check before you copy.** Two forms both ship in production. Stores consumers nest it **inside `client`** (`resources.client.dependencies`, as above — `low-stock-indicator`, `ribbons`, `discount-names` all do this). The internal Builder guide and the Events `event-title` consumer put it as a **sibling of `client`** (`resources.dependencies`). Providers are a third case: Bookings' manifests comment that "context providers declare all dependencies at `resources.dependencies` — the `client`/`editor` Resources hold only `url`."
+   > **⚠️ `dependencies` goes inside `client`, and the wrong placement fails silently.** The published `@wix/astro` type for this builder (`editorReactComponent` is an alias of `siteComponent`) declares:
    >
-   > The public [`resources`](https://dev.wix.com/docs/build-apps/develop-your-app/extensions/site-extensions/editor-react-components/manifest-reference/root-properties/resources) reference documents no `dependencies` key at all, and the published `@wix/component-protocol` schema has `serviceDependencies` but no `contextDependencies` — so neither settles it. Run `wix schema generate --type EDITOR_REACT_COMPONENT` for your CLI version and match whichever the schema accepts, rather than trusting either example.
+   > ```ts
+   > resources: {
+   >   [key: string]: unknown;
+   >   client: {
+   >     [key: string]: unknown;
+   >     componentUrl: string;
+   >     cssUrl?: string;
+   >     dependencies?: { componentDependencies?: string[]; contextDependencies?: string[] };
+   >   };
+   >   editor?: { /* same shape */ };
+   > }
+   > ```
+   >
+   > Because both `resources` and `client` carry `[key: string]: unknown`, writing `dependencies` as a **sibling** of `client` type-checks and is then ignored — no build error, no context at runtime. The internal Builder guide's snippet and the Events `event-title` consumer both use that sibling form, which is why you will see it in the wild; prefer the typed placement above. (Context *providers* are a genuinely different shape — Bookings' manifests note that providers declare deps at `resources.dependencies`, with `client`/`editor` holding only `url`. Don't carry a provider's layout over to a consumer.)
+   >
+   > `componentDependencies` sits beside `contextDependencies` for depending on other components, and `resources.editor` takes the same `dependencies` object when you ship a separate editor bundle. Neither the public [`resources`](https://dev.wix.com/docs/build-apps/develop-your-app/extensions/site-extensions/editor-react-components/manifest-reference/root-properties/resources) reference nor `@wix/component-protocol` mentions `contextDependencies` — `@wix/astro` is the authority.
 
 2. **Context data is platform-supplied, not an external fetch.** [`COMPONENT-API.md`](COMPONENT-API.md) forbids external resources; a vertical context is not one. It arrives through the platform like `a11y` props or `EnvironmentDefinition` in [`DIRECTIONALITY.md`](DIRECTIONALITY.md). Reading it is allowed and expected.
 

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -16,7 +16,7 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
 1. **Declare the dependency in the manifest, import the hook in the component.** Both halves are required — the hook import alone will not cause the platform to provide the context.
 
-   `resources` lives in `<componentName>.extension.ts` — add `dependencies` alongside the existing `client`, inside the `extensions.editorReactComponent({ ... })` call the scaffold already generated. Do not introduce a second `resources` block.
+   `resources` lives in `<componentName>.extension.ts`, inside the `extensions.editorReactComponent({ ... })` call the scaffold generated. Add `dependencies` there — don't introduce a second `resources` block.
 
    ```ts
    // <componentName>.extension.ts
@@ -27,9 +27,9 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
      resources: {
        client: {
          componentUrl: './extensions/site/components/best-seller-badge/best-seller-badge.tsx',
-       },
-       dependencies: {
-         contextDependencies: ['@wix/stores-product-page/product-context-provider'],
+         dependencies: {
+           contextDependencies: ['@wix/stores-product-page/product-context-provider'],
+         },
        },
      },
    });
@@ -40,9 +40,11 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
    import { useProductContext } from '@wix/stores-product-page/product-context-provider';
    ```
 
-   The string in `contextDependencies` is the provider's `moduleSpecifier` — the same value you import from. Get both from the catalog below.
+   The string in `contextDependencies` is the provider's `moduleSpecifier` — the same value you import from. Get both from the catalog below. The array takes more than one entry: a component may consume several contexts.
 
-   > **`contextDependencies` is not in the public manifest reference.** The [`resources`](https://dev.wix.com/docs/build-apps/develop-your-app/extensions/site-extensions/editor-react-components/manifest-reference/root-properties/resources) page documents no `dependencies` key at all — the field is confirmed only by the internal Builder guide and by the verticals' own manifests. Don't conclude it doesn't exist because the public docs omit it; do expect the shape to move while ERCs are alpha.
+   > **⚠️ `dependencies` placement is genuinely ambiguous — check before you copy.** Two forms both ship in production. Stores consumers nest it **inside `client`** (`resources.client.dependencies`, as above — `low-stock-indicator`, `ribbons`, `discount-names` all do this). The internal Builder guide and the Events `event-title` consumer put it as a **sibling of `client`** (`resources.dependencies`). Providers are a third case: Bookings' manifests comment that "context providers declare all dependencies at `resources.dependencies` — the `client`/`editor` Resources hold only `url`."
+   >
+   > The public [`resources`](https://dev.wix.com/docs/build-apps/develop-your-app/extensions/site-extensions/editor-react-components/manifest-reference/root-properties/resources) reference documents no `dependencies` key at all, and the published `@wix/component-protocol` schema has `serviceDependencies` but no `contextDependencies` — so neither settles it. Run `wix schema generate --type EDITOR_REACT_COMPONENT` for your CLI version and match whichever the schema accepts, rather than trusting either example.
 
 2. **Context data is platform-supplied, not an external fetch.** [`COMPONENT-API.md`](COMPONENT-API.md) forbids external resources; a vertical context is not one. It arrives through the platform like `a11y` props or `EnvironmentDefinition` in [`DIRECTIONALITY.md`](DIRECTIONALITY.md). Reading it is allowed and expected.
 
@@ -85,6 +87,7 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 | --- | --- | --- | --- | --- |
 | Stores | `onlineStoresBuilder.ProductPageContextProvider` | `useProductContext` | `@wix/stores-product-page/product-context-provider` | — |
 | Events | `eventsContextsPOC.EventContextProvider` | `useEventContext` | `@wix/events-contexts-poc/event-context-provider` | — |
+| Events | `eventsContextsPOC.EventListContextProvider` | `useEventListContext` | `@wix/events-contexts-poc/event-list-context-provider` | — |
 | Events | `eventsContextsPOC.AvailableTicketsContextProvider` | `useAvailableTicketsContext` | `@wix/events-contexts-poc/available-tickets-context-provider` | Event |
 | Events | `eventsContextsPOC.MembershipOffersContextProvider` | `useMembershipOffersContext` | `@wix/events-contexts-poc/membership-offers-context-provider` | Event |
 | Events | `eventsContextsPOC.SeatingPlanContextProvider` | `useSeatingPlanContext` | `@wix/events-contexts-poc/seating-plan-context-provider` | Event |
@@ -116,6 +119,8 @@ Every price is a **display-formatted string**, not a number — don't parse it b
 - `event` → `title`
 - `locations` → `address`, `description`, `title`, `latitude`, `longitude`
 - `openEventDetails()` — navigates to the public event details page; bound to a pointer event
+
+**Event list context** — a list page rather than a single event. `events` → `title`. Its `filter` is provider config (`upcoming` | `past` | `all`, default `upcoming`), set where the provider is configured, not read from the hook.
 
 **Available tickets** — `ticketDefinitions` → `name`
 **Membership offers** — `plans` → `name`
@@ -152,6 +157,24 @@ This context is plural — it exposes the whole array, so pair it with a repeate
 **Categories context** — `categoryItems[]` → `categoryId`, `categoryName`, `isSelected`; `selectedCategoryId`, `selectedCategoryIndex`, `selectedCategoryName`, `selectCategory(categoryId)`, `refetch()` (async).
 
 Locations and Categories back their selection with the URL — selecting updates the address bar, so treat them as the source of truth rather than mirroring selection into local state.
+
+### Verticals not in this catalog
+
+**This catalog covers Stores, Bookings, and Events only. Other verticals have shipped context providers too**, and more appear regularly — do not conclude a context doesn't exist because it is missing here. Confirmed elsewhere:
+
+| Vertical | Repo | Providers |
+| --- | --- | --- |
+| Members Area | `wix-private/members-area-builder` | my-groups, my-wallet, my-wishlist |
+| eCommerce | `wix-private/ecom-platform-storefront-builder` | cart-context |
+| Donations | `wix-private/wix-donations-builder` | donation, thank-you |
+
+With `wix-private` access, list the current set with:
+
+```bash
+gh api -X GET search/code -f q='contextSpecifier org:wix-private' --jq '.items[].path'
+```
+
+**If the vertical you need genuinely has no context provider, you cannot build the ERC half** — no amount of manifest configuration substitutes for a provider that doesn't exist. Ship the site plugin, and ask the owning team (or `#editor-platform-dev`) for a provider. Wix Blog and Wix Restaurants are site-plugin hosts in [`../site-plugin/SLOTS.md`](../site-plugin/SLOTS.md) with no context provider found at the time of writing.
 
 ---
 

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -20,10 +20,14 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
    ```ts
    // <componentName>.extension.ts
+   import { extensions } from '@wix/astro/builders';
+   import { editorElement } from './best-seller-badge.generated';
+
    export default extensions.editorReactComponent({
      id: '…',
      type: '…',
      editorElement,
+     installation: { /* see Rule 8 */ },
      resources: {
        client: {
          // the withDefaults entry point, NOT the raw component file
@@ -66,7 +70,7 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
 
 2. **Context data is platform-supplied, not an external fetch.** [`COMPONENT-API.md`](COMPONENT-API.md) forbids external resources; a vertical context is not one. It arrives through the platform like `a11y` props or `EnvironmentDefinition` in [`DIRECTIONALITY.md`](DIRECTIONALITY.md). Reading it is allowed and expected.
 
-3. **The context is not attached automatically.** Declaring `contextDependencies` does not put a provider on the page — someone must attach it to the page or section. Until then the hook throws (Rule 4) and the component fails to render. See [Attaching the provider](#attaching-the-provider): this is the single most common reason an otherwise-correct component shows nothing.
+3. **The context is not attached automatically, and you don't control that.** Declaring `contextDependencies` does not put a provider on the page; attachment is platform-controlled and happens at install time. Until it happens the hook throws (Rule 4) and the component fails to render — the single most common reason an otherwise-correct component shows nothing. See [Attaching the provider](#attaching-the-provider).
 
 4. **The hook throws when the provider is absent — it does not return `null`.** Every vertical hook is written as "read context, throw if missing":
 
@@ -89,7 +93,7 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
    if (!serviceName) return null;
    ```
 
-   This is the real pattern — `low-stock-indicator` reads `remainingItemCount`, checks it, and returns `null` when there's nothing to show.
+   This is what shipping consumers do: read the field, check it, render nothing when there is nothing to show.
 
 6. **Split smart from dumb.** Within one component, the hook is called once at the top and the values flow down as props — presentation components never call it themselves. (Across the page, any number of separate components may each consume the same context; the rule is about one component's internals, not a page-wide limit.) See [Patterns](#patterns).
 
@@ -207,7 +211,7 @@ export default function BestSellerBadge({ className, id, label }: BestSellerBadg
 }
 ```
 
-The two comments mark the two different failure modes — see Rules 4 and 5. The root element follows the usual ERC pattern ([`CSS-GUIDELINES.md`](CSS-GUIDELINES.md)); consuming a context changes nothing about it.
+The root element follows the usual ERC pattern ([`CSS-GUIDELINES.md`](CSS-GUIDELINES.md)) — consuming a context changes nothing about it.
 
 ### Composition over one large component
 

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -60,7 +60,7 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
    > }
    > ```
    >
-   > Because both `resources` and `client` carry `[key: string]: unknown`, writing `dependencies` as a **sibling** of `client` type-checks and is then ignored — no build error, no context at runtime. The internal Builder guide's snippet and the Events `event-title` consumer both use that sibling form, which is why you will see it in the wild; prefer the typed placement above. (Context *providers* are a genuinely different shape — Bookings' manifests note that providers declare deps at `resources.dependencies`, with `client`/`editor` holding only `url`. Don't carry a provider's layout over to a consumer.)
+   > Because both `resources` and `client` carry `[key: string]: unknown`, writing `dependencies` as a **sibling** of `client` type-checks and is then ignored — no build error, no context at runtime. Some existing components and some older guidance use that sibling form, so you may encounter it; prefer the typed placement above. (Context *providers* are a different shape, declaring deps at `resources.dependencies` with `client`/`editor` holding only `url` — don't carry a provider's layout over to a consumer.)
    >
    > `componentDependencies` sits beside `contextDependencies` for depending on other components, and `resources.editor` takes the same `dependencies` object when you ship a separate editor bundle. Neither the public [`resources`](https://dev.wix.com/docs/build-apps/develop-your-app/extensions/site-extensions/editor-react-components/manifest-reference/root-properties/resources) reference nor `@wix/component-protocol` mentions `contextDependencies` — `@wix/astro` is the authority.
 
@@ -186,21 +186,9 @@ Locations and Categories back their selection with the URL — selecting updates
 
 ### Verticals not in this catalog
 
-**This catalog covers Stores, Bookings, and Events only. Other verticals have shipped context providers too**, and more appear regularly — do not conclude a context doesn't exist because it is missing here. Confirmed elsewhere:
+**This catalog covers Stores, Bookings, and Events only.** Other verticals have shipped context providers too — Members Area (groups, wallet, wishlist), eCommerce (cart), and Donations among them — and the set grows. Do not conclude a context doesn't exist just because it is missing here; ask Wix developer support whether one is available for your target vertical.
 
-| Vertical | Repo | Providers |
-| --- | --- | --- |
-| Members Area | `wix-private/members-area-builder` | my-groups, my-wallet, my-wishlist |
-| eCommerce | `wix-private/ecom-platform-storefront-builder` | cart-context |
-| Donations | `wix-private/wix-donations-builder` | donation, thank-you |
-
-With `wix-private` access, list the current set with:
-
-```bash
-gh api -X GET search/code -f q='contextSpecifier org:wix-private' --jq '.items[].path'
-```
-
-**If the vertical you need genuinely has no context provider, you cannot build the ERC half** — no amount of manifest configuration substitutes for a provider that doesn't exist. Ship the site plugin, and ask the owning team (or `#editor-platform-dev`) for a provider. Wix Blog and Wix Restaurants are site-plugin hosts in [`../site-plugin/SLOTS.md`](../site-plugin/SLOTS.md) with no context provider found at the time of writing.
+**If the vertical genuinely has no context provider, the ERC half cannot be built** — no manifest configuration substitutes for a provider that doesn't exist. Ship the site plugin and request a provider through Wix developer support. Wix Blog and Wix Restaurants are site-plugin hosts in [`../site-plugin/SLOTS.md`](../site-plugin/SLOTS.md) with no context provider found at the time of writing.
 
 ---
 
@@ -242,21 +230,9 @@ function WithData({ promise }) {
 
 ## Attaching the provider
 
-A context provider is attached to a **page** or a **section**, not to your component. Until it is, your hook throws — so "nothing renders" and "the hook threw" are the same bug seen from two angles.
+A context provider is attached to a **page** or a **section** — never to your component. Components inside that page or section then receive the context. Until a provider is attached, your hook throws, so "nothing renders" and "the hook threw" are the same bug seen from two angles.
 
-To test locally, open the editor with `&experiments=specs.thunderbolt.contextProviders`, select the section, then run this in the editor console — `s` is the editor's scope handle exposed there, not something you import:
-
-```js
-const pointer = { id: s.ds.pages.getCurrentPageId(), type: 'DESKTOP' }; // page
-// const pointer = s.selected.documentPointer;                          // or section
-
-s.ds.contexts.attach(pointer, '<yourContextType>'); // the provider's `type`, e.g. 'onlineStoresBuilder.ProductPageContextProvider'
-s.ds.contexts.list(pointer); // verify
-```
-
-Components inside that page/section then receive the context.
-
-For production, attachment must happen when the app is installed — this is an Editor Platform dependency, not something the component can arrange for itself. If a context will not attach, raise it in `#editor-platform-dev`.
+**You cannot arrange this from inside the component**, and declaring `contextDependencies` does not do it either. Attachment happens when the app is installed, which is platform-controlled. If your component builds correctly but receives no context, that is the thing to raise with Wix developer support — not a bug in your code.
 
 Page and section attachment are the two cases you will meet. Two others exist — a developer wrapping ERC containers, and the legacy OOI slot adapter ([`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md)).
 
@@ -267,7 +243,7 @@ Page and section attachment are the two cases you will meet. Two others exist �
 - **Importing the hook without `contextDependencies`.** Builds, then fails at runtime with no context. Both halves are required.
 - **Guarding a missing provider with `useXContext() ?? {}`.** Dead code — the hook throws before returning, so the fallback can never run. Guard nullable *fields* instead (Rule 5); a missing provider is not recoverable in-component (Rule 4).
 - **Treating the catalog's field list as the hook's return type.** It is the editor-bindable subset; the runtime type is wider. Read the exported `*ContextValue` type.
-- **Expecting the provider to attach itself.** The most common "my component renders nothing" cause. Verify with `s.ds.contexts.list(pointer)`.
+- **Expecting the provider to attach itself.** The most common "my component renders nothing" cause, and not fixable in component code — see [Attaching the provider](#attaching-the-provider).
 - **Writing code against a catalog row without checking the package resolves.** See the TODO at the top — these packages are not on public npm yet.
 - **Re-formatting pre-formatted values.** Stores prices and Events dates/locations arrive display-ready; parsing them back into numbers or `Date`s loses locale and currency handling.
 - **Fetching in `useEffect` for first-render data.** Breaks SSR. Use the `use` utility.

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -60,7 +60,9 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
    }
    ```
 
-   So `useServiceContext() ?? {}` is dead code — the throw happens first. Defending against a missing provider means **not calling the hook** unless the provider is guaranteed, or wrapping the consumer in an error boundary. Users can place a component anywhere, so an ERC that calls a vertical hook unconditionally will crash when dropped outside the vertical's page.
+   So `useServiceContext() ?? {}` is dead code — the throw happens first. There is no in-component way to recover: you either have a provider or you don't.
+
+   **What shipping components actually do: call the hook unguarded.** Every Stores consumer does this, and a search for `ErrorBoundary` across that repo's extensions returns zero hits. They rely on the component only ever being placed where the provider exists. Follow that convention — but understand what you are relying on, and don't add a defensive branch that cannot fire.
 
 5. **Missing *data* is expressed as `null` fields, not a null context.** Most fields are `T | null` (e.g. `serviceName: string | null`), so guard per field and keep first render SSR-safe per [`SSR.md`](SSR.md):
 
@@ -69,9 +71,13 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
    if (!serviceName) return null;
    ```
 
+   This is the real pattern — `low-stock-indicator` reads `remainingItemCount`, checks it, and returns `null` when there's nothing to show.
+
 6. **Split smart from dumb.** Within one component, the hook is called once at the top and the values flow down as props — presentation components never call it themselves. (Across the page, any number of separate components may each consume the same context; the rule is about one component's internals, not a page-wide limit.) See [Patterns](#patterns).
 
 7. **Any backend call of your own must be platformized.** Exported sites run off Wix domains, so calls must go through public `wixapis.com`-mapped APIs. Fetch with the `use` utility so Suspense works during SSR — never `useEffect` + `setState` for first-render data. See [Fetching your own data](#fetching-your-own-data).
+
+8. **Don't leave the scaffold's `installation.staticContainer` on a vertical component.** `wix generate` emits `staticContainer: 'HOMEPAGE'`, which is wrong for something that belongs on a vertical's page. The shipping Stores consumers declare only `installation.initialSize` (content-sized width and height) and omit `staticContainer` entirely.
 
 ---
 
@@ -108,6 +114,8 @@ Product page.
 - `productPriceRange` → `minCurrentSellingPrice`, `maxCurrentSellingPrice`, `minOriginalPrice`, `maxOriginalPrice`, `minPricePerUnit`, `maxPricePerUnit`
 
 Every price is a **display-formatted string**, not a number — don't parse it back for currency math.
+
+The hook returns considerably more than these five bindable items: `low-stock-indicator` reads `remainingItemCount`, which appears nowhere in the manifest. Read `ProductContextValue` for the full set.
 
 ### Wix Events
 
@@ -218,13 +226,13 @@ function WithData({ promise }) {
 
 A context provider is attached to a **page** or a **section**, not to your component. Until it is, your hook throws — so "nothing renders" and "the hook threw" are the same bug seen from two angles.
 
-To test locally, open the editor with `&experiments=specs.thunderbolt.contextProviders`, select the section, then:
+To test locally, open the editor with `&experiments=specs.thunderbolt.contextProviders`, select the section, then run this in the editor console — `s` is the editor's scope handle exposed there, not something you import:
 
 ```js
 const pointer = { id: s.ds.pages.getCurrentPageId(), type: 'DESKTOP' }; // page
 // const pointer = s.selected.documentPointer;                          // or section
 
-s.ds.contexts.attach(pointer, '<yourContextType>');
+s.ds.contexts.attach(pointer, '<yourContextType>'); // the provider's `type`, e.g. 'onlineStoresBuilder.ProductPageContextProvider'
 s.ds.contexts.list(pointer); // verify
 ```
 
@@ -239,7 +247,7 @@ Page and section attachment are the two cases you will meet. Two others exist �
 ## Common Mistakes
 
 - **Importing the hook without `contextDependencies`.** Builds, then fails at runtime with no context. Both halves are required.
-- **Guarding a missing provider with `useXContext() ?? {}`.** Dead code — the hook throws before returning. A component users can place anywhere needs an error boundary or a guaranteed provider (Rule 4).
+- **Guarding a missing provider with `useXContext() ?? {}`.** Dead code — the hook throws before returning, so the fallback can never run. Guard nullable *fields* instead (Rule 5); a missing provider is not recoverable in-component (Rule 4).
 - **Treating the catalog's field list as the hook's return type.** It is the editor-bindable subset; the runtime type is wider. Read the exported `*ContextValue` type.
 - **Expecting the provider to attach itself.** The most common "my component renders nothing" cause. Verify with `s.ds.contexts.list(pointer)`.
 - **Writing code against a catalog row without checking the package resolves.** See the TODO at the top — these packages are not on public npm yet.

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -26,7 +26,8 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
      editorElement,
      resources: {
        client: {
-         componentUrl: './extensions/site/components/best-seller-badge/best-seller-badge.tsx',
+         // the withDefaults entry point, NOT the raw component file
+         componentUrl: './extensions/site/components/best-seller-badge/component.tsx',
          dependencies: {
            contextDependencies: ['@wix/stores-product-page/product-context-provider'],
          },
@@ -34,6 +35,8 @@ Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC al
      },
    });
    ```
+
+   `componentUrl` must point at `component.tsx` — the entry that wraps the component in `withDefaults` (see [`../EDITOR_REACT_COMPONENT.md`](../EDITOR_REACT_COMPONENT.md)). Every shipping Stores consumer does this. Pointing it at `<componentName>.tsx` bypasses `withDefaults`, so `defaultProps` are never applied and props the user hasn't set arrive `undefined`.
 
    ```tsx
    // <componentName>.tsx

--- a/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
+++ b/skills/wix-app/references/editor-react-component/CONSUMING-A-VERTICAL.md
@@ -1,0 +1,209 @@
+# Consuming a Vertical's Context
+
+How an Editor React Component reads data owned by a Wix business solution (Stores, Bookings, Events) on that solution's page — the Harmony counterpart to a site plugin's slot props.
+
+Read [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md) first: an ERC alone does **not** cover all editors, and extending a vertical's *dashboard* is a different extension type entirely.
+
+---
+
+> **🚧 TODO — package names are internal.** The `moduleSpecifier` values in the catalog below are the real identifiers the verticals ship today, taken verbatim from their manifests, but the packages are **not on public npm** (`npm view @wix/bookings-uou` → E404; same for `@wix/stores-product-page` and `@wix/events-contexts-poc`). Replace with the public package names once they are published. Until then a third-party app cannot install these — verify with `npm view <pkg> version` before writing code against a row.
+
+> **Alpha.** Editor React Components are alpha. The Events contexts are an explicit POC (`events-contexts-poc`). Context manifests **cannot take breaking changes once released**, so treat a context's shape as frozen only after it ships.
+
+---
+
+## Rules
+
+1. **Declare the dependency in the manifest, import the hook in the component.** Both halves are required — the hook import alone will not cause the platform to provide the context.
+
+   ```ts
+   // <componentName>.extension.ts
+   resources: {
+     dependencies: {
+       contextDependencies: ['@wix/stores-product-page/product-context-provider'],
+     },
+   }
+   ```
+
+   ```tsx
+   // <componentName>.tsx
+   import { useProductContext } from '@wix/stores-product-page/product-context-provider';
+   ```
+
+   The string in `contextDependencies` is the provider's `moduleSpecifier` — the same value you import from. Get both from the catalog below.
+
+2. **Context data is platform-supplied, not an external fetch.** [`COMPONENT-API.md`](COMPONENT-API.md) forbids external resources; a vertical context is not one. It arrives through the platform like `a11y` props or `EnvironmentDefinition` in [`DIRECTIONALITY.md`](DIRECTIONALITY.md). Reading it is allowed and expected.
+
+3. **The context is not attached automatically.** A correct component renders empty until the provider is attached to the page or section. See [Attaching the provider](#attaching-the-provider) — this is the single most common reason a working component shows nothing.
+
+4. **Never assume the context is present.** Users can place the component anywhere. Render a deterministic placeholder when the hook returns nothing, and keep first render SSR-safe per [`SSR.md`](SSR.md).
+
+5. **Split smart from dumb.** Exactly one component calls the hook; presentation components take props. See [Patterns](#patterns).
+
+6. **Any backend call of your own must be platformized.** Exported sites run off Wix domains, so calls must go through public `wixapis.com`-mapped APIs. Fetch with the `use`/`usePromise` utility (a React-18 implementation of React 19's `use`) so Suspense works during SSR — never `useEffect` + `setState` for first-render data.
+
+---
+
+## Per-vertical catalog
+
+`type` is the provider's dev-center component type. `Hook` + `moduleSpecifier` are what you write in code. `Requires` lists other contexts the provider itself depends on — those must also be present on the page.
+
+| Vertical | `type` | Hook | `moduleSpecifier` | Requires |
+| --- | --- | --- | --- | --- |
+| Stores | `onlineStoresBuilder.ProductPageContextProvider` | `useProductContext` | `@wix/stores-product-page/product-context-provider` | — |
+| Events | `eventsContextsPOC.EventContextProvider` | `useEventContext` | `@wix/events-contexts-poc/event-context-provider` | — |
+| Events | `eventsContextsPOC.AvailableTicketsContextProvider` | `useAvailableTicketsContext` | `@wix/events-contexts-poc/available-tickets-context-provider` | Event |
+| Events | `eventsContextsPOC.MembershipOffersContextProvider` | `useMembershipOffersContext` | `@wix/events-contexts-poc/membership-offers-context-provider` | Event |
+| Events | `eventsContextsPOC.SeatingPlanContextProvider` | `useSeatingPlanContext` | `@wix/events-contexts-poc/seating-plan-context-provider` | Event |
+| Bookings | `BookingsBookings.ServiceContext` | `useServiceContext` | `@wix/bookings-uou/service-context` | — |
+| Bookings | `BookingsBookings.ServicesContext` | `useServicesContext` | `@wix/bookings-uou/services-context` | — |
+| Bookings | `BookingsBookings.SessionsContext` | `useSessionsContext` | `@wix/bookings-uou/sessions-context` | Service |
+| Bookings | `BookingsBookings.TimeSlotsContext` | `useTimeSlotsContext` | `@wix/bookings-uou/time-slots-context` | Service |
+| Bookings | `BookingsBookings.LocationsContext` | `useLocationsContext` | `@wix/bookings-uou/locations-context` | — |
+| Bookings | `BookingsBookings.CategoriesContext` | `useCategoriesContext` | `@wix/bookings-uou/categories-context` | — |
+
+### Wix Stores — product context
+
+Product page. `description` is a Ricos document; everything else here is pre-formatted text.
+
+- `name`, `sku`
+- `description` — Ricos document
+- `prices` → `currentSellingPrice`, `originalPrice`, `pricePerUnit`
+- `productPriceRange` → `minCurrentSellingPrice`, `maxCurrentSellingPrice`, `minOriginalPrice`, `maxOriginalPrice`, `minPricePerUnit`, `maxPricePerUnit`
+
+Prices arrive **formatted for display** — do not re-format or do currency math on them.
+
+### Wix Events
+
+**Event context** — event details page:
+
+- `title`, `shortDescription`
+- `titleRich`, `shortDate`, `longDate`, `shortLocation`, `longLocation` — rich text
+- `image` — image
+- `event` → `title`
+- `locations` → `address`, `description`, `title`, `latitude`, `longitude`
+- `openEventDetails()` — navigates to the public event details page; bound to a pointer event
+
+**Available tickets** — `ticketDefinitions` → `name`
+**Membership offers** — `plans` → `name`
+**Seating plan** — `seatingPlan` → `title`
+
+The three above are thin by design in the POC; expect them to grow.
+
+### Wix Bookings
+
+**Service context** — service page. The richest context of the three verticals:
+
+- Identity — `serviceId`, `serviceSlug`, `serviceName`, `serviceDescription`, `serviceTagLine`, `serviceType`, `serviceCtaState`
+- Price — `servicePrice` → `rateType`, `price`, `priceAfterDiscount`, `discountName`, `calculatedAtCheckout`
+- `pricingOption` → `type` (`CUSTOM` | `STAFF_MEMBER` | `DURATION`), `name`, `choices[]` → `choiceId`, `label`, `price`
+- Flags — `isVariedService`, `hasAddOns`, `isConferenceEnabled`, `isAnyStaff`
+- Course — `courseAvailability` → `totalCapacity`, `remainingCapacity`; `courseStartDate`, `courseEndDate`
+- `serviceDefaultDuration`, `serviceImage`, `offeredDays[]` → `day`
+- Staff — `staffMembers` / `selectedStaffMember` → `staffMemberId`, `name`, `image`, `isSelected`
+- `emptyState` → `title`, `description`
+- Actions — `selectStaffMember(staffMemberId)`, `clearSelection()`, `navigateToNextPage()`
+
+**Services context** — paginated list of visible services: `serviceItems[]`, `emptyState`, `error`, `hasMore`, `categoryId`, `locationId`, `loadMore()` (async).
+
+`serviceItems[]` declares `contextImplementor` targeting `BookingsBookings.ServiceContext` via `propKey: 'serviceData'` — i.e. each row can feed a nested Service context, so a list item's children can consume `useServiceContext()` as if on a service page. Use this instead of threading service data down as props.
+
+**Sessions context** — requires Service. `sessions[]` → `id`, `title`, `startDate`, `endDate`, `durationMinutes`, `staff[]` (`staffMemberId`, `name`), `totalCapacity`, `spotsLeft`, `isFullyBooked`, `isConfirmed`, `isCancelled`, `isAllDay`; plus `timeZone`, `hasMore`, `loadMoreSessions()` (async).
+
+Plural — pair with a repeater to render one row per session.
+
+**Time slots context** — requires Service. `timeSlots` and `nextAvailableSlots`, each slot → `slotId`, `startTime`, `endTime`, `bookable`, `totalCapacity`, `remainingCapacity`, `bookableCapacity`, `eventId`, `eventTitle`, `waitlistCapacity`, `locationId`, `locationName`. Plus `loading`, `error`, `timeZone`, `nextAvailableSlotsCount`, `selectedResourceId`, `selectedTimeSlot` (`slotStartTime`, `slotEndTime`, `bookable`, `eventId`), `staffFromSlots`, `setDateRange(start, end)`, `setSelectedResource(resourceId)`.
+
+`selectTimeSlot` and `navigateToBookingForm` exist on the hook's return value but are deliberately **not** declared as bindable items — they are smart-component API. Call them from code; do not expect them in the editor's binding UI.
+
+**Locations context** — `locationItems[]` → `locationId`, `locationName`, `isSelected`; `selectedLocationId`, `selectedLocationIndex`, `selectedLocationName`, `hasOtherLocations`, `selectLocation(locationId)`, `refetch()` (async).
+
+**Categories context** — `categoryItems[]` → `categoryId`, `categoryName`, `isSelected`; `selectedCategoryId`, `selectedCategoryIndex`, `selectedCategoryName`, `selectCategory(categoryId)`, `refetch()` (async).
+
+Locations and Categories back their selection with the URL — selecting updates the address bar, so treat them as the source of truth rather than mirroring selection into local state.
+
+---
+
+## Patterns
+
+### Smart component reads context, dumb component renders
+
+```tsx
+// smart — the only place the hook appears
+import { useProductContext } from '@wix/stores-product-page/product-context-provider';
+
+export default function BestSellerBadge({ className, id, label }: BestSellerBadgeProps) {
+  const { sku } = useProductContext() ?? {};
+  if (!sku) return null; // placed outside a product page, or not resolved yet
+  return <BadgeUI className={className} id={id} label={label} sku={sku} />;
+}
+```
+
+`useProductContext() ?? {}` plus the early return is the whole missing-context contract. A component that destructures unconditionally crashes the moment a user drags it onto the home page.
+
+### The root node must stay selectable
+
+The editor can only select the component if its root carries all three:
+
+```tsx
+<div className={`${props.className} ${styles.root}`} id={props.id}>
+```
+
+- `className` from props
+- the class matching the selector declared in the manifest
+- `id` from `props.id`
+
+Dropping any one of them makes the component unselectable in the editor even though it renders correctly on the site.
+
+### Composition over one large component
+
+Prefer several small context-consuming components (a name, a price, a badge) that the user can add, remove, and rearrange, over one component that owns the whole page layout. Multiple components may consume the same context, and a provider may itself consume a parent context.
+
+Segregate contexts by data purpose: list vs single item, backend data vs UI state (filters, dropdowns), shareable vs specific.
+
+### Fetching your own data
+
+```tsx
+import { use } from '../usePromise';
+
+function WithData({ promise }) {
+  const result = use(promise); // suspends during SSR until resolved
+  return <div>{result.items.map(/* … */)}</div>;
+}
+```
+
+---
+
+## Attaching the provider
+
+A context provider is attached to a **page** or a **section**, not to your component. Until it is, your hook returns nothing.
+
+To test locally, open the editor with `&experiments=specs.thunderbolt.contextProviders`, select the section, then:
+
+```js
+const pointer = { id: s.ds.pages.getCurrentPageId(), type: 'DESKTOP' }; // page
+// const pointer = s.selected.documentPointer;                          // or section
+
+s.ds.contexts.attach(pointer, '<yourContextType>');
+s.ds.contexts.list(pointer); // verify
+```
+
+Components inside that page/section then receive the context.
+
+For production, attachment must happen when the app is installed — this is an Editor Platform dependency, not something the component can arrange for itself. If a context will not attach, raise it in `#editor-platform-dev`.
+
+There are four ways a provider ends up on stage: attached to a page, attached to a section, wrapping ERC containers the developer injects, or the legacy OOI slot adapter (see [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md)).
+
+---
+
+## Common Mistakes
+
+- **Importing the hook without `contextDependencies`.** Builds, then fails at runtime with no context. Both halves are required.
+- **Assuming the context exists.** Destructuring the hook result unconditionally crashes when the component is placed off the vertical's page.
+- **Expecting the provider to attach itself.** The most common "my component renders nothing" cause. Verify with `s.ds.contexts.list(pointer)`.
+- **Writing code against a catalog row without checking the package resolves.** See the TODO at the top — these packages are not on public npm yet.
+- **Re-formatting pre-formatted values.** Stores prices and Events dates/locations arrive display-ready; parsing them back into numbers or `Date`s loses locale and currency handling.
+- **Fetching in `useEffect` for first-render data.** Breaks SSR. Use `use`/`usePromise`.
+- **Calling a non-platformized backend.** Works on a Wix-hosted site, fails on an exported one.
+- **Shipping only the ERC.** Dead on Wix Editor and Studio — see [`../EXTENDING_A_VERTICAL.md`](../EXTENDING_A_VERTICAL.md).
+- **Building a dashboard extension this way.** Vertical dashboard pages use `observeState()` and typed host props, not contexts — see [`../DASHBOARD_PLUGIN.md`](../DASHBOARD_PLUGIN.md).


### PR DESCRIPTION
…gin + Editor React component

Extending a Wix business solution's site page needs two extensions, not one: a site plugin for Wix Editor/Studio and an Editor React component for Harmony. The platform offers no runtime fallback between them ("no way to conditionally switch between extension types based on the editor"), but the skill routed the two as mutually exclusive and neither reference mentioned the other — so an agent shipped one surface and left the other silently broken.

The ERC references also had no concept of consuming a vertical at all (no mention of context providers, contextDependencies, or vertical data anywhere in the repo), while COMPONENT-API.md's "external resources are forbidden" rule read as "an ERC may not read vertical data."

- Add references/EXTENDING_A_VERTICAL.md — owns the two-surface rule in one place, and routes by surface first since "extend Wix Stores" is ambiguous (site page here, dashboard page to DASHBOARD_PLUGIN.md).
- Add references/editor-react-component/CONSUMING-A-VERTICAL.md — the contextDependencies + hook contract, provider attachment (the top "renders nothing" cause), and a catalog of all 11 context providers across Stores, Bookings, and Events.
- Carve out platform-supplied data in COMPONENT-API.md so the external-resources rule is not read as banning vertical context.
- Wire SKILL.md routing, the ERC topic index, and a SITE_PLUGIN.md pointer.

Catalog type/hook/moduleSpecifier triples are verbatim from the verticals' manifests. Their packages are not yet on public npm, so the catalog carries a TODO to swap in the public names once published.