### PR TITLE
fix(wix-manage): create headless sites via ProvisionHeadlessBusiness

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -248,7 +248,10 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Sites
 
 ### [Create Site from Template](references/sites/create-site-from-template.md)
-**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless business provisioning, and publishing.
+**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, and publishing. Not for headless sites.
+
+### [Create Headless Site](references/sites/create-headless-site.md)
+**Technical:** Creates a Wix Headless site (headless business) with one account-level API call — site, Wix Business Solution apps, and a configured OAuth client.
 
 ### [Query Sites](references/sites/query-sites.md)
 **Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -248,7 +248,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Sites
 
 ### [Create Site from Template](references/sites/create-site-from-template.md)
-**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless site setup, OAuth app creation, and publishing.
+**Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless business provisioning, and publishing.
 
 ### [Query Sites](references/sites/query-sites.md)
 **Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.

--- a/skills/wix-manage/references/sites/create-headless-site.md
+++ b/skills/wix-manage/references/sites/create-headless-site.md
@@ -1,0 +1,52 @@
+---
+name: "Create Headless Site"
+description: Creates a Wix Headless site (headless business) with one account-level API call — site, Wix Business Solution apps, and a configured OAuth client.
+---
+# Create Headless Site
+
+Headless sites are not created from templates. One account-level call creates the site, installs the requested Wix Business Solution apps, and creates and configures the site's OAuth client.
+
+> Do NOT use the [Create Site from Template](create-site-from-template.md) API for headless sites — it only tags the site's namespace and skips the headless setup entirely.
+
+## Prerequisites
+
+- Wix account with site creation permissions
+- Account-level API access
+
+## Provision a Headless Business
+
+**Endpoint**: `POST https://www.wixapis.com/headless-business-setup/v1/headless-business/provision`
+
+**Request Body**:
+```json
+{
+  "newMetasite": {
+    "namingStrategy": { "metaSiteName": "My Headless Business" },
+    "seedOptions": [
+      { "businessSolution": "STORES", "clearTemplateContent": true, "seedDemoContent": false }
+    ]
+  },
+  "synchronousSteps": ["SET_METASITE_NAME", "CONFIGURE_HEADLESS_APP"]
+}
+```
+
+- `namingStrategy` — exactly one of: `metaSiteName` (exact display name), `llmPromptBasedName: {}` (name derived from the top-level `prompt` field), or `defaultName: {}`
+- `seedOptions` — Wix Business Solution apps to install at creation: `STORES`, `BLOG`, `BOOKINGS`, `EVENTS`, `PORTFOLIO`, `PRICING_PLANS`. Each entry takes `clearTemplateContent` (remove sample content) and `seedDemoContent` (seed demo content). Empty installs none
+- `synchronousSteps` — steps to complete before the call returns: `SET_METASITE_NAME`, `CONFIGURE_HEADLESS_APP`, `SEED_CONTENT`. Omitted steps run asynchronously. Include `CONFIGURE_HEADLESS_APP` when the OAuth client must be usable immediately
+
+**Response**:
+```json
+{ "metaSiteId": "<SITE_ID>", "appId": "<OAUTH_CLIENT_ID>" }
+```
+
+`appId` is the site's OAuth client ID — do NOT create a separate OAuth app.
+
+## Existing Sites
+
+To provision headless onto an existing site, pass `"existingMetasite": {}` instead of `newMetasite`. This is a site-level call in the context of that site.
+
+## Next Steps
+
+After creating the site:
+- Install additional apps using [Install Wix Apps](../app-installation/install-wix-apps.md)
+- Add content (products, services, blog posts, etc.)

--- a/skills/wix-manage/references/sites/create-site-from-template.md
+++ b/skills/wix-manage/references/sites/create-site-from-template.md
@@ -1,6 +1,6 @@
 ---
 name: "Create Site from Template"
-description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless business provisioning, and publishing.
+description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, and publishing. Not for headless sites.
 ---
 # Create Site from Template
 
@@ -111,7 +111,7 @@ If `siteName` is not provided, one is generated automatically.
 **Response** includes the new site's `metaSiteId`.
 
 ### IMPORTANT NOTES:
