### PR TITLE
feat(wix-manage): Google Ads [3/7] — create & launch Smart campaign

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -199,12 +199,16 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 **Routing — Google paid-advertising campaigns for a site (Smart & Performance Max).** All flows require a Google Ads account, created once via the setup recipe. Budgets are in micros (1,000,000 = 1 currency unit). REST base: `https://www.wixapis.com/google-ads/v1`.
 - **First-time setup / "connect Google Ads" / `ACCOUNT_NOT_FOUND`** → [Install and Create an Account](references/google-ads/install-and-create-account.md) (do this before anything else).
 - **Suggested keywords / geo / budget / ad copy / images** → [Get AI Campaign Suggestions](references/google-ads/get-campaign-suggestions.md).
+- **Create a simple auto-managed campaign** → [Create a Smart Campaign](references/google-ads/create-smart-campaign.md).
 
 ### [Install Google Ads and Create an Account](references/google-ads/install-and-create-account.md)
 **Technical:** One-time setup prerequisite for all Google Ads flows. Installs the Wix Google Ads app (`POST /v1/install-if-not-installed`) then creates the linked account (`POST /v1/accounts` with `currency`). Covers checking for an existing account (`GET /v1/accounts/current-site`, empty when none), optional promotional incentives, Merchant Center linking, and account deletion.
 
 ### [Get AI Campaign Suggestions for Google Ads](references/google-ads/get-campaign-suggestions.md)
 **Technical:** Read-only Suggestions API reference — keyword themes, geo options, Smart budget tiers, PMAX budget recommendations, text/image assets, search themes, full AI campaign configs from a campaign brief (`POST /v1/campaign-suggestions`), and promotional incentive offers. Budgets in micros; generation endpoints have 60–120s SLAs.
+
+### [Create and Launch a Smart Campaign](references/google-ads/create-smart-campaign.md)
+**Technical:** Creates and launches a Smart campaign (Google auto-manages bidding/delivery). Gathers keyword-theme, geo-target, and daily-budget suggestions, assembles the `SMART` campaign (business name, landing URL, language, `budget.amountMicros`, `locations`, `keywordThemes`), creates it in `PAUSED`, then `POST /v1/campaigns/{id}/launch`. Budgets in micros; 5 live campaigns per site.
 
 ---
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -198,9 +198,13 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 **Routing — Google paid-advertising campaigns for a site (Smart & Performance Max).** All flows require a Google Ads account, created once via the setup recipe. Budgets are in micros (1,000,000 = 1 currency unit). REST base: `https://www.wixapis.com/google-ads/v1`.
 - **First-time setup / "connect Google Ads" / `ACCOUNT_NOT_FOUND`** → [Install and Create an Account](references/google-ads/install-and-create-account.md) (do this before anything else).
+- **Suggested keywords / geo / budget / ad copy / images** → [Get AI Campaign Suggestions](references/google-ads/get-campaign-suggestions.md).
 
 ### [Install Google Ads and Create an Account](references/google-ads/install-and-create-account.md)
 **Technical:** One-time setup prerequisite for all Google Ads flows. Installs the Wix Google Ads app (`POST /v1/install-if-not-installed`) then creates the linked account (`POST /v1/accounts` with `currency`). Covers checking for an existing account (`GET /v1/accounts/current-site`, empty when none), optional promotional incentives, Merchant Center linking, and account deletion.
+
+### [Get AI Campaign Suggestions for Google Ads](references/google-ads/get-campaign-suggestions.md)
+**Technical:** Read-only Suggestions API reference — keyword themes, geo options, Smart budget tiers, PMAX budget recommendations, text/image assets, search themes, full AI campaign configs from a campaign brief (`POST /v1/campaign-suggestions`), and promotional incentive offers. Budgets in micros; generation endpoints have 60–120s SLAs.
 
 ---
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, site-properties, ecommerce, marketing, analytics."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, site-properties, ecommerce, marketing, google-ads, analytics."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -191,6 +191,16 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Payment Links for Bookings](references/get-paid/payment-links-for-bookings.md)
 **Technical:** Creates payment links for unpaid bookings using Payment Links API. Links booking IDs to payment requests with proper redirect handling.
