### PR TITLE
feat(wix-manage): yaml docs entry + eval scenario for Create Headless Site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,13 @@
 # AGENTS.md
 
-Read and follow `CONTRIBUTING.md` before editing this repository.
+Read and follow `CONTRIBUTING.md` before editing this repository. What it covers, one line each:
+
+- **Skill placement** — no new top-level skills (admin-only); new content goes into an existing skill (`wix-manage`, `wix-app`, `wix-design-system`, `wix-headless`), usually as a new reference.
+- **Adding a wix-manage skill** — a change is FOUR files, not one: the reference `.md` + the `SKILL.md` index entry + a `yaml/wix-manage/<area>/documentation.yaml` entry + an eval scenario under `yaml/wix-manage-evals/<area>/`.
+- **wix-manage eval scenarios** — every skill `.md` change needs a covering scenario (the PR gate fails without one): a `ReadFullDocsArticle` tool-call assertion on `<docsEntry>/skills/<slugified-title>` plus an `llm_judge`.
+- **Updating wix-app content** — same rule, different mechanics: change + `SKILL.md` index + a covering scenario under `yaml/wix-app-evals/` (`skill_was_called` + `llm_judge`), selected by tags derived from reference filenames — including negative dependencies.
+- **Writing API skills** — verify every API detail against official docs via the Wix MCP (or distill from a successful agent run); public APIs only, no internal service names; mutating flows ask the user first.
+- **Skill evaluation** — PRs touching wix-manage references or yaml run the automated eval gate: coverage → schema → execution; treat it as a loop, not a one-time check.
+- **PR checklist** — the pre-open checklist; walk it before every PR.
+
+No fork PRs for `wix-manage` changes (the eval bot can't run on forks). Descriptions ≤ 1024 chars.

--- a/yaml/wix-manage-evals/sites/create-headless-site.yml
+++ b/yaml/wix-manage-evals/sites/create-headless-site.yml
@@ -1,0 +1,41 @@
+name: sites/create-headless-site
+description: >-
+  Verifies the agent reads the create-headless-site skill and creates a headless site via the
+  Headless Business Setup provision API (one call: site + business apps + OAuth client), instead
+  of using the meta-site template API with a HEADLESS namespace or creating a standalone OAuth app.
+triggerPrompt: >-
+  Create a new Wix Headless site for my project called "Acme Storefront" with Wix Stores installed,
+  so I can build my own frontend against the Wix APIs. Explain which API call you would make, what
+  the request body looks like, and how I get the OAuth client ID my frontend needs.
+tags: [sites]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/account-level/sites/skills/create-headless-site
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants a new Wix Headless site named "Acme Storefront" with Wix Stores installed, and
+      asked which API call creates it, what the request body looks like, and where the OAuth client
+      ID comes from.
+      Intent: create the headless site with the Headless Business Setup provision API —
+      POST https://www.wixapis.com/headless-business-setup/v1/headless-business/provision — one
+      account-level call that creates the site, installs the requested business solution apps, and
+      creates + configures the site's OAuth client.
+
+      Pass if the response:
+      - creates the site with the provision endpoint (POST .../headless-business-setup/v1/headless-business/provision), AND
+      - shows a request body with a newMetasite target carrying a naming strategy (e.g.
+        metaSiteName "Acme Storefront") and a seedOptions entry installing STORES, AND
+      - says the response's appId is the site's OAuth client ID (no separate OAuth app needs to be
+        created).
+      A response that additionally asks the user to confirm before creating still PASSES, as long
+      as it describes the provision call above.
+
+      Fail if the response:
+      - creates the site with the meta-site template API (msm/v1/meta-site/create-from-template),
+        with or without a namespace: "HEADLESS" field, OR
+      - instructs creating a standalone OAuth app as a separate step, OR
+      - omits the provision endpoint or the request body shape, OR
+      - is generic with no specific endpoint.

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -10,6 +10,10 @@ apiDoc:
       title: Create Site from Template
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
       tags: [sites]
+    - file: ../../../skills/wix-manage/references/sites/create-headless-site.md
+      title: Create Headless Site
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
+      tags: [sites]
     - file: ../../../skills/wix-manage/references/sites/site-import.md
       title: Site Import
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites


### PR DESCRIPTION
Completes #737 per CONTRIBUTING.md: the new `create-headless-site.md` reference needs an entry in `yaml/wix-manage/sites/documentation.yaml` and a covering eval scenario.

- **documentation.yaml** — adds the Create Headless Site doc entry (same `docsEntry` as the other sites recipes)
- **`yaml/wix-manage-evals/sites/create-headless-site.yml`** — scenario: user asks for a headless site with Stores; passes on the provision endpoint + `newMetasite`/`seedOptions` body + appId-is-the-OAuth-client; fails on the legacy template-API-with-namespace path or a standalone OAuth app step

🤖 Generated with [Claude Code](https://claude.com/claude-code)