### PR TITLE
feat(wix-manage): Google Ads [4/6] — manage campaign lifecycle

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -242,6 +242,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 - **First-time setup / "connect Google Ads" / `ACCOUNT_NOT_FOUND`** → [Install and Create an Account](references/google-ads/install-and-create-account.md) (do this before anything else).
 - **Suggested keywords / geo / budget / ad copy / images** → [Get AI Campaign Suggestions](references/google-ads/get-campaign-suggestions.md).
 - **Create a multi-channel / lead-gen / Shopping campaign** → [Create a Performance Max Campaign](references/google-ads/create-performance-max-campaign.md).
+- **Pause / resume / launch / update budget / delete / history** → [Manage Campaign Lifecycle](references/google-ads/manage-campaign-lifecycle.md).
 
 ### [Install Google Ads and Create an Account](references/google-ads/install-and-create-account.md)
 **Technical:** One-time setup prerequisite for all Google Ads flows. Installs the Wix Google Ads app (`POST /v1/install-if-not-installed`) then creates the linked account (`POST /v1/accounts` with `currency`). Covers checking for an existing account (`GET /v1/accounts/current-site`, empty when none), optional promotional incentives, Merchant Center linking, and account deletion.
@@ -251,6 +252,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Create and Launch a Performance Max Campaign](references/google-ads/create-performance-max-campaign.md)
 **Technical:** Creates and launches a PMAX campaign — `PERFORMANCE_MAX`, `PERFORMANCE_MAX_LEADS`, or retail/Shopping. Generates AI text/image assets and search themes, gets a Google budget recommendation, assembles an asset group meeting Google's minimum asset counts (headlines/descriptions/images), creates in `PAUSED`, then launches. Bidding is server-enforced to `MAXIMIZE_CONVERSIONS`.
+
+### [Manage Campaign Lifecycle](references/google-ads/manage-campaign-lifecycle.md)
+**Technical:** Lists/gets campaigns and runs lifecycle actions: launch (first activation) vs resume (reactivate after pause), pause (with optional `scheduledResumeDate`/reminder), partial `UpdateCampaign` (name, budget, targeting), delete (irreversible), and read the change log / status history. Covers the 5-live-campaign cap and budget-boundary validation.
 
 ### [Google Ads Dashboard Navigation](references/google-ads/google-ads-dashboard-navigation.md)
 **Technical:** Direct link to the Wix Google Ads dashboard page on manage.wix.com where API-created campaigns are managed.