+
+---
+
+## Google Ads
+
+**Routing — Google paid-advertising campaigns for a site (Smart & Performance Max).** All flows require a Google Ads account, created once via the setup recipe. Budgets are in micros (1,000,000 = 1 currency unit). REST base: `https://www.wixapis.com/google-ads/v1`.
+- **First-time setup / "connect Google Ads" / `ACCOUNT_NOT_FOUND`** → [Install and Create an Account](references/google-ads/install-and-create-account.md) (do this before anything else).
+
+### [Install Google Ads and Create an Account](references/google-ads/install-and-create-account.md)
+**Technical:** One-time setup prerequisite for all Google Ads flows. Installs the Wix Google Ads app (`POST /v1/install-if-not-installed`) then creates the linked account (`POST /v1/accounts` with `currency`). Covers checking for an existing account (`GET /v1/accounts/current-site`, empty when none), optional promotional incentives, Merchant Center linking, and account deletion.
 
 ---
 

--- a/skills/wix-manage/references/google-ads/create-smart-campaign.md
+++ b/skills/wix-manage/references/google-ads/create-smart-campaign.md
@@ -1,0 +1,169 @@
+---
+name: "Create and Launch a Smart Campaign"
+description: "Creates and launches a Google Ads Smart campaign for a Wix site — the simplest auto-managed campaign type, where Google handles bidding and delivery from keyword themes and geo targets. Covers getting AI keyword-theme, geo-target, and daily-budget suggestions, assembling the campaign (business name, landing page URL, language, budget in micros, targeted locations, keyword themes), creating it in DRAFT/PAUSED, and launching it to start serving ads. Use when the user wants to 'create a Google ad', 'run a Smart campaign', 'advertise my bakery on Google', 'promote my site on Google Search', or 'launch a simple Google Ads campaign'. Requires an existing Google Ads account. REST base https://www.wixapis.com/google-ads/v1."
+---
+# RECIPE: Create and Launch a Smart Campaign
+
+A **Smart campaign** is the simplest Google Ads campaign type: you supply a business name, landing page URL, language, daily budget, target locations, and keyword themes — Google auto-manages bidding and ad delivery. This recipe gathers AI suggestions for the fuzzy inputs (keywords, geo, budget), assembles the campaign, creates it, and launches it.
+
+Base URL: `https://www.wixapis.com/google-ads/v1`. `<AUTH>` is the `Authorization` header; body calls also need `Content-Type: application/json`.
+
+> **Launching a campaign spends real money.** Show the user the assembled campaign — budget, locations, keyword themes — and get explicit approval **before** the Launch call in STEP 4. Creating in `PAUSED` (STEP 3) does not serve ads or spend; only Launch does.
+
+**Prerequisite:** a Google Ads account must exist. If a call returns `ACCOUNT_NOT_FOUND`, run [Install Google Ads and Create an Account](install-and-create-account.md) first. You need the account's `id` (the Wix GUID) as `campaign.accountId`.
+
+**Flow:** STEP 1 gather suggestions → STEP 2 settle budget → STEP 3 create (PAUSED) → **show & approve** → STEP 4 launch.
+
+---
+
+## STEP 1: Get keyword-theme and geo-target suggestions
+
+These endpoints call Google directly and return the values you'll drop into the campaign. Base them on the site's live URL.
+
+### Keyword themes
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/keyword-theme-suggestions' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "suggestionInfo": { "liveSiteUrl": "https://www.example.com", "languageCode": "en", "businessName": "Sunrise Bakery" } }'
+```
+
+```json
+{ "googleSuggestion": { "keywordThemes": { "keywordThemes": [
+  { "id": "theme-001", "displayName": "bakery" },
+  { "id": "theme-002", "displayName": "fresh bread" },
+  { "id": "theme-003", "displayName": "pastries near me" }
+] } } }
+```
+
+Use each theme's `displayName` as a `freeFormKeywordTheme` in the campaign (Google best-effort maps free text to its internal keyword-theme constants). For interactive autocomplete instead, use `GET /v1/keyword-theme-options?queryText=bake&languageCode=en&countryCode=US`.
+
+### Geo targets
+
+```bash
+curl -X GET 'https://www.wixapis.com/google-ads/v1/geo-options?queryLocation=New+York&languageCode=en&countryCode=US' -H 'Authorization: <AUTH>'
+```
+
+```json
+{ "googleSuggestion": { "geoTargetsSuggestions": { "geoTargets": [
+  { "id": "21167", "displayName": "New York, New York, United States", "countryCode": "US" },
+  { "id": "1023191", "displayName": "New York, United States", "countryCode": "US" }
+] } } }
+```
+
+Each geo target's `id` becomes `geoTargetConstants/{id}` in the campaign's `locations[].location.geoTargetConstant`. Results can include **restricted** countries — those are rejected at create time with `RESTRICTED_LOCATION`, so prefer the specific place the user named. To search several places at once, pass `queryLocations` with semicolon-separated names.
+
+---
+
+## STEP 2: Settle the daily budget
+
+Budgets are in **micros**: `1,000,000` micros = 1 currency unit (so `15000000` = $15.00/day). Google caps monthly spend at ~30.4× the daily budget.
+
+Get low/recommended/high tiers with estimated daily clicks:
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/budget-suggestions' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "suggestionInfo": { "liveSiteUrl": "https://www.example.com", "languageCode": "en" } }'
+```
+
+```json
+{ "googleSuggestion": { "budget": {
+  "low":         { "dailyBudget": "5000000",  "minEstimatedClicks": "3",  "maxEstimatedClicks": "8" },
+  "recommended": { "dailyBudget": "15000000", "minEstimatedClicks": "12", "maxEstimatedClicks": "22" },
+  "high":        { "dailyBudget": "30000000", "minEstimatedClicks": "25", "maxEstimatedClicks": "45" }
+} } }
+```
+
+Present the tiers (converted to currency units and expected clicks) and let the user choose, or default to `recommended`. To validate a custom amount against account limits, call `GET /v1/campaign/daily-budget-boundaries` — it returns `minimumDailyBudget` / `maximumDailyBudget` in micros. A budget over the max fails create with `CAMPAIGN_DAILY_BUDGET_TOO_HIGH`.
+
+---
+
+## STEP 3: Create the campaign (in PAUSED)
+
+Assemble everything into a `SMART` campaign. `status` is required — create in `PAUSED` (or `DRAFT`) so nothing serves until you launch. `smartCampaign` needs `businessName`, `url` (landing page), and `languageCode`; the campaign needs `budget.amountMicros`, at least one `locations` entry, and the keyword themes.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{
+    "campaign": {
+      "accountId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "campaignType": "SMART",
+      "status": "PAUSED",
+      "name": "Spring Bakery Promotion",
+      "budget": { "amountMicros": "15000000" },
+      "locations": [
+        { "location": { "geoTargetConstant": "geoTargetConstants/1023191" }, "displayName": "New York, United States" }
+      ],
+      "smartCampaign": {
+        "keywordThemes": [
+          { "freeFormKeywordTheme": "bakery" },
+          { "freeFormKeywordTheme": "fresh bread" }
+        ],
+        "businessName": "Sunrise Bakery",
+        "url": "https://example.com",
+        "languageCode": "en"
+      }
+    }
+  }'
+```
+
+**Response** — save `campaign.id`:
+
+```json
+{
+  "campaign": {
+    "id": "c9d8e7f6-a5b4-3210-fedc-ba9876543210",
+    "campaignType": "SMART",
+    "status": "PAUSED",
+    "name": "Spring Bakery Promotion",
+    "budget": { "amountMicros": "15000000", "resourceName": "customers/1234567890/campaignBudgets/9876543210" },
+    "reportingKey": "spring-bakery-promotion-2024-3-15-c9d8e7f6",
+    "resourceName": "customers/1234567890/campaigns/9876543210"
+  }
+}
+```
+
+`status` is read-only and synced from Google. `resourceName` (`customers/…/campaigns/…`) is what performance analytics uses. `reportingKey` is the auto-generated `utm_campaign` value for conversion attribution.
+
+**Now show the user the campaign** — name, daily budget in currency units, target locations, and keyword themes — and get explicit approval before launching.
+
+Every site allows at most **5 live campaigns simultaneously**. If Launch later fails with `MAXIMUM_NUMBER_OF_CAMPAIGNS_REACHED`, pause another campaign first.
+
+---
+
+## STEP 4: Launch the campaign
+
+After approval, launch it to start serving ads. Use **Launch** for a campaign's first activation (use Resume only to reactivate one that was previously live then paused — see [Manage Campaign Lifecycle](manage-campaign-lifecycle.md)).
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns/c9d8e7f6-a5b4-3210-fedc-ba9876543210/launch' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' -d '{}'
+```
+
+The response returns the campaign with `status: "LIVE"`. Ads begin serving; performance data (see [Query Campaign Performance Analytics](query-campaign-analytics.md)) is typically available within a few hours.
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `ACCOUNT_NOT_FOUND` | No Google Ads account for the site | Run the [install-and-create-account](install-and-create-account.md) recipe first |
+| `INVALID_ARGUMENT` / `RESTRICTED_LOCATION` | A targeted geo target is restricted | Remove it; pick the specific place the user named from Get Geo Options |
+| `INVALID_ARGUMENT` / `CAMPAIGN_DAILY_BUDGET_TOO_HIGH` | Budget exceeds the account/currency max | Check `GET /v1/campaign/daily-budget-boundaries` and lower the amount |
+| `INVALID_ARGUMENT` / `MISSING_URL` | No landing page URL for the campaign type | Provide `smartCampaign.url` |
+| `INVALID_ARGUMENT` / `DUPLICATE_CAMPAIGN_NAME` | A campaign with that name exists on the account | Use a different `name` |
+| `FAILED_PRECONDITION` / `MAXIMUM_NUMBER_OF_CAMPAIGNS_REACHED` | 5 live campaigns already | Pause one before launching |
+| `FAILED_PRECONDITION` / `ACCOUNT_BLOCKED` / `ACCOUNT_NOT_ENABLED` | Account can't create/serve (billing, fraud, unpaid) | Surface to the user; resolve billing before retrying |
+| `INVALID_ARGUMENT` / `GOOGLE_ADS_API_ERROR` | Unexpected Google Ads rejection | Surface the message; verify assets/settings and retry |
+
+## References
+
+- [Campaign Service introduction](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/introduction)
+- [Create Campaign](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/create-campaign)
+- [Launch Campaign](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/launch-campaign)
+- [Get Keyword Theme Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-keyword-theme-suggestions)
+- [Get Geo Options](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-geo-options)
+- [Get Budget Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-budget-suggestions)

