### PR TITLE
feat(wix-vibe-headless): dev-only Wix manage banner + entry-prompt wrap-up step

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -102,6 +102,13 @@ runtime:
    `src/rest/` folder (it does `import { wixApiRequest } from "./wix-client.js"`, so the two
    files must sit side by side).
 
+There is also an optional **manage banner** — `references/shared/wix-manage-banner.js`, a
+dev-build-only banner linking the running app to the Wix Business Manager (the back office)
+behind it. Copy it beside `wix-client.js`, set `WIX_METASITE_ID`, and call
+`mountWixManageBanner()` once from the app entry. It renders only when a dev-build flag
+(`import.meta.env.DEV`) exists and is true — never in production, and not at all on stacks
+without such a flag.
+
 Each vertical's `INSTRUCTIONS.md` is the full playbook for that solution: when to use it,
 prerequisites, the exported API, how to wire it, the hard rules, and a verification checklist.
 **Open the relevant `INSTRUCTIONS.md` before wiring** — the shapes and gotchas live there.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -157,8 +157,10 @@ Once the site is built and seeded:
 1. **Add the dev-only manage banner** (links the app to its Wix back office): copy the
    `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
    `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
-   `mountWixManageBanner()` once from the app entry. It renders only in dev builds — use it
-   as-is, don't rewrite it.
+   `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
+   builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
+   guarantee: verify the gate actually holds in this stack, and that a production build never
+   shows the banner (no dev flag → no banner at all).
 2. **Leave a brief "Wix skills" note in `AGENTS.md`** (project root) so a future session has
    context. If the file already exists, **`read_file` it first and only append your section** —
    do **not** rewrite, reorder, or remove anything already there; if you can't append cleanly,

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -154,14 +154,19 @@ one-by-one, to finish faster.
 
 Once the site is built and seeded:
 
-1. **Leave a brief "Wix skills" note in `AGENTS.md`** (project root) so a future session has
+1. **Add the dev-only manage banner** (links the app to its Wix back office): copy the
+   `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
+   `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
+   `mountWixManageBanner()` once from the app entry. It renders only in dev builds — use it
+   as-is, don't rewrite it.
+2. **Leave a brief "Wix skills" note in `AGENTS.md`** (project root) so a future session has
    context. If the file already exists, **`read_file` it first and only append your section** —
    do **not** rewrite, reorder, or remove anything already there; if you can't append cleanly,
    skip this rather than overwrite. Create the file only if none exists. Keep the note
    high-level, e.g.: the Wix skills are installed under `.agents/skills/`; the client is built
    per the `wix-vibe-headless` skill; seeding/management is done per the `wix-headless` +
    `wix-docs` skills.
-2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
+3. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
    you were given): `https://manage.wix.com/dashboard/{metaSiteId}`
 
 ## Later admin requests

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -114,7 +114,9 @@ After the site is built and seeded:
 1. **Add the dev-only manage banner** (links the app to its Wix back office): copy the
    `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
    `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
-   `mountWixManageBanner()` once from the app entry. It renders only in dev builds — use it
-   as-is, don't rewrite it.
+   `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
+   builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
+   guarantee: verify the gate actually holds in this stack, and that a production build never
+   shows the banner (no dev flag → no banner at all).
 2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
    you were given): `https://manage.wix.com/dashboard/{metaSiteId}`

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -109,5 +109,12 @@ back to the `wix-docs` skill where the operation isn't documented there.
 
 ## When done
 
