### PR TITLE
🦞 igor-claw: Add "Diagnose Stale Content After Publish" recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -256,6 +256,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Site Import](references/sites/site-import.md)
 **Technical:** Drives the autonomous Wix Site Import agent over REST (`/site-import/v1/imports`) to migrate a store/site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix. Covers Start/Poll/Reply/Cancel, relaying agent questions and progress in plain language, handling `DEPLOYED`/`FAILED`/`AUTH_EXPIRED`/`SESSION_EXPIRED` states, and post-deploy follow-up changes. Use when the user wants to import, migrate, or clone an existing store/site into Wix.
 
+### [Diagnose Stale Content After Publish](references/sites/verify-published-content-staleness.md)
+**Technical:** Use when a fetch of a published page's public URL shows outdated content (old text, old nav links) even though the site owner confirms the edit is live in their own browser. Covers the cache-busting query-param check that separates CDN/edge cache staleness (self-healing, not a real bug) from a genuine content problem — never conclude a publish failed from a single plain fetch.
+
 ---
 
 ## Stores

--- a/skills/wix-manage/references/sites/verify-published-content-staleness.md
+++ b/skills/wix-manage/references/sites/verify-published-content-staleness.md
@@ -1,0 +1,68 @@
+---
+name: "Diagnose Stale Content After Publish"
+description: What to do when a site owner or an automated fetch of a published page's public URL shows outdated content (old text, old nav links) even though the Editor confirms the edit is published and correct. Covers the cache-busting query-param check that definitively separates CDN/edge cache staleness from a real content problem, and why it self-heals.
+---
+# Diagnose Stale Content After Publish
+
+## Symptom
+
+A site owner edits content in the Wix Editor and publishes. They confirm in their own
+browser — including after a hard refresh — that the change is live. But a **separate,
+automated fetch** of the exact same public URL (a `curl`/`WebFetch` call, a monitoring
+check, another agent) returns the **pre-edit** version: old text, or stale nav/menu
+links from before a page rename. Repeated fetches over the following several minutes
+can keep returning the same stale bytes, even though the owner's hard refresh already
+shows the new version.
+
+This is not limited to page text — the same pattern shows up for Stores: a deleted
+product can keep rendering on the storefront and its own product-page URL after it's
+confirmed gone from the Catalog API (see
+[Delete Product (Catalog V1)](delete-product-catalog-v1.md)).
+
+## Root cause
+
+Published Wix sites are served through a multi-tier public cache chain (CDN edge →
+internal edge cache → the renderer origin), not directly from the renderer on every
+request. Publishing emits an async cache-invalidation event for the affected content,
+but that invalidation is decoupled from the publish itself — it can lag, or a specific
+cache entry (e.g. one page's route, one product's listing) can miss invalidation while
+sibling content on the same site is invalidated correctly. This is why nav links or one
+page can be stale while other pages on the same site are already fresh. It is a known,
+self-healing class of cache-propagation delay, not data loss — the affected entry's TTL
+expires and it corrects itself, typically within minutes and almost always within a few
+days.
+
+## How to tell definitively: cache-bust before concluding anything is broken
+
+Never conclude a publish failed, or that content is "inconsistent between servers,"
+from a single plain fetch of the public URL. Add a random, unused query parameter and
+re-fetch:
+
+```
+https://example.com/some-page?_cachebust=<random-string>
+```
+
+- If the cache-busted fetch returns the **new** content → this **was** cache staleness,
+  not a real problem. Report it as such; do not treat it as a data or publish bug.
+- If the cache-busted fetch **still** returns the **old** content → this is not caching;
+  escalate as a genuine content/publish problem instead.
+
+A single stale plain fetch is expected and not actionable by itself. Only treat it as a
+real bug if the cache-busted re-fetch is *also* stale, or if the same URL is still stale
+after re-checking a few minutes later.
+
+## What to do about it
+
+- **Nothing is required** — the affected entry clears itself as its cache TTL expires.
+- If it must resolve immediately, republishing the site (`POST` the site's publish
+  endpoint via the Sites API, or `ManageWixSite`) busts the cache faster than waiting
+  out the TTL.
+- Don't tell the site owner their edit was lost or ask them to redo it — the Editor/CMS
+  state is already correct; only the public-facing cached copy is behind.
+
+## References
+
+- [Delete Product (Catalog V1)](delete-product-catalog-v1.md) — same root-cause class
+  applied to storefront product listings.
+- [Query Sites](query-sites.md) / [Create Site from Template](create-site-from-template.md)
+  — for republishing via the Sites API.

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -14,3 +14,7 @@ apiDoc:
       title: Site Import
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
       tags: [sites]
+    - file: ../../../skills/wix-manage/references/sites/verify-published-content-staleness.md
+      title: Diagnose Stale Content After Publish
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
+      tags: [sites]


### PR DESCRIPTION
## What's broken

Follow-up to the ZZTEST/[#735](https://github.com/wix/skills/pull/735) storefront-staleness report on the same site ("West Coast Wear Products"): a site owner edited and published a page's body text, confirmed it live in their own browser (incl. hard refresh) — but four separate automated fetches of the same public URL over ~15-20 minutes kept returning the pre-edit text and stale nav links, while sibling pages on the same site were already showing fresh content.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1785191274537679

## Root cause

Published sites are served through a multi-tier public cache chain (Fastly CDN → internal edge/Varnish cache → renderer origin — confirmed via response headers: `server: Pepyaka`, `server-timing: cache;desc=miss, varnish;desc=miss_hit, dc;desc=fastly_g`). Publish emits an async cache-invalidation event decoupled from the publish itself, and per Wix's own SSR-cache oncall runbook (`comp/meta_site/docs/developers/oncall/clear-ssr-cache.md`), "Missing invalidation in some flow" and "Race condition in invalidation" are documented common causes of exactly this symptom — one cache tag/route missing invalidation while others succeed. It's a known, self-healing propagation-lag class, not data loss; re-fetching the same URL later in this session showed it had already resolved.

This is a platform-level CDN/cache-invalidation issue, not a single-line bug — no PR opened against that layer (see "Not fixed" below).

## The fix (this PR)

The Wix MCP / `WixREADME` skill index had no guidance for this. Any agent (like the one that filed this report) that fetches a public URL to confirm a publish will occasionally hit this transient staleness and can misreport it as a broken publish or a data-consistency bug. Wix's own SREs already have the right diagnostic — a cache-busting query param — documented internally; this PR surfaces that same technique as a `skills/wix-manage` recipe so agents definitively distinguish CDN staleness (self-heals, not actionable) from a genuine content bug, instead of concluding from a single plain fetch that something is broken.

Adds `skills/wix-manage/references/sites/verify-published-content-staleness.md`, wired into `SKILL.md` and `yaml/wix-manage/sites/documentation.yaml`.

## Not fixed here (needs a platform owner, not a skills PR)

The underlying CDN/SSR-cache invalidation race itself lives in `comp/meta_site` (Fastly/Varnish/MPP chain, owned by `@wix-private/ot-meta-site`) — no concrete single-cause fix was found to PR; the oncall runbook itself says the race-condition case has "no easy way [to confirm], check code/flow and try to write a test." Flagging for that team's awareness rather than guessing at a fix.

---
This PR was opened automatically by an AI agent acting on behalf of Ayal (ayalg@wix.com), researching MCP feedback.