### PR TITLE
fix(wix-manage): harden default business hours writes

### DIFF
--- a/skills/wix-manage/references/calendar/configure-default-business-hours.md
+++ b/skills/wix-manage/references/calendar/configure-default-business-hours.md
@@ -6,221 +6,202 @@ description: Uses Calendar Events API to create WORKING_HOURS events on the busi
 
 ## Description
 
-Below are the recommended steps to successfully configure default business hours for Wix Bookings, which control the base availability shown in the "Set default hours" dashboard. This recipe covers the correct API usage, common pitfalls, and cleanup procedures for managing business schedule events.
-
----
+Wix Bookings default business hours are recurring `WORKING_HOURS` events on the site's business schedule. They control the base availability shown under **Set default hours** and are inherited by new staff members that use default working hours.
 
 ## Prerequisites
 
 - **Wix Bookings app installed** (App ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
 
-> **Note:** If you receive errors from Bookings APIs, the Wix Bookings app may not be installed on the site. Use [List Installed Apps](../app-installation/list-installed-apps.md) to verify, and [Install Wix Apps](../app-installation/install-wix-apps.md) to install it if missing.
+If Bookings APIs report that the app isn't installed, use [List Installed Apps](../app-installation/list-installed-apps.md) to verify and [Install Wix Apps](../app-installation/install-wix-apps.md) to install it.
 
-## Overview
+## Critical API and ID distinction
 
-Wix Bookings default business hours define the base availability for your booking system and appear in the Bookings dashboard under "Set default hours". These hours:
+- **Correct API:** Calendar Events V3 (`/calendar/v3/events`).
+- **Wrong API:** Site Properties (`/site-properties/v4/properties/business-schedule`) changes general site business information, not Bookings default hours.
+- **Lookup key only:** `4e0579a5-491e-4e70-a872-d097eed6e520` is the universal `externalId` used to find the business schedule.
+- **Event schedule ID:** Use the returned, site-specific `schedule.id` as each event's `scheduleId`.
 
-- **Control base availability**: Set when your business is generally available for bookings
-- **Apply to new staff**: Default working hours that new staff members inherit
-- **Display in dashboard**: Show as time slots in the "Set default hours" interface
+Do not use the fixed external ID as `resources[].id`. Calendar validates every supplied resource against actual site resources and returns `404 "Resource with ... ID not found"` when the ID doesn't exist there. Don't substitute an arbitrary staff resource either; default business hours don't need a resource.
 
-### 🚨 CRITICAL: Default Hours Upon Installation
+For these events, omit `externalScheduleId`, `scheduleOwnerId`, `resources`, `location`, `participants`, `conferencingDetails`, `capacity`, `adjustedStart`, and `adjustedEnd`. They are unnecessary, inherited, server-populated, or conditionally validated fields.
 
-**IMPORTANT**: When Wix Bookings is first installed on a site, it automatically creates DEFAULT business hours (typically 9 AM - 5 PM, Monday through Friday). You CANNOT simply create new hours without handling these existing default hours first.
+> Schema note: Nested fields marked required are required only when their optional parent object is present. For example, `resources.id` is required if `resources` is supplied, and `location.type` is required if `location` is supplied. Don't create empty optional parent objects to satisfy the schema.
 
-**You MUST either:**
-1. **Update the existing default hours** to your desired schedule, OR
-2. **Delete the existing default hours** and create new ones
+## Safe reconciliation workflow
 
-**Failure to handle existing hours will result in:**
-- Duplicate time slots in the dashboard
-- Conflicting availability schedules
-- Unexpected booking behavior
+Bookings normally creates Monday-Friday defaults during installation. Always query the current state, but don't assume a particular count.
 
-### CRITICAL API DISCOVERY
+1. Find the business schedule and retain its internal `schedule.id`.
+2. Query current `MASTER` `WORKING_HOURS` events and retain their IDs and revisions.
+3. Match current events to the desired weekday/time slots.
+4. Update matching events and create missing desired events using the minimal shapes below.
+5. Re-query and verify that every desired event exists successfully.
+6. Only after that verification, cancel obsolete unmatched events and perform one final query.
 
-**❌ WRONG API**: Site Properties API (`/site-properties/v4/properties/business-schedule`)
-- This sets general site business schedule, NOT Bookings default hours
+Never cancel all current hours before proving that replacement events can be created. A validation or permission error after cancellation can otherwise leave the site with no default hours.
 
-**✅ CORRECT API**: Calendar Events V3 API (`/calendar/v3/events`)
-- Creates `WORKING_HOURS` events on the business schedule
-- Each `MASTER` event creates one time slot in the dashboard
-- Uses fixed business resource ID: `4e0579a5-491e-4e70-a872-d097eed6e520`
+## Step 1: Find the business schedule
 
-### Key Discovery: Universal Business Schedule External ID
+**Endpoint:** `POST https://www.wixapis.com/calendar/v3/schedules/query`
 
-**VERIFIED**: The business schedule external ID `"4e0579a5-491e-4e70-a872-d097eed6e520"` is **universal across all Wix sites**.
+Use [Query Schedules](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules) with:
 
-This has been tested and confirmed on multiple different Wix sites:
-- All sites have a business schedule with this exact external ID
-- The schedule name is consistently `"business"`
-- While the internal schedule `id` varies per site, the `externalId` is constant
-- This makes the recipe reliable without requiring site-specific discovery
-
-### IMPORTANT NOTES
-
-* **Universal External ID**: The business schedule external ID `"4e0579a5-491e-4e70-a872-d097eed6e520"` is verified to work across all Wix sites
-* **Default Hours Always Exist**: Every Wix Bookings installation creates default hours automatically
-* **Event Scheduling Flexibility**: Businesses can create multiple time slots per day or complex schedules as needed - there are no restrictions on number of events per day
-* **MASTER vs INSTANCE Events**: Based on observed behavior, MASTER events appear to generate INSTANCE events automatically, but always verify current event state when working with recurring events
-* **Query Patterns**: Use `"recurrenceType": ["MASTER"]` to focus on the primary recurring event definitions
-* **Revision Numbers**: Calendar events require current revision numbers for updates - always get fresh revision before bulk operations
-
----
-
-## Steps
-
-### 1. Find Business Schedule
-
-Query the business schedule that controls default hours using the fixed external ID.
-
-**Endpoint**: `POST https://www.wixapis.com/calendar/v3/schedules/query`
-
-Use `querySchedules` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)) with filter:
-- `externalId`: `"4e0579a5-491e-4e70-a872-d097eed6e520"`
-
-Keep the returned `schedule.id` for creating events.
-
-### 2. Query Existing Working Hours (MANDATORY)
-
-**🚨 CRITICAL STEP**: You MUST query for existing `WORKING_HOURS` events because Wix Bookings automatically creates default hours upon installation.
-
-**Endpoint**: `POST https://www.wixapis.com/calendar/v3/events/query`
-
-Use `queryEvents` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/query-events)):
-
-Query pattern:
 ```json
 {
-    "recurrenceType": ["MASTER"],
-    "query": {
-        "filter": {
-            "scheduleId": "business-schedule-id",
-            "type": "WORKING_HOURS"
+  "query": {
+    "filter": {
+      "externalId": "4e0579a5-491e-4e70-a872-d097eed6e520"
+    }
+  }
+}
+```
+
+Require exactly one business schedule and save the returned `schedules[0].id`. The fixed value above is not the ID used in event writes.
+
+## Step 2: Query current working hours
+
+**Endpoint:** `POST https://www.wixapis.com/calendar/v3/events/query`
+
+Use [Query Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/query-events):
+
+```json
+{
+  "recurrenceType": ["MASTER"],
+  "query": {
+    "filter": {
+      "scheduleId": "<site-specific-schedule-id>",
+      "type": "WORKING_HOURS"
+    },
+    "cursorPaging": {
+      "limit": 100
+    }
+  }
+}
+```
+
+Paginate if necessary. Retain each event's `id`, `revision`, `start`, `end`, and `recurrenceRule.days`.
+
+## Step 3: Update matching weekdays
+
+**Endpoint:** `POST https://www.wixapis.com/calendar/v3/bulk/events/update`
+
+Use [Bulk Update Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event). Each item has its own `fieldmask`; it isn't a top-level request field.
+
+```json
+{
+  "events": [
+    {
+      "event": {
+        "id": "<existing-monday-event-id>",
+        "revision": "<current-revision>",
+        "start": {"localDate": "<future-monday-date>T17:00:00"},
+        "end": {"localDate": "<future-monday-date>T20:00:00"}
+      },
+      "fieldmask": "start,end"
+    }
+  ],
+  "timeZone": "America/Chicago",
+  "returnEntity": true
+}
+```
+
+Use a current or future local date that falls on the event's recurrence weekday. Always use the latest revision from a fresh query.
+
+## Step 4: Create missing weekdays
+
+**Endpoint:** `POST https://www.wixapis.com/calendar/v3/bulk/events/create`
+
+Use [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event). A recurring business-hours event needs only `type`, the internal `scheduleId`, `start`, `end`, and a weekly `recurrenceRule`:
+
+```json
+{
+  "events": [
+    {
+      "event": {
+        "type": "WORKING_HOURS",
+        "scheduleId": "<site-specific-schedule-id>",
+        "start": {"localDate": "<future-monday-date>T17:00:00"},
+        "end": {"localDate": "<future-monday-date>T20:00:00"},
+        "recurrenceRule": {
+          "frequency": "WEEKLY",
+          "interval": 1,
+          "days": ["MONDAY"]
         }
+      }
     }
+  ],
+  "timeZone": "America/Chicago",
+  "returnEntity": true
 }
 ```
 
