### PR TITLE
feat(wix-manage): Google Ads [3/6] — create & launch Performance Max

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -202,12 +202,16 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 **Routing — Google paid-advertising campaigns for a site (Smart & Performance Max).** All flows require a Google Ads account, created once via the setup recipe. Budgets are in micros (1,000,000 = 1 currency unit). REST base: `https://www.wixapis.com/google-ads/v1`.
 - **First-time setup / "connect Google Ads" / `ACCOUNT_NOT_FOUND`** → [Install and Create an Account](references/google-ads/install-and-create-account.md) (do this before anything else).
 - **Suggested keywords / geo / budget / ad copy / images** → [Get AI Campaign Suggestions](references/google-ads/get-campaign-suggestions.md).
+- **Create a multi-channel / lead-gen / Shopping campaign** → [Create a Performance Max Campaign](references/google-ads/create-performance-max-campaign.md).
 
 ### [Install Google Ads and Create an Account](references/google-ads/install-and-create-account.md)
 **Technical:** One-time setup prerequisite for all Google Ads flows. Installs the Wix Google Ads app (`POST /v1/install-if-not-installed`) then creates the linked account (`POST /v1/accounts` with `currency`). Covers checking for an existing account (`GET /v1/accounts/current-site`, empty when none), optional promotional incentives, Merchant Center linking, and account deletion.
 
 ### [Get AI Campaign Suggestions for Google Ads](references/google-ads/get-campaign-suggestions.md)
 **Technical:** Read-only Suggestions API reference — keyword themes, geo options, Smart budget tiers, PMAX budget recommendations, text/image assets, search themes, full AI campaign configs from a campaign brief (`POST /v1/campaign-suggestions`), and promotional incentive offers. Budgets in micros; generation endpoints have 60–120s SLAs.
+
+### [Create and Launch a Performance Max Campaign](references/google-ads/create-performance-max-campaign.md)
+**Technical:** Creates and launches a PMAX campaign — `PERFORMANCE_MAX`, `PERFORMANCE_MAX_LEADS`, or retail/Shopping. Generates AI text/image assets and search themes, gets a Google budget recommendation, assembles an asset group meeting Google's minimum asset counts (headlines/descriptions/images), creates in `PAUSED`, then launches. Bidding is server-enforced to `MAXIMIZE_CONVERSIONS`.
 
 ---
 

