### PR TITLE
🦞 igor-claw: add Pricing Plans skill for embedded widget checkout navigation

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -219,6 +219,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Pricing Plans Bookings Integration](references/pricing-plans/pricing-plans-bookings-integration.md)
 **Technical:** Links Pricing Plans to Bookings services using the Benefit Programs API. Enables package deals and memberships that grant booking access.
 
+### [Troubleshoot Embedded Pricing Plans Widget Checkout](references/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.md)
+**Technical:** Explains why a Plan List/Single Plan widget added to a non-system page always redirects to the Plans & Pricing page to check out, and diagnoses the duplicated-plan-list-above-checkout and disappearing-checkout symptoms as a duplicate or wrongly-deleted widget on that page rather than a rendering bug.
+
 ---
 
 ## Restaurants

--- a/skills/wix-manage/references/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.md
+++ b/skills/wix-manage/references/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.md
@@ -1,0 +1,67 @@
+---
+name: "Troubleshoot Embedded Pricing Plans Widget Checkout"
+description: "Explains where a Plan List or Single Plan widget sends visitors when it's added to a page other than the Plans & Pricing page, and diagnoses the two most common support complaints that follow: (1) selecting a plan always leaves the current page instead of checking out in place, and (2) the Plans & Pricing page shows the full plan list stacked above checkout, or the checkout section disappeared after removing a plan-list element. Use when a site owner asks why their embedded plan widget doesn't check out on the same page, or reports a confusing double plan-list/checkout layout."
+---
+# Troubleshoot Embedded Pricing Plans Widget Checkout
+
+Wix Pricing Plans lets a site owner add a **Plan List** or **Single Plan** widget to *any* page — not just the automatically-created **Plans & Pricing** page — via **Add Elements > Payments** in the Editor, or via the pricing plan element's **Settings > Add-Ons > "Add to page"** panel. This is by design and documented in [Displaying Plans on Multiple Site Pages](https://support.wix.com/en/article/pricing-plans-displaying-plans-on-multiple-site-pages) — a common use case is putting a plan or plan list directly on a service page so it's visible next to the relevant content.
+
+This recipe covers the two support questions that come up once a widget has been added to a non-system page.
+
+## When to use
+
+- Owner added a Plan List or Single Plan widget to a custom page (e.g. a service page) and asks why clicking **Select**/**Buy** navigates away instead of completing checkout right there → [Checkout always happens on the Plans & Pricing page](#checkout-always-happens-on-the-plans--pricing-page).
+- Owner reports the **Plans & Pricing** page (or its checkout/payment step) shows the **full list of plans stacked above the checkout form**, creating a confusing double-selection experience → [Diagnosing a duplicated plan list above checkout](#diagnosing-a-duplicated-plan-list-above-checkout).
+- Owner tried to remove "the plan list" from the Plans & Pricing page in the Editor and the **checkout/payment section disappeared too** → [Why deleting the wrong element removes checkout](#why-deleting-the-wrong-element-removes-checkout).
+
+> **No API covers any of this.** There is no REST endpoint to read a page's element/widget composition or to change checkout navigation behavior — this is Editor/Viewer layout, not a settable API property. Don't call or invent an endpoint for it; the fixes below are Editor actions you talk the owner through.
+
+---
+
+## Checkout always happens on the Plans & Pricing page
+
+This is expected, current platform behavior, not a bug or a missing setting: **selecting a plan on a Plan List or Single Plan widget always navigates the visitor to the site's built-in Plans & Pricing page to complete checkout**, even when the widget the visitor clicked on lives on a completely different page (e.g. a service page). There is currently no supported way to make an embedded widget complete checkout in place on the page it's on.
+
+- This applies uniformly, regardless of which page the widget was added to.
+- The widget on the custom page is only ever a *preview/entry point* — the actual purchase flow (login/guest details, plan summary, payment) always renders on the Plans & Pricing page.
+
+**What to tell the owner:** this isn't something to configure differently — it's how the checkout flow works today. If the goal was a single-page, in-context purchase experience, that isn't currently possible with the built-in Plan List/Single Plan widgets; the realistic options are to accept the redirect (most visitors expect a distinct checkout step) or simplify the custom page to a lightweight "starting at $X — see plans" teaser that links to Plans & Pricing, rather than a full interactive picker.
+
+---
+
+## Diagnosing a duplicated plan list above checkout
+
+The Plans & Pricing page's own built-in pricing element is a **single widget** that shows either the plan list *or* the checkout/payment step, depending on where the visitor is in the flow — never both at once. So if a visitor reports seeing the full list of plans (or a row of plan/billing-cycle tabs) rendered **above** the checkout form on that same page, that extra list is almost always a **second, separately-added** Plan List or Single Plan widget sitting on the Plans & Pricing page itself — not the built-in element misbehaving.
+
+This typically happens when the "Add to page" panel (see [Displaying Plans on Multiple Site Pages](https://support.wix.com/en/article/pricing-plans-displaying-plans-on-multiple-site-pages)) was used to add a plan list to "more pages" and the Plans & Pricing page was accidentally included, or a plan list was manually dragged onto that page from **Add Elements > Payments**.
+
+**How to guide the owner to confirm and fix it:**
+1. Open the Editor and go to the Plans & Pricing page.
+2. Look for **more than one** pricing-plan element stacked on the page — typically the extra one sits above or below the main pricing element and looks like a plain plan list or plan cards, without a "system page" indicator.
+3. Select and delete only the **extra**, manually-added element. Leave the original pricing element (the one the page came with) alone.
+4. Republish and re-test the checkout flow to confirm the list no longer appears above checkout.
+
+If, after checking, there really is only one pricing element on the page and the list and checkout are still shown together, that's outside this recipe's known cause — treat it as a genuine product bug and escalate through standard Wix support channels rather than trying to fix it via the widget's design/layout settings.
+
+---
+
+## Why deleting the wrong element removes checkout
+
+The Plans & Pricing page's built-in pricing element is **one single widget instance** that renders the plan list in its default state and switches to rendering checkout once a visitor picks a plan — it is not two separate widgets glued together. That means **deleting the built-in pricing element to "just keep checkout"** removes the same widget that would have rendered checkout too — there's no way to keep only the checkout half of that single element.
+
+**What this means in practice:** if an owner deleted the plan list element from the Plans & Pricing page and checkout disappeared from the Editor view, that's expected — they deleted the whole element, not just its list view. The fix is to undo the deletion (or re-add the pricing element from **Add Elements > Payments**) rather than looking for a way to restore "just checkout."
+
+This is also why [the duplicated-list scenario above](#diagnosing-a-duplicated-plan-list-above-checkout) explicitly says to delete only the *extra* element and leave the original one in place — deleting the wrong one reproduces this exact problem.
+
+## Gotchas
+
+- **Don't try to "fix" checkout navigation via settings.** There's no toggle for in-place checkout on embedded Plan List/Single Plan widgets — it's a platform limitation, not a misconfiguration.
+- **A plan list next to checkout on the Plans & Pricing page is a duplicate-widget symptom, not a rendering bug**, unless you've confirmed only one pricing element exists on that page.
+- **The built-in pricing element is one widget with two views (list, checkout), not two widgets.** Deleting it to "simplify" the page removes checkout too.
+- **There's no API for any of this** — page/element composition isn't queryable or settable through the Pricing Plans REST API. Guide the owner through the Editor directly.
+
+## See also
+
+- [About Pricing Plans Pages](https://support.wix.com/en/article/pricing-plans-about-pricing-plans-pages)
+- [Displaying Plans on Multiple Site Pages](https://support.wix.com/en/article/pricing-plans-displaying-plans-on-multiple-site-pages)
+- [Create and Update Pricing Plans](create-and-update-pricing-plans.md)

--- a/yaml/wix-manage-evals/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.yml
+++ b/yaml/wix-manage-evals/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.yml
@@ -1,0 +1,44 @@
+name: pricing-plans/troubleshoot-embedded-plan-widget-checkout
+description: >-
+  Verifies the agent reads the troubleshoot-embedded-plan-widget-checkout recipe
+  when a site owner reports that a Pricing Plans widget placed on a service page
+  redirects to the Plans & Pricing page instead of checking out in place, and that
+  the Plans & Pricing page shows the full plan list stacked above checkout.
+triggerPrompt: >-
+  I added a Plan List widget for my Pricing Plans directly onto one of my service
+  pages so customers could buy a package without leaving that page. But when they
+  click Select, they get sent to my site's Plans & Pricing page instead of checking
+  out right there, and that page shows the full list of all my plans again above the
+  checkout form. Why does this happen and how do I fix it?
+tags: [pricing-plans]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/troubleshoot-embedded-pricing-plans-widget-checkout
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user is a Wix site owner who embedded a Plan List widget on a service page and is
+      confused about two things: (1) selecting a plan redirects to the Plans & Pricing page
+      instead of checking out on the service page, and (2) that Plans & Pricing page shows the
+      full plan list above checkout.
+
+      Pass if the response:
+      - explains that navigating to the Plans & Pricing page to complete checkout is expected,
+        current platform behavior for embedded Plan List/Single Plan widgets — not a bug or a
+        missing setting — and that there's no supported way to check out in place on the page
+        the widget was added to, AND
+      - explains that the full plan list appearing above checkout on the Plans & Pricing page is
+        most likely a second, separately-added Plan List/Single Plan widget on that page (not the
+        built-in element misbehaving), and recommends checking the Editor for a duplicate element
+        and removing only the extra one, AND
+      - does not invent or call a REST API/endpoint to fix this, since none exists for page/widget
+        layout.
+
+      Fail if the response:
+      - claims there's a setting, API, or endpoint to make the embedded widget check out in place, OR
+      - tells the owner to delete the built-in Plans & Pricing widget/element without warning that
+        doing so removes checkout too, OR
+      - is generic and doesn't address the specific redirect-to-system-page or duplicated-list
+        symptoms.

--- a/yaml/wix-manage/pricing-plans/documentation.yaml
+++ b/yaml/wix-manage/pricing-plans/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: Pricing Plans Bookings Integration
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
       tags: [bookings, pricing-plans]
+    - file: ../../../skills/wix-manage/references/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.md
+      title: Troubleshoot Embedded Pricing Plans Widget Checkout
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
+      tags: [pricing-plans]


### PR DESCRIPTION
## Summary

Opened automatically by an **AI agent acting on behalf of Ayal (`ayalg@wix.com`)** — not written by Ayal personally — while researching live MCP feedback from a site owner (Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1785238521708649).

The owner had added a **Plan List** widget directly onto a service page (outside the built-in Plans & Pricing page) so customers could buy a package there. Two symptoms came up with no existing skill/recipe to route an assistant to:

1. Clicking **Select** on the embedded widget always redirects to the site's built-in **Plans & Pricing** page instead of checking out in place. This turns out to be expected, current platform behavior (no in-place checkout is supported for embedded Plan List/Single Plan widgets today) — not a bug or missing setting.
2. The Plans & Pricing page showed the **full plan list stacked above checkout**, and when the owner tried removing "the plan list" from that page, **checkout disappeared too**. This is because the page's built-in pricing element is a single widget that switches between a list view and a checkout view — it isn't two separate widgets. A persistent list-above-checkout is almost always a **second, separately-added** Plan List/Single Plan widget on that page, and deleting the *original* element (instead of the extra one) removes checkout along with the list.

## Changes

- `skills/wix-manage/references/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.md` — new recipe covering both symptoms and the fix (identify/remove the *extra* widget; don't delete the built-in one).
- `skills/wix-manage/SKILL.md` — index entry.
- `yaml/wix-manage/pricing-plans/documentation.yaml` — doc entry.
- `yaml/wix-manage-evals/pricing-plans/troubleshoot-embedded-pricing-plans-widget-checkout.yml` — covering eval scenario (tool-call + `llm_judge`).

## Test plan

- [ ] Eval gate runs and passes for the new scenario against the PR's doc content.
- [ ] Slug/URL consistency double-checked: title "Troubleshoot Embedded Pricing Plans Widget Checkout" → `.../pricing-plans/skills/troubleshoot-embedded-pricing-plans-widget-checkout`, matching the eval's `articleUrl`.

🤖 Generated with an autonomous AI research agent.