--- a/skills/wix-manage/references/google-ads/get-campaign-suggestions.md
+++ b/skills/wix-manage/references/google-ads/get-campaign-suggestions.md
@@ -1,0 +1,106 @@
+---
+name: "Get AI Campaign Suggestions for Google Ads"
+description: "Reference for the Google Ads Suggestions API on a Wix site: AI/Google-generated inputs that help build effective campaigns — keyword themes (from a URL or autocomplete), geo-target options, low/recommended/high daily-budget tiers with estimated clicks, PMAX budget recommendations, text assets (headlines/descriptions), AI image assets (auto-uploaded to Wix Media), search themes, promotional incentive offers, and complete AI-generated campaign configurations from a campaign brief. Use when the user asks 'suggest keywords for my ads', 'what budget should I use', 'where should I target', 'generate ad copy/headlines', 'generate ad images', 'suggest a whole campaign', or when a create-campaign flow needs suggested values. REST base https://www.wixapis.com/google-ads/v1."
+---
+# RECIPE: Get AI Campaign Suggestions for Google Ads
+
+The Suggestions API produces the values that make a campaign effective — keywords, locations, budgets, and creative assets — either from Google directly or from Wix's AI. It's the input layer for the create-campaign recipes; this file is the standalone reference for each endpoint and for the two that don't appear there (full campaign suggestions from a brief, and incentive offers).
+
+Base URL: `https://www.wixapis.com/google-ads/v1`. `<AUTH>` is the `Authorization` header; body calls also need `Content-Type: application/json`. All suggestion endpoints are **read-only** — none create or spend anything, so run them freely. Budgets are in **micros** (`1,000,000` = 1 currency unit).
+
+**Which suggestion do you need?**
+
+| Goal | Endpoint | Used by |
+| --- | --- | --- |
+| Keyword themes for a Smart campaign | `keyword-theme-suggestions` / `keyword-theme-options` | [Smart campaign](create-smart-campaign.md) |
+| Geo targets | `geo-options` | Smart & PMAX |
+| Daily budget tiers (Smart) | `budget-suggestions` | [Smart campaign](create-smart-campaign.md) |
+| Budget recommendation (PMAX) | `budget-recommendation` | [PMAX](create-performance-max-campaign.md) |
+| Headlines & descriptions (PMAX) | `text-asset-suggestions` | [PMAX](create-performance-max-campaign.md) |
+| AI images (PMAX) | `image-asset-suggestions` | [PMAX](create-performance-max-campaign.md) |
+| Search themes (PMAX Leads) | `search-theme-suggestions` | [PMAX](create-performance-max-campaign.md) |
+| A full AI campaign config from a brief | `campaign-suggestions` | this recipe |
+| Promotional credit offers | `incentives` | [account setup](install-and-create-account.md) |
+
+For the endpoints already demonstrated in the create recipes (keyword themes, geo, Smart budget, PMAX text/image/search-theme assets, PMAX budget recommendation), see those recipes for full request/response examples. Below are the two unique to this reference.
+
+---
+
+## Full AI campaign suggestions (from a campaign brief)
+
+Generates one or more complete, ready-to-use campaign configurations — assets, keywords, and geo targets bundled into a `campaign` object you can pass almost directly to Create Campaign. Smart suggestions come from a previously created **campaign brief**; PMAX Leads suggestions come from the site's marketing settings and pages. Uses an LLM — responses can take up to **120 seconds**.
+
+- `campaignBriefId` — required for `SMART` (the brief id you created earlier). PMAX Leads doesn't need one.
+- `amount` — how many suggestions to generate (max 3).
+- `campaignType` — `SMART` (default) or `PERFORMANCE_MAX_LEADS`.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaign-suggestions' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "campaignBriefId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "amount": 1, "campaignType": "SMART" }'
+```
+
+```json
+{ "campaignSuggestions": [ {
+  "campaignMessaging": "Reach local customers searching for fresh-baked goods",
+  "campaign": {
+    "name": "Sunrise Bakery – Smart Campaign",
+    "campaignType": "SMART",
+    "budget": { "amountMicros": "15000000" },
+    "smartCampaign": {
+      "businessName": "Sunrise Bakery",
+      "url": "https://www.example.com",
+      "languageCode": "en",
+      "adGroups": [ { "ads": [ {
+        "headlines": ["Fresh Baked Daily", "Order Custom Cakes"],
+        "descriptions": ["Award-winning pastries made fresh every morning.", "Custom cakes for every occasion."]
+      } ] } ]
+    }
+  }
+} ] }
+```
+
+Present `campaignMessaging` and the config to the user, then use the `campaign` object as the basis for [creating the campaign](create-smart-campaign.md) (add `accountId`, `status`, `budget`, and `locations` before Create). `costInMicrocents` in the response is the AI cost — absorbed by Wix, not charged to the caller. Errors: `MISSING_CAMPAIGN_BRIEF_ID` (Smart without a brief), `MAX_CAMPAIGNS_TO_SUGGEST_EXCEEDED` (`amount` > 3).
+
+---
+
+## Promotional incentive offers
+
+Credit offers for **new** accounts, granted after a spend threshold. Only supported currencies return offers. This drives the optional incentive step of [account setup](install-and-create-account.md).
+
+```bash
+curl -X GET 'https://www.wixapis.com/google-ads/v1/incentives?currency=USD' -H 'Authorization: <AUTH>'
+```
+
+Returns `lowOffer` / `mediumOffer` / `highOffer`, each with `incentiveId`, `awardAmount`, and `requiredAmount`, plus a `consolidatedTermsAndConditionsUrl`. Pass the chosen `incentiveId` as `selectedIncentiveId` when creating the account.
+
+---
+
+## Quick reference — the create-flow suggestion endpoints
+
+- **Keyword themes:** `POST /v1/keyword-theme-suggestions` with `{ suggestionInfo: { liveSiteUrl, languageCode, businessName? } }` → themes with `displayName`. Autocomplete: `GET /v1/keyword-theme-options?queryText=&languageCode=&countryCode=`.
+- **Geo targets:** `GET /v1/geo-options?queryLocation=&languageCode=&countryCode=` → geo targets with `id` (→ `geoTargetConstants/{id}`). May include restricted countries (rejected at create).
+- **Smart budget tiers:** `POST /v1/budget-suggestions` with `{ suggestionInfo: { liveSiteUrl, languageCode } }` → `low`/`recommended`/`high` with `dailyBudget` (micros) and estimated clicks.
+- **PMAX budget:** `POST /v1/budget-recommendation` with `{ campaignType, assetGroupInfo:[{finalUrl,...}], currency, ... }` → `recommendedBudgetAmountMicros` + `budgetOptions`.
+- **Text assets:** `POST /v1/text-asset-suggestions` (`suggestionInfo.landingPageUrl` + `textSuggestionInfo.languageCode` required).
+- **Image assets:** `POST /v1/image-asset-suggestions` (`suggestionInfo.landingPageUrl` required; images auto-uploaded to Wix Media).
+- **Search themes:** `POST /v1/search-theme-suggestions` (`textSuggestionInfo.languageCode` required).
+
+## Error handling
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `INVALID_ARGUMENT` / `MISSING_CAMPAIGN_BRIEF_ID` | `SMART` campaign-suggestions without a brief | Create a campaign brief first, or request `PERFORMANCE_MAX_LEADS` |
+| `INVALID_ARGUMENT` / `MAX_CAMPAIGNS_TO_SUGGEST_EXCEEDED` | `amount` > 3 | Request at most 3 |
+| Slow response on campaign/asset/budget suggestions | LLM/Google calls (SLA up to 60–120s) | Wait; don't retry prematurely |
+| Incentives returns no offers | Currency not supported | Proceed without an incentive |
+| `INVALID_ARGUMENT` on text/image assets | `landingPageUrl`/`languageCode` missing | Provide the required fields |
+
+## References
+
+- [Suggestions Service introduction](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/introduction)
+- [Get Campaign Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-campaign-suggestions)
+- [Get Keyword Theme Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-keyword-theme-suggestions)
+- [Get Geo Options](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-geo-options)
+- [Get Budget Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-budget-suggestions)
+- [Get Incentives](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-incentives)

--- a/skills/wix-manage/references/google-ads/install-and-create-account.md
+++ b/skills/wix-manage/references/google-ads/install-and-create-account.md
@@ -1,0 +1,155 @@
+---
+name: "Install Google Ads and Create an Account"
+description: "One-time setup for running Google paid ads on a Wix site: install the Wix Google Ads app, then create the Google Ads account that every campaign, suggestion, and analytics call depends on. Covers checking whether an account already exists, choosing a currency, optionally attaching a promotional incentive (credit offer), linking a Google Merchant Center account, and deleting an account. Use when the user wants to 'set up Google Ads', 'connect Google Ads', 'start advertising on Google', 'create a Google Ads account', or hits an ACCOUNT_NOT_FOUND / app-not-installed error before creating a campaign. Google Ads REST API, base https://www.wixapis.com/google-ads/v1."
+---
+# RECIPE: Install Google Ads and Create an Account
+
+Setting up Google Ads on a Wix site is a **strict two-step prerequisite** for everything else in this area: (1) install the Wix Google Ads app, then (2) create the Google Ads account. Campaigns, suggestions, analytics, and billing all fail with `ACCOUNT_NOT_FOUND` (or an app-not-installed error) until both are done. This is a one-time setup per site.
+
+Base URL for all endpoints: `https://www.wixapis.com/google-ads/v1`. The `<AUTH>` placeholder is shorthand for the `Authorization` header; body-bearing calls also need `Content-Type: application/json`.
+
+> **This flow creates a billable advertising account.** Creating the account and launching campaigns spends the site owner's real money. Confirm intent with the user before calling **Create Account**, and surface the chosen currency.
+
+---
+
+## STEP 0: Check whether an account already exists (do this first)
+
+Before installing or creating anything, check for an existing account. **Get Account For Current Site** returns an empty response (not an error) when none exists, so it's the safe probe.
+
+```bash
+curl -X GET 'https://www.wixapis.com/google-ads/v1/accounts/current-site' -H 'Authorization: <AUTH>'
+```
+
+- **`account` present** → setup is already done. Skip to whatever the user actually wants (create a campaign, view analytics, etc.). Do **not** create a second account — Create Account returns `ACCOUNT_ALREADY_EXISTS`.
+- **Empty response `{}`** → no account yet. Continue to STEP 1.
+
+Example response for an existing account:
+
+```json
+{
+  "account": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "googleAccountId": "123-456-7890",
+    "currency": "USD",
+    "accountStatus": "ACTIVE",
+    "currentBudget": { "value": "50.00", "currency": "USD" },
+    "spentBudget": { "value": "12.50", "currency": "USD" },
+    "paymentStatus": { "status": "PAID" }
+  }
+}
+```
+
+`account.id` is the Wix-internal GUID used as `campaign.accountId` when creating campaigns. `googleAccountId` is the underlying Google Ads customer ID (display only). `currentBudget` is remaining ad credit — a **negative** value means outstanding debt not yet charged.
+
+---
+
+## STEP 1: Install the Wix Google Ads app
+
+Idempotent — safe to call even if already installed (no effect). Required before Create Account.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/install-if-not-installed' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' -d '{}'
+```
+
+Returns `{}`. Always run this before the first Create Account on a site.
+
+---
+
+## STEP 2 (optional): Offer a promotional incentive
+
+New accounts in supported currencies can attach an **incentive** — a promotional credit granted after the account spends a threshold. Skip this step for unsupported currencies (the call returns no offers).
+
+```bash
+curl -X GET 'https://www.wixapis.com/google-ads/v1/incentives?currency=USD' -H 'Authorization: <AUTH>'
+```
+
+Returns up to three tiers (`lowOffer`, `mediumOffer`, `highOffer`), each with an `incentiveId`, an `awardAmount` (credit granted), and a `requiredAmount` (spend needed to unlock it), plus a `consolidatedTermsAndConditionsUrl`. Present the tiers to the user and let them pick; carry the chosen `incentiveId` into STEP 3 as `selectedIncentiveId`. The incentive is recorded now and applied automatically once the account's budget is assigned — there is no separate apply call in this flow.
+
+---
+
+## STEP 3: Create the Google Ads account
+
+Requires `currency` (ISO-4217, e.g. `USD`). Pass `selectedIncentiveId` if the user picked one in STEP 2. **Confirm with the user before this call** — it provisions a billable account.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/accounts' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{
+    "currency": "USD",
+    "selectedIncentiveId": "incentive-promo-2024-usd-500"
+  }'
+```
+
+**Response** — save `account.id` for campaign creation:
+
+```json
+{
+  "account": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "googleAccountId": "123-456-7890",
+    "currency": "USD",
+    "accountStatus": "ACTIVE",
+    "paymentStatus": { "status": "PENDING_SUBSCRIPTION" },
+    "selectedIncentiveId": "incentive-promo-2024-usd-500"
+  }
+}
+```
+
+The currency choice is durable and drives budget minimums/maximums and manager-account selection — settle it with the user before creating. A currency Google doesn't natively support (only USD, EUR, GBP, JPY are native) still works; the account reports `budgetInSupportedCurrency` as the converted amount.
+
+---
+
+## Managing an existing account
+
+### Link a Google Merchant Center account (for Shopping / retail PMAX)
+
+`UpdateAccount` is a partial update — send only the fields you're changing. Merchant Center linking is needed before a retail Performance Max campaign can serve product ads.
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/google-ads/v1/accounts/a1b2c3d4-e5f6-7890-abcd-ef1234567890' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "account": { "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "merchantCenterAccountId": "9876543210" } }'
+```
+
+The response's `merchantCenterAccountLinkStatus.status` starts at `PENDING` — the Merchant Center account owner must approve the link before it becomes `ENABLED`.
+
+### View conversion actions
+
+Conversion actions (Purchase, Page View, etc.) are what campaigns optimize toward. To inspect them:
+
+```bash
+curl -X GET 'https://www.wixapis.com/google-ads/v1/accounts/current-site/conversion-actions' -H 'Authorization: <AUTH>'
+```
+
+### Delete the account
+
+`DeleteAccount` unlinks and removes the account. This is destructive and cannot be undone — **always confirm with the user first**, and prefer pausing campaigns over deleting the whole account when the user just wants to stop spending.
+
+```bash
+curl -X DELETE 'https://www.wixapis.com/google-ads/v1/accounts/a1b2c3d4-e5f6-7890-abcd-ef1234567890' -H 'Authorization: <AUTH>'
+```
+
+Returns `{}`. Errors with `ACCOUNT_NOT_FOUND` if no account exists.
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `ALREADY_EXISTS` / `ACCOUNT_ALREADY_EXISTS` on Create Account | An account is already linked to this site | Don't create another — use Get Account For Current Site and continue with the existing `account.id` |
+| `INTERNAL` / `CREATION_BLOCKED` on Create Account | Account creation is temporarily disabled platform-wide | Not a caller error; surface it and retry later |
+| `ACCOUNT_NOT_FOUND` on any campaign/analytics/billing call | Setup wasn't completed (no account) | Run this recipe: install the app, then Create Account |
+| App-not-installed error before Create Account | STEP 1 was skipped | Call Install (STEP 1); it's idempotent |
+| Get Incentives returns no offers | Currency not supported for incentives | Proceed to Create Account without `selectedIncentiveId` |
+| `NOT_FOUND` / `ACCOUNT_NOT_FOUND` on Delete Account | No account exists for the site | Nothing to delete; confirm with Get Account For Current Site |
+
+## References
+
+- [Google Ads APIs introduction](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/introduction)
+- [App Installer Service](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-ads-app-installer-v1/introduction)
+- [Account Service](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-account-v1/introduction)
+- [Create Account](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-account-v1/create-account)
+- [Get Account For Current Site](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-account-v1/get-account-for-current-site)
+- [Get Incentives](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-incentives)

--- a/yaml/wix-manage-evals/google-ads/create-smart-campaign.yml
+++ b/yaml/wix-manage-evals/google-ads/create-smart-campaign.yml
@@ -1,0 +1,36 @@
+name: google-ads/create-smart-campaign
+description: >-
+  Verifies the agent uses the Smart campaign recipe: gathering keyword-theme,
+  geo, and budget suggestions, creating the SMART campaign in PAUSED with a
+  micros budget, and launching separately after approval.
+triggerPrompt: >-
+  Create and launch a simple Google Ads Smart campaign for my bakery site using
+  the Wix Google Ads API. Walk me through the endpoints and the request body.
+tags: [marketing]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/create-and-launch-a-smart-campaign
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants to create and launch a Smart campaign.
+
+      Pass if the response:
+      - uses the Smart campaign recipe, AND
+      - creates the campaign with campaignType SMART via POST /v1/campaigns,
+        including budget.amountMicros, at least one location
+        (geoTargetConstant), and smartCampaign with keywordThemes,
+        businessName, url, and languageCode, AND
+      - explains budgets are in micros (1,000,000 = 1 currency unit), AND
+      - launches separately via POST /v1/campaigns/{id}/launch (i.e. create in
+        PAUSED/DRAFT then launch), AND
+      - references getting suggestions (keyword themes / geo / budget) as inputs.
+
+      Fail if the response:
+      - claims a single create call also starts serving without a launch step, OR
+      - omits the micros budget concept, OR
+      - hallucinates endpoints, OR
+      - confuses Launch with Resume for a brand-new campaign.

--- a/yaml/wix-manage-evals/google-ads/get-campaign-suggestions.yml
+++ b/yaml/wix-manage-evals/google-ads/get-campaign-suggestions.yml
@@ -1,0 +1,35 @@
+name: google-ads/get-campaign-suggestions
+description: >-
+  Verifies the agent uses the Suggestions recipe to surface read-only
+  keyword/geo/budget/asset suggestions and picks the right endpoint per need.
+triggerPrompt: >-
+  Before I build a Google Ads campaign on my Wix site, what keyword ideas, target
+  locations, and daily budget does Wix suggest, and which API endpoints return them?
+tags: [marketing]
+maxTokens: 28000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/get-ai-campaign-suggestions-for-google-ads
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants suggested keywords, locations, and budget before building a
+      campaign.
+
+      Pass if the response:
+      - uses the Suggestions recipe, AND
+      - maps each need to the right endpoint: keyword themes
+        (POST /v1/keyword-theme-suggestions), geo targets
+        (GET /v1/geo-options), and daily budget tiers
+        (POST /v1/budget-suggestions), AND
+      - notes budgets are returned in micros and geo results become
+        geoTargetConstants, AND
+      - treats these as read-only (no campaign is created or money spent).
+
+      Fail if the response:
+      - creates a campaign or account, OR
+      - uses the PMAX budget-recommendation endpoint for a basic Smart budget
+        request without explanation, OR
+      - hallucinates endpoints.

--- a/yaml/wix-manage-evals/google-ads/install-and-create-account.yml
+++ b/yaml/wix-manage-evals/google-ads/install-and-create-account.yml
@@ -1,0 +1,35 @@
+name: google-ads/install-and-create-account
+description: >-
+  Verifies the agent uses the Google Ads setup recipe when asked to start
+  advertising on Google, following the strict install-app-then-create-account
+  order and confirming currency before creating the billable account.
+triggerPrompt: >-
+  I want to start running Google Ads for my Wix site. How do I set that up from
+  scratch using the Wix Google Ads REST API? Reference the specific endpoints.
+tags: [marketing]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/install-google-ads-and-create-an-account
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants to set up Google Ads on their Wix site for the first time.
+
+      Pass if the response:
+      - uses the Google Ads setup recipe, AND
+      - explains the two-step prerequisite in order: install the app
+        (POST /v1/install-if-not-installed) BEFORE creating the account
+        (POST /v1/accounts), AND
+      - says Create Account requires a `currency` (ISO-4217), AND
+      - mentions checking for an existing account first via
+        GET /v1/accounts/current-site (empty when none), AND
+      - treats account creation as billable / advises confirming intent.
+
+      Fail if the response:
+      - creates the account before installing the app, OR
+      - invents endpoints not in the Google Ads API, OR
+      - omits the currency requirement, OR
+      - falls back to generic Google Ads (Google's own API) instead of the Wix REST API.

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Google Ads Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/google-ads/install-and-create-account.md
+      title: Install Google Ads and Create an Account
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [marketing]

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -6,3 +6,7 @@ apiDoc:
       title: Install Google Ads and Create an Account
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
       tags: [marketing]
+    - file: ../../../skills/wix-manage/references/google-ads/get-campaign-suggestions.md
+      title: Get AI Campaign Suggestions for Google Ads
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [marketing]

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: Get AI Campaign Suggestions for Google Ads
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
       tags: [marketing]
+    - file: ../../../skills/wix-manage/references/google-ads/create-smart-campaign.md
+      title: Create and Launch a Smart Campaign
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [marketing]


### PR DESCRIPTION
**PR 3 of 7** in the Google Ads skill chain. Base: `feat/gads-2-suggestions` (**merge #722 first**).

Adds the **Smart campaign** recipe: gather keyword/geo/budget suggestions → assemble the `SMART` campaign (budget in micros, locations, keyword themes) → create in `PAUSED` → `POST /v1/campaigns/{id}/launch`.

One new skill file: `references/google-ads/create-smart-campaign.md` (+ SKILL.md entry, documentation.yaml entry, eval scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)