--- a/skills/wix-manage/references/google-ads/create-performance-max-campaign.md
+++ b/skills/wix-manage/references/google-ads/create-performance-max-campaign.md
@@ -1,0 +1,212 @@
+---
+name: "Create and Launch a Performance Max Campaign"
+description: "Creates and launches a Google Ads Performance Max (PMAX) campaign for a Wix site — a goal-based campaign that runs across all Google channels (Search, Display, YouTube, Gmail, Discover, Maps) from an asset group of headlines, descriptions, images, and (for PMAX Leads) search-theme signals. Covers generating AI text and image assets, generating search themes, getting a Google budget recommendation, assembling the asset group with the required minimum assets, choosing PERFORMANCE_MAX vs PERFORMANCE_MAX_LEADS (leads: phone/form goals, negative keywords, 28-day learning) vs retail/Shopping (Merchant Center feed), creating in PAUSED, and launching. Use for 'create a Performance Max campaign', 'PMAX', 'run ads across all of Google', 'lead-gen Google campaign', or 'Google Shopping ads'. Requires an existing Google Ads account. REST base https://www.wixapis.com/google-ads/v1."
+---
+# RECIPE: Create and Launch a Performance Max Campaign
+
+A **Performance Max (PMAX)** campaign runs across every Google channel from a single **asset group** — a bundle of headlines, descriptions, images, and (optionally) videos that Google mixes into ads. There are three flavors, set by `campaignType`:
+
+- **`PERFORMANCE_MAX`** — general multi-channel campaign.
+- **`PERFORMANCE_MAX_LEADS`** — lead-gen variant (phone/form conversions, search-theme signals, negative keywords, a ~28-day learning phase). **Requires** at least one asset group with headlines, descriptions, and images; assets are validated synchronously, so bad assets fail the create call immediately.
+- **Retail / Shopping** — a `PERFORMANCE_MAX` campaign linked to a Google Merchant Center feed (set `merchantCenterAccountId` on the account first — see [install-and-create-account](install-and-create-account.md) — and use `feedLabel`). Retail campaigns don't require a hand-built asset group.
+
+Base URL: `https://www.wixapis.com/google-ads/v1`. `<AUTH>` is the `Authorization` header; body calls also need `Content-Type: application/json`. The bidding strategy is server-enforced to `MAXIMIZE_CONVERSIONS` — never set it yourself.
+
+> **Launching spends real money.** Present the assembled asset group and budget and get explicit approval before the Launch call (STEP 5). Create in `PAUSED` first — nothing serves until Launch.
+
+**Prerequisite:** a Google Ads account (`ACCOUNT_NOT_FOUND` → run [install-and-create-account](install-and-create-account.md)). You need `account.id` as `campaign.accountId`.
+
+**Flow:** STEP 1 text assets → STEP 2 image assets → STEP 3 (leads) search themes → STEP 4 budget recommendation → assemble & create PAUSED → **show & approve** → STEP 5 launch.
+
+---
+
+## STEP 1: Generate text assets (headlines & descriptions)
+
+`suggestionInfo.landingPageUrl` and `textSuggestionInfo.languageCode` are both required. Response may take up to 60s.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/text-asset-suggestions' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{
+    "suggestionInfo": { "landingPageUrl": "https://www.example.com", "assetTypes": ["HEADLINE", "DESCRIPTION"] },
+    "textSuggestionInfo": { "languageCode": "en" }
+  }'
+```
+
+```json
+{ "assetSuggestions": [
+  { "assetType": "HEADLINE", "headlineAsset": { "text": "Fresh Baked Every Morning" } },
+  { "assetType": "HEADLINE", "headlineAsset": { "text": "Award-Winning Pastries" } },
+  { "assetType": "DESCRIPTION", "descriptionAsset": { "text": "Visit us for artisan breads, custom cakes, and more." } }
+] }
+```
+
+## STEP 2: Generate image assets
+
+Images are generated with AI and **automatically uploaded to the site's Wix Media Manager** — the returned `url` is a `static.wixstatic.com` link you can use directly in the asset group. `suggestionInfo.landingPageUrl` is required.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/image-asset-suggestions' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "suggestionInfo": { "landingPageUrl": "https://www.example.com", "assetTypes": ["MARKETING_IMAGE", "SQUARE_MARKETING_IMAGE"] } }'
+```
+
+```json
+{ "assetSuggestions": [
+  { "assetType": "MARKETING_IMAGE", "imageAsset": { "name": "storefront-banner", "url": "https://static.wixstatic.com/media/abc123.jpg" } },
+  { "assetType": "SQUARE_MARKETING_IMAGE", "imageAsset": { "name": "product-square", "url": "https://static.wixstatic.com/media/def456.jpg" } }
+] }
+```
+
+## STEP 3 (PMAX Leads only): Generate search themes
+
+Search themes are the targeting signals for a leads campaign's asset group. `textSuggestionInfo.languageCode` is required.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/search-theme-suggestions' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{ "landingPageUrl": "https://www.example.com", "textSuggestionInfo": { "languageCode": "en" } }'
+```
+
+```json
+{ "searchThemes": ["artisan bakery", "custom birthday cakes", "fresh bread delivery", "gluten free pastries", "wedding cake shop"] }
+```
+
+Each string becomes a `{ "searchTheme": { "text": "…" } }` signal in the asset group (max 25).
+
+## STEP 4: Get a budget recommendation
+
+PMAX uses **Generate Budget Recommendation** (not the Smart-campaign budget-suggestions endpoint). `campaignType`, `assetGroupInfo` (with a `finalUrl`), and `currency` are required.
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/budget-recommendation' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{
+    "campaignType": "PERFORMANCE_MAX",
+    "assetGroupInfo": [ {
+      "finalUrl": "https://www.example.com",
+      "headlines": ["Fresh Baked Every Morning", "Award-Winning Pastries"],
+      "descriptions": ["Artisan breads and custom cakes baked fresh daily."]
+    } ],
+    "currency": "USD",
+    "countryCodes": ["US"],
+    "languageCodes": ["en"]
+  }'
+```
+
+```json
+{ "budgetRecommendation": {
+  "recommendedBudgetAmountMicros": "15000000",
+  "budgetOptions": [
+    { "budgetAmountMicros": "8000000",  "impact": { "potentialMetrics": { "impressions": 1200, "clicks": 35, "conversions": 2 } } },
+    { "budgetAmountMicros": "15000000", "impact": { "potentialMetrics": { "impressions": 2800, "clicks": 78, "conversions": 5 } } }
+  ]
+} }
+```
+
+Use `recommendedBudgetAmountMicros` as `budget.amountMicros`, or present the `budgetOptions` with their projected impact and let the user pick. `budgetRecommendation` is absent when Google has too little data — fall back to a manual budget within `GET /v1/campaign/daily-budget-boundaries`.
+
+---
+
+## Assemble & create the campaign (in PAUSED)
+
+An **asset group** lives at `performanceMaxCampaign.assetGroups[]`. Its creative assets go under `assetGroupAssets.assets[]` — each asset sets **exactly one** payload field plus its `assetFieldType`. For a PMAX Leads asset group, meet Google's minimums or the create call fails with `NOT_ENOUGH_ASSETS`:
+
+| Asset | Payload field | `assetFieldType` | Count | Max chars |
+| --- | --- | --- | --- | --- |
+| Short headline | `headlineAsset.text` | `HEADLINE` | 3–15 | 30 |
+| Long headline | `longHeadlineAsset.text` | `LONG_HEADLINE` | exactly 1 | 90 |
+| Description | `descriptionAsset.text` | `DESCRIPTION` | 2–4 | 90 |
+| Business name | `businessNameAsset.text` | `BUSINESS_NAME` | exactly 1 | 25 |
+| Landscape image (1.91:1) | `imageAsset.{name,url}` | `MARKETING_IMAGE` | ≥1 | — |
+| Square image (1:1) | `imageAsset.{name,url}` | `SQUARE_MARKETING_IMAGE` | ≥1 | — |
+| Logo (1:1) | `imageAsset.{name,url}` | `LOGO` | ≥1 | — |
+| CTA button | `callToActionSelectionAsset.callToAction` | `CALL_TO_ACTION_SELECTION` | optional | `LEARN_MORE` \| `SHOP_NOW` \| `SIGN_UP` \| `CONTACT_US` |
+| YouTube video | `youtubeVideoAsset.{title,id}` | `YOUTUBE_VIDEO` | optional (1–5) | 11-char video id |
+
+Image `url` must be a Wix Media Manager URL (`static.wixstatic.com`) — the STEP 2 generated images already are; for other images, upload via the Media Manager first (see [Upload Media to Wix](../media/upload-media-to-wix.md)). Search themes go under `assetGroupSignals.signals[]` (PMAX Leads).
+
+**Create a PMAX Leads campaign** (status required; create `PAUSED`):
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{
+    "campaign": {
+      "accountId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "campaignType": "PERFORMANCE_MAX_LEADS",
+      "status": "PAUSED",
+      "name": "Summer Lead-Gen PMAX",
+      "budget": { "amountMicros": "15000000" },
+      "locations": [
+        { "location": { "geoTargetConstant": "geoTargetConstants/1023191" }, "displayName": "New York, United States" }
+      ],
+      "performanceMaxCampaign": {
+        "url": "https://www.example.com",
+        "languages": [ { "languageCode": "en" } ],
+        "assetGroups": [ {
+          "assetGroupAssets": { "assets": [
+            { "headlineAsset":     { "text": "Fresh Baked Every Morning" }, "assetFieldType": "HEADLINE" },
+            { "headlineAsset":     { "text": "Award-Winning Pastries" },    "assetFieldType": "HEADLINE" },
+            { "headlineAsset":     { "text": "Order Custom Cakes Today" },  "assetFieldType": "HEADLINE" },
+            { "longHeadlineAsset": { "text": "Artisan breads and custom cakes baked fresh every morning" }, "assetFieldType": "LONG_HEADLINE" },
+            { "descriptionAsset":  { "text": "Award-winning pastries made fresh daily." }, "assetFieldType": "DESCRIPTION" },
+            { "descriptionAsset":  { "text": "Custom cakes for every occasion. Order online." }, "assetFieldType": "DESCRIPTION" },
+            { "businessNameAsset": { "text": "Sunrise Bakery" }, "assetFieldType": "BUSINESS_NAME" },
+            { "imageAsset": { "name": "storefront-banner", "url": "https://static.wixstatic.com/media/abc123.jpg" }, "assetFieldType": "MARKETING_IMAGE" },
+            { "imageAsset": { "name": "product-square",    "url": "https://static.wixstatic.com/media/def456.jpg" }, "assetFieldType": "SQUARE_MARKETING_IMAGE" },
+            { "callToActionSelectionAsset": { "callToAction": "SHOP_NOW" }, "assetFieldType": "CALL_TO_ACTION_SELECTION" }
+          ] },
+          "assetGroupSignals": { "signals": [
+            { "searchTheme": { "text": "artisan bakery" } },
+            { "searchTheme": { "text": "custom birthday cakes" } }
+          ] }
+        } ]
+      }
+    }
+  }'
+```
+
+For a **general `PERFORMANCE_MAX`** campaign, use `campaignType: "PERFORMANCE_MAX"` (the `assetGroupSignals` are Leads-only). For **retail/Shopping**, link a Merchant Center account on the account first and set `performanceMaxCampaign.feedLabel`; a retail campaign can serve from the product feed without a hand-built asset group.
+
+Save the returned `campaign.id` and `resourceName`. `status` is read-only and syncs from Google — a PMAX Leads campaign shows `LEARNING` for ~28 days after launch.
+
+**Now show the user the asset group** (headlines, descriptions, images) and the daily budget, and get explicit approval.
+
+---
+
+## STEP 5: Launch the campaign
+
+```bash
+curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}/launch' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' -d '{}'
+```
+
+Returns the campaign with an updated `status`. Ads begin serving across Google channels; see [Query Campaign Performance Analytics](query-campaign-analytics.md) — PMAX Leads supports per-asset metrics.
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `ACCOUNT_NOT_FOUND` | No Google Ads account | Run [install-and-create-account](install-and-create-account.md) |
+| `INVALID_ARGUMENT` / `NOT_ENOUGH_ASSETS` | Asset group below minimums | Add assets to meet the per-type counts in the table |
+| `INVALID_ARGUMENT` / `INVALID_ASSET_GROUP_ASSETS` | An asset is malformed or violates Google requirements | Fix the offending asset (length, type, url) |
+| `INVALID_ARGUMENT` / `INVALID_IMAGE_FORMAT` | Image format/dimensions unsupported | Use a supported ratio/size; regenerate via image-asset-suggestions |
+| `INVALID_ARGUMENT` / `DUPLICATE_IMAGE_ASSETS` / `DUPLICATE_ASSET` | Same asset provided twice | Deduplicate the asset group |
+| `INVALID_ARGUMENT` / `SEARCH_THEME_POLICY_VIOLATION` / `POLICY_VIOLATION` | A signal/asset violates Google policy | Remove or rewrite the flagged item |
+| `INVALID_ARGUMENT` / `RESTRICTED_LOCATION` | Targeted geo is restricted | Remove it; pick a specific allowed place |
+| `INVALID_ARGUMENT` / `CAMPAIGN_DAILY_BUDGET_TOO_HIGH` | Budget over the account max | Lower it within `daily-budget-boundaries` |
+| `FAILED_PRECONDITION` / `MAXIMUM_NUMBER_OF_CAMPAIGNS_REACHED` | 5 live campaigns already | Pause one before launching |
+| `INVALID_ARGUMENT` / `GOOGLE_ADS_API_ERROR` | Unexpected Google Ads rejection | Surface the message; verify and retry |
+
+## References
+
+- [Campaign Service introduction](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/introduction)
+- [Create Campaign](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/create-campaign)
+- [Launch Campaign](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/campaign-v1/launch-campaign)
+- [Get Text Asset Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-text-asset-suggestions)
+- [Get Image Asset Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-image-asset-suggestions)
+- [Get Search Theme Suggestions](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/get-search-theme-suggestions)
+- [Generate Budget Recommendation](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/google-suggestion-v1/generate-budget-recommendation)

--- a/yaml/wix-manage-evals/google-ads/create-performance-max-campaign.yml
+++ b/yaml/wix-manage-evals/google-ads/create-performance-max-campaign.yml
@@ -1,0 +1,37 @@
+name: google-ads/create-performance-max-campaign
+description: >-
+  Verifies the agent uses the Performance Max recipe: generating text/image
+  assets and search themes, getting a PMAX budget recommendation, and building
+  an asset group that meets Google's minimum asset counts.
+triggerPrompt: >-
+  How do I create a Performance Max lead-generation campaign on my Wix site with
+  the Google Ads API, including generating the ad assets? Reference the endpoints.
+tags: [marketing]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/create-and-launch-a-performance-max-campaign
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants to create a Performance Max (PMAX) Leads campaign including
+      generating assets.
+
+      Pass if the response:
+      - uses the Performance Max recipe, AND
+      - uses campaignType PERFORMANCE_MAX_LEADS (or PERFORMANCE_MAX) via
+        POST /v1/campaigns with a performanceMaxCampaign asset group, AND
+      - generates assets via text-asset-suggestions and image-asset-suggestions
+        (and search-theme-suggestions for Leads), AND
+      - notes the asset group must meet minimum asset counts (e.g. multiple
+        headlines, at least two descriptions, a business name, images), AND
+      - gets a budget via POST /v1/budget-recommendation (not the Smart
+        budget-suggestions endpoint), AND
+      - does NOT set the bidding strategy manually (it is server-enforced).
+
+      Fail if the response:
+      - hand-sets a bidding strategy, OR
+      - uses Smart-campaign fields (keywordThemes/smartCampaign) for PMAX, OR
+      - omits the asset-group minimums, OR
+      - hallucinates endpoints.

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: Get AI Campaign Suggestions for Google Ads
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
       tags: [marketing]
+    - file: ../../../skills/wix-manage/references/google-ads/create-performance-max-campaign.md
+      title: Create and Launch a Performance Max Campaign
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [marketing]


### PR DESCRIPTION
**PR 3 of 6** in the Google Ads skill chain. Base: `feat/gads-2-suggestions` (**merge #722 first**).

Adds the **Performance Max** recipe — `PERFORMANCE_MAX`, `PERFORMANCE_MAX_LEADS`, and retail/Shopping. Generates text/image assets + search themes, gets a PMAX budget recommendation, assembles an asset group meeting Google's minimum asset counts, creates in `PAUSED`, then launches. Bidding is server-enforced to `MAXIMIZE_CONVERSIONS`.

One new skill file: `references/google-ads/create-performance-max-campaign.md` (+ SKILL.md entry, documentation.yaml entry, eval scenario).

> Replaces the earlier #724 (auto-closed when the dropped Smart-campaign base branch was deleted). The Smart-campaign recipe has been removed from the chain.

> Reviewer note: the PMAX asset-group create body is the one payload with no example curl in the source repo — constructed from `asset_group_asset.proto` / `assets.proto`; worth a live-call sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)