-After the site is built and seeded, ask the user to open this URL to complete the setup in Wix
-(substitute the metasite id you were given): `https://manage.wix.com/dashboard/{metaSiteId}`
+After the site is built and seeded:
+
+1. **Add the dev-only manage banner** (links the app to its Wix back office): copy the
+   `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
+   `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
+   `mountWixManageBanner()` once from the app entry. It renders only in dev builds — use it
+   as-is, don't rewrite it.
+2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
+   you were given): `https://manage.wix.com/dashboard/{metaSiteId}`

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -67,7 +67,14 @@ export function mountWixManageBanner() {
     "background:#131720;color:#fff;border-radius:999px;padding:8px 18px;" +
     "font-size:14px;text-decoration:none;";
 
-  card.append(text, button);
+  const info = document.createElement("span");
+  info.textContent = "ⓘ";
+  info.title =
+    "This banner only shows while developing. Don't want it? Ask the agent in the chat to remove it.";
+  info.setAttribute("aria-label", info.title);
+  info.style.cssText = "color:#868aa5;font-size:16px;cursor:help;user-select:none;";
+
+  card.append(text, button, info);
   bar.append(card);
   document.body.append(bar);
 }

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -35,16 +35,17 @@ export function mountWixManageBanner() {
   if (typeof document === "undefined") return;
   if (document.getElementById("wix-manage-banner")) return;
 
+  // In normal flow as <body>'s first child — pushes the site down rather than
+  // floating over it.
   const bar = document.createElement("div");
   bar.id = "wix-manage-banner";
   bar.style.cssText =
-    "position:fixed;top:0;left:0;right:0;z-index:2147483647;display:flex;" +
-    "justify-content:center;padding:10px 16px;pointer-events:none;" +
+    "display:flex;justify-content:center;padding:10px 16px;background:#f4f4f7;" +
     "font-family:system-ui,-apple-system,sans-serif;";
 
   const card = document.createElement("div");
   card.style.cssText =
-    "pointer-events:auto;display:flex;align-items:center;gap:14px;" +
+    "display:flex;align-items:center;gap:14px;" +
     "background:#fff;color:#131720;border-radius:12px;padding:10px 20px;" +
     "font-size:15px;box-shadow:0 1px 4px rgba(0,0,0,.12);";
 
@@ -79,9 +80,9 @@ export function mountWixManageBanner() {
   const tip = document.createElement("span");
   tip.textContent = TIP_TEXT;
   tip.style.cssText =
-    "position:absolute;top:calc(100% + 8px);right:-8px;display:none;width:240px;" +
-    "background:#131720;color:#fff;font-size:12px;line-height:1.4;font-weight:400;" +
-    "border-radius:8px;padding:8px 12px;box-shadow:0 2px 8px rgba(0,0,0,.2);";
+    "position:absolute;top:calc(100% + 8px);right:-8px;z-index:2147483647;display:none;" +
+    "width:240px;background:#131720;color:#fff;font-size:12px;line-height:1.4;" +
+    "font-weight:400;border-radius:8px;padding:8px 12px;box-shadow:0 2px 8px rgba(0,0,0,.2);";
   info.append(tip);
   info.addEventListener("mouseenter", () => (tip.style.display = "block"));
   info.addEventListener("mouseleave", () => (tip.style.display = "none"));
@@ -90,5 +91,5 @@ export function mountWixManageBanner() {
 
   card.append(text, button, info);
   bar.append(card);
-  document.body.append(bar);
+  document.body.prepend(bar);
 }

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -1,0 +1,73 @@
+/**
+ * Dev-only manage banner — a slim banner linking the running app to the Wix
+ * Business Manager (the back office) behind it. Renders ONLY in a dev build;
+ * production builds (and stacks with no dev flag at all) never show it.
+ *
+ * Copy next to wix-client.js, set WIX_METASITE_ID, and mount once from the
+ * app entry (safe to call unconditionally — it no-ops outside dev):
+ *
+ *   import { mountWixManageBanner } from "./rest/wix-manage-banner.js";
+ *   mountWixManageBanner();
+ */
+
+/** The site's metasite id (from the same prompt that carried WIX_CLIENT_ID). */
+export const WIX_METASITE_ID = "<YOUR-METASITE-ID>";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+
+/**
+ * True only in a dev build. `import.meta.env.DEV` is Vite's flag; on bundlers
+ * without it this resolves falsy (or throws — caught), so the banner simply
+ * never renders. Do not replace this with a runtime heuristic (hostname
+ * sniffing etc.) — no flag means no banner.
+ */
+function isDevBuild() {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+export function mountWixManageBanner() {
+  if (!isDevBuild()) return;
+  if (WIX_METASITE_ID.startsWith("<")) return; // placeholder not filled in
+  if (typeof document === "undefined") return;
+  if (document.getElementById("wix-manage-banner")) return;
+
+  const bar = document.createElement("div");
+  bar.id = "wix-manage-banner";
+  bar.style.cssText =
+    "position:fixed;top:0;left:0;right:0;z-index:2147483647;display:flex;" +
+    "justify-content:center;padding:10px 16px;pointer-events:none;" +
+    "font-family:system-ui,-apple-system,sans-serif;";
+
+  const card = document.createElement("div");
+  card.style.cssText =
+    "pointer-events:auto;display:flex;align-items:center;gap:14px;" +
+    "background:#fff;color:#131720;border-radius:12px;padding:10px 20px;" +
+    "font-size:15px;box-shadow:0 1px 4px rgba(0,0,0,.12);";
+
+  const text = document.createElement("span");
+  text.append("Manage your business behind this site in Wix ");
+  const link = document.createElement("a");
+  link.href = DASHBOARD_URL;
+  link.target = "_blank";
+  link.rel = "noopener";
+  link.textContent = "business manager";
+  link.style.cssText = "color:inherit;text-decoration:underline;";
+  text.append(link);
+
+  const button = document.createElement("a");
+  button.href = DASHBOARD_URL;
+  button.target = "_blank";
+  button.rel = "noopener";
+  button.textContent = "Open";
+  button.style.cssText =
+    "background:#131720;color:#fff;border-radius:999px;padding:8px 18px;" +
+    "font-size:14px;text-decoration:none;";
+
+  card.append(text, button);
+  bar.append(card);
+  document.body.append(bar);
+}

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -67,12 +67,26 @@ export function mountWixManageBanner() {
     "background:#131720;color:#fff;border-radius:999px;padding:8px 18px;" +
     "font-size:14px;text-decoration:none;";
 
+  // The tooltip is real DOM, not a `title` attribute — native tooltips don't
+  // show inside sandboxed preview iframes (e.g. a vibe platform's app preview).
+  const TIP_TEXT =
+    "This banner only shows while developing. Don't want it? Ask the agent in the chat to remove it.";
   const info = document.createElement("span");
   info.textContent = "ⓘ";
-  info.title =
-    "This banner only shows while developing. Don't want it? Ask the agent in the chat to remove it.";
-  info.setAttribute("aria-label", info.title);
-  info.style.cssText = "color:#868aa5;font-size:16px;cursor:help;user-select:none;";
+  info.setAttribute("aria-label", TIP_TEXT);
+  info.style.cssText =
+    "position:relative;color:#868aa5;font-size:16px;cursor:pointer;user-select:none;";
+  const tip = document.createElement("span");
+  tip.textContent = TIP_TEXT;
+  tip.style.cssText =
+    "position:absolute;top:calc(100% + 8px);right:-8px;display:none;width:240px;" +
+    "background:#131720;color:#fff;font-size:12px;line-height:1.4;font-weight:400;" +
+    "border-radius:8px;padding:8px 12px;box-shadow:0 2px 8px rgba(0,0,0,.2);";
+  info.append(tip);
+  info.addEventListener("mouseenter", () => (tip.style.display = "block"));
+  info.addEventListener("mouseleave", () => (tip.style.display = "none"));
+  // Touch devices have no hover — a tap toggles instead.
+  info.addEventListener("click", () => (tip.style.display = tip.style.display === "block" ? "none" : "block"));
 
   card.append(text, button, info);
   bar.append(card);


### PR DESCRIPTION
## What

Adds an optional **manage banner** to the `wix-vibe-headless` skill and wires it into both platform entry prompts as a short final build step.

- **New `references/shared/wix-manage-banner.js`** — a copy-as-is, dependency-free module (same style as the other shipped helpers). Exports `WIX_METASITE_ID` (placeholder, like `WIX_CLIENT_ID` in `wix-client.js`) and `mountWixManageBanner()`, which renders a slim fixed top banner: *"Manage your business behind this site in Wix business manager"* + an **Open** pill, both opening `https://manage.wix.com/dashboard/{metaSiteId}` in a new tab.
- **Dev-only, strictly**: renders only when `import.meta.env.DEV` exists and is true (try/catch-guarded, so stacks without the flag get nothing rather than an error). No runtime heuristics fallback — no flag means no banner. Also no-ops if the metasite placeholder isn't filled, outside a browser, or when already mounted.
- **`SKILL.md`** — short paragraph documenting the optional banner under "How this skill is structured".
- **`platforms/base44.md` / `platforms/generic.md`** — new first item in the wrap-up step: copy the file next to `wix-client.js`, set `WIX_METASITE_ID`, mount once from the app entry, use as-is.

## Notes

- Eval/yaml coverage rules in CONTRIBUTING apply to `wix-manage` / `wix-app` only — not `wix-vibe-headless` — so no scenario is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)