--- a/skills/wix-manage/references/google-ads/manage-campaign-lifecycle.md
+++ b/skills/wix-manage/references/google-ads/manage-campaign-lifecycle.md
@@ -1,0 +1,63 @@
+---
+name: "Manage Campaign Lifecycle"
+description: "Manages existing Google Ads campaigns on a Wix site: list/get, launch (first activation) vs resume (reactivate after a pause), pause a running campaign — optionally with a scheduled auto-resume date — update name/budget/targeting, change the daily budget, delete permanently, and read status history / change log. Use when the user wants to 'pause my Google ad', 'resume my campaign', 'stop the campaign', 'change my daily budget', 'rename the campaign', 'delete this campaign', 'list my Google Ads campaigns', or 'why did my campaign status change'. Requires an existing Google Ads account and campaign. REST base https://www.wixapis.com/google-ads/v1."
+---
+# RECIPE: Manage Campaign Lifecycle
+
+Operate on campaigns that already exist. Base URL: `https://www.wixapis.com/google-ads/v1`; `<AUTH>` = `Authorization` header, and body calls also need `Content-Type: application/json`.
+
+**Answer directly.** When the user asks *how* to do something, give the endpoint, an example request, and the key behavior right away — use `{campaignId}` as a placeholder rather than asking which campaign. Only pause to confirm when you are about to **execute** a launch, resume, or delete on the user's behalf (those spend money or are irreversible); explaining how never requires confirmation.
+
+> **Launch vs Resume — the key distinction.** **Launch** activates a campaign for the *first time* (`POST /v1/campaigns/{campaignId}/launch`). **Resume** reactivates one that was live and then *paused* (`POST /v1/campaigns/{campaignId}/resume`). Both move it to `LIVE` and both count against the **5-live-campaigns-per-site** cap.
+
+## Read
+
+- **List:** `GET /v1/campaigns` → `{ "campaigns": [ { "id", "campaignType", "status", "name", "budget": { "amountMicros" } } ] }`
+- **Get one:** `GET /v1/campaigns/{campaignId}` — `status` and `budget` are synced live from Google on each read.
+
+`status` (read-only, can change on its own via policy/billing): `DRAFT`, `LIVE`, `PAUSED`, `LEARNING` (PMAX Leads, ~28d post-launch), `IN_REVIEW`, `DISAPPROVED`, `NOT_SERVING` (budget), `ENDED`, `ERROR`.
+
+## Launch / Pause / Resume
+
+```bash
+# Launch (first activation)  → status LIVE
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}/launch' -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' -d '{}'
+
+# Pause a running campaign (settings + data preserved) → status PAUSED
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}/pause' -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "scheduledResumeDate": "2024-04-15T08:00:00.000Z" }'
+
+# Resume a paused campaign → status LIVE
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}/resume' -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' -d '{}'
+```
+
+- **Pause** stops delivery immediately without losing configuration. Optional body fields: `scheduledResumeDate` (ISO 8601 — the campaign **auto-resumes** at that time; pass `null` to cancel a scheduled resume), `resumeReminderDate` (dashboard reminder), `turnAutoRenewOff`. Send `{}` to pause with no auto-resume. To temporarily stop a campaign, **pause it — never delete**.
+- **Resume** accepts `{ "turnAutoRenewOn": true }` to re-enable subscription auto-renewal. Fails with `MAXIMUM_NUMBER_OF_CAMPAIGNS_REACHED` if 5 are already live.
+
+## Update (partial) & change budget
+
+`PATCH /v1/campaigns/{id}` — send only the fields you're changing, plus the required `id` and `accountId`. Budget is in **micros** (`20000000` = $20.00/day).
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}' -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "campaign": { "id": "...", "accountId": "...", "name": "New name", "budget": { "amountMicros": "20000000" } } }'
+```
+
+Changing only the daily budget = the same call with just `id`, `accountId`, and `budget.amountMicros`. Over the account max → `CAMPAIGN_DAILY_BUDGET_TOO_HIGH` (check `GET /v1/campaign/daily-budget-boundaries`, returns min/max in micros).
+
+## Delete & history
+
+- **Delete (irreversible):** `DELETE /v1/campaigns/{id}` → `{}`. Confirm first; prefer Pause if the user only wants to stop spending.
+- **Change log:** `GET /v1/campaigns/{id}/change-log` → `{ "entries": [ { "action": "CREATED|LAUNCHED|PAUSED|RESUMED|UPDATED|ENDED", "timestamp" } ] }` — use this to explain "why/when did my campaign change." (`GET /v1/campaigns/{id}/status-history` is a legacy equivalent.)
+
+## Errors
+
+| Code | Meaning / fix |
+| --- | --- |
+| `CAMPAIGN_NOT_FOUND` | Wrong or deleted id — re-list campaigns |
+| `ACCOUNT_NOT_FOUND` | No Google Ads account — run the install-and-create-account recipe |
+| `MAXIMUM_NUMBER_OF_CAMPAIGNS_REACHED` | 5 live already — pause one, then Launch/Resume |
+| `CAMPAIGN_DAILY_BUDGET_TOO_HIGH` | Budget over account max — lower within daily-budget-boundaries |
+| `CUSTOM_CHARGES_SUBSCRIPTION_EXPIRED` / `…_AUTO_RENEWAL_OFF` | Renew / re-enable auto-renewal (Resume accepts `turnAutoRenewOn`) |
+
+[Campaign Service docs](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/introduction)

--- a/yaml/wix-manage-evals/google-ads/manage-campaign-lifecycle.yml
+++ b/yaml/wix-manage-evals/google-ads/manage-campaign-lifecycle.yml
@@ -1,0 +1,33 @@
+name: google-ads/manage-campaign-lifecycle
+description: >-
+  Verifies the agent uses the lifecycle recipe and correctly distinguishes pause
+  with a scheduled auto-resume from a permanent stop, and Resume vs Launch.
+triggerPrompt: >-
+  I want to pause my running Google Ads campaign for two weeks and have it turn
+  back on automatically. How do I do that with the Wix Google Ads API?
+tags: [marketing]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/manage-campaign-lifecycle
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants to pause a running campaign now and auto-resume it in two weeks.
+
+      Pass if the response:
+      - uses the campaign lifecycle recipe, AND
+      - calls POST /v1/campaigns/{id}/pause with a scheduledResumeDate (ISO 8601)
+        set ~2 weeks out, AND
+      - explains the campaign auto-resumes at that date (no manual resume needed),
+        and that settings/data are preserved while paused, AND
+      - does NOT suggest deleting the campaign, AND
+      - correctly treats the later reactivation as Resume (not Launch), if it
+        mentions manual reactivation at all.
+
+      Fail if the response:
+      - deletes the campaign to stop it, OR
+      - uses Launch to reactivate a previously-live paused campaign, OR
+      - invents a separate "schedule" endpoint instead of the pause field, OR
+      - hallucinates endpoints.

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -18,3 +18,7 @@ apiDoc:
       title: Google Ads Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
       tags: [google-ads]
+    - file: ../../../skills/wix-manage/references/google-ads/manage-campaign-lifecycle.md
+      title: Manage Campaign Lifecycle
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [marketing]


### PR DESCRIPTION
**PR 5 of 7** in the Google Ads skill chain. Base: `feat/gads-4-pmax` (**merge #724 first**).

Adds the **campaign lifecycle** recipe: list/get; launch (first activation) vs resume (reactivate after pause); pause with optional `scheduledResumeDate`/reminder; partial `UpdateCampaign` (name/budget/targeting); delete (irreversible); change log / status history. Covers the 5-live-campaign cap.

One new skill file: `references/google-ads/manage-campaign-lifecycle.md` (+ SKILL.md entry, documentation.yaml entry, eval scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)