### PR TITLE
feat(eval-gate): authenticate the PR MCP as the user via session header

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34177,11 +34177,15 @@ const SYSTEM_LLM_JUDGE = 'system:llm_judge';
 const SYSTEM_API_CALL = 'system:api_call';
 const SYSTEM_COST = 'system:cost';
 const SYSTEM_TIME_LIMIT = 'system:time_limit';
+const SYSTEM_SKILL_WAS_CALLED = 'system:skill_was_called';
+const SYSTEM_BUILD_PASSED = 'system:build_passed';
+const SYSTEM_TOKEN_COUNT = 'system:token_count';
 function toEvalForgeBody(s) {
     return {
         name: s.name,
         description: s.description,
         triggerPrompt: s.triggerPrompt,
+        ...(s.templateId ? { templateId: s.templateId } : {}),
         assertionLinks: s.assertions.map(mapAssertion),
         siteSetup: s.siteSetup ? mapSiteSetup(s.siteSetup) : { mode: 'NONE' },
     };
@@ -34218,6 +34222,12 @@ function mapAssertion(a) {
         return mapCost(a);
     if ((0, schema_1.isTimeLimit)(a))
         return mapTimeLimit(a);
+    if ((0, schema_1.isSkillWasCalled)(a))
+        return mapSkillWasCalled(a);
+    if ((0, schema_1.isBuildPassed)(a))
+        return mapBuildPassed(a);
+    if ((0, schema_1.isTokenCount)(a))
+        return mapTokenCount(a);
     return mapToolCall(a);
 }
 function mapToolCall(a) {
@@ -34239,9 +34249,41 @@ function mapLlmJudge(a) {
         params.maxTokens = a.maxTokens;
     if (a.temperature !== undefined)
         params.temperature = a.temperature;
+    if (a.scoringMode !== undefined)
+        params.scoringMode = a.scoringMode;
+    if (a.browserTools !== undefined)
+        params.browserTools = a.browserTools;
+    if (a.parameters !== undefined)
+        params.parameters = JSON.stringify(a.parameters);
     if (a.negate !== undefined)
         params.negate = a.negate;
     return { assertionId: SYSTEM_LLM_JUDGE, params };
+}
+function mapSkillWasCalled(a) {
+    const params = { skillNames: JSON.stringify(a.skillNames) };
+    if (a.referenceFiles !== undefined)
+        params.referenceFiles = JSON.stringify(a.referenceFiles);
+    if (a.negate !== undefined)
+        params.negate = a.negate;
+    return { assertionId: SYSTEM_SKILL_WAS_CALLED, params };
+}
+function mapBuildPassed(a) {
+    const params = {};
+    if (a.command !== undefined)
+        params.command = a.command;
+    if (a.expectedExitCode !== undefined)
+        params.expectedExitCode = a.expectedExitCode;
+    if (a.negate !== undefined)
+        params.negate = a.negate;
+    return Object.keys(params).length > 0
+        ? { assertionId: SYSTEM_BUILD_PASSED, params }
+        : { assertionId: SYSTEM_BUILD_PASSED };
+}
+function mapTokenCount(a) {
+    const params = { maxTokens: a.maxTokens };
+    if (a.negate !== undefined)
+        params.negate = a.negate;
+    return { assertionId: SYSTEM_TOKEN_COUNT, params };
 }
 function mapApiCall(a) {
     const params = {
@@ -34299,6 +34341,18 @@ exports.uniqueRemoteScenarios = uniqueRemoteScenarios;
 const auth_1 = __nccwpck_require__(3693);
 const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
+// The Wix MCP authenticates eval runs as the *user* via a session header: the
+// whole `~/.wix/auth/account.json` session, base64-encoded. EvalForge substitutes
+// the `{{wix-auth-account-token}}` placeholder at run time (it mints an
+// on-behalf-of-user session for remote runs), so the credential never lands in
+// this repo or in the capability config stored in EvalForge.
+//
+// This replaced an API-key pair (`Authorization` + `wix-account-id`, fed by the
+// retired `{{wix-auth-token}}`/`{{wix-auth-user-id}}` placeholders). EvalForge
+// no longer resolves those — a config still using them fails the run outright —
+// so the two must stay in lockstep.
+const MCP_AUTH_HEADER = 'x-wix-mcp-account-token';
+const MCP_AUTH_PLACEHOLDER = '{{wix-auth-account-token}}';
 // Cap on concurrent per-name scenario queries, so a PR touching many scenarios
 // doesn't fire an unbounded burst at the V1 gateway (which may rate-limit).
 const MAX_QUERY_CONCURRENCY = 8;
@@ -34437,8 +34491,7 @@ class EvalForgeClient {
                             url: this.buildMcpUrl(skillsRepo, headSha),
                             type: 'http',
                             headers: {
-                                Authorization: '{{wix-auth-token}}',
-                                'wix-account-id': '{{wix-auth-user-id}}',
+                                [MCP_AUTH_HEADER]: MCP_AUTH_PLACEHOLDER,
                             },
                         },
                     },
@@ -34636,6 +34689,9 @@ exports.isApiCall = isApiCall;
 exports.isCost = isCost;
 exports.isTimeLimit = isTimeLimit;
 exports.isToolCall = isToolCall;
+exports.isSkillWasCalled = isSkillWasCalled;
+exports.isBuildPassed = isBuildPassed;
+exports.isTokenCount = isTokenCount;
 exports.parseScenario = parseScenario;
 const zod_1 = __nccwpck_require__(822);
 const jsYaml = __importStar(__nccwpck_require__(3691));
@@ -34661,6 +34717,14 @@ const ToolCallAssertionSchema = zod_1.z.object({
     params: zod_1.z.record(zod_1.z.string(), ParamValueSchema).optional(),
     negate: zod_1.z.boolean().optional(),
 }).strict();
+const AssertionParameterSchema = zod_1.z.object({
+    name: zod_1.z.string().min(1),
+    label: zod_1.z.string().min(1),
+    type: zod_1.z.enum(['string', 'number', 'boolean']),
+    required: zod_1.z.boolean(),
+    defaultValue: zod_1.z.union([zod_1.z.string(), zod_1.z.number(), zod_1.z.boolean()]).optional(),
+    advanced: zod_1.z.boolean().optional(),
+}).strict();
 const LlmJudgeAssertionSchema = zod_1.z.object({
     type: zod_1.z.literal('llm_judge'),
     prompt: zod_1.z.string().min(1),
@@ -34668,6 +34732,9 @@ const LlmJudgeAssertionSchema = zod_1.z.object({
     model: zod_1.z.string().optional(),
     maxTokens: zod_1.z.number().int().positive().optional(),
     temperature: zod_1.z.number().min(0).max(1).optional(),
+    scoringMode: zod_1.z.enum(['numeric', 'boolean']).optional(),
+    browserTools: zod_1.z.boolean().optional(),
+    parameters: zod_1.z.array(AssertionParameterSchema).optional(),
     negate: zod_1.z.boolean().optional(),
 }).strict();
 const ApiCallAssertionSchema = zod_1.z.object({
@@ -34690,12 +34757,32 @@ const TimeLimitAssertionSchema = zod_1.z.object({
     maxDurationMs: zod_1.z.number().int().positive(),
     negate: zod_1.z.boolean().optional(),
 }).strict();
+const SkillWasCalledAssertionSchema = zod_1.z.object({
+    type: zod_1.z.literal('skill_was_called'),
+    skillNames: zod_1.z.array(zod_1.z.string().min(1)).min(1),
+    referenceFiles: zod_1.z.record(zod_1.z.string(), zod_1.z.array(zod_1.z.string().min(1)).min(1)).optional(),
+    negate: zod_1.z.boolean().optional(),
+}).strict();
+const BuildPassedAssertionSchema = zod_1.z.object({
+    type: zod_1.z.literal('build_passed'),
+    command: zod_1.z.string().optional(),
+    expectedExitCode: zod_1.z.number().int().optional(),
+    negate: zod_1.z.boolean().optional(),
+}).strict();
+const TokenCountAssertionSchema = zod_1.z.object({
+    type: zod_1.z.literal('token_count'),
+    maxTokens: zod_1.z.number().int().positive(),
+    negate: zod_1.z.boolean().optional(),
+}).strict();
 const AssertionSchema = zod_1.z.union([
     ToolCallAssertionSchema,
     LlmJudgeAssertionSchema,
     ApiCallAssertionSchema,
     CostAssertionSchema,
     TimeLimitAssertionSchema,
+    SkillWasCalledAssertionSchema,
+    BuildPassedAssertionSchema,
+    TokenCountAssertionSchema,
 ]);
 // Optional per-scenario site provisioning. Only `template` mode is supported.
 const SiteBootstrapStepSchema = zod_1.z.object({
@@ -34718,6 +34805,9 @@ exports.ScenarioSchema = zod_1.z.object({
     name: zod_1.z.string().min(1).regex(NamePattern, 'name must match /^[a-z0-9][a-z0-9/_-]*$/'),
     description: zod_1.z.string(),
     triggerPrompt: zod_1.z.string().min(10),
+    // Optional scenario-level template the run scaffolds from (an EvalForge template
+    // id/alias). Distinct from `siteSetup` (which provisions a site). Omit when unused.
+    templateId: zod_1.z.string().min(1).optional(),
     tags: zod_1.z.array(zod_1.z.string().min(1)).min(1).refine(tags => tags.every(t => !exports.RESERVED_TAG_PREFIXES.some(p => t.startsWith(p)) && !exports.RESERVED_TAGS.some(r => t === r)), { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*, repo:*) or reserved tags (created-via-code) — the action manages those' }),
     maxTokens: zod_1.z.number().int().positive().optional(),
     assertions: zod_1.z.array(AssertionSchema).min(1),
@@ -34746,6 +34836,15 @@ function isTimeLimit(a) {
 }
 function isToolCall(a) {
     return a.type === undefined || a.type === 'tool_called_with_param';
+}
+function isSkillWasCalled(a) {
+    return a.type === 'skill_was_called';
+}
+function isBuildPassed(a) {
+    return a.type === 'build_passed';
+}
+function isTokenCount(a) {
+    return a.type === 'token_count';
 }
 function parseScenario(raw) {
     // CORE_SCHEMA refuses unsafe YAML tags (e.g. !!js/function); defense in depth before Zod.

--- a/.github/actions/skill-eval/dist/index.js
+++ b/.github/actions/skill-eval/dist/index.js
@@ -34668,6 +34668,11 @@ exports.EvalForgeClient = void 0;
 const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_SKILLS_REPO = 'wix/skills';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
+// Kept in step with `packages/evalforge-core` — see the comment there. This gate
+// is disabled (`skill-eval.yml` is `if: false`), but the placeholder pair it used
+// to emit is retired in EvalForge, so leaving it would break on re-enable.
+const MCP_AUTH_HEADER = 'x-wix-mcp-account-token';
+const MCP_AUTH_PLACEHOLDER = '{{wix-auth-account-token}}';
 class EvalForgeClient {
     baseUrl;
     headers;
@@ -34708,8 +34713,7 @@ class EvalForgeClient {
                         url: `${MCP_URL}?skillsRepo=${MCP_SKILLS_REPO}&skillsPr=${headSha}`,
                         type: 'http',
                         headers: {
-                            Authorization: '{{wix-auth-token}}',
-                            'wix-account-id': '{{wix-auth-user-id}}',
+                            [MCP_AUTH_HEADER]: MCP_AUTH_PLACEHOLDER,
                         },
                     },
                 },

--- a/.github/actions/skill-eval/src/utils/evalforge.ts
+++ b/.github/actions/skill-eval/src/utils/evalforge.ts
@@ -4,6 +4,12 @@ const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_SKILLS_REPO = 'wix/skills';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
 
+// Kept in step with `packages/evalforge-core` — see the comment there. This gate
+// is disabled (`skill-eval.yml` is `if: false`), but the placeholder pair it used
+// to emit is retired in EvalForge, so leaving it would break on re-enable.
+const MCP_AUTH_HEADER = 'x-wix-mcp-account-token';
+const MCP_AUTH_PLACEHOLDER = '{{wix-auth-account-token}}';
+
 export type CapabilityVersion = { id: string; capabilityId: string; version: string };
 
 export type EvalRunInput = {
@@ -82,8 +88,7 @@ export class EvalForgeClient {
             url: `${MCP_URL}?skillsRepo=${MCP_SKILLS_REPO}&skillsPr=${headSha}`,
             type: 'http',
             headers: {
-              Authorization: '{{wix-auth-token}}',
-              'wix-account-id': '{{wix-auth-user-id}}',
+              [MCP_AUTH_HEADER]: MCP_AUTH_PLACEHOLDER,
             },
           },
         },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,12 @@ https://mcp.wix.com/mcp?skillsRepo=wix/skills&skillsPr=<headSha>
 
 That PR override makes the Wix MCP load skill content from the pull request instead of from `main`, so eval scenarios test the proposed skill content.
 
+The capability version authenticates as a **user session**, not an API key: it carries an
+`x-wix-mcp-account-token` header whose value is the `{{wix-auth-account-token}}` placeholder, which
+EvalForge substitutes at run time with a base64-encoded Wix session. No credential is ever committed
+here or stored in the capability config. If EvalForge retires or renames that placeholder, this gate
+must be updated in the same rollout — an unresolvable placeholder fails the eval run outright.
+
 Use evaluation as a loop, not a one-time check. Review the failures, tighten the skill or the scenario, and rerun until performance is good enough for the target scenarios.
 
 ### Working on the EvalForge actions themselves

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -5,6 +5,19 @@ export type HttpError = Error & { status: number };
 const MCP_URL = 'https://mcp.wix.com/mcp';
 const MCP_CONFIG_KEY = 'wix-mcp-remote';
 
+// The Wix MCP authenticates eval runs as the *user* via a session header: the
+// whole `~/.wix/auth/account.json` session, base64-encoded. EvalForge substitutes
+// the `{{wix-auth-account-token}}` placeholder at run time (it mints an
+// on-behalf-of-user session for remote runs), so the credential never lands in
+// this repo or in the capability config stored in EvalForge.
+//
+// This replaced an API-key pair (`Authorization` + `wix-account-id`, fed by the
+// retired `{{wix-auth-token}}`/`{{wix-auth-user-id}}` placeholders). EvalForge
+// no longer resolves those — a config still using them fails the run outright —
+// so the two must stay in lockstep.
+const MCP_AUTH_HEADER = 'x-wix-mcp-account-token';
+const MCP_AUTH_PLACEHOLDER = '{{wix-auth-account-token}}';
+
 // Cap on concurrent per-name scenario queries, so a PR touching many scenarios
 // doesn't fire an unbounded burst at the V1 gateway (which may rate-limit).
 const MAX_QUERY_CONCURRENCY = 8;
@@ -223,8 +236,7 @@ export class EvalForgeClient {
                 url: this.buildMcpUrl(skillsRepo, headSha),
                 type: 'http',
                 headers: {
-                  Authorization: '{{wix-auth-token}}',
-                  'wix-account-id': '{{wix-auth-user-id}}',
+                  [MCP_AUTH_HEADER]: MCP_AUTH_PLACEHOLDER,
                 },
               },
             },

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -295,6 +295,49 @@ describe('EvalForgeClient (V1) — 401 handling', () => {
   });
 });
 
+describe('EvalForgeClient (V1) — createMcpVersion payload', () => {
+  // The gate is the only writer of this config, and EvalForge only substitutes
+  // placeholders it still knows about — so pin the exact auth header and URL.
+  // Drifting from EvalForge here fails every eval run, not just this repo's.
+  it('authenticates the PR MCP with the base64 user session, pinned to the PR commit', async () => {
+    let posted: any;
+    mockFetch(({ url, method, body }) => {
+      expect(method).toBe('POST');
+      expect(url).toContain('/v1/projects/P/capabilities/M/versions');
+      posted = body;
+      return { status: 200, body: { capabilityVersion: { id: 'ver-1', capabilityId: 'M', version: 'pr-7-abc1234' } } };
+    });
+    const c = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await c.createMcpVersion('M', 'P', 'pr-7-abc1234', 7, 'abc1234', 'wix/skills');
+
+    const server = posted.capabilityVersion.mcpContent.config['wix-mcp-remote'];
+    expect(server.type).toBe('http');
+    expect(server.url).toBe('https://mcp.wix.com/mcp?skillsRepo=wix%2Fskills&skillsPr=abc1234');
+    expect(server.headers).toEqual({ 'x-wix-mcp-account-token': '{{wix-auth-account-token}}' });
+    expect(posted.capabilityVersion.origin).toBe('pr');
+    expect(posted.capabilityVersion.notes).toBe('Auto-created for PR #7');
+  });
+
+  it('emits no literal credential and none of the retired placeholders', async () => {
+    let raw = '';
+    mockFetch(({ body }) => {
+      raw = JSON.stringify(body);
+      return { status: 200, body: { capabilityVersion: { id: 'ver-1', capabilityId: 'M', version: 'pr-7-abc1234' } } };
+    });
+    const c = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await c.createMcpVersion('M', 'P', 'pr-7-abc1234', 7, 'abc1234', 'wix/skills');
+
+    // EvalForge dropped these; a config still carrying them fails the run.
+    expect(raw).not.toContain('{{wix-auth-token}}');
+    expect(raw).not.toContain('{{wix-auth-user-id}}');
+    expect(raw).not.toContain('Authorization');
+    expect(raw).not.toContain('wix-account-id');
+    // Every credential must arrive as a placeholder EvalForge resolves at run time.
+    expect(raw).not.toContain('IST.');
+    expect(raw).not.toContain('Bearer ');
+  });
+});
+
 describe('EvalForgeClient (V1) — ensureMcpVersion idempotency', () => {
   const listBody = (version: string) => ({ capabilityVersions: [{ id: 'ver-1', capabilityId: 'M', version }] });
 


### PR DESCRIPTION
## What

The Wix MCP moved from API-key auth to **header-based session auth** ([igor-tools#1489](https://github.com/wix-private/igor-tools/pull/1489)). EvalForge followed: it now resolves only `{{wix-auth-account-token}}` — the whole `~/.wix/auth/account.json` session, base64-encoded — and has dropped `{{wix-auth-token}}` / `{{wix-auth-user-id}}` entirely.

This gate is one of the writers of that config, so it has to move in the same rollout:

```diff
 headers: {
-  Authorization: '{{wix-auth-token}}',
-  'wix-account-id': '{{wix-auth-user-id}}',
+  'x-wix-mcp-account-token': '{{wix-auth-account-token}}',
 }
```

## Why this can't lag

EvalForge's placeholder resolution is **fail-closed** — an unresolvable placeholder throws rather than passing the literal through. So the moment EvalForge deploys the change, every capability version this gate writes fails its eval run outright with `MCP config contains unresolvable placeholders`. Not a 401 you'd debug from a run log; a hard gate failure on the next PR touching `yaml/wix-manage*`.

Merging this **before** EvalForge deploys is also safe: the new header simply isn't recognized yet, which is the same "auth missing" outcome the gate already tolerates today when a session is absent.

## Changed

- `packages/evalforge-core/src/evalforge.ts` — the live `evalforge-yaml-gate` path. Header pulled into named `MCP_AUTH_HEADER` / `MCP_AUTH_PLACEHOLDER` constants with a comment recording the lockstep constraint.
- `.github/actions/skill-eval/src/utils/evalforge.ts` — the older gate. Its workflow is `if: false`, so this is dead code, but it emitted the same retired pair and would break silently on re-enable.
- `CONTRIBUTING.md` — §Skill Evaluation documented the PR-override URL but not how the capability authenticates. Added it, plus the lockstep note.
- Two new tests in `packages/evalforge-core/tests/evalforge.test.ts`. There was **no** assertion on the emitted MCP config before — which is why this drift was invisible. One pins the exact header/URL/origin/notes; one asserts the retired placeholders (and any literal credential) never reappear.

## ⚠️ Heads-up for review: the rebuilt `dist/`

CI runs the committed bundles directly with no build step, so both were rebuilt per CONTRIBUTING §"Working on the EvalForge actions themselves".

`.github/actions/skill-eval/dist/index.js` is a clean 3-line swap. **`.github/actions/evalforge-yaml-gate/dist/index.js` is not** — it was last rebuilt in #676, while `packages/evalforge-core` has moved on since. `ncc` bundles current source, so this rebuild necessarily also lands #689's assertion-parity work:

- new assertion types `skill_was_called`, `build_passed`, `token_count`
- `llm_judge` gains `scoringMode`, `browserTools`, `parameters`
- scenario-level `templateId`

**Nothing in `yaml/` uses any of these today** — I checked; all 13 `templateId` hits are `siteSetup.templateId`, which predates #689. So this widens what the gate accepts (previously these failed `.strict()` schema validation) without changing any scenario that passes today. Flagging it because it's more diff than the auth change warrants, and it's real behavior, not noise.

Worth a follow-up: there is no dist-freshness check for `evalforge-yaml-gate` (only `skill-eval-ci.yml` has one, and only for the disabled action) — which is how the bundle drifted three PRs behind its source unnoticed. Separate PR.

## Validation

| | |
|---|---|
| `packages/evalforge-core` | typecheck clean, **103 tests pass** (incl. 2 new) |
| `.github/actions/evalforge-yaml-gate` | typecheck clean, **98 tests pass**, dist rebuilt |
| `.github/actions/skill-eval` | typecheck clean, **96 tests pass**, dist rebuilt |

Verified no legacy placeholder remains in any emitted position — the only surviving occurrences repo-wide are the explanatory comment and the negative test assertions.

## Rollout order

1. [igor-tools#1489](https://github.com/wix-private/igor-tools/pull/1489) deploys (session header live)
2. **this PR**, plus the same fix in `wix-private/ax-tools` (`evalforge-pipeline` and `proto-eval-gate` both hardcode the retired pair)
3. migrate the hand-authored MCP capability configs in EvalForge
4. EvalForge drops legacy placeholder support

🤖 Generated with [Claude Code](https://claude.com/claude-code)