### PR TITLE
feat(ci): add EvalForge actions CI gate; fix stale evalforge-yaml-gate dist

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34177,11 +34177,15 @@ const SYSTEM_LLM_JUDGE = 'system:llm_judge';
 const SYSTEM_API_CALL = 'system:api_call';
 const SYSTEM_COST = 'system:cost';
 const SYSTEM_TIME_LIMIT = 'system:time_limit';
+const SYSTEM_SKILL_WAS_CALLED = 'system:skill_was_called';
+const SYSTEM_BUILD_PASSED = 'system:build_passed';
+const SYSTEM_TOKEN_COUNT = 'system:token_count';
 function toEvalForgeBody(s) {
     return {
         name: s.name,
         description: s.description,
         triggerPrompt: s.triggerPrompt,
+        ...(s.templateId ? { templateId: s.templateId } : {}),
         assertionLinks: s.assertions.map(mapAssertion),
         siteSetup: s.siteSetup ? mapSiteSetup(s.siteSetup) : { mode: 'NONE' },
     };
@@ -34218,6 +34222,12 @@ function mapAssertion(a) {
         return mapCost(a);
     if ((0, schema_1.isTimeLimit)(a))
         return mapTimeLimit(a);
+    if ((0, schema_1.isSkillWasCalled)(a))
+        return mapSkillWasCalled(a);
+    if ((0, schema_1.isBuildPassed)(a))
+        return mapBuildPassed(a);
+    if ((0, schema_1.isTokenCount)(a))
+        return mapTokenCount(a);
     return mapToolCall(a);
 }
 function mapToolCall(a) {
@@ -34239,9 +34249,41 @@ function mapLlmJudge(a) {
         params.maxTokens = a.maxTokens;
     if (a.temperature !== undefined)
         params.temperature = a.temperature;
+    if (a.scoringMode !== undefined)
+        params.scoringMode = a.scoringMode;
+    if (a.browserTools !== undefined)
+        params.browserTools = a.browserTools;
+    if (a.parameters !== undefined)
+        params.parameters = JSON.stringify(a.parameters);
     if (a.negate !== undefined)
         params.negate = a.negate;
     return { assertionId: SYSTEM_LLM_JUDGE, params };
+}
+function mapSkillWasCalled(a) {
+    const params = { skillNames: JSON.stringify(a.skillNames) };
+    if (a.referenceFiles !== undefined)
+        params.referenceFiles = JSON.stringify(a.referenceFiles);
+    if (a.negate !== undefined)
+        params.negate = a.negate;
+    return { assertionId: SYSTEM_SKILL_WAS_CALLED, params };
+}
+function mapBuildPassed(a) {
+    const params = {};
+    if (a.command !== undefined)
+        params.command = a.command;
+    if (a.expectedExitCode !== undefined)
+        params.expectedExitCode = a.expectedExitCode;
+    if (a.negate !== undefined)
+        params.negate = a.negate;
+    return Object.keys(params).length > 0
+        ? { assertionId: SYSTEM_BUILD_PASSED, params }
+        : { assertionId: SYSTEM_BUILD_PASSED };
+}
+function mapTokenCount(a) {
+    const params = { maxTokens: a.maxTokens };
+    if (a.negate !== undefined)
+        params.negate = a.negate;
+    return { assertionId: SYSTEM_TOKEN_COUNT, params };
 }
 function mapApiCall(a) {
     const params = {
@@ -34636,6 +34678,9 @@ exports.isApiCall = isApiCall;
 exports.isCost = isCost;
 exports.isTimeLimit = isTimeLimit;
 exports.isToolCall = isToolCall;
+exports.isSkillWasCalled = isSkillWasCalled;
+exports.isBuildPassed = isBuildPassed;
+exports.isTokenCount = isTokenCount;
 exports.parseScenario = parseScenario;
 const zod_1 = __nccwpck_require__(822);
 const jsYaml = __importStar(__nccwpck_require__(3691));
@@ -34661,6 +34706,14 @@ const ToolCallAssertionSchema = zod_1.z.object({
     params: zod_1.z.record(zod_1.z.string(), ParamValueSchema).optional(),
     negate: zod_1.z.boolean().optional(),
 }).strict();
+const AssertionParameterSchema = zod_1.z.object({
+    name: zod_1.z.string().min(1),
+    label: zod_1.z.string().min(1),
+    type: zod_1.z.enum(['string', 'number', 'boolean']),
+    required: zod_1.z.boolean(),
+    defaultValue: zod_1.z.union([zod_1.z.string(), zod_1.z.number(), zod_1.z.boolean()]).optional(),
+    advanced: zod_1.z.boolean().optional(),
+}).strict();
 const LlmJudgeAssertionSchema = zod_1.z.object({
     type: zod_1.z.literal('llm_judge'),
     prompt: zod_1.z.string().min(1),
@@ -34668,6 +34721,9 @@ const LlmJudgeAssertionSchema = zod_1.z.object({
     model: zod_1.z.string().optional(),
     maxTokens: zod_1.z.number().int().positive().optional(),
     temperature: zod_1.z.number().min(0).max(1).optional(),
+    scoringMode: zod_1.z.enum(['numeric', 'boolean']).optional(),
+    browserTools: zod_1.z.boolean().optional(),
+    parameters: zod_1.z.array(AssertionParameterSchema).optional(),
     negate: zod_1.z.boolean().optional(),
 }).strict();
 const ApiCallAssertionSchema = zod_1.z.object({
@@ -34690,12 +34746,32 @@ const TimeLimitAssertionSchema = zod_1.z.object({
     maxDurationMs: zod_1.z.number().int().positive(),
     negate: zod_1.z.boolean().optional(),
 }).strict();
+const SkillWasCalledAssertionSchema = zod_1.z.object({
+    type: zod_1.z.literal('skill_was_called'),
+    skillNames: zod_1.z.array(zod_1.z.string().min(1)).min(1),
+    referenceFiles: zod_1.z.record(zod_1.z.string(), zod_1.z.array(zod_1.z.string().min(1)).min(1)).optional(),
+    negate: zod_1.z.boolean().optional(),
+}).strict();
+const BuildPassedAssertionSchema = zod_1.z.object({
+    type: zod_1.z.literal('build_passed'),
+    command: zod_1.z.string().optional(),
+    expectedExitCode: zod_1.z.number().int().optional(),
+    negate: zod_1.z.boolean().optional(),
+}).strict();
+const TokenCountAssertionSchema = zod_1.z.object({
+    type: zod_1.z.literal('token_count'),
+    maxTokens: zod_1.z.number().int().positive(),
+    negate: zod_1.z.boolean().optional(),
+}).strict();
 const AssertionSchema = zod_1.z.union([
     ToolCallAssertionSchema,
     LlmJudgeAssertionSchema,
     ApiCallAssertionSchema,
     CostAssertionSchema,
     TimeLimitAssertionSchema,
+    SkillWasCalledAssertionSchema,
+    BuildPassedAssertionSchema,
+    TokenCountAssertionSchema,
 ]);
 // Optional per-scenario site provisioning. Only `template` mode is supported.
 const SiteBootstrapStepSchema = zod_1.z.object({
@@ -34718,6 +34794,9 @@ exports.ScenarioSchema = zod_1.z.object({
     name: zod_1.z.string().min(1).regex(NamePattern, 'name must match /^[a-z0-9][a-z0-9/_-]*$/'),
     description: zod_1.z.string(),
     triggerPrompt: zod_1.z.string().min(10),
+    // Optional scenario-level template the run scaffolds from (an EvalForge template
+    // id/alias). Distinct from `siteSetup` (which provisions a site). Omit when unused.
+    templateId: zod_1.z.string().min(1).optional(),
     tags: zod_1.z.array(zod_1.z.string().min(1)).min(1).refine(tags => tags.every(t => !exports.RESERVED_TAG_PREFIXES.some(p => t.startsWith(p)) && !exports.RESERVED_TAGS.some(r => t === r)), { message: 'tags must not include reserved namespaces (draft:*, pending:*, rejected:*, repo:*) or reserved tags (created-via-code) — the action manages those' }),
     maxTokens: zod_1.z.number().int().positive().optional(),
     assertions: zod_1.z.array(AssertionSchema).min(1),
@@ -34746,6 +34825,15 @@ function isTimeLimit(a) {
 }
 function isToolCall(a) {
     return a.type === undefined || a.type === 'tool_called_with_param';
+}
+function isSkillWasCalled(a) {
+    return a.type === 'skill_was_called';
+}
+function isBuildPassed(a) {
+    return a.type === 'build_passed';
+}
+function isTokenCount(a) {
+    return a.type === 'token_count';
 }
 function parseScenario(raw) {
     // CORE_SCHEMA refuses unsafe YAML tags (e.g. !!js/function); defense in depth before Zod.

--- a/.github/workflows/evalforge-actions-ci.yml
+++ b/.github/workflows/evalforge-actions-ci.yml
@@ -1,0 +1,53 @@
+name: EvalForge Actions CI
+
+on:
+  pull_request:
+    paths:
+      - 'packages/evalforge-core/**'
+      - '.github/actions/evalforge-yaml-gate/**'
+      - '.github/actions/evalforge-skill-gate/**'
+      - '.github/workflows/evalforge-actions-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+
+      # Built first (and not typecheck'd/tested in isolation from the others) because the
+      # actions below depend on it via a `portal:` link — their typecheck resolves
+      # @wix/evalforge-core to this package's dist/index.d.ts, so it must exist first.
+      - name: evalforge-core — install, typecheck, test, build
+        working-directory: packages/evalforge-core
+        run: |
+          node .yarn/releases/yarn-*.cjs install --immutable
+          node .yarn/releases/yarn-*.cjs typecheck
+          node .yarn/releases/yarn-*.cjs test
+          node .yarn/releases/yarn-*.cjs build
+
+      - name: evalforge-yaml-gate — install, typecheck, test, verify dist is committed
+        working-directory: .github/actions/evalforge-yaml-gate
+        run: |
+          node .yarn/releases/yarn-*.cjs install --immutable
+          node .yarn/releases/yarn-*.cjs typecheck
+          node .yarn/releases/yarn-*.cjs test
+          node .yarn/releases/yarn-*.cjs build
+          git diff --exit-code dist/index.js
+
+      # Guarded on the directory existing: this workflow lands before the action itself does.
+      - name: evalforge-skill-gate — install, typecheck, test, verify dist is committed
+        if: ${{ hashFiles('.github/actions/evalforge-skill-gate/package.json') != '' }}
+        working-directory: .github/actions/evalforge-skill-gate
+        run: |
+          node .yarn/releases/yarn-*.cjs install --immutable
+          node .yarn/releases/yarn-*.cjs typecheck
+          node .yarn/releases/yarn-*.cjs test
+          node .yarn/releases/yarn-*.cjs build
+          git diff --exit-code dist/index.js


### PR DESCRIPTION
## What & why
Found while investigating why #731's checks weren't showing up: there is
**no CI workflow at all** covering `packages/evalforge-core` or the
`.github/actions/evalforge-yaml-gate`/`evalforge-skill-gate` actions. Every
"typecheck clean" / "N/N tests passing" / "dist rebuilt" claim in recent PRs
touching these (e.g. #696, #731) has come from a manual local run by the PR
author — never enforced by CI.

## Changes
- New `.github/workflows/evalforge-actions-ci.yml`, triggered on PRs touching
  `packages/evalforge-core/**` or either `evalforge-*-gate` action. Builds
  `evalforge-core` first (both actions resolve `@wix/evalforge-core` to its
  `dist/index.d.ts`/`dist/index.js` via a `portal:` link, so it has to exist
  before the actions' own typecheck/build can succeed), then for each action:
  install, typecheck, test, build, and fail if the rebuilt `dist/index.js`
  differs from what's committed. Modeled on the existing `skill-eval-ci.yml`.
- The `evalforge-skill-gate` step is guarded on the directory existing
  (`hashFiles(...) != ''`) since this workflow lands before that action does.

## A live bug this surfaced
Running the new "dist must match a fresh build" check against unmodified
`main` failed immediately: `evalforge-yaml-gate/dist/index.js` was already
stale. It predates `evalforge-core`'s `skill_was_called`/`build_passed`/
`token_count` assertions, scenario-level `templateId`, and the `llm_judge`
`scoringMode`/`browserTools`/`parameters` fields — all landed in `evalforge-core`
source via #689, never bundled into the action that actually runs in CI. Any
scenario YAML using those would fail schema validation today, not because the
YAML is wrong but because the live gate is executing dead code. Rebuilt here
so the new check starts green and those fields actually work.

## Testing
- `evalforge-core`: 101/101 passing, typecheck clean.
- `evalforge-yaml-gate`: 98/98 passing, typecheck clean, `yarn build` output
  now matches the committed `dist/index.js` exactly (verified by re-running
  the build against the committed state after this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)