-**Important**: Always query for MASTER events specifically to see actual recurring schedules.
+Create one event per weekday/time slot. Omit `recurrenceRule.until` for hours that should continue indefinitely. Check both `bulkActionMetadata` and every result item's metadata; an HTTP success alone doesn't prove every bulk item succeeded.
 
-**Expected Result**: You will typically find 5 existing MASTER events (Monday through Friday, 9 AM - 5 PM) from the default Bookings installation.
+## Step 5: Verify, then cancel obsolete events
 
-### 3. Choose Your Strategy: Update OR Replace
+Re-run the Step 2 query and verify:
 
-Based on the existing hours found in Step 2, choose one approach:
+1. Every desired weekday/time slot has exactly one successful `MASTER` event, unless split hours were requested.
+2. Each event has `type: "WORKING_HOURS"` and the expected recurrence day and local times.
+3. No desired create or update returned an item-level failure.
 
-#### Strategy A: Update Existing Hours (Recommended)
-If you want to modify the times but keep the same days, update the existing events.
-
-#### Strategy B: Replace All Hours
-If you want completely different days/times, delete existing events and create new ones.
-
-### 4A. Update Existing Business Hours (Strategy A)
-
-**Endpoint**: `POST https://www.wixapis.com/calendar/v3/bulk/events/update`
-
-Use `bulkUpdateEvents` API ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)) with `fieldmask` pattern:
-
-Update fields:
-- `start`/`end`: New times
-- `revision`: Current revision number (from Step 2 query)
-- `fieldmask`: `"start,end"`
-
-**Example**: Change Monday hours from 9 AM-5 PM to 12 AM-4 PM:
-```json
-{
-  "events": [{
-    "event": {
-      "id": "existing-monday-event-id",
-      "start": {"localDate": "2025-06-16T00:00:00"},
-      "end": {"localDate": "2025-06-16T16:00:00"},
-      "revision": "current-revision-number"
-    }
-  }],
-  "fieldmask": "start,end"
-}
-```
-
-### 4B. Replace All Business Hours (Strategy B)
-
-#### Step 4B.1: Delete Existing Hours
-Cancel existing MASTER events using `bulkCancelEvents` API (`POST https://www.wixapis.com/calendar/v3/bulk/events/cancel`) ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-cancel-event)):
+Only then cancel obsolete unmatched events with [Bulk Cancel Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-cancel-event):
 
 ```json
 {
-  "eventIds": ["event-id-1", "event-id-2", "event-id-3", "event-id-4", "event-id-5"]
+  "eventIds": ["<obsolete-event-id>"],
+  "timeZone": "America/Chicago",
+  "returnEntity": true
 }
 ```
 
