### PR TITLE
fix(wix-vibe-headless): manage banner — solid strip, persistent ✕ dismiss, no info tooltip

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -107,7 +107,8 @@ dev-build-only banner linking the running app to the Wix Business Manager (the b
 behind it. Copy it beside `wix-client.js`, set `WIX_METASITE_ID`, and call
 `mountWixManageBanner()` once from the app entry. It renders only when a dev-build flag
 (`import.meta.env.DEV`) exists and is true — never in production, and not at all on stacks
-without such a flag.
+without such a flag. It sits in normal flow at the top (pushes the site down, doesn't float
+over it) and is dismissible via its ✕ (persisted in `localStorage`).
 
 Each vertical's `INSTRUCTIONS.md` is the full playbook for that solution: when to use it,
 prerequisites, the exported API, how to wire it, the hard rules, and a verification checklist.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -160,7 +160,9 @@ Once the site is built and seeded:
    `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
    builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
    guarantee: verify the gate actually holds in this stack, and that a production build never
-   shows the banner (no dev flag → no banner at all).
+   shows the banner (no dev flag → no banner at all). Also verify it really pushes the site
+   down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
+   banner — offset such a header by the banner's height.
 2. **Leave a brief "Wix skills" note in `AGENTS.md`** (project root) so a future session has
    context. If the file already exists, **`read_file` it first and only append your section** —
    do **not** rewrite, reorder, or remove anything already there; if you can't append cleanly,

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -117,6 +117,8 @@ After the site is built and seeded:
    `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
    builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
    guarantee: verify the gate actually holds in this stack, and that a production build never
-   shows the banner (no dev flag → no banner at all).
+   shows the banner (no dev flag → no banner at all). Also verify it really pushes the site
+   down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
+   banner — offset such a header by the banner's height.
 2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
    you were given): `https://manage.wix.com/dashboard/{metaSiteId}`

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -1,7 +1,8 @@
 /**
  * Dev-only manage banner — a slim banner linking the running app to the Wix
  * Business Manager (the back office) behind it. Renders ONLY in a dev build;
- * production builds (and stacks with no dev flag at all) never show it.
+ * production builds (and stacks with no dev flag at all) never show it. The
+ * ✕ button dismisses it persistently (localStorage).
  *
  * Copy next to wix-client.js, set WIX_METASITE_ID, and mount once from the
  * app entry (safe to call unconditionally — it no-ops outside dev):
@@ -14,6 +15,7 @@
 export const WIX_METASITE_ID = "<YOUR-METASITE-ID>";
 
 const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
 
 /**
  * True only in a dev build. `import.meta.env.DEV` is Vite's flag; on bundlers
@@ -33,21 +35,25 @@ export function mountWixManageBanner() {
   if (!isDevBuild()) return;
   if (WIX_METASITE_ID.startsWith("<")) return; // placeholder not filled in
   if (typeof document === "undefined") return;
+  try {
+    if (window.localStorage.getItem(DISMISS_KEY)) return; // user dismissed it
+  } catch {
+    /* ignore disabled storage */
+  }
   if (document.getElementById("wix-manage-banner")) return;
 
-  // In normal flow as <body>'s first child — pushes the site down rather than
-  // floating over it.
+  // A solid, full-width strip in normal flow as <body>'s first child, so it
+  // pushes the whole site down rather than floating over it. CAUTION: an app
+  // header that is position:fixed (or absolute over a hero) is NOT in normal
+  // flow and will NOT be pushed — it slides under the banner. If the app has
+  // one, offset it by this element's offsetHeight; verify visually.
   const bar = document.createElement("div");
   bar.id = "wix-manage-banner";
   bar.style.cssText =