-- This API creates regular Wix sites. Do NOT use it for headless sites (even with a `namespace` field) — see [Headless Sites](#headless-sites) below
+- This API creates regular Wix sites. Do NOT use it for headless sites (even with a `namespace` field) — use [Create Headless Site](create-headless-site.md) instead
 
 ---
 
@@ -135,40 +135,6 @@ curl -X POST \
 ### IMPORTANT NOTES:
 - NEVER publish without asking the user first
 - This makes the site publicly accessible
-
----
-
-## Headless Sites
-
-Headless sites are NOT created from templates. One account-level call creates the site, installs the requested Wix Business Solution apps, and creates and configures the site's OAuth client:
-
-**Endpoint**: `POST https://www.wixapis.com/headless-business-setup/v1/headless-business/provision`
-
-**Request Body**:
-```json
-{
-  "newMetasite": {
-    "namingStrategy": { "metaSiteName": "My Headless Business" },
-    "seedOptions": [
-      { "businessSolution": "STORES", "clearTemplateContent": true, "seedDemoContent": false }
-    ]
-  },
-  "synchronousSteps": ["SET_METASITE_NAME", "CONFIGURE_HEADLESS_APP"]
-}
-```
-
-- `namingStrategy` — exactly one of: `metaSiteName` (exact display name), `llmPromptBasedName: {}` (name derived from the top-level `prompt` field), or `defaultName: {}`
-- `seedOptions` — Wix Business Solution apps to install at creation: `STORES`, `BLOG`, `BOOKINGS`, `EVENTS`, `PORTFOLIO`, `PRICING_PLANS`. Each entry takes `clearTemplateContent` (remove sample content) and `seedDemoContent` (seed demo content). Empty installs none
-- `synchronousSteps` — steps to complete before the call returns: `SET_METASITE_NAME`, `CONFIGURE_HEADLESS_APP`, `SEED_CONTENT`. Omitted steps run asynchronously. Include `CONFIGURE_HEADLESS_APP` when the OAuth client must be usable immediately
-
-**Response**:
-```json
-{ "metaSiteId": "<SITE_ID>", "appId": "<OAUTH_CLIENT_ID>" }
-```
-
-`appId` is the site's OAuth client ID — do NOT create a separate OAuth app.
-
-To provision headless onto an existing site, pass `"existingMetasite": {}` instead of `newMetasite` (site-level call in the context of that site).
 
 ---
 

--- a/skills/wix-manage/references/sites/create-site-from-template.md
+++ b/skills/wix-manage/references/sites/create-site-from-template.md
@@ -1,6 +1,6 @@
 ---
 name: "Create Site from Template"
-description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless site setup, OAuth app creation, and publishing.
+description: Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, headless business provisioning, and publishing.
 ---
 # Create Site from Template
 
@@ -108,23 +108,10 @@ The `siteName` must follow these rules:
 
 If `siteName` is not provided, one is generated automatically.
 
-### For Headless Sites
-
-Add `"namespace": "HEADLESS"` to the request body:
-
-```json
-{
-  "originTemplateId": "<TEMPLATE_ID>",
-  "siteName": "my-headless-site",
-  "namespace": "HEADLESS"
-}
-```
-
 **Response** includes the new site's `metaSiteId`.
 
 ### IMPORTANT NOTES:
-- Only mention headless if user specifically requests it
-- If user doesn't ask for headless, do NOT include the `namespace` field
+- This API creates regular Wix sites. Do NOT use it for headless sites (even with a `namespace` field) — see [Headless Sites](#headless-sites) below
 
 ---
 
@@ -151,13 +138,37 @@ curl -X POST \
 
 ---
 
-## Step 5: For Headless Sites - Create OAuth App
+## Headless Sites
 
-If the site was created as headless, you MUST create an OAuth app for authentication.
+Headless sites are NOT created from templates. One account-level call creates the site, installs the requested Wix Business Solution apps, and creates and configures the site's OAuth client:
 
-See [Create OAuth App](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/create-oauth-app) documentation.
+**Endpoint**: `POST https://www.wixapis.com/headless-business-setup/v1/headless-business/provision`
 
-This is a site-level call in the context of the newly created site.
+**Request Body**:
+```json
+{
+  "newMetasite": {
+    "namingStrategy": { "metaSiteName": "My Headless Business" },
+    "seedOptions": [
+      { "businessSolution": "STORES", "clearTemplateContent": true, "seedDemoContent": false }
+    ]
+  },
+  "synchronousSteps": ["SET_METASITE_NAME", "CONFIGURE_HEADLESS_APP"]
+}
+```
+
+- `namingStrategy` — exactly one of: `metaSiteName` (exact display name), `llmPromptBasedName: {}` (name derived from the top-level `prompt` field), or `defaultName: {}`
+- `seedOptions` — Wix Business Solution apps to install at creation: `STORES`, `BLOG`, `BOOKINGS`, `EVENTS`, `PORTFOLIO`, `PRICING_PLANS`. Each entry takes `clearTemplateContent` (remove sample content) and `seedDemoContent` (seed demo content). Empty installs none
+- `synchronousSteps` — steps to complete before the call returns: `SET_METASITE_NAME`, `CONFIGURE_HEADLESS_APP`, `SEED_CONTENT`. Omitted steps run asynchronously. Include `CONFIGURE_HEADLESS_APP` when the OAuth client must be usable immediately
+
+**Response**:
+```json
+{ "metaSiteId": "<SITE_ID>", "appId": "<OAUTH_CLIENT_ID>" }
+```
+
+`appId` is the site's OAuth client ID — do NOT create a separate OAuth app.
+
+To provision headless onto an existing site, pass `"existingMetasite": {}` instead of `newMetasite` (site-level call in the context of that site).
 
 ---
 


### PR DESCRIPTION
## Problem

The create-site-from-template recipe created "headless" sites via the generic meta-site API with `namespace: HEADLESS` — that only tags a regular template clone. None of the real headless setup happens (companion app, OAuth client, Wix Business Solution installs), and step 5 then had the agent create a standalone OAuth app, which is the legacy shape.

Context: https://wix.slack.com/archives/C0BCMUDTZPV/p1785156966027839

## Change

Headless creation isn't "create site from template" (no template search, different API, different result), so it gets its own reference:

- **New `references/sites/create-headless-site.md`** — `POST /headless-business-setup/v1/headless-business/provision`: one account-level call that creates the site, installs the requested Wix Business Solution apps (`seedOptions`), and creates + configures the site's OAuth client (returned `appId`); covers `namingStrategy`, `synchronousSteps`, and the `existingMetasite` variant
- **`create-site-from-template.md`** is templates-only again: the `namespace: HEADLESS` subsection and step 5 (standalone OAuth app) are removed, replaced by a do-not-use-for-headless note linking to the new reference
- **`SKILL.md`** index lists the new reference

## Verification

Ran end-to-end in production with a device-flow account token (required [headless-bo#767](https://github.com/wix-private/headless-bo/pull/767), GA'd as 1.143.0): provision with STORES → site + OAuth client created, Stores installed, catalog seeded per the wix-headless recipe, products queryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)