-#### Step 4B.2: Create New Business Hours
-Create `WORKING_HOURS` events for each day using `bulkCreateEvents` API (`POST https://www.wixapis.com/calendar/v3/bulk/events/create`) ([REST](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)).
+Perform a final Step 2 query to prove there are no duplicates or unwanted slots.
 
-**Each event pattern**:
-- `type`: `"WORKING_HOURS"`
-- `scheduleId`: Business schedule ID from step 1
-- `scheduleOwnerId`: `"4e0579a5-491e-4e70-a872-d097eed6e520"`
-- `externalScheduleId`: `"4e0579a5-491e-4e70-a872-d097eed6e520"`
-- `recurrenceRule`: Weekly recurring with single day
-- `start`/`end`: Business hours times
+## Troubleshooting
 
-**Note**: Create separate events for each day of the week (Monday, Tuesday, etc.).
+**`404 "Resource with <id> ID not found"`**
 
-### 5. Verify Final Configuration
+- Remove `resources` from the business-hours event.
+- Use the fixed UUID only to query the business schedule by `externalId`.
+- Use the returned internal `schedule.id` as `event.scheduleId`.
+- Don't add a staff resource merely to make the request pass.
 
-Query the business schedule events again to confirm:
-1. No duplicate time slots exist
-2. Each desired day has exactly one MASTER event
-3. Times match your requirements
+**`location.type` is required**
 
