### PR TITLE
feat(wix-manage): Google Ads [6/6] — billing & payment details

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -244,6 +244,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 - **Create a multi-channel / lead-gen / Shopping campaign** → [Create a Performance Max Campaign](references/google-ads/create-performance-max-campaign.md).
 - **Pause / resume / launch / update budget / delete / history** → [Manage Campaign Lifecycle](references/google-ads/manage-campaign-lifecycle.md).
 - **Performance, conversions, search terms, per-product / per-asset metrics** → [Query Campaign Performance Analytics](references/google-ads/query-campaign-analytics.md).
+- **Ad spend, fees, upcoming charges, credit balance** → [Retrieve Billing and Payment Details](references/google-ads/billing-and-payment.md).
 
 ### [Install Google Ads and Create an Account](references/google-ads/install-and-create-account.md)
 **Technical:** One-time setup prerequisite for all Google Ads flows. Installs the Wix Google Ads app (`POST /v1/install-if-not-installed`) then creates the linked account (`POST /v1/accounts` with `currency`). Covers checking for an existing account (`GET /v1/accounts/current-site`, empty when none), optional promotional incentives, Merchant Center linking, and account deletion.
@@ -259,6 +260,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Query Campaign Performance Analytics](references/google-ads/query-campaign-analytics.md)
 **Technical:** Reads campaign analytics via six endpoints — daily performance metrics (with previous-period trends), conversion metrics (orders/revenue/ROAS from Wix), search terms, per-product shopping performance, and per-asset PMAX-Leads metrics. Explains `campaignResourceName` vs Wix `campaignId`, the `dateRange` shape, field enums, sorting, and paging.
+
+### [Retrieve Google Ads Billing and Payment Details](references/google-ads/billing-and-payment.md)
+**Technical:** Reads billing for the site's Google Ads account (`GET /v1/payment-details`, 30s SLA): current-period ad spend (`usageAmount`), Wix service fee, coupon adjustment, `totalAmount`, billing period, and `creditBalance` (positive = credits, negative = debt). Contrasts with the account's `currentBudget`/`spentBudget`.
 
 ### [Google Ads Dashboard Navigation](references/google-ads/google-ads-dashboard-navigation.md)
 **Technical:** Direct link to the Wix Google Ads dashboard page on manage.wix.com where API-created campaigns are managed.