-    "display:flex;justify-content:center;padding:10px 16px;background:#f4f4f7;" +
-    "font-family:system-ui,-apple-system,sans-serif;";
-
-  const card = document.createElement("div");
-  card.style.cssText =
-    "display:flex;align-items:center;gap:14px;" +
-    "background:#fff;color:#131720;border-radius:12px;padding:10px 20px;" +
-    "font-size:15px;box-shadow:0 1px 4px rgba(0,0,0,.12);";
+    "position:relative;z-index:2147483647;box-sizing:border-box;display:flex;" +
+    "align-items:center;justify-content:center;gap:14px;width:100%;" +
+    "padding:12px 48px;background:#fff;color:#131720;font-size:15px;" +
+    "font-family:system-ui,-apple-system,sans-serif;border-bottom:1px solid #e2e2ea;";
 
   const text = document.createElement("span");
   text.append("Manage your business behind this site in Wix ");
@@ -68,28 +74,23 @@ export function mountWixManageBanner() {
     "background:#131720;color:#fff;border-radius:999px;padding:8px 18px;" +
     "font-size:14px;text-decoration:none;";
 
-  // The tooltip is real DOM, not a `title` attribute — native tooltips don't
-  // show inside sandboxed preview iframes (e.g. a vibe platform's app preview).
-  const TIP_TEXT =
-    "This banner only shows while developing. Don't want it? Ask the agent in the chat to remove it.";
-  const info = document.createElement("span");
-  info.textContent = "ⓘ";
-  info.setAttribute("aria-label", TIP_TEXT);
-  info.style.cssText =
-    "position:relative;color:#868aa5;font-size:16px;cursor:pointer;user-select:none;";
-  const tip = document.createElement("span");
-  tip.textContent = TIP_TEXT;
-  tip.style.cssText =
-    "position:absolute;top:calc(100% + 8px);right:-8px;z-index:2147483647;display:none;" +
-    "width:240px;background:#131720;color:#fff;font-size:12px;line-height:1.4;" +
-    "font-weight:400;border-radius:8px;padding:8px 12px;box-shadow:0 2px 8px rgba(0,0,0,.2);";
-  info.append(tip);
-  info.addEventListener("mouseenter", () => (tip.style.display = "block"));
-  info.addEventListener("mouseleave", () => (tip.style.display = "none"));
-  // Touch devices have no hover — a tap toggles instead.
-  info.addEventListener("click", () => (tip.style.display = tip.style.display === "block" ? "none" : "block"));
+  const close = document.createElement("button");
+  close.type = "button";
+  close.setAttribute("aria-label", "Dismiss banner");
+  close.textContent = "✕";
+  close.style.cssText =
+    "position:absolute;right:12px;top:50%;transform:translateY(-50%);" +
+    "background:none;border:none;color:#868aa5;font-size:16px;line-height:1;" +
+    "cursor:pointer;padding:6px;";
+  close.addEventListener("click", () => {
+    bar.remove();
+    try {
+      window.localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      /* ignore — dismisses for this load only */
+    }
+  });
 
-  card.append(text, button, info);
-  bar.append(card);
+  bar.append(text, button, close);
   document.body.prepend(bar);
 }


### PR DESCRIPTION
## What

Follow-up to #744, from real-app feedback (screenshot showed the banner floating over a fixed header, looking transparent and mangled with the site UI).

- **Solid full-width strip** instead of a floating white card on a gray band — white background, bottom border, `z-index` max, `box-sizing:border-box`. Nothing shows through it.
- **✕ dismiss button** (right edge) replaces the info icon/tooltip. Clicking removes the banner and persists the dismissal in `localStorage` (`wix-manage-banner-dismissed-<metasiteId>`), so it stays gone across reloads; `mountWixManageBanner()` checks the flag before rendering.
- **Fixed-header caveat made explicit**: a `fixed`/`absolute` app header is not in normal flow, so prepending to `<body>` can't push it — the code comment and both entry prompts now tell the building agent to verify visually and offset such a header by the banner's height.
- SKILL.md paragraph updated (in-flow, dismissible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)