-### IMPORTANT NOTES
+- Remove the entire optional `location` object. Don't send `location: {}`.
 
-* **Future dates required**: Recurring events must start today or in the future
-* **Revision management**: Always use current revision numbers when updating events
-* **MASTER vs INSTANCE**: Based on observed behavior, MASTER events appear to control recurring patterns while INSTANCE events are auto-generated, but always verify current event state
-* **Default Hours Impact**: Remember that these hours will be inherited by any new staff members created after this configuration
+**`conferencingDetails.type` or provider is required**
 
-### Troubleshooting Common Issues
+- Remove the entire optional `conferencingDetails` object. Working-hours events don't need conferencing details.
 
-**"App not installed" Error (428):**
-- Install Wix Bookings app using Apps Installer API
-- Verify installation by querying existing services
+**App not installed (`428`)**
 
-**Duplicate time slots in dashboard:**
-- **Root Cause**: You created new events without handling existing default hours
-- **Solution**: Query MASTER events to find duplicates and cancel unwanted ones
-- Each day should have only one MASTER event unless split hours are needed
+- Install Wix Bookings, then query the business schedule again.
 
-**Updates not reflecting in dashboard:**
-- Verify you're updating MASTER events, not INSTANCE events
-- Check that revision numbers are current
-- Confirm `fieldmask` includes the fields you're changing
+**Duplicate time slots**
 
-**Cannot create events in the past:**
-- Set `start.localDate` to current date or future
-- Recurring events automatically generate past INSTANCE events
+- Query all `MASTER` events, verify the desired events, then cancel only obsolete events.
 
-**Business schedule not found:**
-- Query schedules using the fixed external ID: `4e0579a5-491e-4e70-a872-d097eed6e520`
-- Ensure Wix Bookings is installed (schedule is created when Bookings is installed)
+**Updates don't appear in the dashboard**
 
-**Working hours not affecting staff/services:**
-- Default hours only apply to staff using `usesDefaultWorkingHours: true`
-- Services with custom schedules ignore default business hours
-- Staff with assigned custom schedules override default hours
+- Confirm you updated `MASTER`, not generated `INSTANCE`, events.
+- Refresh revisions before updating and put `fieldmask` inside each `events[]` item.
+- Re-query the Calendar API, then confirm the dashboard state.
 
-### Common Gotchas
+**Cannot create a recurring event in the past**
 
-1. **Skipping the Query Step**: Never assume no hours exist - always query first
-2. **Creating Without Cleaning**: Adding new hours without removing defaults creates duplicates
-3. **Wrong Event Type**: Using INSTANCE instead of MASTER events for queries/updates
-4. **Missing Revision Numbers**: Updates require current revision numbers from the query response
+- Use a current or future `start.localDate` that matches the recurrence weekday.
 
-## API Documentation References
+**Hours don't affect a staff member or service**
 