--- a/skills/wix-manage/references/google-ads/billing-and-payment.md
+++ b/skills/wix-manage/references/google-ads/billing-and-payment.md
@@ -1,0 +1,80 @@
+---
+name: "Retrieve Google Ads Billing and Payment Details"
+description: "Retrieves billing and payment details for a Wix site's Google Ads account: the current billing period's ad spend (usage), the Wix service fee, the total charge, any promotional coupon adjustment, the billing period dates, and the account's credit balance (positive = available credits, negative = outstanding debt not yet charged). Also explains reading current vs remaining budget from the account object. Use when the user asks 'how much have I spent on Google Ads', 'what's my next Google Ads charge', 'show my ad billing', 'do I have ad credits left', 'why was I charged', or 'upcoming Google Ads payment'. Requires an existing Google Ads account. REST base https://www.wixapis.com/google-ads/v1."
+---
+# RECIPE: Retrieve Google Ads Billing and Payment Details
+
+Report what a site owner will be charged for Google Ads: ad spend, the Wix service fee, coupon adjustments, the total, the billing period, and the account's credit balance.
+
+Base URL: `https://www.wixapis.com/google-ads/v1`. `<AUTH>` is the `Authorization` header. This endpoint is read-only.
+
+**Prerequisite:** a Google Ads account must exist (`ACCOUNT_NOT_FOUND` → run [install-and-create-account](install-and-create-account.md)).
+
+---
+
+## Get payment details
+
+Billing is calculated from cached subscription data (not fetched live from Google), and the charge calculation is heavy — this endpoint has a **30-second SLA**, so allow time and don't retry prematurely.
+
+```bash
+curl -X GET 'https://www.wixapis.com/google-ads/v1/payment-details' -H 'Authorization: <AUTH>'
+```
+
+```json
+{
+  "paymentDetails": {
+    "currency": "USD",
+    "upcomingPayments": [
+      {
+        "usageAmount": "123.45",
+        "wixServiceFee": "12.35",
+        "totalAmount": "135.80",
+        "billingPeriod": { "from": "2026-03-01", "to": "2026-03-31" },
+        "couponAdjustmentAmount": "0.00"
+      }
+    ],
+    "creditBalance": "0.00"
+  }
+}
+```
+
+**Reading the response:**
+- `currency` — the account's billing currency; all amounts here are in it.
+- `upcomingPayments[]` — the current billing period breakdown (up to 2 entries). Per entry:
+  - `usageAmount` — ad spend for the period, **excluding** the Wix fee.
+  - `wixServiceFee` — the Wix platform fee.
+  - `couponAdjustmentAmount` — discount applied from a promotional coupon.
+  - `totalAmount` — what will actually be charged: `usageAmount + wixServiceFee − couponAdjustmentAmount`.
+  - `billingPeriod` — `from`/`to` dates (YYYY-MM-DD).
+- `creditBalance` — the site's credits. **Positive** = credits available (e.g. from an incentive) that offset upcoming charges; **negative** = outstanding debt not yet charged. The final amount can shift slightly once the charge is processed.
+
+When summarizing for the user, lead with `totalAmount` and the billing period, then break out spend vs fee, and flag a non-zero `creditBalance` (credits remaining, or debt owed).
+
+> Note: an older `monthlyPayments` field is deprecated in favor of `upcomingPayments` — always read `upcomingPayments`.
+
+---
+
+## Budget vs. billing — a related but different view
+
+Payment details cover *charges*. The **account object** (from `GET /v1/accounts/current-site`, see [install-and-create-account](install-and-create-account.md)) carries the *ad-budget* view:
+- `currentBudget` — remaining ad budget/credit (negative = debt not yet charged).
+- `spentBudget` — total spent on ads so far.
+
+Use payment details for "what will I be charged and when"; use the account's budget fields for "how much ad budget is left."
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `NOT_FOUND` / `ACCOUNT_NOT_FOUND` | No Google Ads account for the site | Run [install-and-create-account](install-and-create-account.md) |
+| Slow response (up to ~30s) | Charge calculation SLA | Wait; don't retry prematurely |
+| `upcomingPayments` empty | No charges accrued yet this period | Report zero upcoming charges; check `creditBalance` for credits/debt |
+| Negative `creditBalance` | Outstanding debt not yet charged | Explain it's owed and will be charged; not an error |
+
+## References
+
+- [Payment Details Service introduction](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/payment-details-v1/introduction)
+- [Get Payment Details](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/payment-details-v1/get-payment-details)
+- [Account Service](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-account-v1/introduction)

--- a/yaml/wix-manage-evals/google-ads/billing-and-payment.yml
+++ b/yaml/wix-manage-evals/google-ads/billing-and-payment.yml
@@ -1,0 +1,31 @@
+name: google-ads/billing-and-payment
+description: >-
+  Verifies the agent uses the billing recipe to read payment details and
+  correctly interprets the totalAmount breakdown and creditBalance sign.
+triggerPrompt: >-
+  How much am I going to be charged for my Google Ads this billing period on my
+  Wix site, and do I have any ad credits left? Which endpoint returns this?
+tags: [marketing]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/retrieve-google-ads-billing-and-payment-details
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants their upcoming Google Ads charge and remaining credits.
+
+      Pass if the response:
+      - uses the billing recipe and GET /v1/payment-details, AND
+      - explains the upcomingPayments breakdown: usageAmount (ad spend) plus
+        wixServiceFee minus couponAdjustmentAmount equals totalAmount, over a
+        billingPeriod, AND
+      - interprets creditBalance sign correctly: positive = available credits,
+        negative = outstanding debt not yet charged.
+
+      Fail if the response:
+      - reads the deprecated monthlyPayments field instead of upcomingPayments, OR
+      - inverts the creditBalance meaning, OR
+      - invents a billing endpoint, OR
+      - conflates totalAmount with usageAmount (ignoring the Wix fee).

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -26,3 +26,7 @@ apiDoc:
       title: Query Campaign Performance Analytics
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
       tags: [marketing]
+    - file: ../../../skills/wix-manage/references/google-ads/billing-and-payment.md
+      title: Retrieve Google Ads Billing and Payment Details
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [marketing]


### PR DESCRIPTION
**PR 7 of 7** — final PR in the Google Ads skill chain. Base: `feat/gads-6-analytics` (**merge #726 first**).

Adds the **billing** recipe: `GET /v1/payment-details` (30s SLA) — current-period ad spend (`usageAmount`), Wix service fee, coupon adjustment, `totalAmount`, billing period, and `creditBalance` (positive = credits, negative = debt). Contrasts with the account's `currentBudget`/`spentBudget`. Completes the `google-ads` area (7 recipes).

One new skill file: `references/google-ads/billing-and-payment.md` (+ SKILL.md entry, documentation.yaml entry, eval scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)