-* [Query Schedules](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)
-* [Query Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/query-events)
-* [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)
-* [Bulk Update Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)
-* [Bulk Cancel Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-cancel-event)
-* [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)
+- Default hours apply only to staff using `usesDefaultWorkingHours: true`.
+- Custom staff or service schedules override default business hours.
+
+## API documentation references
+
+- [Query Schedules](https://dev.wix.com/docs/api-reference/business-management/calendar/schedules-v3/query-schedules)
+- [Query Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/query-events)
+- [Bulk Create Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event)
+- [Bulk Update Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-update-event)
+- [Bulk Cancel Events](https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-cancel-event)
+- [Apps Installer API](https://dev.wix.com/docs/api-reference/business-management/app-installation/install-app)

--- a/yaml/wix-manage-evals/calendar/configure-default-business-hours.yml
+++ b/yaml/wix-manage-evals/calendar/configure-default-business-hours.yml
@@ -1,0 +1,49 @@
+name: calendar/configure-default-business-hours
+description: >-
+  Verifies that the agent configures Bookings default business hours with the
+  business schedule's internal ID, a minimal WORKING_HOURS event shape, and safe
+  reconciliation that preserves existing hours until replacements are proven.
+triggerPrompt: >-
+  This is a dedicated test site. Set Wix Bookings default business hours to
+  Monday through Friday from 5:00 PM to 8:00 PM and Saturday through Sunday from
+  8:00 AM to 8:00 PM in America/Chicago. I explicitly authorize the mutation.
+  Verify the final MASTER working-hours events when you finish.
+tags: [calendar, bookings]
+siteSetup:
+  mode: template
+  templateId: bookings-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/calendar/skills/configure-default-business-hours
+  - tool: ExecuteWixAPI
+    params:
+      hasMutations: true
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 4096
+    prompt: |
+      The user authorized configuring Bookings default business hours on a
+      dedicated test site and required final verification.
+
+      Pass only if the transcript shows that the agent:
+      - queries the business schedule using externalId
+        `4e0579a5-491e-4e70-a872-d097eed6e520`, then uses the returned
+        site-specific `schedule.id` as each event's `scheduleId`, AND
+      - successfully creates or updates recurring MASTER `WORKING_HOURS` events
+        for all seven requested days and verifies the final state by querying
+        it, AND
+      - reports Monday-Friday 17:00-20:00 and Saturday-Sunday 08:00-20:00 in
+        America/Chicago, with no failed bulk items, AND
+      - does not send the fixed external ID or an arbitrary staff ID in
+        `resources`, and does not send `externalScheduleId` or
+        `scheduleOwnerId`, AND
+      - omits unnecessary optional parent objects such as `location`,
+        `participants`, and `conferencingDetails`, AND
+      - does not cancel all existing hours before a successful create/update and
+        verification has established the replacement state.
+
+      Fail if any write ends in an API or item-level error, if the response only
+      explains what to do without completing the mutation, if final state isn't
+      queried, if fewer than seven requested MASTER events are verified, or if
+      the site is left without its prior working hours after a failed write.


### PR DESCRIPTION
Automation: feedback-to-fix

Opened by: AI agent on behalf of Guy Sopher

## Summary

Corrects the Wix Manage default-business-hours recipe so Calendar Events V3 writes use the business schedule's site-specific internal ID and a minimal `WORKING_HOURS` event shape. It also makes reconciliation create/update-and-verify before canceling obsolete events, and adds an isolated-site mutation eval.

## Research record

- Conversation: https://wix-bo.com/ai-assistant/conversations/0faa5930-96fe-43c0-b71f-ca01ad59ff8b
- Failing assistant message: `118d1067-f594-46c5-9fcd-c13294899ad4`
- Request ID: `1785173730.4229844959121364`
- ExecuteWixAPI failure log: `da7e0fed-6316-42fd-8e1c-a05374911ac0`
- Activated recipe log: `773a85d3-adb0-4439-84db-f1b232fd06e8`

The served recipe called `4e0579a5-491e-4e70-a872-d097eed6e520` a fixed business **resource** ID and provided no concrete create body. The assistant copied that UUID into `resources[].id`, `externalScheduleId`, and `scheduleOwnerId`. Query Schedules found one schedule, Query Events found seven `WORKING_HOURS` masters, and Bulk Cancel canceled all seven; Bulk Create then failed `404 Resource with 4e0579a5-491e-4e70-a872-d097eed6e520 ID not found`.

This is a true issue, not unsupported feedback: the tool trace contains the exact request body, successful destructive calls, and failed create response. The assistant's final response also acknowledged that it did not recreate the hours.

### Source-of-truth proof

- Calendar's business-schedule guide says the UUID is the schedule `externalId` and that creates use the business schedule's internal `id` as `scheduleId`: https://github.com/wix-private/scheduler/blob/c2105f85601f1c165e7a3afb5e08213e0d966104/bookings-backend/calendar-3/docs/BusinessScheduleManagement.md#L3-L35
- Events validation rejects every supplied resource ID missing from the site's resource map with this exact 404: https://github.com/wix-private/scheduler/blob/c2105f85601f1c165e7a3afb5e08213e0d966104/bookings-backend/calendar-3/events/src/com/wixpress/calendar/events/v3/EventsService.scala#L466-L471
- The service test asserts the same missing-resource behavior: https://github.com/wix-private/scheduler/blob/c2105f85601f1c165e7a3afb5e08213e0d966104/bookings-backend/calendar-3/events/test/com/wixpress/calendar/events/v3/CreateEventTest.scala#L375-L378
- The public service contract states that a recurring event requires only `scheduleId`, `start`, `end`, plus `recurrenceRule.frequency` and `days`; nested required annotations are conditional: https://github.com/wix-private/scheduler/blob/c2105f85601f1c165e7a3afb5e08213e0d966104/bookings-backend/calendar-3/events/proto/wix/calendar/events/v3/events_service.proto#L190-L216

### Frequency

Agent-platform logs for 2026-07-20 through 2026-07-27 contain 42 occurrences of this exact missing-resource error across 40 conversations. This is systemic rather than a one-off request mistake.

### Exact-path reproduction

Reproduced with the production Aria unified-assistant version on an owner-controlled Bookings test site using the same recipe, SearchWixAPISpec, and ExecuteWixAPI path:

- https://wix-bo.com/ai-assistant/conversations/1f14ccab-ad5f-4863-9b5f-111ec73aa834
- https://wix-bo.com/ai-assistant/conversations/9c24e39a-59dc-41e2-abfb-4059d3a3e5b4

The recipe caused create attempts to fail on invented optional objects (`location.type` and conferencing validation). It had already canceled the five defaults, demonstrating the cancel-first data-loss risk. A later retry restored and verified seven events, but only by inventing an arbitrary staff resource and still using `externalScheduleId`/`scheduleOwnerId`; that is not the supported business-hours contract. The test site's final query verified all seven hours were restored.

Sanitized reproduction transcript:

1. User authorized setting seven default business-hours events on a dedicated test site.
2. Agent queried the fixed external ID and found the internal business schedule.
3. Agent queried five existing masters and canceled them.
4. Bulk Create failed because optional schema objects were instantiated with invalid nested fields.
5. Agent retried until it restored seven events, but attached an unrelated Bookings resource.

## Changes

- Relabel the fixed UUID as the schedule lookup key only.
- Explicitly use the returned per-site `schedule.id` as `event.scheduleId`.
- Provide minimal verified Bulk Create and per-item Bulk Update bodies.
- Explicitly omit resources and inherited/server-populated optional fields.
- Explain conditional nested `required` annotations and the observed errors.
- Reconcile safely: update/create desired hours, verify, then cancel obsolete events and verify again.
- Add a fresh `bookings-editor` mutation eval that requires doc activation, a real write, seven verified masters, correct IDs/shape, and safe ordering.

## Related work

PR #443 independently identified the resource-ID mislabel but has no required eval and its gate is failing. This is a separate issue-scoped PR for this feedback item; it incorporates the source research, adds the mandatory mutation eval, corrects the misplaced Bulk Update `fieldmask`, and covers cancel-first safety. It does not add this issue to another PR.

## Validation

- `git diff --check` — pass
- YAML parses and its schema-shape/coverage URL were checked locally — pass
- Canonical coverage URL matches `yaml/wix-manage/calendar/documentation.yaml` — pass
- Production-path reproduction completed; owner-controlled test site restored to seven verified masters
- `yarn install --immutable` for the local EvalForge package could not fetch dependencies because the registry connection returned `ENOTCONN`; the PR's EvalForge gate is the authoritative schema and PR-vs-production mutation run

No eval threshold, assertion, or existing test was weakened.

## PR override result

EvalForge compared the PR override to production on the isolated `bookings-editor` scenario:

- PR: all assertions passed; LLM judge **10/10**; 181,981 tokens; $0.3845; 54.4s
- Production: LLM judge **2/10**; it sent `externalScheduleId` and canceled existing hours before establishing the replacement state; 345,777 tokens; $0.7134; 61.6s
- Pairwise verdict: **PR wins with high confidence** across task completion, tool accuracy, error handling, and efficiency
- PR run: https://bo.wix.com/pages/evalforge/926d0e11-32bb-4d85-b302-e0b9a5cf40e9/results?runId=e5bab6b4-b071-4cae-a7d4-ec7a3b6e39de
- Production run: https://bo.wix.com/pages/evalforge/926d0e11-32bb-4d85-b302-e0b9a5cf40e9/results?runId=ee3651f7-de63-4c27-947c-e1192b053c4f
