### PR TITLE
feat(evalforge-core): the wix-app gate's decision logic

### DIFF
--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -31118,9 +31118,11 @@ function loadScenarios(root, globPattern) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CleanupKind = void 0;
 exports.planCleanup = planCleanup;
 const evalforge_1 = __nccwpck_require__(7230);
 const plan_pr_scenario_sync_1 = __nccwpck_require__(7208);
+exports.CleanupKind = { RESTORE: 'RESTORE', DELETE: 'DELETE' };
 /**
  * Decides what to do with each of this PR's draft-tagged scenarios once the PR closes.
  * A name present in the base SHA's YAML pre-existed the PR, so it is RESTOREd to that
@@ -31134,13 +31136,13 @@ function planCleanup(remote, baseScenarios, draftTag, repo) {
         const baseScenario = baseScenarios.get(scenario.name);
         actions.push(baseScenario
             ? {
-                kind: 'RESTORE',
+                kind: exports.CleanupKind.RESTORE,
                 id: scenario.id,
                 name: scenario.name,
                 body: (0, plan_pr_scenario_sync_1.toScenarioBody)(baseScenario.scenario),
                 tags: (0, evalforge_1.withManagedTags)(baseScenario.scenario.tags, repo),
             }
-            : { kind: 'DELETE', id: scenario.id, name: scenario.name });
+            : { kind: exports.CleanupKind.DELETE, id: scenario.id, name: scenario.name });
     }
     return actions;
 }
@@ -31154,7 +31156,7 @@ function planCleanup(remote, baseScenarios, draftTag, repo) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.semanticPlusDraftTags = exports.draftOnlyTags = void 0;
+exports.semanticPlusDraftTags = exports.draftOnlyTags = exports.SyncActionKind = void 0;
 exports.toScenarioBody = toScenarioBody;
 exports.diffSyncPlan = diffSyncPlan;
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
@@ -31162,6 +31164,12 @@ exports.listRemoteScenariosForGate = listRemoteScenariosForGate;
 exports.stripInactiveForeignDraftTags = stripInactiveForeignDraftTags;
 const evalforge_1 = __nccwpck_require__(7230);
 const evalforge_mapper_1 = __nccwpck_require__(6006);
+exports.SyncActionKind = {
+    CREATE: 'CREATE',
+    UPDATE: 'UPDATE',
+    DELETE: 'DELETE',
+    DEFER_DELETE: 'DEFER_DELETE',
+};
 function toScenarioBody(scenario) {
     return (0, evalforge_mapper_1.toEvalForgeBody)(scenario);
 }
@@ -31182,7 +31190,7 @@ function diffSyncPlan(input) {
         const tags = (0, evalforge_1.withManagedTags)(tagStrategy(localScenario.scenario, draftTag), repo);
         const match = remoteByName.get(name);
         if (!match) {
-            actions.push({ kind: 'CREATE', name, body: toScenarioBody(localScenario.scenario), tags });
+            actions.push({ kind: exports.SyncActionKind.CREATE, name, body: toScenarioBody(localScenario.scenario), tags });
             continue;
         }
         const foreign = foreignDraftTags(match.tags, draftTag);
@@ -31190,7 +31198,7 @@ function diffSyncPlan(input) {
             errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: localScenario.path });
             continue;
         }
-        actions.push({ kind: 'UPDATE', id: match.id, name, body: toScenarioBody(localScenario.scenario), tags });
+        actions.push({ kind: exports.SyncActionKind.UPDATE, id: match.id, name, body: toScenarioBody(localScenario.scenario), tags });
     }
     for (const [name, baseScenario] of base) {
         if (head.has(name))
@@ -31199,7 +31207,7 @@ function diffSyncPlan(input) {
         if (!match)
             continue;
         if (match.tags.includes(draftTag)) {
-            actions.push({ kind: 'DELETE', id: match.id, name });
+            actions.push({ kind: exports.SyncActionKind.DELETE, id: match.id, name });
             continue;
         }
         const foreign = foreignDraftTags(match.tags, draftTag);
@@ -31207,7 +31215,7 @@ function diffSyncPlan(input) {
             errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: baseScenario.path });
         }
         else {
-            actions.push({ kind: 'DEFER_DELETE', id: match.id, name });
+            actions.push({ kind: exports.SyncActionKind.DEFER_DELETE, id: match.id, name });
         }
     }
     return { actions, errors };

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30481,6 +30481,43 @@ class EvalForgeClient {
             return existing;
         }
     }
+    /**
+     * Creates a skill-content capability version — the same endpoint as createMcpVersion,
+     * with the content oneof set to `skillContent` rather than `mcpContent`. This is what
+     * lets a run evaluate a PR's skill files directly, with no MCP URL indirection (and so
+     * without the eval-pipeline comparison service, which builds its MCP URL from
+     * skillsRepo/commitSha and cannot drive skill content).
+     */
+    async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+        const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
+            capabilityVersion: {
+                capabilityId,
+                version: versionLabel,
+                origin: 'pr',
+                notes: `Auto-created for PR #${prNumber}`,
+                skillContent: { files },
+            },
+        });
+        const created = res.capabilityVersion;
+        return { id: created.id, capabilityId: created.capabilityId, version: created.version };
+    }
+    async ensureSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+        try {
+            return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
+        }
+        catch (error) {
+            // A duplicate label should be 409, but the backend currently throws a plain
+            // "already exists" that transcodes to 500 — so recover on either by reusing the
+            // existing version, and only rethrow if it genuinely is not there.
+            if (!isHttpError(error) || (error.status !== 409 && error.status !== 500))
+                throw error;
+            const versions = await this.listCapabilityVersions(capabilityId, projectId);
+            const existing = versions.find(candidate => candidate.version === versionLabel);
+            if (!existing)
+                throw error;
+            return existing;
+        }
+    }
     // Without `names`: lists ALL scenarios via an empty-filter query (used by
     // promote / cleanup / run-all). With `names`: fetches only those scenarios —
     // the V1 `name` filter is a substring match, so each name is queried and then

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30785,6 +30785,7 @@ function evaluateRunResult(status) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GATE_COMMENT_MARKER = void 0;
 exports.formatYamlErrors = formatYamlErrors;
+exports.formatGateSkipped = formatGateSkipped;
 exports.formatNoGatedChanges = formatNoGatedChanges;
 exports.formatGuardFailure = formatGuardFailure;
 exports.formatForeignDraftConflicts = formatForeignDraftConflicts;
@@ -30828,6 +30829,17 @@ function formatYamlErrors(errors) {
         'These scenario files did not parse against the schema:',
         '',
         ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+    ]);
+}
+/**
+ * The gate did not evaluate this PR. Said out loud because otherwise a green check is
+ * indistinguishable from one that actually ran the scenarios.
+ */
+function formatGateSkipped(reason) {
+    return render('⏭', 'Skipped', [
+        `This PR was **not evaluated**: ${reason}`,
+        '',
+        'The check is green because the gate did not run, not because the scenarios passed.',
     ]);
 }
 function formatNoGatedChanges(unmapped) {

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30778,6 +30778,41 @@ function enc(segment) {
 
 /***/ }),
 
+/***/ 3460:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.evaluateRunResult = evaluateRunResult;
+/**
+ * Decides whether a finished run counts as a pass.
+ *
+ * Note the zero-assertion rule: a run that evaluated nothing has no failures, so a naive
+ * `failed + errors === 0` check would report green having verified nothing. That is exactly
+ * the false pass the gate exists to prevent, so it is an explicit failure.
+ */
+function evaluateRunResult(status) {
+    const reasons = [];
+    const metrics = status.aggregateMetrics;
+    if (status.status !== 'completed') {
+        reasons.push(`the eval run ${status.status === 'cancelled' ? 'was cancelled' : `ended as "${status.status}"`}`);
+    }
+    if (metrics.failed > 0) {
+        reasons.push(`${metrics.failed} assertion${metrics.failed === 1 ? '' : 's'} failed`);
+    }
+    if (metrics.errors > 0) {
+        reasons.push(`${metrics.errors} assertion${metrics.errors === 1 ? '' : 's'} errored`);
+    }
+    if (metrics.totalAssertions === 0) {
+        reasons.push('the run produced no assertions, so nothing was verified');
+    }
+    return { passed: reasons.length === 0, reasons };
+}
+
+
+/***/ }),
+
 /***/ 3308:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -30916,6 +30951,8 @@ __exportStar(__nccwpck_require__(5781), exports);
 __exportStar(__nccwpck_require__(4527), exports);
 __exportStar(__nccwpck_require__(7264), exports);
 __exportStar(__nccwpck_require__(3308), exports);
+__exportStar(__nccwpck_require__(8833), exports);
+__exportStar(__nccwpck_require__(3460), exports);
 
 
 /***/ }),
@@ -31571,6 +31608,57 @@ function parseScenario(raw) {
         }
     }
     return exports.ScenarioSchema.parse(parsed);
+}
+
+
+/***/ }),
+
+/***/ 8833:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.selectScenarios = selectScenarios;
+/**
+ * Builds the run's scenario set.
+ *
+ * `nameToId` is the union of the sync plan's own results (CREATE returns the new id, UPDATE
+ * already has it) and the remote tag query, so the gate never depends on read-after-write
+ * consistency: a slow tag index cannot silently shrink the run.
+ *
+ * The cap prioritises scenarios this PR touched. Sorting purely alphabetically would let a
+ * capped run drop the author's own new scenario in favour of an unrelated one.
+ */
+function selectScenarios(input) {
+    const derivedTags = new Set(input.tags);
+    const candidates = [...input.localScenarios.values()].filter(loaded => input.broadImpact
+        || input.touchedScenarioPaths.has(loaded.path)
+        || loaded.scenario.tags.some(tag => derivedTags.has(tag)));
+    const ordered = candidates.sort((left, right) => {
+        const leftTouched = input.touchedScenarioPaths.has(left.path) ? 0 : 1;
+        const rightTouched = input.touchedScenarioPaths.has(right.path) ? 0 : 1;
+        if (leftTouched !== rightTouched)
+            return leftTouched - rightTouched;
+        return left.scenario.name.localeCompare(right.scenario.name);
+    });
+    const missingIds = [];
+    const resolvable = [];
+    for (const loaded of ordered) {
+        const id = input.nameToId.get(loaded.scenario.name);
+        if (id)
+            resolvable.push({ name: loaded.scenario.name, id });
+        else
+            missingIds.push(loaded.scenario.name);
+    }
+    const running = resolvable.slice(0, Math.max(0, input.maxScenarios));
+    const cut = resolvable.slice(running.length);
+    return {
+        ids: running.map(entry => entry.id),
+        selected: running.map(entry => entry.name),
+        dropped: cut.map(entry => entry.name).sort(),
+        missingIds: missingIds.sort(),
+    };
 }
 
 

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30190,13 +30190,7 @@ exports.deriveTags = deriveTags;
 exports.touchedScenarioPaths = touchedScenarioPaths;
 const minimatch_1 = __nccwpck_require__(8911);
 exports.DEFAULT_IGNORE_GLOBS = ['scripts/**'];
-/**
- * `SKILL.md` plus the six references that apply across scenarios rather than to one
- * capability. "Changed → run everything" is the honest semantics for these: their effect is
- * not confined to one capability, so no single tag could describe it, and demanding a
- * `code-quality`-tagged scenario would be asking for a scenario that verifies nothing in
- * particular.
- */
+/** References that apply across scenarios, so no single tag describes them. */
 exports.DEFAULT_BROAD_IMPACT_GLOBS = [
     'SKILL.md',
     'references/APP_IDENTIFIERS.md',
@@ -30218,13 +30212,11 @@ function relativeToSkillDir(changedPath, skillDir) {
     return changedPath.startsWith(prefix) ? changedPath.slice(prefix.length) : undefined;
 }
 /**
- * Classifies the PR's changed paths into the tags whose scenarios must run.
+ * Changed paths → the tags whose scenarios must run.
  *
- * Precedence is first-match-wins: **ignore → broad-impact → reference → unmapped**. The
- * order is load-bearing. A broad-impact file that happens to live inside `referenceDir` must
- * be caught before the reference rule sees it, or `references/CODE_QUALITY.md` would derive
- * a `code-quality` tag and the coverage guard would block on a tag no scenario will ever
- * carry.
+ * Order is load-bearing: ignore → broad-impact → reference → unmapped, first match wins. Let
+ * the reference rule run first and `references/CODE_QUALITY.md` derives a `code-quality` tag
+ * the coverage guard can never satisfy.
  */
 function deriveTags(changedPaths, rules) {
     const tags = new Set();
@@ -30244,8 +30236,7 @@ function deriveTags(changedPaths, rules) {
         if (relativePath.startsWith(referencePrefix)) {
             const withinReferences = relativePath.slice(referencePrefix.length);
             const [head, ...rest] = withinReferences.split('/');
-            // A sub-doc directory is already named for its capability, so the directory name is
-            // the tag; a flat reference file derives its tag from the filename.
+            // A sub-doc directory is already named for its capability.
             tags.add(rest.length > 0 ? head.toLowerCase() : tagForReferencePath(head));
             continue;
         }
@@ -30257,10 +30248,7 @@ function deriveTags(changedPaths, rules) {
         unmapped: unmapped.sort(),
     };
 }
-/**
- * Scenario files this PR added, modified or renamed. Removals are excluded: a deleted
- * scenario cannot be quality-checked, and the sync plan handles the delete.
- */
+/** Scenario files added, modified or renamed. Removals are the sync plan's business. */
 function touchedScenarioPaths(changed, evalsGlob) {
     return changed
         .filter(file => file.status !== 'removed' && (0, minimatch_1.minimatch)(file.path, evalsGlob))
@@ -30634,11 +30622,8 @@ class EvalForgeClient {
         }
     }
     /**
-     * Creates a skill-content capability version — the same endpoint as createMcpVersion,
-     * with the content oneof set to `skillContent` rather than `mcpContent`. This is what
-     * lets a run evaluate a PR's skill files directly, with no MCP URL indirection (and so
-     * without the eval-pipeline comparison service, which builds its MCP URL from
-     * skillsRepo/commitSha and cannot drive skill content).
+     * Same endpoint as createMcpVersion, with the content oneof set to `skillContent`. Lets a
+     * run evaluate a PR's skill files directly, with no MCP URL indirection.
      */
     async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
         const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
@@ -30658,9 +30643,7 @@ class EvalForgeClient {
             return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
         }
         catch (error) {
-            // A duplicate label should be 409, but the backend currently throws a plain
-            // "already exists" that transcodes to 500 — so recover on either by reusing the
-            // existing version, and only rethrow if it genuinely is not there.
+            // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
             if (!isHttpError(error) || (error.status !== 409 && error.status !== 500))
                 throw error;
             const versions = await this.listCapabilityVersions(capabilityId, projectId);
@@ -30779,11 +30762,8 @@ function enc(segment) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateRunResult = evaluateRunResult;
 /**
- * Decides whether a finished run counts as a pass.
- *
- * Note the zero-assertion rule: a run that evaluated nothing has no failures, so a naive
- * `failed + errors === 0` check would report green having verified nothing. That is exactly
- * the false pass the gate exists to prevent, so it is an explicit failure.
+ * Zero assertions fails: such a run has no failures either, so `failed + errors === 0` alone
+ * would report green having verified nothing.
  */
 function evaluateRunResult(status) {
     const reasons = [];
@@ -30971,15 +30951,11 @@ function meetsQualityBar(scenario, bar = exports.DEFAULT_QUALITY_BAR) {
     return { ok: reasons.length === 0, reasons };
 }
 /**
- * The quality guard, evaluated entirely on local YAML plus the PR's changed-file list — no
- * EvalForge calls, no capability version, no run. That is why it comes first: a coverage
- * failure costs nothing.
+ * Runs on local YAML alone, so a coverage failure costs no EvalForge call.
  *
- * Coverage folds the bar in: a tag is covered only by a scenario that *meets* the bar,
- * because a one-assertion scenario would run, pass, and have verified nothing. Untouched
- * shortfalls on an otherwise-covered tag warn instead of blocking — blocking there would
- * hold a PR hostage to a weak scenario someone else authored, which is how thresholds get
- * lowered and gates get bypassed.
+ * A tag counts as covered only by a scenario that meets the bar — a one-assertion scenario
+ * would run, pass, and verify nothing. Untouched shortfalls warn rather than block, so a PR is
+ * never held hostage to a weak scenario someone else wrote.
  */
 function guardScenarios(input) {
     const bar = input.bar ?? exports.DEFAULT_QUALITY_BAR;
@@ -31001,7 +30977,7 @@ function guardScenarios(input) {
             });
             continue;
         }
-        // Tag is covered. Surface the weak siblings the PR did not touch, without blocking.
+        // Covered — surface weak siblings without blocking.
         for (const loaded of carrying) {
             if (input.touchedScenarioPaths.has(loaded.path))
                 continue;
@@ -31022,8 +30998,7 @@ function guardScenarios(input) {
             });
         }
     }
-    // No weakening: every scenario this PR added or edited must meet the bar, whatever its
-    // tags and whether or not a strong sibling already satisfies coverage.
+    // No weakening: a touched scenario must meet the bar even if a strong sibling covers its tag.
     for (const loaded of allScenarios) {
         if (!input.touchedScenarioPaths.has(loaded.path))
             continue;
@@ -31753,14 +31728,11 @@ function parseScenario(raw) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.selectScenarios = selectScenarios;
 /**
- * Builds the run's scenario set.
+ * Builds the run's scenario set. Callers pass `nameToId` as the union of the sync plan's own
+ * results and the tag query, so a slow tag index cannot silently shrink the run.
  *
- * `nameToId` is the union of the sync plan's own results (CREATE returns the new id, UPDATE
- * already has it) and the remote tag query, so the gate never depends on read-after-write
- * consistency: a slow tag index cannot silently shrink the run.
- *
- * The cap prioritises scenarios this PR touched. Sorting purely alphabetically would let a
- * capped run drop the author's own new scenario in favour of an unrelated one.
+ * Touched scenarios sort first: a purely alphabetical cap could drop the author's own new
+ * scenario for an unrelated one.
  */
 function selectScenarios(input) {
     const derivedTags = new Set(input.tags);

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30125,18 +30125,17 @@ async function assertWixAuthor(octokit, owner, repo, prNumber, log) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_COLLECT_LIMITS = void 0;
 exports.collectSkillFiles = collectSkillFiles;
 const node_fs_1 = __nccwpck_require__(3024);
 const node_path_1 = __nccwpck_require__(6760);
 const glob_1 = __nccwpck_require__(2311);
-exports.DEFAULT_COLLECT_LIMITS = {
+const DEFAULT_COLLECT_LIMITS = {
     maxFileBytes: 1_000_000,
     maxTotalBytes: 10_000_000,
 };
 /** Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`. */
 function collectSkillFiles(root, skillDir, options = {}) {
-    const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
+    const limits = options.limits ?? DEFAULT_COLLECT_LIMITS;
     const skillRoot = node_path_1.posix.join(root, skillDir);
     const relativePaths = glob_1.glob.sync('**/*', {
         cwd: skillRoot,
@@ -30181,7 +30180,6 @@ function collectSkillFiles(root, skillDir, options = {}) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = void 0;
-exports.tagForReferencePath = tagForReferencePath;
 exports.deriveTags = deriveTags;
 exports.touchedScenarioPaths = touchedScenarioPaths;
 const minimatch_1 = __nccwpck_require__(8911);
@@ -30617,10 +30615,6 @@ class EvalForgeClient {
             return existing;
         }
     }
-    /**
-     * Same endpoint as createMcpVersion, with the content oneof set to `skillContent`. Lets a
-     * run evaluate a PR's skill files directly, with no MCP URL indirection.
-     */
     async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
         const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
             capabilityVersion: {

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30506,10 +30506,11 @@ function assertNotTruncated(received, meta, path) {
 function normalizeStatus(s) {
     return String(s).toLowerCase();
 }
-// V1 `pass_rate` is a fraction (0.0–1.0); the action's internal contract (and
-// comment.ts) expects an integer percentage (0–100).
-function toPercent(fraction) {
-    return Math.round((fraction ?? 0) * 100);
+// V1 `pass_rate` already arrives as a percentage (0–100), verified against 8 real runs in the
+// App Builder project: 4/5 reports 80, 26/30 reports 86.667. Multiplying by 100 here rendered
+// every comment as "10000%".
+function toPercent(passRate) {
+    return Math.round(passRate ?? 0);
 }
 // Client for the EvalForge V1 REST API (`${baseUrl}/v1/...`, e.g.
 // https://manage.wix.com/_api/evalforge-backend/v1/...), authenticated with an

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30135,13 +30135,9 @@ exports.DEFAULT_COLLECT_LIMITS = {
     maxTotalBytes: 10_000_000,
 };
 /**
- * Reads `<root>/<skillDir>/**` into the file list a skill-content capability version takes.
- *
- * Paths are relative to `skillDir`, so a collected file reads `references/DASHBOARD_PAGE.md`
- * — matching what a scenario's `referenceFiles` assertions name.
- *
- * Caps throw rather than truncate: a silently shortened skill would be evaluated as if it
- * were the whole thing, and the run would report on a skill that never existed.
+ * Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`.
+ * Ships the whole directory because docs send the agent to sibling paths like
+ * `<SKILL_ROOT>/scripts/…`. Over-cap throws rather than truncating.
  */
 function collectSkillFiles(root, skillDir, options = {}) {
     const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
@@ -30157,27 +30153,24 @@ function collectSkillFiles(root, skillDir, options = {}) {
     let totalBytes = 0;
     for (const relativePath of relativePaths) {
         const buffer = (0, node_fs_1.readFileSync)(node_path_1.posix.join(skillRoot, relativePath));
-        // A NUL byte means this is not text, and skill content is text. Skipping keeps a stray
-        // image from breaking the version; warning keeps it from being invisible.
+        // A NUL byte means binary, and skill content is text. Skip it, but say so.
         if (buffer.includes(0)) {
             options.warn?.(`Skipping non-text file in ${skillDir}: ${relativePath}`);
             continue;
         }
         if (buffer.byteLength > limits.maxFileBytes) {
             throw new Error(`Skill file ${relativePath} is ${buffer.byteLength} bytes, over the per-file cap of `
-                + `${limits.maxFileBytes}. Split it or raise the cap — truncating would evaluate a skill `
-                + `that does not exist.`);
+                + `${limits.maxFileBytes}. Split it or raise the cap.`);
         }
         totalBytes += buffer.byteLength;
         if (totalBytes > limits.maxTotalBytes) {
             throw new Error(`Skill ${skillDir} exceeds the total content cap of ${limits.maxTotalBytes} bytes at `
-                + `${relativePath}. Raise the cap deliberately rather than shipping a partial skill.`);
+                + `${relativePath}. Raise the cap deliberately.`);
         }
         files.push({ path: relativePath, content: buffer.toString('utf8') });
     }
     if (files.length === 0) {
-        throw new Error(`No files collected from ${skillRoot} — the skill directory is empty or mis-configured. `
-            + `Check the skill-dir input.`);
+        throw new Error(`No files collected from ${skillRoot}. Check the skill-dir and reference-dir inputs.`);
     }
     return files;
 }

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30179,10 +30179,12 @@ function collectSkillFiles(root, skillDir, options = {}) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = void 0;
+exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = exports.DEFAULT_REFERENCE_DIR = void 0;
 exports.deriveTags = deriveTags;
 exports.touchedScenarioPaths = touchedScenarioPaths;
 const minimatch_1 = __nccwpck_require__(8911);
+/** Single home for the default: `action.yml`, the config reader and the workflow all defer to it. */
+exports.DEFAULT_REFERENCE_DIR = 'references';
 exports.DEFAULT_IGNORE_GLOBS = ['scripts/**'];
 /** References that apply across scenarios, so no single tag describes them. */
 exports.DEFAULT_BROAD_IMPACT_GLOBS = [
@@ -31737,7 +31739,13 @@ function parseScenario(raw) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_MAX_SCENARIOS = void 0;
 exports.selectScenarios = selectScenarios;
+/**
+ * Cap on scenarios per gate run. Every wix-app scenario is a live agent build, so this bounds real
+ * money and wall-clock, not test runtime. Single home for the default — see DEFAULT_REFERENCE_DIR.
+ */
+exports.DEFAULT_MAX_SCENARIOS = 25;
 /**
  * Builds the run's scenario set. Callers pass `nameToId` as the union of the sync plan's own
  * results and the tag query, so a slow tag index cannot silently shrink the run.

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30119,6 +30119,72 @@ async function assertWixAuthor(octokit, owner, repo, prNumber, log) {
 
 /***/ }),
 
+/***/ 4527:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_COLLECT_LIMITS = void 0;
+exports.collectSkillFiles = collectSkillFiles;
+const node_fs_1 = __nccwpck_require__(3024);
+const node_path_1 = __nccwpck_require__(6760);
+const glob_1 = __nccwpck_require__(2311);
+exports.DEFAULT_COLLECT_LIMITS = {
+    maxFileBytes: 1_000_000,
+    maxTotalBytes: 10_000_000,
+};
+/**
+ * Reads `<root>/<skillDir>/**` into the file list a skill-content capability version takes.
+ *
+ * Paths are relative to `skillDir`, so a collected file reads `references/DASHBOARD_PAGE.md`
+ * — matching what a scenario's `referenceFiles` assertions name.
+ *
+ * Caps throw rather than truncate: a silently shortened skill would be evaluated as if it
+ * were the whole thing, and the run would report on a skill that never existed.
+ */
+function collectSkillFiles(root, skillDir, options = {}) {
+    const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
+    const skillRoot = node_path_1.posix.join(root, skillDir);
+    const relativePaths = glob_1.glob.sync('**/*', {
+        cwd: skillRoot,
+        nodir: true,
+        dot: false,
+        ignore: ['**/node_modules/**', '**/dist/**'],
+        posix: true,
+    }).sort();
+    const files = [];
+    let totalBytes = 0;
+    for (const relativePath of relativePaths) {
+        const buffer = (0, node_fs_1.readFileSync)(node_path_1.posix.join(skillRoot, relativePath));
+        // A NUL byte means this is not text, and skill content is text. Skipping keeps a stray
+        // image from breaking the version; warning keeps it from being invisible.
+        if (buffer.includes(0)) {
+            options.warn?.(`Skipping non-text file in ${skillDir}: ${relativePath}`);
+            continue;
+        }
+        if (buffer.byteLength > limits.maxFileBytes) {
+            throw new Error(`Skill file ${relativePath} is ${buffer.byteLength} bytes, over the per-file cap of `
+                + `${limits.maxFileBytes}. Split it or raise the cap — truncating would evaluate a skill `
+                + `that does not exist.`);
+        }
+        totalBytes += buffer.byteLength;
+        if (totalBytes > limits.maxTotalBytes) {
+            throw new Error(`Skill ${skillDir} exceeds the total content cap of ${limits.maxTotalBytes} bytes at `
+                + `${relativePath}. Raise the cap deliberately rather than shipping a partial skill.`);
+        }
+        files.push({ path: relativePath, content: buffer.toString('utf8') });
+    }
+    if (files.length === 0) {
+        throw new Error(`No files collected from ${skillRoot} — the skill directory is empty or mis-configured. `
+            + `Check the skill-dir input.`);
+    }
+    return files;
+}
+
+
+/***/ }),
+
 /***/ 6006:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -30652,6 +30718,7 @@ __exportStar(__nccwpck_require__(5992), exports);
 __exportStar(__nccwpck_require__(7208), exports);
 __exportStar(__nccwpck_require__(473), exports);
 __exportStar(__nccwpck_require__(5781), exports);
+__exportStar(__nccwpck_require__(4527), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30185,6 +30185,99 @@ function collectSkillFiles(root, skillDir, options = {}) {
 
 /***/ }),
 
+/***/ 7264:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = void 0;
+exports.tagForReferencePath = tagForReferencePath;
+exports.deriveTags = deriveTags;
+exports.touchedScenarioPaths = touchedScenarioPaths;
+const minimatch_1 = __nccwpck_require__(8911);
+exports.DEFAULT_IGNORE_GLOBS = ['scripts/**'];
+/**
+ * `SKILL.md` plus the six references that apply across scenarios rather than to one
+ * capability. "Changed → run everything" is the honest semantics for these: their effect is
+ * not confined to one capability, so no single tag could describe it, and demanding a
+ * `code-quality`-tagged scenario would be asking for a scenario that verifies nothing in
+ * particular.
+ */
+exports.DEFAULT_BROAD_IMPACT_GLOBS = [
+    'SKILL.md',
+    'references/APP_IDENTIFIERS.md',
+    'references/APP_MARKET_REVIEW.md',
+    'references/APP_VALIDATION.md',
+    'references/CODE_QUALITY.md',
+    'references/DOCUMENTATION.md',
+    'references/EXTENSION_REGISTRATION.md',
+];
+/** `DASHBOARD_PAGE.md` → `dashboard-page`. */
+function tagForReferencePath(relativeReferencePath) {
+    return relativeReferencePath.replace(/\.md$/i, '').toLowerCase().replace(/_/g, '-');
+}
+function matchesAny(relativePath, globs) {
+    return globs.some(pattern => (0, minimatch_1.minimatch)(relativePath, pattern, { dot: true }));
+}
+function relativeToSkillDir(changedPath, skillDir) {
+    const prefix = `${skillDir}/`;
+    return changedPath.startsWith(prefix) ? changedPath.slice(prefix.length) : undefined;
+}
+/**
+ * Classifies the PR's changed paths into the tags whose scenarios must run.
+ *
+ * Precedence is first-match-wins: **ignore → broad-impact → reference → unmapped**. The
+ * order is load-bearing. A broad-impact file that happens to live inside `referenceDir` must
+ * be caught before the reference rule sees it, or `references/CODE_QUALITY.md` would derive
+ * a `code-quality` tag and the coverage guard would block on a tag no scenario will ever
+ * carry.
+ */
+function deriveTags(changedPaths, rules) {
+    const tags = new Set();
+    const unmapped = [];
+    let broadImpact = false;
+    const referencePrefix = `${rules.referenceDir}/`;
+    for (const changedPath of changedPaths) {
+        const relativePath = relativeToSkillDir(changedPath, rules.skillDir);
+        if (relativePath === undefined)
+            continue;
+        if (matchesAny(relativePath, rules.ignoreGlobs))
+            continue;
+        if (matchesAny(relativePath, rules.broadImpactGlobs)) {
+            broadImpact = true;
+            continue;
+        }
+        if (relativePath.startsWith(referencePrefix)) {
+            const withinReferences = relativePath.slice(referencePrefix.length);
+            const [head, ...rest] = withinReferences.split('/');
+            // A sub-doc directory is already named for its capability, so the directory name is
+            // the tag; a flat reference file derives its tag from the filename.
+            tags.add(rest.length > 0 ? head.toLowerCase() : tagForReferencePath(head));
+            continue;
+        }
+        unmapped.push(changedPath);
+    }
+    return {
+        tags: [...tags].sort(),
+        broadImpact,
+        unmapped: unmapped.sort(),
+    };
+}
+/**
+ * Scenario files this PR added, modified or renamed. Removals are excluded: a deleted
+ * scenario cannot be quality-checked, and the sync plan handles the delete.
+ */
+function touchedScenarioPaths(changed, evalsGlob) {
+    return changed
+        .filter(file => file.status !== 'removed' && (0, minimatch_1.minimatch)(file.path, evalsGlob))
+        .map(file => file.path)
+        .sort();
+}
+
+
+/***/ }),
+
 /***/ 6006:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -30719,6 +30812,7 @@ __exportStar(__nccwpck_require__(7208), exports);
 __exportStar(__nccwpck_require__(473), exports);
 __exportStar(__nccwpck_require__(5781), exports);
 __exportStar(__nccwpck_require__(4527), exports);
+__exportStar(__nccwpck_require__(7264), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30628,7 +30628,7 @@ class EvalForgeClient {
         const created = res.capabilityVersion;
         return { id: created.id, capabilityId: created.capabilityId, version: created.version };
     }
-    async ensureSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+    async createOrReuseSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
         try {
             return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
         }

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30813,6 +30813,144 @@ function evaluateRunResult(status) {
 
 /***/ }),
 
+/***/ 5970:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GATE_COMMENT_MARKER = void 0;
+exports.formatYamlErrors = formatYamlErrors;
+exports.formatNoGatedChanges = formatNoGatedChanges;
+exports.formatGuardFailure = formatGuardFailure;
+exports.formatForeignDraftConflicts = formatForeignDraftConflicts;
+exports.formatGateResult = formatGateResult;
+exports.formatGateTimeout = formatGateTimeout;
+exports.formatGateServiceError = formatGateServiceError;
+const evalforge_1 = __nccwpck_require__(7230);
+exports.GATE_COMMENT_MARKER = '<!-- evalforge-skill-gate-action -->';
+const HEADING = 'EvalForge Skill Gate';
+function render(icon, label, body) {
+    return [exports.GATE_COMMENT_MARKER, `## ${icon} ${HEADING}: ${label}`, '', ...body].join('\n');
+}
+function failIcon(blocking) {
+    return blocking ? { icon: '❌', label: 'Failed' } : { icon: '⚠️', label: 'Warning' };
+}
+function soakNote(blocking) {
+    return blocking
+        ? []
+        : ['', '_The gate is in its soak period (`blocking: false`), so this check still passes._'];
+}
+function unmappedSection(unmapped) {
+    if (unmapped.length === 0)
+        return [];
+    return [
+        '',
+        '**Unmapped paths** — these changed under the skill directory but no rule covers them, so they triggered nothing. Add them to `ignore-globs` if that is correct:',
+        ...unmapped.map(path => `- \`${path}\``),
+    ];
+}
+function warningSection(warnings) {
+    if (warnings.length === 0)
+        return [];
+    return [
+        '',
+        '**Existing scenarios below the quality bar** (not blocking — you did not write these, but they are worth fixing):',
+        ...warnings.map(warning => `- \`${warning.path}\` (\`${warning.name}\`, tagged ${warning.tags.map(tag => `\`${tag}\``).join(', ')}) — ${warning.reasons.join('; ')}`),
+    ];
+}
+function formatYamlErrors(errors) {
+    return render('❌', 'Invalid Scenario YAML', [
+        'These scenario files did not parse against the schema:',
+        '',
+        ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+    ]);
+}
+function formatNoGatedChanges(unmapped) {
+    return render('✅', 'No Gated Changes', [
+        'Nothing in this PR maps to an eval tag, so no run was needed.',
+        ...unmappedSection(unmapped),
+    ]);
+}
+function violationLine(violation) {
+    switch (violation.kind) {
+        case 'UNCOVERED_TAG':
+            return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under the scenario directory tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+        case 'WEAK_TAG':
+            return `- **\`${violation.tag}\`** is carried only by scenarios below the quality bar (${violation.scenarios.map(name => `\`${name}\``).join(', ')}). Strengthen one of them, or add a scenario that meets the bar.`;
+        case 'WEAK_TOUCHED_SCENARIO':
+            return `- \`${violation.path}\` (\`${violation.name}\`) — ${violation.reasons.join('; ')}. This PR added or edited it, so it must meet the bar.`;
+    }
+}
+function formatGuardFailure(input) {
+    const { icon, label } = failIcon(input.blocking);
+    return render(icon, `Coverage ${label}`, [
+        'The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.',
+        '',
+        ...input.violations.map(violationLine),
+        '',
+        '_No eval run was started — a coverage failure is caught before any run cost._',
+        ...warningSection(input.warnings),
+        ...soakNote(input.blocking),
+    ]);
+}
+function formatForeignDraftConflicts(errors, blocking) {
+    const { icon } = failIcon(blocking);
+    return render(icon, 'Scenario Locked by Another PR', [
+        'These scenarios are draft-tagged for other open PRs. Wait for those to merge or close, or coordinate with their authors:',
+        '',
+        ...errors.map(error => {
+            const links = error.foreignTags.map(tag => {
+                const draft = (0, evalforge_1.parseDraftTag)(tag);
+                return draft ? `https://github.com/${draft.repo}/pull/${draft.prNumber}` : tag;
+            });
+            return `- \`${error.name}\` is held by: ${links.join(', ')}`;
+        }),
+        ...soakNote(blocking),
+    ]);
+}
+function formatGateResult(input) {
+    const { metrics, verdict, selection } = input;
+    const { icon, label } = verdict.passed ? { icon: '✅', label: 'Passed' } : failIcon(input.blocking);
+    const body = [
+        `**Pass rate:** ${metrics.passRate}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
+            + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
+            + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
+        `**Run:** [${input.runId}](${input.runUrl})`,
+    ];
+    if (!verdict.passed) {
+        body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
+    }
+    body.push('', input.broadImpact
+        ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${selection.selected.length} scenario(s) ran.`
+        : `**Scope:** ${selection.selected.length} scenario(s) ran.`, '', ...selection.selected.map(name => `- \`${name}\``));
+    if (selection.dropped.length > 0) {
+        body.push('', `**Capped at \`max-scenarios: ${input.maxScenarios}\`** — these were not run:`, ...selection.dropped.map(name => `- \`${name}\``));
+    }
+    if (selection.missingIds.length > 0) {
+        body.push('', '**Not run — no EvalForge scenario found for these names.** They are in the repo YAML but not in EvalForge, which points at a sync gap:', ...selection.missingIds.map(name => `- \`${name}\``));
+    }
+    body.push(...warningSection(input.warnings), ...unmappedSection(input.unmapped));
+    if (!verdict.passed)
+        body.push(...soakNote(input.blocking));
+    return render(icon, label, body);
+}
+function formatGateTimeout(runId, runUrl, blocking) {
+    return render(blocking ? '⏱' : '⚠️', 'Timed Out', [
+        'The eval run did not finish within the poll window. It may still be running in EvalForge.',
+        '',
+        `**Run:** [${runId}](${runUrl})`,
+        ...soakNote(blocking),
+    ]);
+}
+function formatGateServiceError(message, blocking) {
+    const { icon, label } = failIcon(blocking);
+    return render(icon, label, [message, ...soakNote(blocking)]);
+}
+
+
+/***/ }),
+
 /***/ 3308:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -30953,6 +31091,7 @@ __exportStar(__nccwpck_require__(7264), exports);
 __exportStar(__nccwpck_require__(3308), exports);
 __exportStar(__nccwpck_require__(8833), exports);
 __exportStar(__nccwpck_require__(3460), exports);
+__exportStar(__nccwpck_require__(5970), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30778,6 +30778,108 @@ function enc(segment) {
 
 /***/ }),
 
+/***/ 3308:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_QUALITY_BAR = void 0;
+exports.meetsQualityBar = meetsQualityBar;
+exports.guardScenarios = guardScenarios;
+const schema_1 = __nccwpck_require__(3540);
+exports.DEFAULT_QUALITY_BAR = {
+    minAssertions: 3,
+    requireLlmJudge: true,
+};
+/** Does this scenario verify enough to be worth running? */
+function meetsQualityBar(scenario, bar = exports.DEFAULT_QUALITY_BAR) {
+    const reasons = [];
+    if (scenario.assertions.length < bar.minAssertions) {
+        reasons.push(`has ${scenario.assertions.length} assertion${scenario.assertions.length === 1 ? '' : 's'} `
+            + `(needs at least ${bar.minAssertions})`);
+    }
+    if (bar.requireLlmJudge && !scenario.assertions.some(schema_1.isLlmJudge)) {
+        reasons.push('has no llm_judge assertion');
+    }
+    return { ok: reasons.length === 0, reasons };
+}
+/**
+ * The quality guard, evaluated entirely on local YAML plus the PR's changed-file list — no
+ * EvalForge calls, no capability version, no run. That is why it comes first: a coverage
+ * failure costs nothing.
+ *
+ * Coverage folds the bar in: a tag is covered only by a scenario that *meets* the bar,
+ * because a one-assertion scenario would run, pass, and have verified nothing. Untouched
+ * shortfalls on an otherwise-covered tag warn instead of blocking — blocking there would
+ * hold a PR hostage to a weak scenario someone else authored, which is how thresholds get
+ * lowered and gates get bypassed.
+ */
+function guardScenarios(input) {
+    const bar = input.bar ?? exports.DEFAULT_QUALITY_BAR;
+    const allScenarios = [...input.scenarios.values()];
+    const violations = [];
+    const weakUntouched = new Map();
+    for (const tag of input.tags) {
+        const carrying = allScenarios.filter(loaded => loaded.scenario.tags.includes(tag));
+        if (carrying.length === 0) {
+            violations.push({ kind: 'UNCOVERED_TAG', tag });
+            continue;
+        }
+        const meeting = carrying.filter(loaded => meetsQualityBar(loaded.scenario, bar).ok);
+        if (meeting.length === 0) {
+            violations.push({
+                kind: 'WEAK_TAG',
+                tag,
+                scenarios: carrying.map(loaded => loaded.scenario.name).sort(),
+            });
+            continue;
+        }
+        // Tag is covered. Surface the weak siblings the PR did not touch, without blocking.
+        for (const loaded of carrying) {
+            if (input.touchedScenarioPaths.has(loaded.path))
+                continue;
+            const check = meetsQualityBar(loaded.scenario, bar);
+            if (check.ok)
+                continue;
+            const existing = weakUntouched.get(loaded.scenario.name);
+            if (existing) {
+                existing.tags.push(tag);
+                continue;
+            }
+            weakUntouched.set(loaded.scenario.name, {
+                kind: 'WEAK_UNTOUCHED_SCENARIO',
+                name: loaded.scenario.name,
+                path: loaded.path,
+                tags: [tag],
+                reasons: check.reasons,
+            });
+        }
+    }
+    // No weakening: every scenario this PR added or edited must meet the bar, whatever its
+    // tags and whether or not a strong sibling already satisfies coverage.
+    for (const loaded of allScenarios) {
+        if (!input.touchedScenarioPaths.has(loaded.path))
+            continue;
+        const check = meetsQualityBar(loaded.scenario, bar);
+        if (check.ok)
+            continue;
+        violations.push({
+            kind: 'WEAK_TOUCHED_SCENARIO',
+            name: loaded.scenario.name,
+            path: loaded.path,
+            reasons: check.reasons,
+        });
+    }
+    return {
+        violations,
+        warnings: [...weakUntouched.values()].sort((left, right) => left.name.localeCompare(right.name)),
+    };
+}
+
+
+/***/ }),
+
 /***/ 7495:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -30813,6 +30915,7 @@ __exportStar(__nccwpck_require__(473), exports);
 __exportStar(__nccwpck_require__(5781), exports);
 __exportStar(__nccwpck_require__(4527), exports);
 __exportStar(__nccwpck_require__(7264), exports);
+__exportStar(__nccwpck_require__(3308), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30134,19 +30134,14 @@ exports.DEFAULT_COLLECT_LIMITS = {
     maxFileBytes: 1_000_000,
     maxTotalBytes: 10_000_000,
 };
-/**
- * Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`.
- * Ships the whole directory because docs send the agent to sibling paths like
- * `<SKILL_ROOT>/scripts/…`. Over-cap throws rather than truncating.
- */
+/** Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`. */
 function collectSkillFiles(root, skillDir, options = {}) {
     const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
     const skillRoot = node_path_1.posix.join(root, skillDir);
     const relativePaths = glob_1.glob.sync('**/*', {
         cwd: skillRoot,
         nodir: true,
-        // Dotfiles included: a silently dropped file the docs reference is worse than a stray one.
-        dot: true,
+        dot: false,
         ignore: ['**/node_modules/**', '**/dist/**'],
         posix: true,
     }).sort();

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30145,7 +30145,8 @@ function collectSkillFiles(root, skillDir, options = {}) {
     const relativePaths = glob_1.glob.sync('**/*', {
         cwd: skillRoot,
         nodir: true,
-        dot: false,
+        // Dotfiles included: a silently dropped file the docs reference is worse than a stray one.
+        dot: true,
         ignore: ['**/node_modules/**', '**/dist/**'],
         posix: true,
     }).sort();

--- a/.github/actions/evalforge-skill-gate/yarn.lock
+++ b/.github/actions/evalforge-skill-gate/yarn.lock
@@ -657,6 +657,7 @@ __metadata:
     "@actions/core": "npm:^1.10.1"
     glob: "npm:^11.0.0"
     js-yaml: "npm:^4.1.1"
+    minimatch: "npm:^10.1.1"
     zod: "npm:^3.23.0"
   languageName: node
   linkType: soft

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -35232,9 +35232,11 @@ function loadScenarios(root, globPattern) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CleanupKind = void 0;
 exports.planCleanup = planCleanup;
 const evalforge_1 = __nccwpck_require__(7230);
 const plan_pr_scenario_sync_1 = __nccwpck_require__(7208);
+exports.CleanupKind = { RESTORE: 'RESTORE', DELETE: 'DELETE' };
 /**
  * Decides what to do with each of this PR's draft-tagged scenarios once the PR closes.
  * A name present in the base SHA's YAML pre-existed the PR, so it is RESTOREd to that
@@ -35248,13 +35250,13 @@ function planCleanup(remote, baseScenarios, draftTag, repo) {
         const baseScenario = baseScenarios.get(scenario.name);
         actions.push(baseScenario
             ? {
-                kind: 'RESTORE',
+                kind: exports.CleanupKind.RESTORE,
                 id: scenario.id,
                 name: scenario.name,
                 body: (0, plan_pr_scenario_sync_1.toScenarioBody)(baseScenario.scenario),
                 tags: (0, evalforge_1.withManagedTags)(baseScenario.scenario.tags, repo),
             }
-            : { kind: 'DELETE', id: scenario.id, name: scenario.name });
+            : { kind: exports.CleanupKind.DELETE, id: scenario.id, name: scenario.name });
     }
     return actions;
 }
@@ -35268,7 +35270,7 @@ function planCleanup(remote, baseScenarios, draftTag, repo) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.semanticPlusDraftTags = exports.draftOnlyTags = void 0;
+exports.semanticPlusDraftTags = exports.draftOnlyTags = exports.SyncActionKind = void 0;
 exports.toScenarioBody = toScenarioBody;
 exports.diffSyncPlan = diffSyncPlan;
 exports.remoteScenarioFiltersForGate = remoteScenarioFiltersForGate;
@@ -35276,6 +35278,12 @@ exports.listRemoteScenariosForGate = listRemoteScenariosForGate;
 exports.stripInactiveForeignDraftTags = stripInactiveForeignDraftTags;
 const evalforge_1 = __nccwpck_require__(7230);
 const evalforge_mapper_1 = __nccwpck_require__(6006);
+exports.SyncActionKind = {
+    CREATE: 'CREATE',
+    UPDATE: 'UPDATE',
+    DELETE: 'DELETE',
+    DEFER_DELETE: 'DEFER_DELETE',
+};
 function toScenarioBody(scenario) {
     return (0, evalforge_mapper_1.toEvalForgeBody)(scenario);
 }
@@ -35296,7 +35304,7 @@ function diffSyncPlan(input) {
         const tags = (0, evalforge_1.withManagedTags)(tagStrategy(localScenario.scenario, draftTag), repo);
         const match = remoteByName.get(name);
         if (!match) {
-            actions.push({ kind: 'CREATE', name, body: toScenarioBody(localScenario.scenario), tags });
+            actions.push({ kind: exports.SyncActionKind.CREATE, name, body: toScenarioBody(localScenario.scenario), tags });
             continue;
         }
         const foreign = foreignDraftTags(match.tags, draftTag);
@@ -35304,7 +35312,7 @@ function diffSyncPlan(input) {
             errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: localScenario.path });
             continue;
         }
-        actions.push({ kind: 'UPDATE', id: match.id, name, body: toScenarioBody(localScenario.scenario), tags });
+        actions.push({ kind: exports.SyncActionKind.UPDATE, id: match.id, name, body: toScenarioBody(localScenario.scenario), tags });
     }
     for (const [name, baseScenario] of base) {
         if (head.has(name))
@@ -35313,7 +35321,7 @@ function diffSyncPlan(input) {
         if (!match)
             continue;
         if (match.tags.includes(draftTag)) {
-            actions.push({ kind: 'DELETE', id: match.id, name });
+            actions.push({ kind: exports.SyncActionKind.DELETE, id: match.id, name });
             continue;
         }
         const foreign = foreignDraftTags(match.tags, draftTag);
@@ -35321,7 +35329,7 @@ function diffSyncPlan(input) {
             errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: baseScenario.path });
         }
         else {
-            actions.push({ kind: 'DEFER_DELETE', id: match.id, name });
+            actions.push({ kind: exports.SyncActionKind.DEFER_DELETE, id: match.id, name });
         }
     }
     return { actions, errors };

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34259,7 +34259,8 @@ function collectSkillFiles(root, skillDir, options = {}) {
     const relativePaths = glob_1.glob.sync('**/*', {
         cwd: skillRoot,
         nodir: true,
-        dot: false,
+        // Dotfiles included: a silently dropped file the docs reference is worse than a stray one.
+        dot: true,
         ignore: ['**/node_modules/**', '**/dist/**'],
         posix: true,
     }).sort();

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34899,6 +34899,7 @@ function evaluateRunResult(status) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GATE_COMMENT_MARKER = void 0;
 exports.formatYamlErrors = formatYamlErrors;
+exports.formatGateSkipped = formatGateSkipped;
 exports.formatNoGatedChanges = formatNoGatedChanges;
 exports.formatGuardFailure = formatGuardFailure;
 exports.formatForeignDraftConflicts = formatForeignDraftConflicts;
@@ -34942,6 +34943,17 @@ function formatYamlErrors(errors) {
         'These scenario files did not parse against the schema:',
         '',
         ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+    ]);
+}
+/**
+ * The gate did not evaluate this PR. Said out loud because otherwise a green check is
+ * indistinguishable from one that actually ran the scenarios.
+ */
+function formatGateSkipped(reason) {
+    return render('⏭', 'Skipped', [
+        `This PR was **not evaluated**: ${reason}`,
+        '',
+        'The check is green because the gate did not run, not because the scenarios passed.',
     ]);
 }
 function formatNoGatedChanges(unmapped) {

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34248,19 +34248,14 @@ exports.DEFAULT_COLLECT_LIMITS = {
     maxFileBytes: 1_000_000,
     maxTotalBytes: 10_000_000,
 };
-/**
- * Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`.
- * Ships the whole directory because docs send the agent to sibling paths like
- * `<SKILL_ROOT>/scripts/…`. Over-cap throws rather than truncating.
- */
+/** Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`. */
 function collectSkillFiles(root, skillDir, options = {}) {
     const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
     const skillRoot = node_path_1.posix.join(root, skillDir);
     const relativePaths = glob_1.glob.sync('**/*', {
         cwd: skillRoot,
         nodir: true,
-        // Dotfiles included: a silently dropped file the docs reference is worse than a stray one.
-        dot: true,
+        dot: false,
         ignore: ['**/node_modules/**', '**/dist/**'],
         posix: true,
     }).sort();

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34742,7 +34742,7 @@ class EvalForgeClient {
         const created = res.capabilityVersion;
         return { id: created.id, capabilityId: created.capabilityId, version: created.version };
     }
-    async ensureSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+    async createOrReuseSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
         try {
             return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
         }

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34239,18 +34239,17 @@ async function assertWixAuthor(octokit, owner, repo, prNumber, log) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_COLLECT_LIMITS = void 0;
 exports.collectSkillFiles = collectSkillFiles;
 const node_fs_1 = __nccwpck_require__(3024);
 const node_path_1 = __nccwpck_require__(6760);
 const glob_1 = __nccwpck_require__(2311);
-exports.DEFAULT_COLLECT_LIMITS = {
+const DEFAULT_COLLECT_LIMITS = {
     maxFileBytes: 1_000_000,
     maxTotalBytes: 10_000_000,
 };
 /** Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`. */
 function collectSkillFiles(root, skillDir, options = {}) {
-    const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
+    const limits = options.limits ?? DEFAULT_COLLECT_LIMITS;
     const skillRoot = node_path_1.posix.join(root, skillDir);
     const relativePaths = glob_1.glob.sync('**/*', {
         cwd: skillRoot,
@@ -34295,7 +34294,6 @@ function collectSkillFiles(root, skillDir, options = {}) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = void 0;
-exports.tagForReferencePath = tagForReferencePath;
 exports.deriveTags = deriveTags;
 exports.touchedScenarioPaths = touchedScenarioPaths;
 const minimatch_1 = __nccwpck_require__(8911);
@@ -34731,10 +34729,6 @@ class EvalForgeClient {
             return existing;
         }
     }
-    /**
-     * Same endpoint as createMcpVersion, with the content oneof set to `skillContent`. Lets a
-     * run evaluate a PR's skill files directly, with no MCP URL indirection.
-     */
     async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
         const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
             capabilityVersion: {

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34595,6 +34595,43 @@ class EvalForgeClient {
             return existing;
         }
     }
+    /**
+     * Creates a skill-content capability version — the same endpoint as createMcpVersion,
+     * with the content oneof set to `skillContent` rather than `mcpContent`. This is what
+     * lets a run evaluate a PR's skill files directly, with no MCP URL indirection (and so
+     * without the eval-pipeline comparison service, which builds its MCP URL from
+     * skillsRepo/commitSha and cannot drive skill content).
+     */
+    async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+        const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
+            capabilityVersion: {
+                capabilityId,
+                version: versionLabel,
+                origin: 'pr',
+                notes: `Auto-created for PR #${prNumber}`,
+                skillContent: { files },
+            },
+        });
+        const created = res.capabilityVersion;
+        return { id: created.id, capabilityId: created.capabilityId, version: created.version };
+    }
+    async ensureSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+        try {
+            return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
+        }
+        catch (error) {
+            // A duplicate label should be 409, but the backend currently throws a plain
+            // "already exists" that transcodes to 500 — so recover on either by reusing the
+            // existing version, and only rethrow if it genuinely is not there.
+            if (!isHttpError(error) || (error.status !== 409 && error.status !== 500))
+                throw error;
+            const versions = await this.listCapabilityVersions(capabilityId, projectId);
+            const existing = versions.find(candidate => candidate.version === versionLabel);
+            if (!existing)
+                throw error;
+            return existing;
+        }
+    }
     // Without `names`: lists ALL scenarios via an empty-filter query (used by
     // promote / cleanup / run-all). With `names`: fetches only those scenarios —
     // the V1 `name` filter is a substring match, so each name is queried and then

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34293,10 +34293,12 @@ function collectSkillFiles(root, skillDir, options = {}) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = void 0;
+exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = exports.DEFAULT_REFERENCE_DIR = void 0;
 exports.deriveTags = deriveTags;
 exports.touchedScenarioPaths = touchedScenarioPaths;
 const minimatch_1 = __nccwpck_require__(8911);
+/** Single home for the default: `action.yml`, the config reader and the workflow all defer to it. */
+exports.DEFAULT_REFERENCE_DIR = 'references';
 exports.DEFAULT_IGNORE_GLOBS = ['scripts/**'];
 /** References that apply across scenarios, so no single tag describes them. */
 exports.DEFAULT_BROAD_IMPACT_GLOBS = [
@@ -35851,7 +35853,13 @@ function parseScenario(raw) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_MAX_SCENARIOS = void 0;
 exports.selectScenarios = selectScenarios;
+/**
+ * Cap on scenarios per gate run. Every wix-app scenario is a live agent build, so this bounds real
+ * money and wall-clock, not test runtime. Single home for the default — see DEFAULT_REFERENCE_DIR.
+ */
+exports.DEFAULT_MAX_SCENARIOS = 25;
 /**
  * Builds the run's scenario set. Callers pass `nameToId` as the union of the sync plan's own
  * results and the tag query, so a slow tag index cannot silently shrink the run.

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34304,13 +34304,7 @@ exports.deriveTags = deriveTags;
 exports.touchedScenarioPaths = touchedScenarioPaths;
 const minimatch_1 = __nccwpck_require__(8911);
 exports.DEFAULT_IGNORE_GLOBS = ['scripts/**'];
-/**
- * `SKILL.md` plus the six references that apply across scenarios rather than to one
- * capability. "Changed → run everything" is the honest semantics for these: their effect is
- * not confined to one capability, so no single tag could describe it, and demanding a
- * `code-quality`-tagged scenario would be asking for a scenario that verifies nothing in
- * particular.
- */
+/** References that apply across scenarios, so no single tag describes them. */
 exports.DEFAULT_BROAD_IMPACT_GLOBS = [
     'SKILL.md',
     'references/APP_IDENTIFIERS.md',
@@ -34332,13 +34326,11 @@ function relativeToSkillDir(changedPath, skillDir) {
     return changedPath.startsWith(prefix) ? changedPath.slice(prefix.length) : undefined;
 }
 /**
- * Classifies the PR's changed paths into the tags whose scenarios must run.
+ * Changed paths → the tags whose scenarios must run.
  *
- * Precedence is first-match-wins: **ignore → broad-impact → reference → unmapped**. The
- * order is load-bearing. A broad-impact file that happens to live inside `referenceDir` must
- * be caught before the reference rule sees it, or `references/CODE_QUALITY.md` would derive
- * a `code-quality` tag and the coverage guard would block on a tag no scenario will ever
- * carry.
+ * Order is load-bearing: ignore → broad-impact → reference → unmapped, first match wins. Let
+ * the reference rule run first and `references/CODE_QUALITY.md` derives a `code-quality` tag
+ * the coverage guard can never satisfy.
  */
 function deriveTags(changedPaths, rules) {
     const tags = new Set();
@@ -34358,8 +34350,7 @@ function deriveTags(changedPaths, rules) {
         if (relativePath.startsWith(referencePrefix)) {
             const withinReferences = relativePath.slice(referencePrefix.length);
             const [head, ...rest] = withinReferences.split('/');
-            // A sub-doc directory is already named for its capability, so the directory name is
-            // the tag; a flat reference file derives its tag from the filename.
+            // A sub-doc directory is already named for its capability.
             tags.add(rest.length > 0 ? head.toLowerCase() : tagForReferencePath(head));
             continue;
         }
@@ -34371,10 +34362,7 @@ function deriveTags(changedPaths, rules) {
         unmapped: unmapped.sort(),
     };
 }
-/**
- * Scenario files this PR added, modified or renamed. Removals are excluded: a deleted
- * scenario cannot be quality-checked, and the sync plan handles the delete.
- */
+/** Scenario files added, modified or renamed. Removals are the sync plan's business. */
 function touchedScenarioPaths(changed, evalsGlob) {
     return changed
         .filter(file => file.status !== 'removed' && (0, minimatch_1.minimatch)(file.path, evalsGlob))
@@ -34748,11 +34736,8 @@ class EvalForgeClient {
         }
     }
     /**
-     * Creates a skill-content capability version — the same endpoint as createMcpVersion,
-     * with the content oneof set to `skillContent` rather than `mcpContent`. This is what
-     * lets a run evaluate a PR's skill files directly, with no MCP URL indirection (and so
-     * without the eval-pipeline comparison service, which builds its MCP URL from
-     * skillsRepo/commitSha and cannot drive skill content).
+     * Same endpoint as createMcpVersion, with the content oneof set to `skillContent`. Lets a
+     * run evaluate a PR's skill files directly, with no MCP URL indirection.
      */
     async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
         const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
@@ -34772,9 +34757,7 @@ class EvalForgeClient {
             return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
         }
         catch (error) {
-            // A duplicate label should be 409, but the backend currently throws a plain
-            // "already exists" that transcodes to 500 — so recover on either by reusing the
-            // existing version, and only rethrow if it genuinely is not there.
+            // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
             if (!isHttpError(error) || (error.status !== 409 && error.status !== 500))
                 throw error;
             const versions = await this.listCapabilityVersions(capabilityId, projectId);
@@ -34893,11 +34876,8 @@ function enc(segment) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.evaluateRunResult = evaluateRunResult;
 /**
- * Decides whether a finished run counts as a pass.
- *
- * Note the zero-assertion rule: a run that evaluated nothing has no failures, so a naive
- * `failed + errors === 0` check would report green having verified nothing. That is exactly
- * the false pass the gate exists to prevent, so it is an explicit failure.
+ * Zero assertions fails: such a run has no failures either, so `failed + errors === 0` alone
+ * would report green having verified nothing.
  */
 function evaluateRunResult(status) {
     const reasons = [];
@@ -35085,15 +35065,11 @@ function meetsQualityBar(scenario, bar = exports.DEFAULT_QUALITY_BAR) {
     return { ok: reasons.length === 0, reasons };
 }
 /**
- * The quality guard, evaluated entirely on local YAML plus the PR's changed-file list — no
- * EvalForge calls, no capability version, no run. That is why it comes first: a coverage
- * failure costs nothing.
+ * Runs on local YAML alone, so a coverage failure costs no EvalForge call.
  *
- * Coverage folds the bar in: a tag is covered only by a scenario that *meets* the bar,
- * because a one-assertion scenario would run, pass, and have verified nothing. Untouched
- * shortfalls on an otherwise-covered tag warn instead of blocking — blocking there would
- * hold a PR hostage to a weak scenario someone else authored, which is how thresholds get
- * lowered and gates get bypassed.
+ * A tag counts as covered only by a scenario that meets the bar — a one-assertion scenario
+ * would run, pass, and verify nothing. Untouched shortfalls warn rather than block, so a PR is
+ * never held hostage to a weak scenario someone else wrote.
  */
 function guardScenarios(input) {
     const bar = input.bar ?? exports.DEFAULT_QUALITY_BAR;
@@ -35115,7 +35091,7 @@ function guardScenarios(input) {
             });
             continue;
         }
-        // Tag is covered. Surface the weak siblings the PR did not touch, without blocking.
+        // Covered — surface weak siblings without blocking.
         for (const loaded of carrying) {
             if (input.touchedScenarioPaths.has(loaded.path))
                 continue;
@@ -35136,8 +35112,7 @@ function guardScenarios(input) {
             });
         }
     }
-    // No weakening: every scenario this PR added or edited must meet the bar, whatever its
-    // tags and whether or not a strong sibling already satisfies coverage.
+    // No weakening: a touched scenario must meet the bar even if a strong sibling covers its tag.
     for (const loaded of allScenarios) {
         if (!input.touchedScenarioPaths.has(loaded.path))
             continue;
@@ -35867,14 +35842,11 @@ function parseScenario(raw) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.selectScenarios = selectScenarios;
 /**
- * Builds the run's scenario set.
+ * Builds the run's scenario set. Callers pass `nameToId` as the union of the sync plan's own
+ * results and the tag query, so a slow tag index cannot silently shrink the run.
  *
- * `nameToId` is the union of the sync plan's own results (CREATE returns the new id, UPDATE
- * already has it) and the remote tag query, so the gate never depends on read-after-write
- * consistency: a slow tag index cannot silently shrink the run.
- *
- * The cap prioritises scenarios this PR touched. Sorting purely alphabetically would let a
- * capped run drop the author's own new scenario in favour of an unrelated one.
+ * Touched scenarios sort first: a purely alphabetical cap could drop the author's own new
+ * scenario for an unrelated one.
  */
 function selectScenarios(input) {
     const derivedTags = new Set(input.tags);

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34249,13 +34249,9 @@ exports.DEFAULT_COLLECT_LIMITS = {
     maxTotalBytes: 10_000_000,
 };
 /**
- * Reads `<root>/<skillDir>/**` into the file list a skill-content capability version takes.
- *
- * Paths are relative to `skillDir`, so a collected file reads `references/DASHBOARD_PAGE.md`
- * — matching what a scenario's `referenceFiles` assertions name.
- *
- * Caps throw rather than truncate: a silently shortened skill would be evaluated as if it
- * were the whole thing, and the run would report on a skill that never existed.
+ * Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`.
+ * Ships the whole directory because docs send the agent to sibling paths like
+ * `<SKILL_ROOT>/scripts/…`. Over-cap throws rather than truncating.
  */
 function collectSkillFiles(root, skillDir, options = {}) {
     const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
@@ -34271,27 +34267,24 @@ function collectSkillFiles(root, skillDir, options = {}) {
     let totalBytes = 0;
     for (const relativePath of relativePaths) {
         const buffer = (0, node_fs_1.readFileSync)(node_path_1.posix.join(skillRoot, relativePath));
-        // A NUL byte means this is not text, and skill content is text. Skipping keeps a stray
-        // image from breaking the version; warning keeps it from being invisible.
+        // A NUL byte means binary, and skill content is text. Skip it, but say so.
         if (buffer.includes(0)) {
             options.warn?.(`Skipping non-text file in ${skillDir}: ${relativePath}`);
             continue;
         }
         if (buffer.byteLength > limits.maxFileBytes) {
             throw new Error(`Skill file ${relativePath} is ${buffer.byteLength} bytes, over the per-file cap of `
-                + `${limits.maxFileBytes}. Split it or raise the cap — truncating would evaluate a skill `
-                + `that does not exist.`);
+                + `${limits.maxFileBytes}. Split it or raise the cap.`);
         }
         totalBytes += buffer.byteLength;
         if (totalBytes > limits.maxTotalBytes) {
             throw new Error(`Skill ${skillDir} exceeds the total content cap of ${limits.maxTotalBytes} bytes at `
-                + `${relativePath}. Raise the cap deliberately rather than shipping a partial skill.`);
+                + `${relativePath}. Raise the cap deliberately.`);
         }
         files.push({ path: relativePath, content: buffer.toString('utf8') });
     }
     if (files.length === 0) {
-        throw new Error(`No files collected from ${skillRoot} — the skill directory is empty or mis-configured. `
-            + `Check the skill-dir input.`);
+        throw new Error(`No files collected from ${skillRoot}. Check the skill-dir and reference-dir inputs.`);
     }
     return files;
 }

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34299,6 +34299,99 @@ function collectSkillFiles(root, skillDir, options = {}) {
 
 /***/ }),
 
+/***/ 7264:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_BROAD_IMPACT_GLOBS = exports.DEFAULT_IGNORE_GLOBS = void 0;
+exports.tagForReferencePath = tagForReferencePath;
+exports.deriveTags = deriveTags;
+exports.touchedScenarioPaths = touchedScenarioPaths;
+const minimatch_1 = __nccwpck_require__(8911);
+exports.DEFAULT_IGNORE_GLOBS = ['scripts/**'];
+/**
+ * `SKILL.md` plus the six references that apply across scenarios rather than to one
+ * capability. "Changed → run everything" is the honest semantics for these: their effect is
+ * not confined to one capability, so no single tag could describe it, and demanding a
+ * `code-quality`-tagged scenario would be asking for a scenario that verifies nothing in
+ * particular.
+ */
+exports.DEFAULT_BROAD_IMPACT_GLOBS = [
+    'SKILL.md',
+    'references/APP_IDENTIFIERS.md',
+    'references/APP_MARKET_REVIEW.md',
+    'references/APP_VALIDATION.md',
+    'references/CODE_QUALITY.md',
+    'references/DOCUMENTATION.md',
+    'references/EXTENSION_REGISTRATION.md',
+];
+/** `DASHBOARD_PAGE.md` → `dashboard-page`. */
+function tagForReferencePath(relativeReferencePath) {
+    return relativeReferencePath.replace(/\.md$/i, '').toLowerCase().replace(/_/g, '-');
+}
+function matchesAny(relativePath, globs) {
+    return globs.some(pattern => (0, minimatch_1.minimatch)(relativePath, pattern, { dot: true }));
+}
+function relativeToSkillDir(changedPath, skillDir) {
+    const prefix = `${skillDir}/`;
+    return changedPath.startsWith(prefix) ? changedPath.slice(prefix.length) : undefined;
+}
+/**
+ * Classifies the PR's changed paths into the tags whose scenarios must run.
+ *
+ * Precedence is first-match-wins: **ignore → broad-impact → reference → unmapped**. The
+ * order is load-bearing. A broad-impact file that happens to live inside `referenceDir` must
+ * be caught before the reference rule sees it, or `references/CODE_QUALITY.md` would derive
+ * a `code-quality` tag and the coverage guard would block on a tag no scenario will ever
+ * carry.
+ */
+function deriveTags(changedPaths, rules) {
+    const tags = new Set();
+    const unmapped = [];
+    let broadImpact = false;
+    const referencePrefix = `${rules.referenceDir}/`;
+    for (const changedPath of changedPaths) {
+        const relativePath = relativeToSkillDir(changedPath, rules.skillDir);
+        if (relativePath === undefined)
+            continue;
+        if (matchesAny(relativePath, rules.ignoreGlobs))
+            continue;
+        if (matchesAny(relativePath, rules.broadImpactGlobs)) {
+            broadImpact = true;
+            continue;
+        }
+        if (relativePath.startsWith(referencePrefix)) {
+            const withinReferences = relativePath.slice(referencePrefix.length);
+            const [head, ...rest] = withinReferences.split('/');
+            // A sub-doc directory is already named for its capability, so the directory name is
+            // the tag; a flat reference file derives its tag from the filename.
+            tags.add(rest.length > 0 ? head.toLowerCase() : tagForReferencePath(head));
+            continue;
+        }
+        unmapped.push(changedPath);
+    }
+    return {
+        tags: [...tags].sort(),
+        broadImpact,
+        unmapped: unmapped.sort(),
+    };
+}
+/**
+ * Scenario files this PR added, modified or renamed. Removals are excluded: a deleted
+ * scenario cannot be quality-checked, and the sync plan handles the delete.
+ */
+function touchedScenarioPaths(changed, evalsGlob) {
+    return changed
+        .filter(file => file.status !== 'removed' && (0, minimatch_1.minimatch)(file.path, evalsGlob))
+        .map(file => file.path)
+        .sort();
+}
+
+
+/***/ }),
+
 /***/ 6006:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -34833,6 +34926,7 @@ __exportStar(__nccwpck_require__(7208), exports);
 __exportStar(__nccwpck_require__(473), exports);
 __exportStar(__nccwpck_require__(5781), exports);
 __exportStar(__nccwpck_require__(4527), exports);
+__exportStar(__nccwpck_require__(7264), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34233,6 +34233,72 @@ async function assertWixAuthor(octokit, owner, repo, prNumber, log) {
 
 /***/ }),
 
+/***/ 4527:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_COLLECT_LIMITS = void 0;
+exports.collectSkillFiles = collectSkillFiles;
+const node_fs_1 = __nccwpck_require__(3024);
+const node_path_1 = __nccwpck_require__(6760);
+const glob_1 = __nccwpck_require__(2311);
+exports.DEFAULT_COLLECT_LIMITS = {
+    maxFileBytes: 1_000_000,
+    maxTotalBytes: 10_000_000,
+};
+/**
+ * Reads `<root>/<skillDir>/**` into the file list a skill-content capability version takes.
+ *
+ * Paths are relative to `skillDir`, so a collected file reads `references/DASHBOARD_PAGE.md`
+ * — matching what a scenario's `referenceFiles` assertions name.
+ *
+ * Caps throw rather than truncate: a silently shortened skill would be evaluated as if it
+ * were the whole thing, and the run would report on a skill that never existed.
+ */
+function collectSkillFiles(root, skillDir, options = {}) {
+    const limits = options.limits ?? exports.DEFAULT_COLLECT_LIMITS;
+    const skillRoot = node_path_1.posix.join(root, skillDir);
+    const relativePaths = glob_1.glob.sync('**/*', {
+        cwd: skillRoot,
+        nodir: true,
+        dot: false,
+        ignore: ['**/node_modules/**', '**/dist/**'],
+        posix: true,
+    }).sort();
+    const files = [];
+    let totalBytes = 0;
+    for (const relativePath of relativePaths) {
+        const buffer = (0, node_fs_1.readFileSync)(node_path_1.posix.join(skillRoot, relativePath));
+        // A NUL byte means this is not text, and skill content is text. Skipping keeps a stray
+        // image from breaking the version; warning keeps it from being invisible.
+        if (buffer.includes(0)) {
+            options.warn?.(`Skipping non-text file in ${skillDir}: ${relativePath}`);
+            continue;
+        }
+        if (buffer.byteLength > limits.maxFileBytes) {
+            throw new Error(`Skill file ${relativePath} is ${buffer.byteLength} bytes, over the per-file cap of `
+                + `${limits.maxFileBytes}. Split it or raise the cap — truncating would evaluate a skill `
+                + `that does not exist.`);
+        }
+        totalBytes += buffer.byteLength;
+        if (totalBytes > limits.maxTotalBytes) {
+            throw new Error(`Skill ${skillDir} exceeds the total content cap of ${limits.maxTotalBytes} bytes at `
+                + `${relativePath}. Raise the cap deliberately rather than shipping a partial skill.`);
+        }
+        files.push({ path: relativePath, content: buffer.toString('utf8') });
+    }
+    if (files.length === 0) {
+        throw new Error(`No files collected from ${skillRoot} — the skill directory is empty or mis-configured. `
+            + `Check the skill-dir input.`);
+    }
+    return files;
+}
+
+
+/***/ }),
+
 /***/ 6006:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -34766,6 +34832,7 @@ __exportStar(__nccwpck_require__(5992), exports);
 __exportStar(__nccwpck_require__(7208), exports);
 __exportStar(__nccwpck_require__(473), exports);
 __exportStar(__nccwpck_require__(5781), exports);
+__exportStar(__nccwpck_require__(4527), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34927,6 +34927,144 @@ function evaluateRunResult(status) {
 
 /***/ }),
 
+/***/ 5970:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GATE_COMMENT_MARKER = void 0;
+exports.formatYamlErrors = formatYamlErrors;
+exports.formatNoGatedChanges = formatNoGatedChanges;
+exports.formatGuardFailure = formatGuardFailure;
+exports.formatForeignDraftConflicts = formatForeignDraftConflicts;
+exports.formatGateResult = formatGateResult;
+exports.formatGateTimeout = formatGateTimeout;
+exports.formatGateServiceError = formatGateServiceError;
+const evalforge_1 = __nccwpck_require__(7230);
+exports.GATE_COMMENT_MARKER = '<!-- evalforge-skill-gate-action -->';
+const HEADING = 'EvalForge Skill Gate';
+function render(icon, label, body) {
+    return [exports.GATE_COMMENT_MARKER, `## ${icon} ${HEADING}: ${label}`, '', ...body].join('\n');
+}
+function failIcon(blocking) {
+    return blocking ? { icon: '❌', label: 'Failed' } : { icon: '⚠️', label: 'Warning' };
+}
+function soakNote(blocking) {
+    return blocking
+        ? []
+        : ['', '_The gate is in its soak period (`blocking: false`), so this check still passes._'];
+}
+function unmappedSection(unmapped) {
+    if (unmapped.length === 0)
+        return [];
+    return [
+        '',
+        '**Unmapped paths** — these changed under the skill directory but no rule covers them, so they triggered nothing. Add them to `ignore-globs` if that is correct:',
+        ...unmapped.map(path => `- \`${path}\``),
+    ];
+}
+function warningSection(warnings) {
+    if (warnings.length === 0)
+        return [];
+    return [
+        '',
+        '**Existing scenarios below the quality bar** (not blocking — you did not write these, but they are worth fixing):',
+        ...warnings.map(warning => `- \`${warning.path}\` (\`${warning.name}\`, tagged ${warning.tags.map(tag => `\`${tag}\``).join(', ')}) — ${warning.reasons.join('; ')}`),
+    ];
+}
+function formatYamlErrors(errors) {
+    return render('❌', 'Invalid Scenario YAML', [
+        'These scenario files did not parse against the schema:',
+        '',
+        ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+    ]);
+}
+function formatNoGatedChanges(unmapped) {
+    return render('✅', 'No Gated Changes', [
+        'Nothing in this PR maps to an eval tag, so no run was needed.',
+        ...unmappedSection(unmapped),
+    ]);
+}
+function violationLine(violation) {
+    switch (violation.kind) {
+        case 'UNCOVERED_TAG':
+            return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under the scenario directory tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+        case 'WEAK_TAG':
+            return `- **\`${violation.tag}\`** is carried only by scenarios below the quality bar (${violation.scenarios.map(name => `\`${name}\``).join(', ')}). Strengthen one of them, or add a scenario that meets the bar.`;
+        case 'WEAK_TOUCHED_SCENARIO':
+            return `- \`${violation.path}\` (\`${violation.name}\`) — ${violation.reasons.join('; ')}. This PR added or edited it, so it must meet the bar.`;
+    }
+}
+function formatGuardFailure(input) {
+    const { icon, label } = failIcon(input.blocking);
+    return render(icon, `Coverage ${label}`, [
+        'The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.',
+        '',
+        ...input.violations.map(violationLine),
+        '',
+        '_No eval run was started — a coverage failure is caught before any run cost._',
+        ...warningSection(input.warnings),
+        ...soakNote(input.blocking),
+    ]);
+}
+function formatForeignDraftConflicts(errors, blocking) {
+    const { icon } = failIcon(blocking);
+    return render(icon, 'Scenario Locked by Another PR', [
+        'These scenarios are draft-tagged for other open PRs. Wait for those to merge or close, or coordinate with their authors:',
+        '',
+        ...errors.map(error => {
+            const links = error.foreignTags.map(tag => {
+                const draft = (0, evalforge_1.parseDraftTag)(tag);
+                return draft ? `https://github.com/${draft.repo}/pull/${draft.prNumber}` : tag;
+            });
+            return `- \`${error.name}\` is held by: ${links.join(', ')}`;
+        }),
+        ...soakNote(blocking),
+    ]);
+}
+function formatGateResult(input) {
+    const { metrics, verdict, selection } = input;
+    const { icon, label } = verdict.passed ? { icon: '✅', label: 'Passed' } : failIcon(input.blocking);
+    const body = [
+        `**Pass rate:** ${metrics.passRate}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
+            + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
+            + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
+        `**Run:** [${input.runId}](${input.runUrl})`,
+    ];
+    if (!verdict.passed) {
+        body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
+    }
+    body.push('', input.broadImpact
+        ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${selection.selected.length} scenario(s) ran.`
+        : `**Scope:** ${selection.selected.length} scenario(s) ran.`, '', ...selection.selected.map(name => `- \`${name}\``));
+    if (selection.dropped.length > 0) {
+        body.push('', `**Capped at \`max-scenarios: ${input.maxScenarios}\`** — these were not run:`, ...selection.dropped.map(name => `- \`${name}\``));
+    }
+    if (selection.missingIds.length > 0) {
+        body.push('', '**Not run — no EvalForge scenario found for these names.** They are in the repo YAML but not in EvalForge, which points at a sync gap:', ...selection.missingIds.map(name => `- \`${name}\``));
+    }
+    body.push(...warningSection(input.warnings), ...unmappedSection(input.unmapped));
+    if (!verdict.passed)
+        body.push(...soakNote(input.blocking));
+    return render(icon, label, body);
+}
+function formatGateTimeout(runId, runUrl, blocking) {
+    return render(blocking ? '⏱' : '⚠️', 'Timed Out', [
+        'The eval run did not finish within the poll window. It may still be running in EvalForge.',
+        '',
+        `**Run:** [${runId}](${runUrl})`,
+        ...soakNote(blocking),
+    ]);
+}
+function formatGateServiceError(message, blocking) {
+    const { icon, label } = failIcon(blocking);
+    return render(icon, label, [message, ...soakNote(blocking)]);
+}
+
+
+/***/ }),
+
 /***/ 3308:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -35067,6 +35205,7 @@ __exportStar(__nccwpck_require__(7264), exports);
 __exportStar(__nccwpck_require__(3308), exports);
 __exportStar(__nccwpck_require__(8833), exports);
 __exportStar(__nccwpck_require__(3460), exports);
+__exportStar(__nccwpck_require__(5970), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34892,6 +34892,41 @@ function enc(segment) {
 
 /***/ }),
 
+/***/ 3460:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.evaluateRunResult = evaluateRunResult;
+/**
+ * Decides whether a finished run counts as a pass.
+ *
+ * Note the zero-assertion rule: a run that evaluated nothing has no failures, so a naive
+ * `failed + errors === 0` check would report green having verified nothing. That is exactly
+ * the false pass the gate exists to prevent, so it is an explicit failure.
+ */
+function evaluateRunResult(status) {
+    const reasons = [];
+    const metrics = status.aggregateMetrics;
+    if (status.status !== 'completed') {
+        reasons.push(`the eval run ${status.status === 'cancelled' ? 'was cancelled' : `ended as "${status.status}"`}`);
+    }
+    if (metrics.failed > 0) {
+        reasons.push(`${metrics.failed} assertion${metrics.failed === 1 ? '' : 's'} failed`);
+    }
+    if (metrics.errors > 0) {
+        reasons.push(`${metrics.errors} assertion${metrics.errors === 1 ? '' : 's'} errored`);
+    }
+    if (metrics.totalAssertions === 0) {
+        reasons.push('the run produced no assertions, so nothing was verified');
+    }
+    return { passed: reasons.length === 0, reasons };
+}
+
+
+/***/ }),
+
 /***/ 3308:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -35030,6 +35065,8 @@ __exportStar(__nccwpck_require__(5781), exports);
 __exportStar(__nccwpck_require__(4527), exports);
 __exportStar(__nccwpck_require__(7264), exports);
 __exportStar(__nccwpck_require__(3308), exports);
+__exportStar(__nccwpck_require__(8833), exports);
+__exportStar(__nccwpck_require__(3460), exports);
 
 
 /***/ }),
@@ -35685,6 +35722,57 @@ function parseScenario(raw) {
         }
     }
     return exports.ScenarioSchema.parse(parsed);
+}
+
+
+/***/ }),
+
+/***/ 8833:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.selectScenarios = selectScenarios;
+/**
+ * Builds the run's scenario set.
+ *
+ * `nameToId` is the union of the sync plan's own results (CREATE returns the new id, UPDATE
+ * already has it) and the remote tag query, so the gate never depends on read-after-write
+ * consistency: a slow tag index cannot silently shrink the run.
+ *
+ * The cap prioritises scenarios this PR touched. Sorting purely alphabetically would let a
+ * capped run drop the author's own new scenario in favour of an unrelated one.
+ */
+function selectScenarios(input) {
+    const derivedTags = new Set(input.tags);
+    const candidates = [...input.localScenarios.values()].filter(loaded => input.broadImpact
+        || input.touchedScenarioPaths.has(loaded.path)
+        || loaded.scenario.tags.some(tag => derivedTags.has(tag)));
+    const ordered = candidates.sort((left, right) => {
+        const leftTouched = input.touchedScenarioPaths.has(left.path) ? 0 : 1;
+        const rightTouched = input.touchedScenarioPaths.has(right.path) ? 0 : 1;
+        if (leftTouched !== rightTouched)
+            return leftTouched - rightTouched;
+        return left.scenario.name.localeCompare(right.scenario.name);
+    });
+    const missingIds = [];
+    const resolvable = [];
+    for (const loaded of ordered) {
+        const id = input.nameToId.get(loaded.scenario.name);
+        if (id)
+            resolvable.push({ name: loaded.scenario.name, id });
+        else
+            missingIds.push(loaded.scenario.name);
+    }
+    const running = resolvable.slice(0, Math.max(0, input.maxScenarios));
+    const cut = resolvable.slice(running.length);
+    return {
+        ids: running.map(entry => entry.id),
+        selected: running.map(entry => entry.name),
+        dropped: cut.map(entry => entry.name).sort(),
+        missingIds: missingIds.sort(),
+    };
 }
 
 

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34620,10 +34620,11 @@ function assertNotTruncated(received, meta, path) {
 function normalizeStatus(s) {
     return String(s).toLowerCase();
 }
-// V1 `pass_rate` is a fraction (0.0–1.0); the action's internal contract (and
-// comment.ts) expects an integer percentage (0–100).
-function toPercent(fraction) {
-    return Math.round((fraction ?? 0) * 100);
+// V1 `pass_rate` already arrives as a percentage (0–100), verified against 8 real runs in the
+// App Builder project: 4/5 reports 80, 26/30 reports 86.667. Multiplying by 100 here rendered
+// every comment as "10000%".
+function toPercent(passRate) {
+    return Math.round(passRate ?? 0);
 }
 // Client for the EvalForge V1 REST API (`${baseUrl}/v1/...`, e.g.
 // https://manage.wix.com/_api/evalforge-backend/v1/...), authenticated with an

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34892,6 +34892,108 @@ function enc(segment) {
 
 /***/ }),
 
+/***/ 3308:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.DEFAULT_QUALITY_BAR = void 0;
+exports.meetsQualityBar = meetsQualityBar;
+exports.guardScenarios = guardScenarios;
+const schema_1 = __nccwpck_require__(3540);
+exports.DEFAULT_QUALITY_BAR = {
+    minAssertions: 3,
+    requireLlmJudge: true,
+};
+/** Does this scenario verify enough to be worth running? */
+function meetsQualityBar(scenario, bar = exports.DEFAULT_QUALITY_BAR) {
+    const reasons = [];
+    if (scenario.assertions.length < bar.minAssertions) {
+        reasons.push(`has ${scenario.assertions.length} assertion${scenario.assertions.length === 1 ? '' : 's'} `
+            + `(needs at least ${bar.minAssertions})`);
+    }
+    if (bar.requireLlmJudge && !scenario.assertions.some(schema_1.isLlmJudge)) {
+        reasons.push('has no llm_judge assertion');
+    }
+    return { ok: reasons.length === 0, reasons };
+}
+/**
+ * The quality guard, evaluated entirely on local YAML plus the PR's changed-file list — no
+ * EvalForge calls, no capability version, no run. That is why it comes first: a coverage
+ * failure costs nothing.
+ *
+ * Coverage folds the bar in: a tag is covered only by a scenario that *meets* the bar,
+ * because a one-assertion scenario would run, pass, and have verified nothing. Untouched
+ * shortfalls on an otherwise-covered tag warn instead of blocking — blocking there would
+ * hold a PR hostage to a weak scenario someone else authored, which is how thresholds get
+ * lowered and gates get bypassed.
+ */
+function guardScenarios(input) {
+    const bar = input.bar ?? exports.DEFAULT_QUALITY_BAR;
+    const allScenarios = [...input.scenarios.values()];
+    const violations = [];
+    const weakUntouched = new Map();
+    for (const tag of input.tags) {
+        const carrying = allScenarios.filter(loaded => loaded.scenario.tags.includes(tag));
+        if (carrying.length === 0) {
+            violations.push({ kind: 'UNCOVERED_TAG', tag });
+            continue;
+        }
+        const meeting = carrying.filter(loaded => meetsQualityBar(loaded.scenario, bar).ok);
+        if (meeting.length === 0) {
+            violations.push({
+                kind: 'WEAK_TAG',
+                tag,
+                scenarios: carrying.map(loaded => loaded.scenario.name).sort(),
+            });
+            continue;
+        }
+        // Tag is covered. Surface the weak siblings the PR did not touch, without blocking.
+        for (const loaded of carrying) {
+            if (input.touchedScenarioPaths.has(loaded.path))
+                continue;
+            const check = meetsQualityBar(loaded.scenario, bar);
+            if (check.ok)
+                continue;
+            const existing = weakUntouched.get(loaded.scenario.name);
+            if (existing) {
+                existing.tags.push(tag);
+                continue;
+            }
+            weakUntouched.set(loaded.scenario.name, {
+                kind: 'WEAK_UNTOUCHED_SCENARIO',
+                name: loaded.scenario.name,
+                path: loaded.path,
+                tags: [tag],
+                reasons: check.reasons,
+            });
+        }
+    }
+    // No weakening: every scenario this PR added or edited must meet the bar, whatever its
+    // tags and whether or not a strong sibling already satisfies coverage.
+    for (const loaded of allScenarios) {
+        if (!input.touchedScenarioPaths.has(loaded.path))
+            continue;
+        const check = meetsQualityBar(loaded.scenario, bar);
+        if (check.ok)
+            continue;
+        violations.push({
+            kind: 'WEAK_TOUCHED_SCENARIO',
+            name: loaded.scenario.name,
+            path: loaded.path,
+            reasons: check.reasons,
+        });
+    }
+    return {
+        violations,
+        warnings: [...weakUntouched.values()].sort((left, right) => left.name.localeCompare(right.name)),
+    };
+}
+
+
+/***/ }),
+
 /***/ 7495:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -34927,6 +35029,7 @@ __exportStar(__nccwpck_require__(473), exports);
 __exportStar(__nccwpck_require__(5781), exports);
 __exportStar(__nccwpck_require__(4527), exports);
 __exportStar(__nccwpck_require__(7264), exports);
+__exportStar(__nccwpck_require__(3308), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-yaml-gate/yarn.lock
+++ b/.github/actions/evalforge-yaml-gate/yarn.lock
@@ -671,6 +671,7 @@ __metadata:
     "@actions/core": "npm:^1.10.1"
     glob: "npm:^11.0.0"
     js-yaml: "npm:^4.1.1"
+    minimatch: "npm:^10.1.1"
     zod: "npm:^3.23.0"
   languageName: node
   linkType: soft

--- a/packages/evalforge-core/package.json
+++ b/packages/evalforge-core/package.json
@@ -13,6 +13,7 @@
     "@actions/core": "^1.10.1",
     "glob": "^11.0.0",
     "js-yaml": "^4.1.1",
+    "minimatch": "^10.1.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/evalforge-core/src/collect-skill-files.ts
+++ b/packages/evalforge-core/src/collect-skill-files.ts
@@ -8,7 +8,7 @@ export type CollectLimits = {
   maxTotalBytes: number;
 };
 
-export const DEFAULT_COLLECT_LIMITS: CollectLimits = {
+const DEFAULT_COLLECT_LIMITS: CollectLimits = {
   maxFileBytes: 1_000_000,
   maxTotalBytes: 10_000_000,
 };

--- a/packages/evalforge-core/src/collect-skill-files.ts
+++ b/packages/evalforge-core/src/collect-skill-files.ts
@@ -18,11 +18,7 @@ export type CollectOptions = {
   warn?: (message: string) => void;
 };
 
-/**
- * Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`.
- * Ships the whole directory because docs send the agent to sibling paths like
- * `<SKILL_ROOT>/scripts/…`. Over-cap throws rather than truncating.
- */
+/** Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`. */
 export function collectSkillFiles(
   root: string,
   skillDir: string,
@@ -34,8 +30,7 @@ export function collectSkillFiles(
   const relativePaths = glob.sync('**/*', {
     cwd: skillRoot,
     nodir: true,
-    // Dotfiles included: a silently dropped file the docs reference is worse than a stray one.
-    dot: true,
+    dot: false,
     ignore: ['**/node_modules/**', '**/dist/**'],
     posix: true,
   }).sort();

--- a/packages/evalforge-core/src/collect-skill-files.ts
+++ b/packages/evalforge-core/src/collect-skill-files.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { posix } from 'node:path';
+import { glob } from 'glob';
+import type { SkillFileContent } from './evalforge';
+
+export type CollectLimits = {
+  maxFileBytes: number;
+  maxTotalBytes: number;
+};
+
+export const DEFAULT_COLLECT_LIMITS: CollectLimits = {
+  maxFileBytes: 1_000_000,
+  maxTotalBytes: 10_000_000,
+};
+
+export type CollectOptions = {
+  limits?: CollectLimits;
+  warn?: (message: string) => void;
+};
+
+/**
+ * Reads `<root>/<skillDir>/**` into the file list a skill-content capability version takes.
+ *
+ * Paths are relative to `skillDir`, so a collected file reads `references/DASHBOARD_PAGE.md`
+ * — matching what a scenario's `referenceFiles` assertions name.
+ *
+ * Caps throw rather than truncate: a silently shortened skill would be evaluated as if it
+ * were the whole thing, and the run would report on a skill that never existed.
+ */
+export function collectSkillFiles(
+  root: string,
+  skillDir: string,
+  options: CollectOptions = {},
+): SkillFileContent[] {
+  const limits = options.limits ?? DEFAULT_COLLECT_LIMITS;
+  const skillRoot = posix.join(root, skillDir);
+
+  const relativePaths = glob.sync('**/*', {
+    cwd: skillRoot,
+    nodir: true,
+    dot: false,
+    ignore: ['**/node_modules/**', '**/dist/**'],
+    posix: true,
+  }).sort();
+
+  const files: SkillFileContent[] = [];
+  let totalBytes = 0;
+
+  for (const relativePath of relativePaths) {
+    const buffer = readFileSync(posix.join(skillRoot, relativePath));
+
+    // A NUL byte means this is not text, and skill content is text. Skipping keeps a stray
+    // image from breaking the version; warning keeps it from being invisible.
+    if (buffer.includes(0)) {
+      options.warn?.(`Skipping non-text file in ${skillDir}: ${relativePath}`);
+      continue;
+    }
+
+    if (buffer.byteLength > limits.maxFileBytes) {
+      throw new Error(
+        `Skill file ${relativePath} is ${buffer.byteLength} bytes, over the per-file cap of `
+        + `${limits.maxFileBytes}. Split it or raise the cap — truncating would evaluate a skill `
+        + `that does not exist.`,
+      );
+    }
+
+    totalBytes += buffer.byteLength;
+    if (totalBytes > limits.maxTotalBytes) {
+      throw new Error(
+        `Skill ${skillDir} exceeds the total content cap of ${limits.maxTotalBytes} bytes at `
+        + `${relativePath}. Raise the cap deliberately rather than shipping a partial skill.`,
+      );
+    }
+
+    files.push({ path: relativePath, content: buffer.toString('utf8') });
+  }
+
+  if (files.length === 0) {
+    throw new Error(
+      `No files collected from ${skillRoot} — the skill directory is empty or mis-configured. `
+      + `Check the skill-dir input.`,
+    );
+  }
+
+  return files;
+}

--- a/packages/evalforge-core/src/collect-skill-files.ts
+++ b/packages/evalforge-core/src/collect-skill-files.ts
@@ -34,7 +34,8 @@ export function collectSkillFiles(
   const relativePaths = glob.sync('**/*', {
     cwd: skillRoot,
     nodir: true,
-    dot: false,
+    // Dotfiles included: a silently dropped file the docs reference is worse than a stray one.
+    dot: true,
     ignore: ['**/node_modules/**', '**/dist/**'],
     posix: true,
   }).sort();

--- a/packages/evalforge-core/src/collect-skill-files.ts
+++ b/packages/evalforge-core/src/collect-skill-files.ts
@@ -19,13 +19,9 @@ export type CollectOptions = {
 };
 
 /**
- * Reads `<root>/<skillDir>/**` into the file list a skill-content capability version takes.
- *
- * Paths are relative to `skillDir`, so a collected file reads `references/DASHBOARD_PAGE.md`
- * — matching what a scenario's `referenceFiles` assertions name.
- *
- * Caps throw rather than truncate: a silently shortened skill would be evaluated as if it
- * were the whole thing, and the run would report on a skill that never existed.
+ * Reads all of `<root>/<skillDir>`, minus build artifacts, with paths relative to `skillDir`.
+ * Ships the whole directory because docs send the agent to sibling paths like
+ * `<SKILL_ROOT>/scripts/…`. Over-cap throws rather than truncating.
  */
 export function collectSkillFiles(
   root: string,
@@ -49,8 +45,7 @@ export function collectSkillFiles(
   for (const relativePath of relativePaths) {
     const buffer = readFileSync(posix.join(skillRoot, relativePath));
 
-    // A NUL byte means this is not text, and skill content is text. Skipping keeps a stray
-    // image from breaking the version; warning keeps it from being invisible.
+    // A NUL byte means binary, and skill content is text. Skip it, but say so.
     if (buffer.includes(0)) {
       options.warn?.(`Skipping non-text file in ${skillDir}: ${relativePath}`);
       continue;
@@ -59,8 +54,7 @@ export function collectSkillFiles(
     if (buffer.byteLength > limits.maxFileBytes) {
       throw new Error(
         `Skill file ${relativePath} is ${buffer.byteLength} bytes, over the per-file cap of `
-        + `${limits.maxFileBytes}. Split it or raise the cap — truncating would evaluate a skill `
-        + `that does not exist.`,
+        + `${limits.maxFileBytes}. Split it or raise the cap.`,
       );
     }
 
@@ -68,7 +62,7 @@ export function collectSkillFiles(
     if (totalBytes > limits.maxTotalBytes) {
       throw new Error(
         `Skill ${skillDir} exceeds the total content cap of ${limits.maxTotalBytes} bytes at `
-        + `${relativePath}. Raise the cap deliberately rather than shipping a partial skill.`,
+        + `${relativePath}. Raise the cap deliberately.`,
       );
     }
 
@@ -77,8 +71,7 @@ export function collectSkillFiles(
 
   if (files.length === 0) {
     throw new Error(
-      `No files collected from ${skillRoot} — the skill directory is empty or mis-configured. `
-      + `Check the skill-dir input.`,
+      `No files collected from ${skillRoot}. Check the skill-dir and reference-dir inputs.`,
     );
   }
 

--- a/packages/evalforge-core/src/derive-tags.ts
+++ b/packages/evalforge-core/src/derive-tags.ts
@@ -1,39 +1,32 @@
 import { minimatch } from 'minimatch';
 
+/** Everything but `skillDir` is relative to it. */
 export type TagRules = {
   /** Repo-relative skill root, e.g. `skills/wix-app`. */
   skillDir: string;
-  /** Reference directory relative to `skillDir`, e.g. `references`. */
+  /** e.g. `references`. */
   referenceDir: string;
-  /** Globs, relative to `skillDir`, whose changes derive nothing at all. */
+  /** Changes here derive nothing. */
   ignoreGlobs: string[];
-  /** Globs, relative to `skillDir`, whose changes put the whole suite in play. */
+  /** Changes here put the whole suite in play. */
   broadImpactGlobs: string[];
 };
 
 export type DerivedTags = {
-  /** Reference-derived tags only — sorted and deduped. Never includes broad-impact expansion. */
+  /** Reference-derived tags, sorted and deduped. */
   tags: string[];
   /**
-   * A cross-cutting file changed, so the whole suite is in play. Consumed by scenario
-   * selection only: a broad-impact path derives no tag, so there is no tag for the coverage
-   * guard to demand a scenario for. Feeding an expanded tag union to the guard instead would
-   * block a SKILL.md typo fix on any weak scenario anywhere in the repo.
+   * Whole suite is in play. Drives selection only — expanding it to a tag union for the guard
+   * would block a SKILL.md typo fix on any weak scenario in the repo.
    */
   broadImpact: boolean;
-  /** Paths under `skillDir` that no rule covered — reported, never blocking. */
+  /** Paths under `skillDir` no rule covered — reported, never blocking. */
   unmapped: string[];
 };
 
 export const DEFAULT_IGNORE_GLOBS: string[] = ['scripts/**'];
 
-/**
- * `SKILL.md` plus the six references that apply across scenarios rather than to one
- * capability. "Changed → run everything" is the honest semantics for these: their effect is
- * not confined to one capability, so no single tag could describe it, and demanding a
- * `code-quality`-tagged scenario would be asking for a scenario that verifies nothing in
- * particular.
- */
+/** References that apply across scenarios, so no single tag describes them. */
 export const DEFAULT_BROAD_IMPACT_GLOBS: string[] = [
   'SKILL.md',
   'references/APP_IDENTIFIERS.md',
@@ -59,13 +52,11 @@ function relativeToSkillDir(changedPath: string, skillDir: string): string | und
 }
 
 /**
- * Classifies the PR's changed paths into the tags whose scenarios must run.
+ * Changed paths → the tags whose scenarios must run.
  *
- * Precedence is first-match-wins: **ignore → broad-impact → reference → unmapped**. The
- * order is load-bearing. A broad-impact file that happens to live inside `referenceDir` must
- * be caught before the reference rule sees it, or `references/CODE_QUALITY.md` would derive
- * a `code-quality` tag and the coverage guard would block on a tag no scenario will ever
- * carry.
+ * Order is load-bearing: ignore → broad-impact → reference → unmapped, first match wins. Let
+ * the reference rule run first and `references/CODE_QUALITY.md` derives a `code-quality` tag
+ * the coverage guard can never satisfy.
  */
 export function deriveTags(changedPaths: string[], rules: TagRules): DerivedTags {
   const tags = new Set<string>();
@@ -88,8 +79,7 @@ export function deriveTags(changedPaths: string[], rules: TagRules): DerivedTags
     if (relativePath.startsWith(referencePrefix)) {
       const withinReferences = relativePath.slice(referencePrefix.length);
       const [head, ...rest] = withinReferences.split('/');
-      // A sub-doc directory is already named for its capability, so the directory name is
-      // the tag; a flat reference file derives its tag from the filename.
+      // A sub-doc directory is already named for its capability.
       tags.add(rest.length > 0 ? head.toLowerCase() : tagForReferencePath(head));
       continue;
     }
@@ -106,10 +96,7 @@ export function deriveTags(changedPaths: string[], rules: TagRules): DerivedTags
 
 export type ChangedPath = { path: string; status: string };
 
-/**
- * Scenario files this PR added, modified or renamed. Removals are excluded: a deleted
- * scenario cannot be quality-checked, and the sync plan handles the delete.
- */
+/** Scenario files added, modified or renamed. Removals are the sync plan's business. */
 export function touchedScenarioPaths(changed: ChangedPath[], evalsGlob: string): string[] {
   return changed
     .filter(file => file.status !== 'removed' && minimatch(file.path, evalsGlob))

--- a/packages/evalforge-core/src/derive-tags.ts
+++ b/packages/evalforge-core/src/derive-tags.ts
@@ -1,0 +1,118 @@
+import { minimatch } from 'minimatch';
+
+export type TagRules = {
+  /** Repo-relative skill root, e.g. `skills/wix-app`. */
+  skillDir: string;
+  /** Reference directory relative to `skillDir`, e.g. `references`. */
+  referenceDir: string;
+  /** Globs, relative to `skillDir`, whose changes derive nothing at all. */
+  ignoreGlobs: string[];
+  /** Globs, relative to `skillDir`, whose changes put the whole suite in play. */
+  broadImpactGlobs: string[];
+};
+
+export type DerivedTags = {
+  /** Reference-derived tags only — sorted and deduped. Never includes broad-impact expansion. */
+  tags: string[];
+  /**
+   * A cross-cutting file changed, so the whole suite is in play. Consumed by scenario
+   * selection only: a broad-impact path derives no tag, so there is no tag for the coverage
+   * guard to demand a scenario for. Feeding an expanded tag union to the guard instead would
+   * block a SKILL.md typo fix on any weak scenario anywhere in the repo.
+   */
+  broadImpact: boolean;
+  /** Paths under `skillDir` that no rule covered — reported, never blocking. */
+  unmapped: string[];
+};
+
+export const DEFAULT_IGNORE_GLOBS: string[] = ['scripts/**'];
+
+/**
+ * `SKILL.md` plus the six references that apply across scenarios rather than to one
+ * capability. "Changed → run everything" is the honest semantics for these: their effect is
+ * not confined to one capability, so no single tag could describe it, and demanding a
+ * `code-quality`-tagged scenario would be asking for a scenario that verifies nothing in
+ * particular.
+ */
+export const DEFAULT_BROAD_IMPACT_GLOBS: string[] = [
+  'SKILL.md',
+  'references/APP_IDENTIFIERS.md',
+  'references/APP_MARKET_REVIEW.md',
+  'references/APP_VALIDATION.md',
+  'references/CODE_QUALITY.md',
+  'references/DOCUMENTATION.md',
+  'references/EXTENSION_REGISTRATION.md',
+];
+
+/** `DASHBOARD_PAGE.md` → `dashboard-page`. */
+export function tagForReferencePath(relativeReferencePath: string): string {
+  return relativeReferencePath.replace(/\.md$/i, '').toLowerCase().replace(/_/g, '-');
+}
+
+function matchesAny(relativePath: string, globs: string[]): boolean {
+  return globs.some(pattern => minimatch(relativePath, pattern, { dot: true }));
+}
+
+function relativeToSkillDir(changedPath: string, skillDir: string): string | undefined {
+  const prefix = `${skillDir}/`;
+  return changedPath.startsWith(prefix) ? changedPath.slice(prefix.length) : undefined;
+}
+
+/**
+ * Classifies the PR's changed paths into the tags whose scenarios must run.
+ *
+ * Precedence is first-match-wins: **ignore → broad-impact → reference → unmapped**. The
+ * order is load-bearing. A broad-impact file that happens to live inside `referenceDir` must
+ * be caught before the reference rule sees it, or `references/CODE_QUALITY.md` would derive
+ * a `code-quality` tag and the coverage guard would block on a tag no scenario will ever
+ * carry.
+ */
+export function deriveTags(changedPaths: string[], rules: TagRules): DerivedTags {
+  const tags = new Set<string>();
+  const unmapped: string[] = [];
+  let broadImpact = false;
+
+  const referencePrefix = `${rules.referenceDir}/`;
+
+  for (const changedPath of changedPaths) {
+    const relativePath = relativeToSkillDir(changedPath, rules.skillDir);
+    if (relativePath === undefined) continue;
+
+    if (matchesAny(relativePath, rules.ignoreGlobs)) continue;
+
+    if (matchesAny(relativePath, rules.broadImpactGlobs)) {
+      broadImpact = true;
+      continue;
+    }
+
+    if (relativePath.startsWith(referencePrefix)) {
+      const withinReferences = relativePath.slice(referencePrefix.length);
+      const [head, ...rest] = withinReferences.split('/');
+      // A sub-doc directory is already named for its capability, so the directory name is
+      // the tag; a flat reference file derives its tag from the filename.
+      tags.add(rest.length > 0 ? head.toLowerCase() : tagForReferencePath(head));
+      continue;
+    }
+
+    unmapped.push(changedPath);
+  }
+
+  return {
+    tags: [...tags].sort(),
+    broadImpact,
+    unmapped: unmapped.sort(),
+  };
+}
+
+export type ChangedPath = { path: string; status: string };
+
+/**
+ * Scenario files this PR added, modified or renamed. Removals are excluded: a deleted
+ * scenario cannot be quality-checked, and the sync plan handles the delete.
+ */
+export function touchedScenarioPaths(changed: ChangedPath[], evalsGlob: string): string[] {
+  return changed
+    .filter(file => file.status !== 'removed' && minimatch(file.path, evalsGlob))
+    .map(file => file.path)
+    .sort();
+}

--- a/packages/evalforge-core/src/derive-tags.ts
+++ b/packages/evalforge-core/src/derive-tags.ts
@@ -15,6 +15,9 @@ export type DerivedTags = {
   unmapped: string[];
 };
 
+/** Single home for the default: `action.yml`, the config reader and the workflow all defer to it. */
+export const DEFAULT_REFERENCE_DIR = 'references';
+
 export const DEFAULT_IGNORE_GLOBS: string[] = ['scripts/**'];
 
 /** References that apply across scenarios, so no single tag describes them. */

--- a/packages/evalforge-core/src/derive-tags.ts
+++ b/packages/evalforge-core/src/derive-tags.ts
@@ -1,26 +1,17 @@
 import { minimatch } from 'minimatch';
 
-/** Everything but `skillDir` is relative to it. */
+/** `skillDir` is repo-relative (`skills/wix-app`); everything else is relative to it. */
 export type TagRules = {
-  /** Repo-relative skill root, e.g. `skills/wix-app`. */
   skillDir: string;
-  /** e.g. `references`. */
   referenceDir: string;
-  /** Changes here derive nothing. */
   ignoreGlobs: string[];
-  /** Changes here put the whole suite in play. */
   broadImpactGlobs: string[];
 };
 
 export type DerivedTags = {
-  /** Reference-derived tags, sorted and deduped. */
   tags: string[];
-  /**
-   * Whole suite is in play. Drives selection only — expanding it to a tag union for the guard
-   * would block a SKILL.md typo fix on any weak scenario in the repo.
-   */
+  /** Drives selection only — feeding it to the guard as a tag union would block on any weak scenario. */
   broadImpact: boolean;
-  /** Paths under `skillDir` no rule covered — reported, never blocking. */
   unmapped: string[];
 };
 
@@ -38,7 +29,7 @@ export const DEFAULT_BROAD_IMPACT_GLOBS: string[] = [
 ];
 
 /** `DASHBOARD_PAGE.md` → `dashboard-page`. */
-export function tagForReferencePath(relativeReferencePath: string): string {
+function tagForReferencePath(relativeReferencePath: string): string {
   return relativeReferencePath.replace(/\.md$/i, '').toLowerCase().replace(/_/g, '-');
 }
 

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -279,10 +279,6 @@ export class EvalForgeClient {
     }
   }
 
-  /**
-   * Same endpoint as createMcpVersion, with the content oneof set to `skillContent`. Lets a
-   * run evaluate a PR's skill files directly, with no MCP URL indirection.
-   */
   async createSkillVersion(
     capabilityId: string,
     projectId: string,

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -279,7 +279,7 @@ export class EvalForgeClient {
     }
   }
 
-  async createSkillVersion(
+  private async createSkillVersion(
     capabilityId: string,
     projectId: string,
     versionLabel: string,
@@ -303,7 +303,7 @@ export class EvalForgeClient {
     return { id: created.id, capabilityId: created.capabilityId, version: created.version };
   }
 
-  async ensureSkillVersion(
+  async createOrReuseSkillVersion(
     capabilityId: string,
     projectId: string,
     versionLabel: string,

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -19,6 +19,9 @@ export type RunStatus = 'pending' | 'running' | typeof TERMINAL_RUN_STATUSES[num
 
 export type CapabilityVersion = { id: string; capabilityId: string; version: string };
 
+/** One file of a skill-content capability version. `path` is relative to the skill root. */
+export type SkillFileContent = { path: string; content: string };
+
 import type { EvalForgeBody } from './evalforge-mapper';
 
 export type RemoteScenario = { id: string; name: string; tags: string[] };
@@ -272,6 +275,58 @@ export class EvalForgeClient {
       const versions = await this.listCapabilityVersions(mcpId, projectId);
       const existing = versions.find(v => v.version === versionLabel);
       if (!existing) throw e;
+      return existing;
+    }
+  }
+
+  /**
+   * Creates a skill-content capability version — the same endpoint as createMcpVersion,
+   * with the content oneof set to `skillContent` rather than `mcpContent`. This is what
+   * lets a run evaluate a PR's skill files directly, with no MCP URL indirection (and so
+   * without the eval-pipeline comparison service, which builds its MCP URL from
+   * skillsRepo/commitSha and cannot drive skill content).
+   */
+  async createSkillVersion(
+    capabilityId: string,
+    projectId: string,
+    versionLabel: string,
+    prNumber: number,
+    files: SkillFileContent[],
+  ): Promise<CapabilityVersion> {
+    const res = await this.request<{ capabilityVersion: RawCapabilityVersion }>(
+      'POST',
+      `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`,
+      {
+        capabilityVersion: {
+          capabilityId,
+          version: versionLabel,
+          origin: 'pr',
+          notes: `Auto-created for PR #${prNumber}`,
+          skillContent: { files },
+        },
+      },
+    );
+    const created = res.capabilityVersion;
+    return { id: created.id, capabilityId: created.capabilityId, version: created.version };
+  }
+
+  async ensureSkillVersion(
+    capabilityId: string,
+    projectId: string,
+    versionLabel: string,
+    prNumber: number,
+    files: SkillFileContent[],
+  ): Promise<CapabilityVersion> {
+    try {
+      return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
+    } catch (error) {
+      // A duplicate label should be 409, but the backend currently throws a plain
+      // "already exists" that transcodes to 500 — so recover on either by reusing the
+      // existing version, and only rethrow if it genuinely is not there.
+      if (!isHttpError(error) || (error.status !== 409 && error.status !== 500)) throw error;
+      const versions = await this.listCapabilityVersions(capabilityId, projectId);
+      const existing = versions.find(candidate => candidate.version === versionLabel);
+      if (!existing) throw error;
       return existing;
     }
   }

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -19,7 +19,7 @@ export type RunStatus = 'pending' | 'running' | typeof TERMINAL_RUN_STATUSES[num
 
 export type CapabilityVersion = { id: string; capabilityId: string; version: string };
 
-/** One file of a skill-content capability version. `path` is relative to the skill root. */
+/** One file of a skill capability version; `path` is relative to the skill root. */
 export type SkillFileContent = { path: string; content: string };
 
 import type { EvalForgeBody } from './evalforge-mapper';
@@ -280,11 +280,8 @@ export class EvalForgeClient {
   }
 
   /**
-   * Creates a skill-content capability version — the same endpoint as createMcpVersion,
-   * with the content oneof set to `skillContent` rather than `mcpContent`. This is what
-   * lets a run evaluate a PR's skill files directly, with no MCP URL indirection (and so
-   * without the eval-pipeline comparison service, which builds its MCP URL from
-   * skillsRepo/commitSha and cannot drive skill content).
+   * Same endpoint as createMcpVersion, with the content oneof set to `skillContent`. Lets a
+   * run evaluate a PR's skill files directly, with no MCP URL indirection.
    */
   async createSkillVersion(
     capabilityId: string,
@@ -320,9 +317,7 @@ export class EvalForgeClient {
     try {
       return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
     } catch (error) {
-      // A duplicate label should be 409, but the backend currently throws a plain
-      // "already exists" that transcodes to 500 — so recover on either by reusing the
-      // existing version, and only rethrow if it genuinely is not there.
+      // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
       if (!isHttpError(error) || (error.status !== 409 && error.status !== 500)) throw error;
       const versions = await this.listCapabilityVersions(capabilityId, projectId);
       const existing = versions.find(candidate => candidate.version === versionLabel);

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -140,10 +140,11 @@ function normalizeStatus(s: string): RunStatus {
   return String(s).toLowerCase() as RunStatus;
 }
 
-// V1 `pass_rate` is a fraction (0.0–1.0); the action's internal contract (and
-// comment.ts) expects an integer percentage (0–100).
-function toPercent(fraction: number | undefined): number {
-  return Math.round((fraction ?? 0) * 100);
+// V1 `pass_rate` already arrives as a percentage (0–100), verified against 8 real runs in the
+// App Builder project: 4/5 reports 80, 26/30 reports 86.667. Multiplying by 100 here rendered
+// every comment as "10000%".
+function toPercent(passRate: number | undefined): number {
+  return Math.round(passRate ?? 0);
 }
 
 // Client for the EvalForge V1 REST API (`${baseUrl}/v1/...`, e.g.

--- a/packages/evalforge-core/src/evaluate-run-result.ts
+++ b/packages/evalforge-core/src/evaluate-run-result.ts
@@ -1,0 +1,39 @@
+import type { EvalRunStatus } from './evalforge';
+
+export type RunVerdict = {
+  passed: boolean;
+  /** Why it failed, in comment-ready wording. Empty when it passed. */
+  reasons: string[];
+};
+
+/**
+ * Decides whether a finished run counts as a pass.
+ *
+ * Note the zero-assertion rule: a run that evaluated nothing has no failures, so a naive
+ * `failed + errors === 0` check would report green having verified nothing. That is exactly
+ * the false pass the gate exists to prevent, so it is an explicit failure.
+ */
+export function evaluateRunResult(status: EvalRunStatus): RunVerdict {
+  const reasons: string[] = [];
+  const metrics = status.aggregateMetrics;
+
+  if (status.status !== 'completed') {
+    reasons.push(
+      `the eval run ${status.status === 'cancelled' ? 'was cancelled' : `ended as "${status.status}"`}`,
+    );
+  }
+
+  if (metrics.failed > 0) {
+    reasons.push(`${metrics.failed} assertion${metrics.failed === 1 ? '' : 's'} failed`);
+  }
+
+  if (metrics.errors > 0) {
+    reasons.push(`${metrics.errors} assertion${metrics.errors === 1 ? '' : 's'} errored`);
+  }
+
+  if (metrics.totalAssertions === 0) {
+    reasons.push('the run produced no assertions, so nothing was verified');
+  }
+
+  return { passed: reasons.length === 0, reasons };
+}

--- a/packages/evalforge-core/src/evaluate-run-result.ts
+++ b/packages/evalforge-core/src/evaluate-run-result.ts
@@ -2,16 +2,13 @@ import type { EvalRunStatus } from './evalforge';
 
 export type RunVerdict = {
   passed: boolean;
-  /** Why it failed, in comment-ready wording. Empty when it passed. */
+  /** Comment-ready wording. Empty when it passed. */
   reasons: string[];
 };
 
 /**
- * Decides whether a finished run counts as a pass.
- *
- * Note the zero-assertion rule: a run that evaluated nothing has no failures, so a naive
- * `failed + errors === 0` check would report green having verified nothing. That is exactly
- * the false pass the gate exists to prevent, so it is an explicit failure.
+ * Zero assertions fails: such a run has no failures either, so `failed + errors === 0` alone
+ * would report green having verified nothing.
  */
 export function evaluateRunResult(status: EvalRunStatus): RunVerdict {
   const reasons: string[] = [];

--- a/packages/evalforge-core/src/format-gate-comment.ts
+++ b/packages/evalforge-core/src/format-gate-comment.ts
@@ -50,6 +50,18 @@ export function formatYamlErrors(errors: LoadError[]): string {
   ]);
 }
 
+/**
+ * The gate did not evaluate this PR. Said out loud because otherwise a green check is
+ * indistinguishable from one that actually ran the scenarios.
+ */
+export function formatGateSkipped(reason: string): string {
+  return render('⏭', 'Skipped', [
+    `This PR was **not evaluated**: ${reason}`,
+    '',
+    'The check is green because the gate did not run, not because the scenarios passed.',
+  ]);
+}
+
 export function formatNoGatedChanges(unmapped: string[]): string {
   return render('✅', 'No Gated Changes', [
     'Nothing in this PR maps to an eval tag, so no run was needed.',

--- a/packages/evalforge-core/src/format-gate-comment.ts
+++ b/packages/evalforge-core/src/format-gate-comment.ts
@@ -1,0 +1,173 @@
+import type { LoadError } from './load-scenarios';
+import type { GuardViolation, GuardWarning } from './guard-scenarios';
+import type { SyncError } from './plan-pr-scenario-sync';
+import type { ScenarioSelection } from './select-scenarios';
+import type { RunVerdict } from './evaluate-run-result';
+import { parseDraftTag, type EvalRunStatus } from './evalforge';
+
+export const GATE_COMMENT_MARKER = '<!-- evalforge-skill-gate-action -->';
+const HEADING = 'EvalForge Skill Gate';
+
+function render(icon: string, label: string, body: string[]): string {
+  return [GATE_COMMENT_MARKER, `## ${icon} ${HEADING}: ${label}`, '', ...body].join('\n');
+}
+
+function failIcon(blocking: boolean): { icon: string; label: string } {
+  return blocking ? { icon: '❌', label: 'Failed' } : { icon: '⚠️', label: 'Warning' };
+}
+
+function soakNote(blocking: boolean): string[] {
+  return blocking
+    ? []
+    : ['', '_The gate is in its soak period (`blocking: false`), so this check still passes._'];
+}
+
+function unmappedSection(unmapped: string[]): string[] {
+  if (unmapped.length === 0) return [];
+  return [
+    '',
+    '**Unmapped paths** — these changed under the skill directory but no rule covers them, so they triggered nothing. Add them to `ignore-globs` if that is correct:',
+    ...unmapped.map(path => `- \`${path}\``),
+  ];
+}
+
+function warningSection(warnings: GuardWarning[]): string[] {
+  if (warnings.length === 0) return [];
+  return [
+    '',
+    '**Existing scenarios below the quality bar** (not blocking — you did not write these, but they are worth fixing):',
+    ...warnings.map(warning =>
+      `- \`${warning.path}\` (\`${warning.name}\`, tagged ${warning.tags.map(tag => `\`${tag}\``).join(', ')}) — ${warning.reasons.join('; ')}`,
+    ),
+  ];
+}
+
+export function formatYamlErrors(errors: LoadError[]): string {
+  return render('❌', 'Invalid Scenario YAML', [
+    'These scenario files did not parse against the schema:',
+    '',
+    ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+  ]);
+}
+
+export function formatNoGatedChanges(unmapped: string[]): string {
+  return render('✅', 'No Gated Changes', [
+    'Nothing in this PR maps to an eval tag, so no run was needed.',
+    ...unmappedSection(unmapped),
+  ]);
+}
+
+function violationLine(violation: GuardViolation): string {
+  switch (violation.kind) {
+    case 'UNCOVERED_TAG':
+      return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under the scenario directory tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+    case 'WEAK_TAG':
+      return `- **\`${violation.tag}\`** is carried only by scenarios below the quality bar (${violation.scenarios.map(name => `\`${name}\``).join(', ')}). Strengthen one of them, or add a scenario that meets the bar.`;
+    case 'WEAK_TOUCHED_SCENARIO':
+      return `- \`${violation.path}\` (\`${violation.name}\`) — ${violation.reasons.join('; ')}. This PR added or edited it, so it must meet the bar.`;
+  }
+}
+
+export function formatGuardFailure(input: {
+  violations: GuardViolation[];
+  warnings: GuardWarning[];
+  blocking: boolean;
+}): string {
+  const { icon, label } = failIcon(input.blocking);
+  return render(icon, `Coverage ${label}`, [
+    'The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.',
+    '',
+    ...input.violations.map(violationLine),
+    '',
+    '_No eval run was started — a coverage failure is caught before any run cost._',
+    ...warningSection(input.warnings),
+    ...soakNote(input.blocking),
+  ]);
+}
+
+export function formatForeignDraftConflicts(errors: SyncError[], blocking: boolean): string {
+  const { icon } = failIcon(blocking);
+  return render(icon, 'Scenario Locked by Another PR', [
+    'These scenarios are draft-tagged for other open PRs. Wait for those to merge or close, or coordinate with their authors:',
+    '',
+    ...errors.map(error => {
+      const links = error.foreignTags.map(tag => {
+        const draft = parseDraftTag(tag);
+        return draft ? `https://github.com/${draft.repo}/pull/${draft.prNumber}` : tag;
+      });
+      return `- \`${error.name}\` is held by: ${links.join(', ')}`;
+    }),
+    ...soakNote(blocking),
+  ]);
+}
+
+export function formatGateResult(input: {
+  metrics: EvalRunStatus['aggregateMetrics'];
+  verdict: RunVerdict;
+  runId: string;
+  runUrl: string;
+  selection: ScenarioSelection;
+  maxScenarios: number;
+  warnings: GuardWarning[];
+  unmapped: string[];
+  broadImpact: boolean;
+  blocking: boolean;
+}): string {
+  const { metrics, verdict, selection } = input;
+  const { icon, label } = verdict.passed ? { icon: '✅', label: 'Passed' } : failIcon(input.blocking);
+
+  const body: string[] = [
+    `**Pass rate:** ${metrics.passRate}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
+    + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
+    + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
+    `**Run:** [${input.runId}](${input.runUrl})`,
+  ];
+
+  if (!verdict.passed) {
+    body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
+  }
+
+  body.push(
+    '',
+    input.broadImpact
+      ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${selection.selected.length} scenario(s) ran.`
+      : `**Scope:** ${selection.selected.length} scenario(s) ran.`,
+    '',
+    ...selection.selected.map(name => `- \`${name}\``),
+  );
+
+  if (selection.dropped.length > 0) {
+    body.push(
+      '',
+      `**Capped at \`max-scenarios: ${input.maxScenarios}\`** — these were not run:`,
+      ...selection.dropped.map(name => `- \`${name}\``),
+    );
+  }
+
+  if (selection.missingIds.length > 0) {
+    body.push(
+      '',
+      '**Not run — no EvalForge scenario found for these names.** They are in the repo YAML but not in EvalForge, which points at a sync gap:',
+      ...selection.missingIds.map(name => `- \`${name}\``),
+    );
+  }
+
+  body.push(...warningSection(input.warnings), ...unmappedSection(input.unmapped));
+  if (!verdict.passed) body.push(...soakNote(input.blocking));
+
+  return render(icon, label, body);
+}
+
+export function formatGateTimeout(runId: string, runUrl: string, blocking: boolean): string {
+  return render(blocking ? '⏱' : '⚠️', 'Timed Out', [
+    'The eval run did not finish within the poll window. It may still be running in EvalForge.',
+    '',
+    `**Run:** [${runId}](${runUrl})`,
+    ...soakNote(blocking),
+  ]);
+}
+
+export function formatGateServiceError(message: string, blocking: boolean): string {
+  const { icon, label } = failIcon(blocking);
+  return render(icon, label, [message, ...soakNote(blocking)]);
+}

--- a/packages/evalforge-core/src/guard-scenarios.ts
+++ b/packages/evalforge-core/src/guard-scenarios.ts
@@ -22,7 +22,7 @@ export type GuardWarning = {
   kind: 'WEAK_UNTOUCHED_SCENARIO';
   name: string;
   path: string;
-  /** The derived tags this scenario carries — why it is in scope for this PR at all. */
+  /** The derived tags it carries — why it is in scope for this PR. */
   tags: string[];
   reasons: string[];
 };
@@ -43,21 +43,16 @@ export function meetsQualityBar(scenario: Scenario, bar: QualityBar = DEFAULT_QU
 }
 
 /**
- * The quality guard, evaluated entirely on local YAML plus the PR's changed-file list — no
- * EvalForge calls, no capability version, no run. That is why it comes first: a coverage
- * failure costs nothing.
+ * Runs on local YAML alone, so a coverage failure costs no EvalForge call.
  *
- * Coverage folds the bar in: a tag is covered only by a scenario that *meets* the bar,
- * because a one-assertion scenario would run, pass, and have verified nothing. Untouched
- * shortfalls on an otherwise-covered tag warn instead of blocking — blocking there would
- * hold a PR hostage to a weak scenario someone else authored, which is how thresholds get
- * lowered and gates get bypassed.
+ * A tag counts as covered only by a scenario that meets the bar — a one-assertion scenario
+ * would run, pass, and verify nothing. Untouched shortfalls warn rather than block, so a PR is
+ * never held hostage to a weak scenario someone else wrote.
  */
 export function guardScenarios(input: {
-  /** Reference-derived tags. Broad impact contributes none — it has no tag to cover. */
+  /** Reference-derived tags. Broad impact contributes none. */
   tags: string[];
   scenarios: Map<string, LoadedScenario>;
-  /** Repo-relative paths of scenario files this PR added or edited. */
   touchedScenarioPaths: Set<string>;
   bar?: QualityBar;
 }): { violations: GuardViolation[]; warnings: GuardWarning[] } {
@@ -84,7 +79,7 @@ export function guardScenarios(input: {
       continue;
     }
 
-    // Tag is covered. Surface the weak siblings the PR did not touch, without blocking.
+    // Covered — surface weak siblings without blocking.
     for (const loaded of carrying) {
       if (input.touchedScenarioPaths.has(loaded.path)) continue;
       const check = meetsQualityBar(loaded.scenario, bar);
@@ -105,8 +100,7 @@ export function guardScenarios(input: {
     }
   }
 
-  // No weakening: every scenario this PR added or edited must meet the bar, whatever its
-  // tags and whether or not a strong sibling already satisfies coverage.
+  // No weakening: a touched scenario must meet the bar even if a strong sibling covers its tag.
   for (const loaded of allScenarios) {
     if (!input.touchedScenarioPaths.has(loaded.path)) continue;
     const check = meetsQualityBar(loaded.scenario, bar);

--- a/packages/evalforge-core/src/guard-scenarios.ts
+++ b/packages/evalforge-core/src/guard-scenarios.ts
@@ -1,0 +1,126 @@
+import { isLlmJudge, type Scenario } from './schema';
+import type { LoadedScenario } from './load-scenarios';
+
+export type QualityBar = {
+  minAssertions: number;
+  requireLlmJudge: boolean;
+};
+
+export const DEFAULT_QUALITY_BAR: QualityBar = {
+  minAssertions: 3,
+  requireLlmJudge: true,
+};
+
+export type BarCheck = { ok: boolean; reasons: string[] };
+
+export type GuardViolation =
+  | { kind: 'UNCOVERED_TAG'; tag: string }
+  | { kind: 'WEAK_TAG'; tag: string; scenarios: string[] }
+  | { kind: 'WEAK_TOUCHED_SCENARIO'; name: string; path: string; reasons: string[] };
+
+export type GuardWarning = {
+  kind: 'WEAK_UNTOUCHED_SCENARIO';
+  name: string;
+  path: string;
+  /** The derived tags this scenario carries — why it is in scope for this PR at all. */
+  tags: string[];
+  reasons: string[];
+};
+
+/** Does this scenario verify enough to be worth running? */
+export function meetsQualityBar(scenario: Scenario, bar: QualityBar = DEFAULT_QUALITY_BAR): BarCheck {
+  const reasons: string[] = [];
+  if (scenario.assertions.length < bar.minAssertions) {
+    reasons.push(
+      `has ${scenario.assertions.length} assertion${scenario.assertions.length === 1 ? '' : 's'} `
+      + `(needs at least ${bar.minAssertions})`,
+    );
+  }
+  if (bar.requireLlmJudge && !scenario.assertions.some(isLlmJudge)) {
+    reasons.push('has no llm_judge assertion');
+  }
+  return { ok: reasons.length === 0, reasons };
+}
+
+/**
+ * The quality guard, evaluated entirely on local YAML plus the PR's changed-file list — no
+ * EvalForge calls, no capability version, no run. That is why it comes first: a coverage
+ * failure costs nothing.
+ *
+ * Coverage folds the bar in: a tag is covered only by a scenario that *meets* the bar,
+ * because a one-assertion scenario would run, pass, and have verified nothing. Untouched
+ * shortfalls on an otherwise-covered tag warn instead of blocking — blocking there would
+ * hold a PR hostage to a weak scenario someone else authored, which is how thresholds get
+ * lowered and gates get bypassed.
+ */
+export function guardScenarios(input: {
+  /** Reference-derived tags. Broad impact contributes none — it has no tag to cover. */
+  tags: string[];
+  scenarios: Map<string, LoadedScenario>;
+  /** Repo-relative paths of scenario files this PR added or edited. */
+  touchedScenarioPaths: Set<string>;
+  bar?: QualityBar;
+}): { violations: GuardViolation[]; warnings: GuardWarning[] } {
+  const bar = input.bar ?? DEFAULT_QUALITY_BAR;
+  const allScenarios = [...input.scenarios.values()];
+  const violations: GuardViolation[] = [];
+  const weakUntouched = new Map<string, GuardWarning>();
+
+  for (const tag of input.tags) {
+    const carrying = allScenarios.filter(loaded => loaded.scenario.tags.includes(tag));
+
+    if (carrying.length === 0) {
+      violations.push({ kind: 'UNCOVERED_TAG', tag });
+      continue;
+    }
+
+    const meeting = carrying.filter(loaded => meetsQualityBar(loaded.scenario, bar).ok);
+    if (meeting.length === 0) {
+      violations.push({
+        kind: 'WEAK_TAG',
+        tag,
+        scenarios: carrying.map(loaded => loaded.scenario.name).sort(),
+      });
+      continue;
+    }
+
+    // Tag is covered. Surface the weak siblings the PR did not touch, without blocking.
+    for (const loaded of carrying) {
+      if (input.touchedScenarioPaths.has(loaded.path)) continue;
+      const check = meetsQualityBar(loaded.scenario, bar);
+      if (check.ok) continue;
+
+      const existing = weakUntouched.get(loaded.scenario.name);
+      if (existing) {
+        existing.tags.push(tag);
+        continue;
+      }
+      weakUntouched.set(loaded.scenario.name, {
+        kind: 'WEAK_UNTOUCHED_SCENARIO',
+        name: loaded.scenario.name,
+        path: loaded.path,
+        tags: [tag],
+        reasons: check.reasons,
+      });
+    }
+  }
+
+  // No weakening: every scenario this PR added or edited must meet the bar, whatever its
+  // tags and whether or not a strong sibling already satisfies coverage.
+  for (const loaded of allScenarios) {
+    if (!input.touchedScenarioPaths.has(loaded.path)) continue;
+    const check = meetsQualityBar(loaded.scenario, bar);
+    if (check.ok) continue;
+    violations.push({
+      kind: 'WEAK_TOUCHED_SCENARIO',
+      name: loaded.scenario.name,
+      path: loaded.path,
+      reasons: check.reasons,
+    });
+  }
+
+  return {
+    violations,
+    warnings: [...weakUntouched.values()].sort((left, right) => left.name.localeCompare(right.name)),
+  };
+}

--- a/packages/evalforge-core/src/index.ts
+++ b/packages/evalforge-core/src/index.ts
@@ -14,3 +14,5 @@ export * from './pr-github';
 export * from './collect-skill-files';
 export * from './derive-tags';
 export * from './guard-scenarios';
+export * from './select-scenarios';
+export * from './evaluate-run-result';

--- a/packages/evalforge-core/src/index.ts
+++ b/packages/evalforge-core/src/index.ts
@@ -13,3 +13,4 @@ export * from './plan-cleanup';
 export * from './pr-github';
 export * from './collect-skill-files';
 export * from './derive-tags';
+export * from './guard-scenarios';

--- a/packages/evalforge-core/src/index.ts
+++ b/packages/evalforge-core/src/index.ts
@@ -12,3 +12,4 @@ export * from './plan-pr-scenario-sync';
 export * from './plan-cleanup';
 export * from './pr-github';
 export * from './collect-skill-files';
+export * from './derive-tags';

--- a/packages/evalforge-core/src/index.ts
+++ b/packages/evalforge-core/src/index.ts
@@ -11,3 +11,4 @@ export * from './plan-version-cleanup';
 export * from './plan-pr-scenario-sync';
 export * from './plan-cleanup';
 export * from './pr-github';
+export * from './collect-skill-files';

--- a/packages/evalforge-core/src/index.ts
+++ b/packages/evalforge-core/src/index.ts
@@ -16,3 +16,4 @@ export * from './derive-tags';
 export * from './guard-scenarios';
 export * from './select-scenarios';
 export * from './evaluate-run-result';
+export * from './format-gate-comment';

--- a/packages/evalforge-core/src/plan-cleanup.ts
+++ b/packages/evalforge-core/src/plan-cleanup.ts
@@ -2,14 +2,16 @@ import type { LoadedScenario } from './load-scenarios';
 import { withManagedTags, type RemoteScenario, type ScenarioBody } from './evalforge';
 import { toScenarioBody } from './plan-pr-scenario-sync';
 
+export const CleanupKind = { RESTORE: 'RESTORE', DELETE: 'DELETE' } as const;
+
 export type CleanupRestoreAction = {
-  kind: 'RESTORE';
+  kind: typeof CleanupKind.RESTORE;
   id: string;
   name: string;
   body: ScenarioBody;
   tags: string[];
 };
-export type CleanupDeleteAction = { kind: 'DELETE'; id: string; name: string };
+export type CleanupDeleteAction = { kind: typeof CleanupKind.DELETE; id: string; name: string };
 export type CleanupAction = CleanupRestoreAction | CleanupDeleteAction;
 
 /**
@@ -29,13 +31,13 @@ export function planCleanup(
     const baseScenario = baseScenarios.get(scenario.name);
     actions.push(baseScenario
       ? {
-          kind: 'RESTORE',
+          kind: CleanupKind.RESTORE,
           id: scenario.id,
           name: scenario.name,
           body: toScenarioBody(baseScenario.scenario),
           tags: withManagedTags(baseScenario.scenario.tags, repo),
         }
-      : { kind: 'DELETE', id: scenario.id, name: scenario.name });
+      : { kind: CleanupKind.DELETE, id: scenario.id, name: scenario.name });
   }
   return actions;
 }

--- a/packages/evalforge-core/src/plan-pr-scenario-sync.ts
+++ b/packages/evalforge-core/src/plan-pr-scenario-sync.ts
@@ -3,10 +3,17 @@ import type { LoadedScenario } from './load-scenarios';
 import { withManagedTags, uniqueRemoteScenarios, DRAFT_PREFIX, type RemoteScenario, type ScenarioBody } from './evalforge';
 import { toEvalForgeBody } from './evalforge-mapper';
 
-export type CreateAction = { kind: 'CREATE'; name: string; body: ScenarioBody; tags: string[] };
-export type UpdateAction = { kind: 'UPDATE'; id: string; name: string; body: ScenarioBody; tags: string[] };
-export type DeleteAction = { kind: 'DELETE'; id: string; name: string };
-export type DeferDeleteAction = { kind: 'DEFER_DELETE'; id: string; name: string };
+export const SyncActionKind = {
+  CREATE: 'CREATE',
+  UPDATE: 'UPDATE',
+  DELETE: 'DELETE',
+  DEFER_DELETE: 'DEFER_DELETE',
+} as const;
+
+export type CreateAction = { kind: typeof SyncActionKind.CREATE; name: string; body: ScenarioBody; tags: string[] };
+export type UpdateAction = { kind: typeof SyncActionKind.UPDATE; id: string; name: string; body: ScenarioBody; tags: string[] };
+export type DeleteAction = { kind: typeof SyncActionKind.DELETE; id: string; name: string };
+export type DeferDeleteAction = { kind: typeof SyncActionKind.DEFER_DELETE; id: string; name: string };
 export type SyncAction = CreateAction | UpdateAction | DeleteAction | DeferDeleteAction;
 
 export type SyncError = {
@@ -70,7 +77,7 @@ export function diffSyncPlan(input: {
     const tags = withManagedTags(tagStrategy(localScenario.scenario, draftTag), repo);
     const match = remoteByName.get(name);
     if (!match) {
-      actions.push({ kind: 'CREATE', name, body: toScenarioBody(localScenario.scenario), tags });
+      actions.push({ kind: SyncActionKind.CREATE, name, body: toScenarioBody(localScenario.scenario), tags });
       continue;
     }
     const foreign = foreignDraftTags(match.tags, draftTag);
@@ -78,7 +85,7 @@ export function diffSyncPlan(input: {
       errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: localScenario.path });
       continue;
     }
-    actions.push({ kind: 'UPDATE', id: match.id, name, body: toScenarioBody(localScenario.scenario), tags });
+    actions.push({ kind: SyncActionKind.UPDATE, id: match.id, name, body: toScenarioBody(localScenario.scenario), tags });
   }
 
   for (const [name, baseScenario] of base) {
@@ -86,14 +93,14 @@ export function diffSyncPlan(input: {
     const match = remoteByName.get(name);
     if (!match) continue;
     if (match.tags.includes(draftTag)) {
-      actions.push({ kind: 'DELETE', id: match.id, name });
+      actions.push({ kind: SyncActionKind.DELETE, id: match.id, name });
       continue;
     }
     const foreign = foreignDraftTags(match.tags, draftTag);
     if (foreign.length > 0) {
       errors.push({ kind: 'FOREIGN_DRAFT', name, foreignTags: foreign, path: baseScenario.path });
     } else {
-      actions.push({ kind: 'DEFER_DELETE', id: match.id, name });
+      actions.push({ kind: SyncActionKind.DEFER_DELETE, id: match.id, name });
     }
   }
 

--- a/packages/evalforge-core/src/plan-pr-scenario-sync.ts
+++ b/packages/evalforge-core/src/plan-pr-scenario-sync.ts
@@ -27,9 +27,12 @@ export function toScenarioBody(scenario: Scenario): ScenarioBody {
  * - `draftOnlyTags` replaces the scenario's semantic tags with the draft tag. Correct only
  *   when the gate selects scenarios by explicit id and a promote step restores the real
  *   tags on merge (wix-manage).
- * - `semanticPlusDraftTags` keeps them. Required whenever the gate *queries by tag*: strip
- *   `dashboard-page` off the scenario and the query looking for it returns nothing, so the
- *   gate runs zero scenarios and reports green. Needs no promote step.
+ * - `semanticPlusDraftTags` keeps them, for a gate that selects by tag. Not needed for the run
+ *   that does the stripping — a touched scenario is also queried by name, so it still resolves.
+ *   It matters afterwards: once the semantic tag is gone from EvalForge, a later run of the same
+ *   PR that no longer has the scenario in its diff (the author reverted that edit) cannot find it
+ *   by tag either, so it silently drops out of tag-based selection. Keeping the tags avoids that,
+ *   and avoids needing a promote step to put them back.
  */
 export type PrTagStrategy = (scenario: Scenario, draftTag: string) => string[];
 

--- a/packages/evalforge-core/src/select-scenarios.ts
+++ b/packages/evalforge-core/src/select-scenarios.ts
@@ -1,25 +1,20 @@
 import type { LoadedScenario } from './load-scenarios';
 
 export type ScenarioSelection = {
-  /** EvalForge ids to run, in selection order. */
   ids: string[];
-  /** Names actually running. */
   selected: string[];
-  /** Names cut by the cap — reported in the comment, never dropped silently. */
+  /** Cut by the cap. Reported in the comment, never dropped silently. */
   dropped: string[];
-  /** Names selected locally with no known EvalForge id — a sync gap worth surfacing. */
+  /** Selected locally but absent from EvalForge — a sync gap worth surfacing. */
   missingIds: string[];
 };
 
 /**
- * Builds the run's scenario set.
+ * Builds the run's scenario set. Callers pass `nameToId` as the union of the sync plan's own
+ * results and the tag query, so a slow tag index cannot silently shrink the run.
  *
- * `nameToId` is the union of the sync plan's own results (CREATE returns the new id, UPDATE
- * already has it) and the remote tag query, so the gate never depends on read-after-write
- * consistency: a slow tag index cannot silently shrink the run.
- *
- * The cap prioritises scenarios this PR touched. Sorting purely alphabetically would let a
- * capped run drop the author's own new scenario in favour of an unrelated one.
+ * Touched scenarios sort first: a purely alphabetical cap could drop the author's own new
+ * scenario for an unrelated one.
  */
 export function selectScenarios(input: {
   broadImpact: boolean;

--- a/packages/evalforge-core/src/select-scenarios.ts
+++ b/packages/evalforge-core/src/select-scenarios.ts
@@ -1,5 +1,11 @@
 import type { LoadedScenario } from './load-scenarios';
 
+/**
+ * Cap on scenarios per gate run. Every wix-app scenario is a live agent build, so this bounds real
+ * money and wall-clock, not test runtime. Single home for the default — see DEFAULT_REFERENCE_DIR.
+ */
+export const DEFAULT_MAX_SCENARIOS = 25;
+
 export type ScenarioSelection = {
   ids: string[];
   selected: string[];

--- a/packages/evalforge-core/src/select-scenarios.ts
+++ b/packages/evalforge-core/src/select-scenarios.ts
@@ -1,0 +1,64 @@
+import type { LoadedScenario } from './load-scenarios';
+
+export type ScenarioSelection = {
+  /** EvalForge ids to run, in selection order. */
+  ids: string[];
+  /** Names actually running. */
+  selected: string[];
+  /** Names cut by the cap — reported in the comment, never dropped silently. */
+  dropped: string[];
+  /** Names selected locally with no known EvalForge id — a sync gap worth surfacing. */
+  missingIds: string[];
+};
+
+/**
+ * Builds the run's scenario set.
+ *
+ * `nameToId` is the union of the sync plan's own results (CREATE returns the new id, UPDATE
+ * already has it) and the remote tag query, so the gate never depends on read-after-write
+ * consistency: a slow tag index cannot silently shrink the run.
+ *
+ * The cap prioritises scenarios this PR touched. Sorting purely alphabetically would let a
+ * capped run drop the author's own new scenario in favour of an unrelated one.
+ */
+export function selectScenarios(input: {
+  broadImpact: boolean;
+  tags: string[];
+  localScenarios: Map<string, LoadedScenario>;
+  nameToId: Map<string, string>;
+  touchedScenarioPaths: Set<string>;
+  maxScenarios: number;
+}): ScenarioSelection {
+  const derivedTags = new Set(input.tags);
+
+  const candidates = [...input.localScenarios.values()].filter(loaded =>
+    input.broadImpact
+    || input.touchedScenarioPaths.has(loaded.path)
+    || loaded.scenario.tags.some(tag => derivedTags.has(tag)),
+  );
+
+  const ordered = candidates.sort((left, right) => {
+    const leftTouched = input.touchedScenarioPaths.has(left.path) ? 0 : 1;
+    const rightTouched = input.touchedScenarioPaths.has(right.path) ? 0 : 1;
+    if (leftTouched !== rightTouched) return leftTouched - rightTouched;
+    return left.scenario.name.localeCompare(right.scenario.name);
+  });
+
+  const missingIds: string[] = [];
+  const resolvable: Array<{ name: string; id: string }> = [];
+  for (const loaded of ordered) {
+    const id = input.nameToId.get(loaded.scenario.name);
+    if (id) resolvable.push({ name: loaded.scenario.name, id });
+    else missingIds.push(loaded.scenario.name);
+  }
+
+  const running = resolvable.slice(0, Math.max(0, input.maxScenarios));
+  const cut = resolvable.slice(running.length);
+
+  return {
+    ids: running.map(entry => entry.id),
+    selected: running.map(entry => entry.name),
+    dropped: cut.map(entry => entry.name).sort(),
+    missingIds: missingIds.sort(),
+  };
+}

--- a/packages/evalforge-core/tests/collect-skill-files.test.ts
+++ b/packages/evalforge-core/tests/collect-skill-files.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { collectSkillFiles } from '../src/collect-skill-files';
+import { collectSkillFiles, DEFAULT_COLLECT_LIMITS } from '../src/collect-skill-files';
 
 let root: string;
 
@@ -14,6 +14,12 @@ function write(relativePath: string, content: string): void {
   mkdirSync(join(full, '..'), { recursive: true });
   writeFileSync(full, content);
 }
+
+describe('DEFAULT_COLLECT_LIMITS', () => {
+  it('leaves room for a real skill', () => {
+    expect(DEFAULT_COLLECT_LIMITS).toEqual({ maxFileBytes: 1_000_000, maxTotalBytes: 10_000_000 });
+  });
+});
 
 describe('collectSkillFiles', () => {
   it('returns paths relative to the skill dir, sorted deterministically', () => {
@@ -29,6 +35,45 @@ describe('collectSkillFiles', () => {
       'references/dashboard-page/API.md',
     ]);
     expect(files[0].content).toBe('# skill');
+  });
+
+  it('collects the whole skill dir, scripts and assets included', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/references/DASHBOARD_PAGE.md', 'dashboard');
+    write('skills/wix-app/scripts/gen.js', 'x');
+    write('skills/wix-app/assets/template.txt', 'y');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toEqual([
+      'SKILL.md',
+      'assets/template.txt',
+      'references/DASHBOARD_PAGE.md',
+      'scripts/gen.js',
+    ]);
+  });
+
+  it('collects dotfiles', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/.eslintrc', '{}');
+    write('skills/wix-app/references/.shared.md', 'shared');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toEqual([
+      '.eslintrc',
+      'SKILL.md',
+      'references/.shared.md',
+    ]);
+  });
+
+  it('collects nested reference sub-docs at their full relative path', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/references/stores/deep/NOTE.md', 'note');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toContain('references/stores/deep/NOTE.md');
   });
 
   it('excludes node_modules and dist', () => {
@@ -73,32 +118,5 @@ describe('collectSkillFiles', () => {
     mkdirSync(join(root, 'skills/wix-app'), { recursive: true });
 
     expect(() => collectSkillFiles(root, 'skills/wix-app')).toThrow(/no files/i);
-  });
-
-  // Not just the docs: they tell the agent to run `<SKILL_ROOT>/scripts/…`, and selecting only
-  // referenced files would miss what those in turn require.
-  it('collects the whole skill dir, scripts and assets included', () => {
-    write('skills/wix-app/SKILL.md', '# skill');
-    write('skills/wix-app/references/DASHBOARD_PAGE.md', 'dashboard');
-    write('skills/wix-app/scripts/gen.js', 'x');
-    write('skills/wix-app/assets/template.txt', 'y');
-
-    const files = collectSkillFiles(root, 'skills/wix-app');
-
-    expect(files.map(file => file.path)).toEqual([
-      'SKILL.md',
-      'assets/template.txt',
-      'references/DASHBOARD_PAGE.md',
-      'scripts/gen.js',
-    ]);
-  });
-
-  it('collects nested reference sub-docs at their full relative path', () => {
-    write('skills/wix-app/SKILL.md', '# skill');
-    write('skills/wix-app/references/stores/deep/NOTE.md', 'note');
-
-    const files = collectSkillFiles(root, 'skills/wix-app');
-
-    expect(files.map(file => file.path)).toContain('references/stores/deep/NOTE.md');
   });
 });

--- a/packages/evalforge-core/tests/collect-skill-files.test.ts
+++ b/packages/evalforge-core/tests/collect-skill-files.test.ts
@@ -75,18 +75,9 @@ describe('collectSkillFiles', () => {
     expect(() => collectSkillFiles(root, 'skills/wix-app')).toThrow(/no files/i);
   });
 
-  // Docs tell the agent to run `<SKILL_ROOT>/scripts/…`; omit it and the capability breaks.
-  it('includes executable helpers the docs tell the agent to run', () => {
-    write('skills/wix-app/SKILL.md', '# skill');
-    write('skills/wix-app/references/AUTO_PATTERNS_DASHBOARD.md', 'run <SKILL_ROOT>/scripts/gen.js');
-    write('skills/wix-app/scripts/gen.js', 'module.exports = {}');
-
-    const files = collectSkillFiles(root, 'skills/wix-app');
-
-    expect(files.map(file => file.path)).toContain('scripts/gen.js');
-  });
-
-  it('collects the whole skill dir — the directory is the deployed unit', () => {
+  // Not just the docs: they tell the agent to run `<SKILL_ROOT>/scripts/…`, and selecting only
+  // referenced files would miss what those in turn require.
+  it('collects the whole skill dir, scripts and assets included', () => {
     write('skills/wix-app/SKILL.md', '# skill');
     write('skills/wix-app/references/DASHBOARD_PAGE.md', 'dashboard');
     write('skills/wix-app/scripts/gen.js', 'x');

--- a/packages/evalforge-core/tests/collect-skill-files.test.ts
+++ b/packages/evalforge-core/tests/collect-skill-files.test.ts
@@ -75,9 +75,7 @@ describe('collectSkillFiles', () => {
     expect(() => collectSkillFiles(root, 'skills/wix-app')).toThrow(/no files/i);
   });
 
-  // references/AUTO_PATTERNS_DASHBOARD.md tells the agent to run
-  // `node <SKILL_ROOT>/scripts/generate-auto-patterns.js`. Ship only the docs and that
-  // capability breaks at run time, and the eval failure looks like a skill regression.
+  // Docs tell the agent to run `<SKILL_ROOT>/scripts/…`; omit it and the capability breaks.
   it('includes executable helpers the docs tell the agent to run', () => {
     write('skills/wix-app/SKILL.md', '# skill');
     write('skills/wix-app/references/AUTO_PATTERNS_DASHBOARD.md', 'run <SKILL_ROOT>/scripts/gen.js');

--- a/packages/evalforge-core/tests/collect-skill-files.test.ts
+++ b/packages/evalforge-core/tests/collect-skill-files.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectSkillFiles } from '../src/collect-skill-files';
+
+let root: string;
+
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'collect-skill-')); });
+afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+function write(relativePath: string, content: string): void {
+  const full = join(root, relativePath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, content);
+}
+
+describe('collectSkillFiles', () => {
+  it('returns paths relative to the skill dir, sorted deterministically', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/references/DASHBOARD_PAGE.md', 'dashboard');
+    write('skills/wix-app/references/dashboard-page/API.md', 'api');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toEqual([
+      'SKILL.md',
+      'references/DASHBOARD_PAGE.md',
+      'references/dashboard-page/API.md',
+    ]);
+    expect(files[0].content).toBe('# skill');
+  });
+
+  it('excludes node_modules and dist', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/node_modules/pkg/index.js', 'ignored');
+    write('skills/wix-app/dist/bundle.js', 'ignored');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toEqual(['SKILL.md']);
+  });
+
+  it('skips a binary file with a warning rather than corrupting the version', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    writeFileSync(join(root, 'skills/wix-app/logo.png'), Buffer.from([0x89, 0x50, 0x00, 0x01]));
+    const warn = vi.fn();
+
+    const files = collectSkillFiles(root, 'skills/wix-app', { warn });
+
+    expect(files.map(file => file.path)).toEqual(['SKILL.md']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('logo.png'));
+  });
+
+  it('throws when one file exceeds the per-file cap', () => {
+    write('skills/wix-app/SKILL.md', 'x'.repeat(50));
+
+    expect(() => collectSkillFiles(root, 'skills/wix-app', {
+      limits: { maxFileBytes: 10, maxTotalBytes: 1_000 },
+    })).toThrow(/SKILL\.md/);
+  });
+
+  it('throws when the collection exceeds the total cap', () => {
+    write('skills/wix-app/a.md', 'x'.repeat(40));
+    write('skills/wix-app/b.md', 'x'.repeat(40));
+
+    expect(() => collectSkillFiles(root, 'skills/wix-app', {
+      limits: { maxFileBytes: 1_000, maxTotalBytes: 50 },
+    })).toThrow(/total/i);
+  });
+
+  it('throws when the skill directory holds no files at all', () => {
+    mkdirSync(join(root, 'skills/wix-app'), { recursive: true });
+
+    expect(() => collectSkillFiles(root, 'skills/wix-app')).toThrow(/no files/i);
+  });
+
+  it('collects nested reference sub-docs at their full relative path', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/references/stores/deep/NOTE.md', 'note');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toContain('references/stores/deep/NOTE.md');
+  });
+});

--- a/packages/evalforge-core/tests/collect-skill-files.test.ts
+++ b/packages/evalforge-core/tests/collect-skill-files.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { collectSkillFiles, DEFAULT_COLLECT_LIMITS } from '../src/collect-skill-files';
+import { collectSkillFiles } from '../src/collect-skill-files';
 
 let root: string;
 
@@ -14,12 +14,6 @@ function write(relativePath: string, content: string): void {
   mkdirSync(join(full, '..'), { recursive: true });
   writeFileSync(full, content);
 }
-
-describe('DEFAULT_COLLECT_LIMITS', () => {
-  it('leaves room for a real skill', () => {
-    expect(DEFAULT_COLLECT_LIMITS).toEqual({ maxFileBytes: 1_000_000, maxTotalBytes: 10_000_000 });
-  });
-});
 
 describe('collectSkillFiles', () => {
   it('returns paths relative to the skill dir, sorted deterministically', () => {
@@ -53,18 +47,15 @@ describe('collectSkillFiles', () => {
     ]);
   });
 
-  it('collects dotfiles', () => {
+  it('excludes dotfiles', () => {
     write('skills/wix-app/SKILL.md', '# skill');
     write('skills/wix-app/.eslintrc', '{}');
+    write('skills/wix-app/.env', 'SECRET=x');
     write('skills/wix-app/references/.shared.md', 'shared');
 
     const files = collectSkillFiles(root, 'skills/wix-app');
 
-    expect(files.map(file => file.path)).toEqual([
-      '.eslintrc',
-      'SKILL.md',
-      'references/.shared.md',
-    ]);
+    expect(files.map(file => file.path)).toEqual(['SKILL.md']);
   });
 
   it('collects nested reference sub-docs at their full relative path', () => {

--- a/packages/evalforge-core/tests/collect-skill-files.test.ts
+++ b/packages/evalforge-core/tests/collect-skill-files.test.ts
@@ -75,6 +75,35 @@ describe('collectSkillFiles', () => {
     expect(() => collectSkillFiles(root, 'skills/wix-app')).toThrow(/no files/i);
   });
 
+  // references/AUTO_PATTERNS_DASHBOARD.md tells the agent to run
+  // `node <SKILL_ROOT>/scripts/generate-auto-patterns.js`. Ship only the docs and that
+  // capability breaks at run time, and the eval failure looks like a skill regression.
+  it('includes executable helpers the docs tell the agent to run', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/references/AUTO_PATTERNS_DASHBOARD.md', 'run <SKILL_ROOT>/scripts/gen.js');
+    write('skills/wix-app/scripts/gen.js', 'module.exports = {}');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toContain('scripts/gen.js');
+  });
+
+  it('collects the whole skill dir — the directory is the deployed unit', () => {
+    write('skills/wix-app/SKILL.md', '# skill');
+    write('skills/wix-app/references/DASHBOARD_PAGE.md', 'dashboard');
+    write('skills/wix-app/scripts/gen.js', 'x');
+    write('skills/wix-app/assets/template.txt', 'y');
+
+    const files = collectSkillFiles(root, 'skills/wix-app');
+
+    expect(files.map(file => file.path)).toEqual([
+      'SKILL.md',
+      'assets/template.txt',
+      'references/DASHBOARD_PAGE.md',
+      'scripts/gen.js',
+    ]);
+  });
+
   it('collects nested reference sub-docs at their full relative path', () => {
     write('skills/wix-app/SKILL.md', '# skill');
     write('skills/wix-app/references/stores/deep/NOTE.md', 'note');

--- a/packages/evalforge-core/tests/derive-tags.test.ts
+++ b/packages/evalforge-core/tests/derive-tags.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveTags, tagForReferencePath, touchedScenarioPaths,
+  DEFAULT_IGNORE_GLOBS, DEFAULT_BROAD_IMPACT_GLOBS, type TagRules,
+} from '../src/derive-tags';
+
+const WIX_APP_RULES: TagRules = {
+  skillDir: 'skills/wix-app',
+  referenceDir: 'references',
+  ignoreGlobs: DEFAULT_IGNORE_GLOBS,
+  broadImpactGlobs: DEFAULT_BROAD_IMPACT_GLOBS,
+};
+
+describe('tagForReferencePath', () => {
+  it('lowercases, maps underscores to hyphens and drops the .md', () => {
+    expect(tagForReferencePath('DASHBOARD_PAGE.md')).toBe('dashboard-page');
+    expect(tagForReferencePath('STORES_VERSIONING.md')).toBe('stores-versioning');
+  });
+});
+
+describe('deriveTags — precedence', () => {
+  // The ordering bug this rule set exists to prevent: a broad-impact file living inside
+  // referenceDir must be classified broad-impact BEFORE the reference rule sees it,
+  // otherwise the guard demands a `code-quality` scenario that will never exist.
+  it('classifies references/CODE_QUALITY.md as broad impact and derives no tag from it', () => {
+    const derived = deriveTags(['skills/wix-app/references/CODE_QUALITY.md'], WIX_APP_RULES);
+    expect(derived.broadImpact).toBe(true);
+    expect(derived.tags).toEqual([]);
+    expect(derived.unmapped).toEqual([]);
+  });
+
+  it('treats each of the six cross-cutting references as broad impact, tagless', () => {
+    for (const crossCutting of [
+      'APP_IDENTIFIERS.md', 'APP_MARKET_REVIEW.md', 'APP_VALIDATION.md',
+      'CODE_QUALITY.md', 'DOCUMENTATION.md', 'EXTENSION_REGISTRATION.md',
+    ]) {
+      const derived = deriveTags([`skills/wix-app/references/${crossCutting}`], WIX_APP_RULES);
+      expect(derived.broadImpact, crossCutting).toBe(true);
+      expect(derived.tags, crossCutting).toEqual([]);
+    }
+  });
+
+  it('ignores a path matching ignoreGlobs even though it sits under the skill dir', () => {
+    const derived = deriveTags(['skills/wix-app/scripts/generate-auto-patterns.js'], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: [], broadImpact: false, unmapped: [] });
+  });
+
+  it('prefers ignore over broad impact when a path matches both', () => {
+    const rules: TagRules = { ...WIX_APP_RULES, ignoreGlobs: ['SKILL.md'], broadImpactGlobs: ['SKILL.md'] };
+    const derived = deriveTags(['skills/wix-app/SKILL.md'], rules);
+    expect(derived.broadImpact).toBe(false);
+  });
+});
+
+describe('deriveTags — reference forms', () => {
+  it('derives a tag from a reference file name', () => {
+    const derived = deriveTags(['skills/wix-app/references/DASHBOARD_PAGE.md'], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: ['dashboard-page'], broadImpact: false, unmapped: [] });
+  });
+
+  it('derives the tag from the directory name for a nested sub-doc', () => {
+    const derived = deriveTags(['skills/wix-app/references/dashboard-page/API_SPEC.md'], WIX_APP_RULES);
+    expect(derived.tags).toEqual(['dashboard-page']);
+  });
+
+  it('maps both reference forms of one capability to a single deduped tag', () => {
+    const derived = deriveTags([
+      'skills/wix-app/references/DASHBOARD_PAGE.md',
+      'skills/wix-app/references/dashboard-page/API_SPEC.md',
+    ], WIX_APP_RULES);
+    expect(derived.tags).toEqual(['dashboard-page']);
+  });
+
+  it('keeps STORES_VERSIONING.md tag-deriving — it describes one capability', () => {
+    const derived = deriveTags(['skills/wix-app/references/STORES_VERSIONING.md'], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: ['stores-versioning'], broadImpact: false, unmapped: [] });
+  });
+
+  it('returns tags sorted and deduped across many changed references', () => {
+    const derived = deriveTags([
+      'skills/wix-app/references/SERVICE_PLUGIN.md',
+      'skills/wix-app/references/DATA_COLLECTION.md',
+      'skills/wix-app/references/DASHBOARD_PAGE.md',
+    ], WIX_APP_RULES);
+    expect(derived.tags).toEqual(['dashboard-page', 'data-collection', 'service-plugin']);
+  });
+});
+
+describe('deriveTags — SKILL.md, unmapped and out-of-scope paths', () => {
+  it('treats SKILL.md as broad impact', () => {
+    const derived = deriveTags(['skills/wix-app/SKILL.md'], WIX_APP_RULES);
+    expect(derived.broadImpact).toBe(true);
+    expect(derived.tags).toEqual([]);
+  });
+
+  it('reports an unrecognised file under the skill dir as unmapped, deriving nothing', () => {
+    const derived = deriveTags(['skills/wix-app/NOTES.txt'], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: [], broadImpact: false, unmapped: ['skills/wix-app/NOTES.txt'] });
+  });
+
+  it('ignores paths outside the skill dir entirely', () => {
+    const derived = deriveTags([
+      'README.md',
+      'skills/wix-manage/references/blog/post.md',
+      'yaml/wix-app-evals/employee-shift-dashboard.yml',
+    ], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: [], broadImpact: false, unmapped: [] });
+  });
+
+  it('combines broad impact with tags derived from other changed references', () => {
+    const derived = deriveTags([
+      'skills/wix-app/SKILL.md',
+      'skills/wix-app/references/DASHBOARD_PAGE.md',
+    ], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: ['dashboard-page'], broadImpact: true, unmapped: [] });
+  });
+});
+
+describe('deriveTags — the layout really is a parameter', () => {
+  it('works for a different repo layout with no code change', () => {
+    const rules: TagRules = {
+      skillDir: 'packages/my-skill',
+      referenceDir: 'docs',
+      ignoreGlobs: ['tools/**'],
+      broadImpactGlobs: ['README.md'],
+    };
+    expect(deriveTags(['packages/my-skill/docs/WIDGET_THING.md'], rules).tags).toEqual(['widget-thing']);
+    expect(deriveTags(['packages/my-skill/README.md'], rules).broadImpact).toBe(true);
+    expect(deriveTags(['packages/my-skill/tools/build.sh'], rules).unmapped).toEqual([]);
+    expect(deriveTags(['packages/my-skill/other.md'], rules).unmapped)
+      .toEqual(['packages/my-skill/other.md']);
+  });
+
+  it('does not treat skills/wix-app-extra as inside skills/wix-app', () => {
+    const derived = deriveTags(['skills/wix-app-extra/SKILL.md'], WIX_APP_RULES);
+    expect(derived).toEqual({ tags: [], broadImpact: false, unmapped: [] });
+  });
+});
+
+describe('touchedScenarioPaths', () => {
+  const GLOB = 'yaml/wix-app-evals/**/*.{yml,yaml}';
+
+  it('returns added, modified and renamed scenario paths, sorted', () => {
+    const touched = touchedScenarioPaths([
+      { path: 'yaml/wix-app-evals/b.yml', status: 'modified' },
+      { path: 'yaml/wix-app-evals/a.yml', status: 'added' },
+      { path: 'yaml/wix-app-evals/nested/c.yaml', status: 'renamed' },
+    ], GLOB);
+    expect(touched).toEqual([
+      'yaml/wix-app-evals/a.yml',
+      'yaml/wix-app-evals/b.yml',
+      'yaml/wix-app-evals/nested/c.yaml',
+    ]);
+  });
+
+  it('excludes removed scenarios — a deleted file cannot be quality-checked', () => {
+    const touched = touchedScenarioPaths([
+      { path: 'yaml/wix-app-evals/gone.yml', status: 'removed' },
+    ], GLOB);
+    expect(touched).toEqual([]);
+  });
+
+  it('ignores paths outside the evals glob', () => {
+    const touched = touchedScenarioPaths([
+      { path: 'yaml/wix-manage-evals/blog/a.yml', status: 'modified' },
+      { path: 'skills/wix-app/SKILL.md', status: 'modified' },
+    ], GLOB);
+    expect(touched).toEqual([]);
+  });
+});

--- a/packages/evalforge-core/tests/derive-tags.test.ts
+++ b/packages/evalforge-core/tests/derive-tags.test.ts
@@ -19,8 +19,6 @@ describe('tagForReferencePath', () => {
 });
 
 describe('deriveTags — precedence', () => {
-  // The ordering bug this exists to prevent — otherwise the guard demands a
-  // `code-quality` scenario that will never exist.
   it('classifies references/CODE_QUALITY.md as broad impact and derives no tag from it', () => {
     const derived = deriveTags(['skills/wix-app/references/CODE_QUALITY.md'], WIX_APP_RULES);
     expect(derived.broadImpact).toBe(true);

--- a/packages/evalforge-core/tests/derive-tags.test.ts
+++ b/packages/evalforge-core/tests/derive-tags.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  deriveTags, tagForReferencePath, touchedScenarioPaths,
+  deriveTags, touchedScenarioPaths,
   DEFAULT_IGNORE_GLOBS, DEFAULT_BROAD_IMPACT_GLOBS, type TagRules,
 } from '../src/derive-tags';
 
@@ -10,13 +10,6 @@ const WIX_APP_RULES: TagRules = {
   ignoreGlobs: DEFAULT_IGNORE_GLOBS,
   broadImpactGlobs: DEFAULT_BROAD_IMPACT_GLOBS,
 };
-
-describe('tagForReferencePath', () => {
-  it('lowercases, maps underscores to hyphens and drops the .md', () => {
-    expect(tagForReferencePath('DASHBOARD_PAGE.md')).toBe('dashboard-page');
-    expect(tagForReferencePath('STORES_VERSIONING.md')).toBe('stores-versioning');
-  });
-});
 
 describe('deriveTags — precedence', () => {
   it('classifies references/CODE_QUALITY.md as broad impact and derives no tag from it', () => {

--- a/packages/evalforge-core/tests/derive-tags.test.ts
+++ b/packages/evalforge-core/tests/derive-tags.test.ts
@@ -19,9 +19,8 @@ describe('tagForReferencePath', () => {
 });
 
 describe('deriveTags — precedence', () => {
-  // The ordering bug this rule set exists to prevent: a broad-impact file living inside
-  // referenceDir must be classified broad-impact BEFORE the reference rule sees it,
-  // otherwise the guard demands a `code-quality` scenario that will never exist.
+  // The ordering bug this exists to prevent — otherwise the guard demands a
+  // `code-quality` scenario that will never exist.
   it('classifies references/CODE_QUALITY.md as broad impact and derives no tag from it', () => {
     const derived = deriveTags(['skills/wix-app/references/CODE_QUALITY.md'], WIX_APP_RULES);
     expect(derived.broadImpact).toBe(true);

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -378,7 +378,7 @@ describe('EvalForgeClient (V1) — skill capability versions', () => {
     });
 
     const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    const version = await client.createSkillVersion('C', 'P', 'pr-42-abc1234', 42, files);
+    const version = await client.createOrReuseSkillVersion('C', 'P', 'pr-42-abc1234', 42, files);
 
     expect(version).toEqual({ id: 'v1', capabilityId: 'C', version: 'pr-42-abc1234' });
     expect(captured).toMatchObject({
@@ -399,46 +399,46 @@ describe('EvalForgeClient (V1) — skill capability versions', () => {
     });
 
     const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    await client.createSkillVersion('C', 'P', 'L', 42, files);
+    await client.createOrReuseSkillVersion('C', 'P', 'L', 42, files);
 
     expect(captured).not.toHaveProperty('mcpContent');
   });
 
-  it('ensureSkillVersion reuses an existing version on a 409', async () => {
+  it('createOrReuseSkillVersion reuses an existing version on a 409', async () => {
     mockFetch(({ method }) => {
       if (method === 'POST') return { status: 409, body: { message: 'already exists' } };
       return { status: 200, body: { capabilityVersions: [{ id: 'v9', capabilityId: 'C', version: 'pr-42-abc1234' }] } };
     });
 
     const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    const version = await client.ensureSkillVersion('C', 'P', 'pr-42-abc1234', 42, files);
+    const version = await client.createOrReuseSkillVersion('C', 'P', 'pr-42-abc1234', 42, files);
 
     expect(version).toEqual({ id: 'v9', capabilityId: 'C', version: 'pr-42-abc1234' });
   });
 
-  it('ensureSkillVersion also recovers from the backend 500 for a duplicate label', async () => {
+  it('createOrReuseSkillVersion also recovers from the backend 500 for a duplicate label', async () => {
     mockFetch(({ method }) => {
       if (method === 'POST') return { status: 500, body: { message: 'already exists' } };
       return { status: 200, body: { capabilityVersions: [{ id: 'v9', capabilityId: 'C', version: 'L' }] } };
     });
 
     const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    await expect(client.ensureSkillVersion('C', 'P', 'L', 42, files)).resolves.toMatchObject({ id: 'v9' });
+    await expect(client.createOrReuseSkillVersion('C', 'P', 'L', 42, files)).resolves.toMatchObject({ id: 'v9' });
   });
 
-  it('ensureSkillVersion rethrows when the label genuinely is not there', async () => {
+  it('createOrReuseSkillVersion rethrows when the label genuinely is not there', async () => {
     mockFetch(({ method }) => {
       if (method === 'POST') return { status: 500, body: { message: 'boom' } };
       return { status: 200, body: { capabilityVersions: [] } };
     });
 
     const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    await expect(client.ensureSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 500 });
+    await expect(client.createOrReuseSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 500 });
   });
 
-  it('ensureSkillVersion does not swallow a 400', async () => {
+  it('createOrReuseSkillVersion does not swallow a 400', async () => {
     mockFetch(() => ({ status: 400, body: { message: 'bad request' } }));
     const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    await expect(client.ensureSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 400 });
+    await expect(client.createOrReuseSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 400 });
   });
 });

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -391,18 +391,6 @@ describe('EvalForgeClient (V1) — skill capability versions', () => {
     });
   });
 
-  it('sends no mcpContent alongside skillContent — the field is a oneof', async () => {
-    let captured: Record<string, unknown> | undefined;
-    mockFetch(({ body }) => {
-      captured = (body as { capabilityVersion: Record<string, unknown> }).capabilityVersion;
-      return { status: 200, body: { capabilityVersion: { id: 'v1', capabilityId: 'C', version: 'L' } } };
-    });
-
-    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
-    await client.createOrReuseSkillVersion('C', 'P', 'L', 42, files);
-
-    expect(captured).not.toHaveProperty('mcpContent');
-  });
 
   it('createOrReuseSkillVersion reuses an existing version on a 409', async () => {
     mockFetch(({ method }) => {

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -260,13 +260,13 @@ describe('EvalForgeClient (V1) — eval runs', () => {
     await expect(c.triggerEvalRun('P', 'run-1')).resolves.toEqual({ evalRunId: 'run-1' });
   });
 
-  it('getEvalRun unwraps {evalRun}, lowercases status, and converts passRate to a percent', async () => {
+  it('getEvalRun unwraps {evalRun}, lowercases status, and keeps passRate as a percentage', async () => {
     mockFetch(({ url, method }) => {
       expect(method).toBe('GET');
       expect(url).toContain('/v1/projects/P/eval-runs/run-1');
       return {
         status: 200,
-        body: { evalRun: { id: 'run-1', status: 'COMPLETED', progress: 100, aggregateMetrics: { totalAssertions: 4, passed: 3, failed: 1, passRate: 0.75 } } },
+        body: { evalRun: { id: 'run-1', status: 'COMPLETED', progress: 100, aggregateMetrics: { totalAssertions: 4, passed: 3, failed: 1, passRate: 75 } } },
       };
     });
     const c = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -361,3 +361,84 @@ describe('EvalForgeClient (V1) — ensureMcpVersion idempotency', () => {
     await expect(c.ensureMcpVersion('M', 'P', 'pr-1-abc', 1, 'abc1234', 'wix/skills')).rejects.toMatchObject({ status: 500 });
   });
 });
+
+describe('EvalForgeClient (V1) — skill capability versions', () => {
+  const files = [
+    { path: 'SKILL.md', content: '# wix-app' },
+    { path: 'references/DASHBOARD_PAGE.md', content: 'dashboard docs' },
+  ];
+
+  it('posts skillContent with the file list to the capability versions endpoint', async () => {
+    let captured: unknown;
+    mockFetch(({ url, method, body }) => {
+      expect(method).toBe('POST');
+      expect(url).toContain('/v1/projects/P/capabilities/C/versions');
+      captured = body;
+      return { status: 200, body: { capabilityVersion: { id: 'v1', capabilityId: 'C', version: 'pr-42-abc1234' } } };
+    });
+
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    const version = await client.createSkillVersion('C', 'P', 'pr-42-abc1234', 42, files);
+
+    expect(version).toEqual({ id: 'v1', capabilityId: 'C', version: 'pr-42-abc1234' });
+    expect(captured).toMatchObject({
+      capabilityVersion: {
+        capabilityId: 'C',
+        version: 'pr-42-abc1234',
+        origin: 'pr',
+        skillContent: { files },
+      },
+    });
+  });
+
+  it('sends no mcpContent alongside skillContent — the field is a oneof', async () => {
+    let captured: Record<string, unknown> | undefined;
+    mockFetch(({ body }) => {
+      captured = (body as { capabilityVersion: Record<string, unknown> }).capabilityVersion;
+      return { status: 200, body: { capabilityVersion: { id: 'v1', capabilityId: 'C', version: 'L' } } };
+    });
+
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await client.createSkillVersion('C', 'P', 'L', 42, files);
+
+    expect(captured).not.toHaveProperty('mcpContent');
+  });
+
+  it('ensureSkillVersion reuses an existing version on a 409', async () => {
+    mockFetch(({ method }) => {
+      if (method === 'POST') return { status: 409, body: { message: 'already exists' } };
+      return { status: 200, body: { capabilityVersions: [{ id: 'v9', capabilityId: 'C', version: 'pr-42-abc1234' }] } };
+    });
+
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    const version = await client.ensureSkillVersion('C', 'P', 'pr-42-abc1234', 42, files);
+
+    expect(version).toEqual({ id: 'v9', capabilityId: 'C', version: 'pr-42-abc1234' });
+  });
+
+  it('ensureSkillVersion also recovers from the backend 500 for a duplicate label', async () => {
+    mockFetch(({ method }) => {
+      if (method === 'POST') return { status: 500, body: { message: 'already exists' } };
+      return { status: 200, body: { capabilityVersions: [{ id: 'v9', capabilityId: 'C', version: 'L' }] } };
+    });
+
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await expect(client.ensureSkillVersion('C', 'P', 'L', 42, files)).resolves.toMatchObject({ id: 'v9' });
+  });
+
+  it('ensureSkillVersion rethrows when the label genuinely is not there', async () => {
+    mockFetch(({ method }) => {
+      if (method === 'POST') return { status: 500, body: { message: 'boom' } };
+      return { status: 200, body: { capabilityVersions: [] } };
+    });
+
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await expect(client.ensureSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('ensureSkillVersion does not swallow a 400', async () => {
+    mockFetch(() => ({ status: 400, body: { message: 'bad request' } }));
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await expect(client.ensureSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/packages/evalforge-core/tests/evaluate-run-result.test.ts
+++ b/packages/evalforge-core/tests/evaluate-run-result.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateRunResult } from '../src/evaluate-run-result';
+import type { EvalRunStatus } from '../src/evalforge';
+
+const runStatus = (
+  overrides: Partial<EvalRunStatus['aggregateMetrics']> & { status?: EvalRunStatus['status'] } = {},
+): EvalRunStatus => {
+  const { status, ...metrics } = overrides;
+  return {
+    status: status ?? 'completed',
+    progress: 100,
+    aggregateMetrics: {
+      totalAssertions: 5, passed: 5, failed: 0, skipped: 0,
+      errors: 0, passRate: 100, avgDuration: 0, totalDuration: 0,
+      ...metrics,
+    },
+  };
+};
+
+describe('evaluateRunResult', () => {
+  it('passes a completed run with no failures and no errors', () => {
+    expect(evaluateRunResult(runStatus())).toEqual({ passed: true, reasons: [] });
+  });
+
+  it('fails on failed assertions, naming the count', () => {
+    const verdict = evaluateRunResult(runStatus({ failed: 2, passed: 3, passRate: 60 }));
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reasons).toEqual([expect.stringContaining('2 assertion')]);
+  });
+
+  it('fails on errored assertions', () => {
+    const verdict = evaluateRunResult(runStatus({ errors: 1, passed: 4 }));
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reasons).toEqual([expect.stringContaining('error')]);
+  });
+
+  it('reports both failures and errors', () => {
+    const verdict = evaluateRunResult(runStatus({ failed: 1, errors: 1, passed: 3 }));
+    expect(verdict.reasons).toHaveLength(2);
+  });
+
+  it('fails a run whose own status is failed even with clean metrics', () => {
+    const verdict = evaluateRunResult(runStatus({ status: 'failed' }));
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reasons).toEqual([expect.stringContaining('failed')]);
+  });
+
+  it('fails a cancelled run', () => {
+    const verdict = evaluateRunResult(runStatus({ status: 'cancelled' }));
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reasons).toEqual([expect.stringContaining('cancelled')]);
+  });
+
+  it('fails a run that is still running — a non-terminal status is not a pass', () => {
+    const verdict = evaluateRunResult(runStatus({ status: 'running' }));
+    expect(verdict.passed).toBe(false);
+  });
+
+  // The false-pass case: zero assertions means nothing was verified, which must never read
+  // as green just because no assertion happened to fail.
+  it('fails a run that produced no assertions at all', () => {
+    const verdict = evaluateRunResult(runStatus({ totalAssertions: 0, passed: 0, passRate: 0 }));
+    expect(verdict.passed).toBe(false);
+    expect(verdict.reasons).toEqual([expect.stringContaining('no assertions')]);
+  });
+
+  it('uses singular wording for a single failure', () => {
+    const verdict = evaluateRunResult(runStatus({ failed: 1, passed: 4 }));
+    expect(verdict.reasons[0]).toContain('1 assertion failed');
+  });
+});

--- a/packages/evalforge-core/tests/evaluate-run-result.test.ts
+++ b/packages/evalforge-core/tests/evaluate-run-result.test.ts
@@ -56,8 +56,7 @@ describe('evaluateRunResult', () => {
     expect(verdict.passed).toBe(false);
   });
 
-  // The false-pass case: zero assertions means nothing was verified, which must never read
-  // as green just because no assertion happened to fail.
+  // The false pass: nothing verified must not read as green.
   it('fails a run that produced no assertions at all', () => {
     const verdict = evaluateRunResult(runStatus({ totalAssertions: 0, passed: 0, passRate: 0 }));
     expect(verdict.passed).toBe(false);

--- a/packages/evalforge-core/tests/evaluate-run-result.test.ts
+++ b/packages/evalforge-core/tests/evaluate-run-result.test.ts
@@ -56,7 +56,6 @@ describe('evaluateRunResult', () => {
     expect(verdict.passed).toBe(false);
   });
 
-  // The false pass: nothing verified must not read as green.
   it('fails a run that produced no assertions at all', () => {
     const verdict = evaluateRunResult(runStatus({ totalAssertions: 0, passed: 0, passRate: 0 }));
     expect(verdict.passed).toBe(false);

--- a/packages/evalforge-core/tests/format-gate-comment.test.ts
+++ b/packages/evalforge-core/tests/format-gate-comment.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   GATE_COMMENT_MARKER, formatYamlErrors, formatNoGatedChanges, formatGuardFailure,
-  formatForeignDraftConflicts, formatGateResult, formatGateTimeout, formatGateServiceError,
+  formatForeignDraftConflicts, formatGateResult, formatGateTimeout, formatGateServiceError, formatGateSkipped,
 } from '../src/format-gate-comment';
 import type { EvalRunStatus } from '../src/evalforge';
 
@@ -221,5 +221,18 @@ describe('formatGateTimeout and formatGateServiceError', () => {
   it('surfaces the service error message', () => {
     expect(formatGateServiceError('Could not reach EvalForge', false))
       .toContain('Could not reach EvalForge');
+  });
+});
+
+describe('formatGateSkipped', () => {
+  it('says the PR was not evaluated and why', () => {
+    const body = formatGateSkipped('the PR author is not a @wix.com address');
+    expect(body).toContain(GATE_COMMENT_MARKER);
+    expect(body).toMatch(/not \*\*evaluated\*\*|not evaluated/);
+    expect(body).toContain('not a @wix.com address');
+  });
+
+  it('spells out that green does not mean the scenarios passed', () => {
+    expect(formatGateSkipped('reason')).toMatch(/did not run, not because the scenarios passed/);
   });
 });

--- a/packages/evalforge-core/tests/format-gate-comment.test.ts
+++ b/packages/evalforge-core/tests/format-gate-comment.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GATE_COMMENT_MARKER, formatYamlErrors, formatNoGatedChanges, formatGuardFailure,
+  formatForeignDraftConflicts, formatGateResult, formatGateTimeout, formatGateServiceError,
+} from '../src/format-gate-comment';
+import type { EvalRunStatus } from '../src/evalforge';
+
+const metrics = (overrides: Partial<EvalRunStatus['aggregateMetrics']> = {}): EvalRunStatus['aggregateMetrics'] => ({
+  totalAssertions: 5, passed: 5, failed: 0, skipped: 0,
+  errors: 0, passRate: 100, avgDuration: 0, totalDuration: 0,
+  ...overrides,
+});
+
+const baseResult = {
+  metrics: metrics(),
+  verdict: { passed: true, reasons: [] },
+  runId: 'run-1',
+  runUrl: 'https://bo.wix.com/pages/evalforge/P/results?runId=run-1',
+  selection: { ids: ['id-a'], selected: ['covers'], dropped: [], missingIds: [] },
+  maxScenarios: 25,
+  warnings: [],
+  unmapped: [],
+  broadImpact: false,
+  blocking: false,
+};
+
+describe('every gate comment', () => {
+  it('carries the marker so the upserter can find and edit it', () => {
+    for (const body of [
+      formatYamlErrors([{ path: 'a.yml', message: 'bad' }]),
+      formatNoGatedChanges([]),
+      formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true }),
+      formatForeignDraftConflicts([{ kind: 'FOREIGN_DRAFT', name: 'n', foreignTags: ['draft:o/r#1'] }], true),
+      formatGateResult(baseResult),
+      formatGateTimeout('run-1', 'https://x', false),
+      formatGateServiceError('boom', false),
+    ]) {
+      expect(body).toContain(GATE_COMMENT_MARKER);
+    }
+  });
+});
+
+describe('formatYamlErrors', () => {
+  it('lists each offending file and message', () => {
+    const body = formatYamlErrors([{ path: 'yaml/wix-app-evals/a.yml', message: 'tags required' }]);
+    expect(body).toContain('yaml/wix-app-evals/a.yml');
+    expect(body).toContain('tags required');
+  });
+});
+
+describe('formatNoGatedChanges', () => {
+  it('says nothing gated changed', () => {
+    expect(formatNoGatedChanges([])).toMatch(/no gated changes/i);
+  });
+
+  it('still lists unmapped paths so a new kind of file is visible', () => {
+    const body = formatNoGatedChanges(['skills/wix-app/NOTES.txt']);
+    expect(body).toContain('skills/wix-app/NOTES.txt');
+  });
+});
+
+describe('formatGuardFailure', () => {
+  it('names an uncovered tag and says a scenario is needed', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
+      warnings: [], blocking: true,
+    });
+    expect(body).toContain('backend-api');
+    expect(body).toMatch(/scenario/i);
+  });
+
+  it('distinguishes a weak tag from an uncovered one, naming the weak scenarios', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'WEAK_TAG', tag: 'dashboard-page', scenarios: ['thin'] }],
+      warnings: [], blocking: true,
+    });
+    expect(body).toContain('dashboard-page');
+    expect(body).toContain('thin');
+  });
+
+  it('reports a touched scenario below the bar with its reasons', () => {
+    const body = formatGuardFailure({
+      violations: [{
+        kind: 'WEAK_TOUCHED_SCENARIO', name: 'thin',
+        path: 'yaml/wix-app-evals/thin.yml', reasons: ['has 1 assertion (needs at least 3)'],
+      }],
+      warnings: [], blocking: true,
+    });
+    expect(body).toContain('yaml/wix-app-evals/thin.yml');
+    expect(body).toContain('has 1 assertion');
+  });
+
+  it('states that the run was skipped, since a guard failure costs no run', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true,
+    });
+    expect(body).toMatch(/no eval run|skipped|not run/i);
+  });
+
+  it('renders as a warning rather than a failure when not blocking', () => {
+    const blocked = formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true });
+    const soaking = formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: false });
+    expect(blocked).not.toBe(soaking);
+    expect(soaking).toContain('⚠️');
+    expect(blocked).toContain('❌');
+  });
+
+  it('includes carried-forward warnings alongside the violations', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
+      warnings: [{
+        kind: 'WEAK_UNTOUCHED_SCENARIO', name: 'old', path: 'yaml/wix-app-evals/old.yml',
+        tags: ['dashboard-page'], reasons: ['has no llm_judge assertion'],
+      }],
+      blocking: true,
+    });
+    expect(body).toContain('old');
+    expect(body).toContain('llm_judge');
+  });
+});
+
+describe('formatForeignDraftConflicts', () => {
+  it('links the PR holding each scenario', () => {
+    const body = formatForeignDraftConflicts([
+      { kind: 'FOREIGN_DRAFT', name: 'held', foreignTags: ['draft:wix/skills#99'], path: 'a.yml' },
+    ], true);
+    expect(body).toContain('held');
+    expect(body).toContain('https://github.com/wix/skills/pull/99');
+  });
+
+  it('falls back to the raw tag when it is not a parseable draft tag', () => {
+    const body = formatForeignDraftConflicts([
+      { kind: 'FOREIGN_DRAFT', name: 'held', foreignTags: ['draft:garbage'], path: 'a.yml' },
+    ], true);
+    expect(body).toContain('draft:garbage');
+  });
+});
+
+describe('formatGateResult', () => {
+  it('reports a pass with the pass rate, the run link and the scenarios that ran', () => {
+    const body = formatGateResult(baseResult);
+    expect(body).toContain('✅');
+    expect(body).toContain('100%');
+    expect(body).toContain(baseResult.runUrl);
+    expect(body).toContain('covers');
+  });
+
+  it('reports failure reasons on a failing run', () => {
+    const body = formatGateResult({
+      ...baseResult,
+      metrics: metrics({ failed: 2, passed: 3, passRate: 60 }),
+      verdict: { passed: false, reasons: ['2 assertions failed'] },
+    });
+    expect(body).toContain('2 assertions failed');
+    expect(body).toContain('60%');
+  });
+
+  it('names the dropped scenarios and the cap when the run was truncated', () => {
+    const body = formatGateResult({
+      ...baseResult,
+      selection: { ids: ['id-a'], selected: ['ran'], dropped: ['cut-one', 'cut-two'], missingIds: [] },
+      maxScenarios: 1,
+    });
+    expect(body).toContain('cut-one');
+    expect(body).toContain('cut-two');
+    expect(body).toContain('max-scenarios');
+  });
+
+  it('flags scenarios with no EvalForge id rather than hiding the sync gap', () => {
+    const body = formatGateResult({
+      ...baseResult,
+      selection: { ids: ['id-a'], selected: ['ran'], dropped: [], missingIds: ['unsynced'] },
+    });
+    expect(body).toContain('unsynced');
+  });
+
+  it('says the whole suite was in play on broad impact', () => {
+    const body = formatGateResult({ ...baseResult, broadImpact: true });
+    expect(body).toMatch(/whole suite|cross-cutting/i);
+  });
+
+  it('lists unmapped paths and carried warnings on an otherwise passing run', () => {
+    const body = formatGateResult({
+      ...baseResult,
+      unmapped: ['skills/wix-app/NOTES.txt'],
+      warnings: [{
+        kind: 'WEAK_UNTOUCHED_SCENARIO', name: 'old', path: 'yaml/wix-app-evals/old.yml',
+        tags: ['dashboard-page'], reasons: ['has no llm_judge assertion'],
+      }],
+    });
+    expect(body).toContain('NOTES.txt');
+    expect(body).toContain('old');
+  });
+
+  it('renders a failing run as a warning during the soak period', () => {
+    const body = formatGateResult({
+      ...baseResult,
+      verdict: { passed: false, reasons: ['1 assertion failed'] },
+      blocking: false,
+    });
+    expect(body).toContain('⚠️');
+    expect(body).toMatch(/soak/i);
+  });
+
+  it('renders a failing run as a failure when blocking', () => {
+    const body = formatGateResult({
+      ...baseResult,
+      verdict: { passed: false, reasons: ['1 assertion failed'] },
+      blocking: true,
+    });
+    expect(body).toContain('❌');
+    expect(body).not.toMatch(/soak/i);
+  });
+});
+
+describe('formatGateTimeout and formatGateServiceError', () => {
+  it('links the run that timed out', () => {
+    expect(formatGateTimeout('run-1', 'https://x/run-1', true)).toContain('https://x/run-1');
+  });
+
+  it('surfaces the service error message', () => {
+    expect(formatGateServiceError('Could not reach EvalForge', false))
+      .toContain('Could not reach EvalForge');
+  });
+});

--- a/packages/evalforge-core/tests/guard-scenarios.test.ts
+++ b/packages/evalforge-core/tests/guard-scenarios.test.ts
@@ -93,7 +93,7 @@ describe('guardScenarios — the outcome table', () => {
     expect(violations).toEqual([
       { kind: 'WEAK_TOUCHED_SCENARIO', name: 'thin', path: pathOf('thin'), reasons: expect.any(Array) },
     ]);
-    // Already blocking on the touched scenario — no duplicate warning for the same file.
+    // Already blocking on it — no duplicate warning.
     expect(warnings).toEqual([]);
   });
 });

--- a/packages/evalforge-core/tests/guard-scenarios.test.ts
+++ b/packages/evalforge-core/tests/guard-scenarios.test.ts
@@ -93,7 +93,6 @@ describe('guardScenarios — the outcome table', () => {
     expect(violations).toEqual([
       { kind: 'WEAK_TOUCHED_SCENARIO', name: 'thin', path: pathOf('thin'), reasons: expect.any(Array) },
     ]);
-    // Already blocking on it — no duplicate warning.
     expect(warnings).toEqual([]);
   });
 });

--- a/packages/evalforge-core/tests/guard-scenarios.test.ts
+++ b/packages/evalforge-core/tests/guard-scenarios.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { guardScenarios, meetsQualityBar, DEFAULT_QUALITY_BAR } from '../src/guard-scenarios';
+import type { Assertion, Scenario } from '../src/schema';
+
+const judge: Assertion = { type: 'llm_judge', prompt: 'is it good', minScore: 7 };
+const build: Assertion = { type: 'build_passed', command: 'npm run build' };
+const called: Assertion = { type: 'skill_was_called', skillNames: ['wix-app'] };
+const cost: Assertion = { type: 'cost', maxCostUsd: 1 };
+
+const scenario = (name: string, tags: string[], assertions: Assertion[]): Scenario => ({
+  name, description: '', triggerPrompt: 'build me a dashboard page', tags, assertions,
+});
+
+const strong = (name: string, tags: string[]) => scenario(name, tags, [called, build, judge]);
+const weak = (name: string, tags: string[]) => scenario(name, tags, [called]);
+
+const pathOf = (name: string) => `yaml/wix-app-evals/${name}.yml`;
+
+function loadedMap(...scenarios: Scenario[]): Map<string, { path: string; scenario: Scenario }> {
+  return new Map(scenarios.map(entry => [entry.name, { path: pathOf(entry.name), scenario: entry }]));
+}
+
+describe('meetsQualityBar', () => {
+  it('accepts three assertions including an llm_judge', () => {
+    expect(meetsQualityBar(strong('a', ['t']), DEFAULT_QUALITY_BAR)).toEqual({ ok: true, reasons: [] });
+  });
+
+  it('rejects too few assertions, naming the count', () => {
+    const check = meetsQualityBar(scenario('a', ['t'], [called, judge]), DEFAULT_QUALITY_BAR);
+    expect(check.ok).toBe(false);
+    expect(check.reasons).toEqual([expect.stringContaining('2 assertion')]);
+  });
+
+  it('rejects a scenario with enough assertions but no llm_judge', () => {
+    const check = meetsQualityBar(scenario('a', ['t'], [called, build, cost]), DEFAULT_QUALITY_BAR);
+    expect(check.ok).toBe(false);
+    expect(check.reasons).toEqual([expect.stringContaining('llm_judge')]);
+  });
+
+  it('reports both shortfalls at once', () => {
+    const check = meetsQualityBar(scenario('a', ['t'], [called]), DEFAULT_QUALITY_BAR);
+    expect(check.reasons).toHaveLength(2);
+  });
+
+  it('defaults to the standard bar when none is passed', () => {
+    expect(meetsQualityBar(strong('a', ['t'])).ok).toBe(true);
+    expect(meetsQualityBar(weak('b', ['t'])).ok).toBe(false);
+  });
+});
+
+describe('guardScenarios — the outcome table', () => {
+  it('row 1: blocks when a derived tag has no scenario at all', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: ['backend-api'],
+      scenarios: loadedMap(strong('other', ['dashboard-page'])),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations).toEqual([{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('row 2: blocks when the tag only scenario is below the bar and untouched', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: ['dashboard-page'],
+      scenarios: loadedMap(weak('thin', ['dashboard-page'])),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations).toEqual([
+      { kind: 'WEAK_TAG', tag: 'dashboard-page', scenarios: ['thin'] },
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('row 3: passes with a warning when a good and a weak scenario share the tag', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: ['dashboard-page'],
+      scenarios: loadedMap(strong('good', ['dashboard-page']), weak('thin', ['dashboard-page'])),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      kind: 'WEAK_UNTOUCHED_SCENARIO', name: 'thin', path: pathOf('thin'), tags: ['dashboard-page'],
+    });
+  });
+
+  it('row 4: blocks a touched below-bar scenario even when a strong sibling covers the tag', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: ['dashboard-page'],
+      scenarios: loadedMap(strong('good', ['dashboard-page']), weak('thin', ['dashboard-page'])),
+      touchedScenarioPaths: new Set([pathOf('thin')]),
+    });
+    expect(violations).toEqual([
+      { kind: 'WEAK_TOUCHED_SCENARIO', name: 'thin', path: pathOf('thin'), reasons: expect.any(Array) },
+    ]);
+    // Already blocking on the touched scenario — no duplicate warning for the same file.
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('guardScenarios — further cases', () => {
+  it('passes cleanly when every derived tag has a scenario meeting the bar', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: ['dashboard-page', 'data-collection'],
+      scenarios: loadedMap(strong('both', ['dashboard-page', 'data-collection'])),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('checks a touched scenario even when the PR derived no tags at all', () => {
+    const { violations } = guardScenarios({
+      tags: [],
+      scenarios: loadedMap(weak('thin', ['dashboard-page'])),
+      touchedScenarioPaths: new Set([pathOf('thin')]),
+    });
+    expect(violations).toEqual([
+      { kind: 'WEAK_TOUCHED_SCENARIO', name: 'thin', path: pathOf('thin'), reasons: expect.any(Array) },
+    ]);
+  });
+
+  it('reports one warning per weak scenario, listing every derived tag it carries', () => {
+    const { warnings } = guardScenarios({
+      tags: ['dashboard-page', 'data-collection'],
+      scenarios: loadedMap(
+        strong('good', ['dashboard-page', 'data-collection']),
+        weak('thin', ['dashboard-page', 'data-collection']),
+      ),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].tags).toEqual(['dashboard-page', 'data-collection']);
+  });
+
+  it('does not warn about a weak scenario whose tags the PR did not touch', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: ['dashboard-page'],
+      scenarios: loadedMap(strong('good', ['dashboard-page']), weak('elsewhere', ['backend-api'])),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('reports every uncovered tag rather than stopping at the first', () => {
+    const { violations } = guardScenarios({
+      tags: ['backend-api', 'site-plugin'],
+      scenarios: loadedMap(),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations.map(violation => violation.kind)).toEqual(['UNCOVERED_TAG', 'UNCOVERED_TAG']);
+  });
+
+  it('honours a custom bar', () => {
+    const { violations } = guardScenarios({
+      tags: ['dashboard-page'],
+      scenarios: loadedMap(scenario('two', ['dashboard-page'], [called, judge])),
+      touchedScenarioPaths: new Set(),
+      bar: { minAssertions: 2, requireLlmJudge: true },
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('passes with no tags and nothing touched — nothing to check', () => {
+    const { violations, warnings } = guardScenarios({
+      tags: [],
+      scenarios: loadedMap(weak('thin', ['dashboard-page'])),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(violations).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('sorts warnings by scenario name for a stable comment', () => {
+    const { warnings } = guardScenarios({
+      tags: ['dashboard-page'],
+      scenarios: loadedMap(
+        strong('good', ['dashboard-page']),
+        weak('zebra', ['dashboard-page']),
+        weak('alpha', ['dashboard-page']),
+      ),
+      touchedScenarioPaths: new Set(),
+    });
+    expect(warnings.map(warning => warning.name)).toEqual(['alpha', 'zebra']);
+  });
+});

--- a/packages/evalforge-core/tests/select-scenarios.test.ts
+++ b/packages/evalforge-core/tests/select-scenarios.test.ts
@@ -107,6 +107,44 @@ describe('selectScenarios', () => {
     expect(selection.selected).toEqual(['known']);
   });
 
+  it('does not run a scenario the PR deleted, though EvalForge still holds it', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['dashboard-page'],
+      localScenarios: loadedMap(['kept', ['dashboard-page']]),
+      nameToId: idsFor('kept', 'deleted-in-pr'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection.selected).toEqual(['kept']);
+    expect(selection.ids).toEqual(['id-kept']);
+    expect(selection.missingIds).toEqual([]);
+  });
+
+  it('keeps a deleted scenario out of a broad-impact run too', () => {
+    const selection = selectScenarios({
+      broadImpact: true,
+      tags: [],
+      localScenarios: loadedMap(['kept', ['dashboard-page']]),
+      nameToId: idsFor('kept', 'deleted-in-pr'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection.selected).toEqual(['kept']);
+  });
+
+  it('runs the PR version of a renamed scenario, not the old name', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['dashboard-page'],
+      localScenarios: loadedMap(['new-name', ['dashboard-page']]),
+      nameToId: idsFor('old-name', 'new-name'),
+      touchedScenarioPaths: new Set([pathOf('new-name')]),
+      maxScenarios: 25,
+    });
+    expect(selection.selected).toEqual(['new-name']);
+  });
+
   it('returns an empty selection when nothing matches', () => {
     const selection = selectScenarios({
       broadImpact: false,

--- a/packages/evalforge-core/tests/select-scenarios.test.ts
+++ b/packages/evalforge-core/tests/select-scenarios.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { selectScenarios } from '../src/select-scenarios';
+import type { Scenario } from '../src/schema';
+
+const scenario = (name: string, tags: string[]): Scenario => ({
+  name, description: '', triggerPrompt: 'build something real', tags,
+  assertions: [{ type: 'llm_judge', prompt: 'good?', minScore: 7 }],
+});
+
+const pathOf = (name: string) => `yaml/wix-app-evals/${name}.yml`;
+
+function loadedMap(...entries: Array<[string, string[]]>) {
+  return new Map(entries.map(([name, tags]) => [name, { path: pathOf(name), scenario: scenario(name, tags) }]));
+}
+
+const idsFor = (...names: string[]) => new Map(names.map(name => [name, `id-${name}`]));
+
+describe('selectScenarios', () => {
+  it('selects scenarios carrying any derived tag', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['dashboard-page'],
+      localScenarios: loadedMap(['covers', ['dashboard-page']], ['other', ['backend-api']]),
+      nameToId: idsFor('covers', 'other'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection.selected).toEqual(['covers']);
+    expect(selection.ids).toEqual(['id-covers']);
+    expect(selection.dropped).toEqual([]);
+    expect(selection.missingIds).toEqual([]);
+  });
+
+  it('selects every scenario on broad impact, ignoring the tag list', () => {
+    const selection = selectScenarios({
+      broadImpact: true,
+      tags: [],
+      localScenarios: loadedMap(['a', ['dashboard-page']], ['b', ['backend-api']]),
+      nameToId: idsFor('a', 'b'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection.selected).toEqual(['a', 'b']);
+  });
+
+  it('includes a touched scenario even when it carries no derived tag', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['dashboard-page'],
+      localScenarios: loadedMap(['tagged', ['dashboard-page']], ['edited', ['backend-api']]),
+      nameToId: idsFor('tagged', 'edited'),
+      touchedScenarioPaths: new Set([pathOf('edited')]),
+      maxScenarios: 25,
+    });
+    expect([...selection.selected].sort()).toEqual(['edited', 'tagged']);
+  });
+
+  it('dedupes a scenario matching several derived tags', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['dashboard-page', 'data-collection'],
+      localScenarios: loadedMap(['both', ['dashboard-page', 'data-collection']]),
+      nameToId: idsFor('both'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection.ids).toEqual(['id-both']);
+  });
+
+  it('caps at maxScenarios and reports what was dropped', () => {
+    const selection = selectScenarios({
+      broadImpact: true,
+      tags: [],
+      localScenarios: loadedMap(['a', ['t']], ['b', ['t']], ['c', ['t']]),
+      nameToId: idsFor('a', 'b', 'c'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 2,
+    });
+    expect(selection.selected).toEqual(['a', 'b']);
+    expect(selection.dropped).toEqual(['c']);
+  });
+
+  it('keeps the PR own touched scenarios when the cap bites', () => {
+    const selection = selectScenarios({
+      broadImpact: true,
+      tags: [],
+      localScenarios: loadedMap(['aaa', ['t']], ['bbb', ['t']], ['zzz', ['t']]),
+      nameToId: idsFor('aaa', 'bbb', 'zzz'),
+      touchedScenarioPaths: new Set([pathOf('zzz')]),
+      maxScenarios: 1,
+    });
+    expect(selection.selected).toEqual(['zzz']);
+    expect(selection.dropped).toEqual(['aaa', 'bbb']);
+  });
+
+  it('reports a selected scenario with no known EvalForge id instead of silently skipping it', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['dashboard-page'],
+      localScenarios: loadedMap(['known', ['dashboard-page']], ['unsynced', ['dashboard-page']]),
+      nameToId: idsFor('known'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection.ids).toEqual(['id-known']);
+    expect(selection.missingIds).toEqual(['unsynced']);
+    expect(selection.selected).toEqual(['known']);
+  });
+
+  it('returns an empty selection when nothing matches', () => {
+    const selection = selectScenarios({
+      broadImpact: false,
+      tags: ['backend-api'],
+      localScenarios: loadedMap(['other', ['dashboard-page']]),
+      nameToId: idsFor('other'),
+      touchedScenarioPaths: new Set(),
+      maxScenarios: 25,
+    });
+    expect(selection).toEqual({ ids: [], selected: [], dropped: [], missingIds: [] });
+  });
+
+  it('orders selection deterministically — touched first, then alphabetical', () => {
+    const selection = selectScenarios({
+      broadImpact: true,
+      tags: [],
+      localScenarios: loadedMap(['c', ['t']], ['a', ['t']], ['b', ['t']]),
+      nameToId: idsFor('a', 'b', 'c'),
+      touchedScenarioPaths: new Set([pathOf('c')]),
+      maxScenarios: 25,
+    });
+    expect(selection.selected).toEqual(['c', 'a', 'b']);
+  });
+});

--- a/packages/evalforge-core/yarn.lock
+++ b/packages/evalforge-core/yarn.lock
@@ -520,6 +520,7 @@ __metadata:
     "@types/node": "npm:^20.0.0"
     glob: "npm:^11.0.0"
     js-yaml: "npm:^4.1.1"
+    minimatch: "npm:^10.1.1"
     typescript: "npm:^5.0.0"
     vitest: "npm:^2.0.0"
     zod: "npm:^3.23.0"


### PR DESCRIPTION
Core modules for the wix-app PR eval gate ([CODEAI-889](https://wix.atlassian.net/browse/CODEAI-889)). **No action, no workflow, nothing wired yet** — this is the logic, with its tests. The wiring follows in #751.

> **Stacked on #750.** Merge that first. Split out of #751 to keep the review surface small.

## What's here

| Module | Responsibility |
|---|---|
| `evalforge.ts` | `createSkillVersion` / `ensureSkillVersion` — same endpoint as the MCP pair, `skillContent` oneof |
| `collect-skill-files.ts` | skill dir → `{ path, content }[]`, skillDir-relative, size-capped |
| `derive-tags.ts` | changed paths + `TagRules` → `{ tags, broadImpact, unmapped }` |
| `guard-scenarios.ts` | the quality guard — coverage + no-weakening |
| `select-scenarios.ts` | tag set + name→id → capped run id set |
| `evaluate-run-result.ts` | `EvalRunStatus` → pass/fail verdict |
| `format-gate-comment.ts` | markdown for every outcome |

All pure or IO-injected; no `@actions/*` import. `evalforge-core` goes 163 → 252 tests.

## The three judgement calls worth your attention

**1. Tag precedence is first-match-wins: ignore → broad-impact → reference → unmapped.**
The order is load-bearing. Put the reference rule first and `references/CODE_QUALITY.md` derives a `code-quality` tag, whereupon the coverage guard demands a scenario carrying a tag no scenario will ever carry. Asserted, not assumed — see the `deriveTags — precedence` block.

**2. Coverage folds the quality bar in** (≥3 assertions, ≥1 `llm_judge`). A tag whose only scenario has one assertion is not covered in any useful sense: the gate would run it, pass, and have verified nothing. Each row of the four-row outcome table has its own test, because those rows *are* the contract.

**3. `broadImpact` is a flag that contributes no tags** — a deviation from the spec. The spec said both that broad-impact paths are "never coverage-checked" *and* that they expand to "the union of all tags". Together at the guard, a `SKILL.md` typo fix would block on any weak scenario anywhere in the repo — the inherited-debt failure the warning tier exists to prevent.

## Mutation-checked, because passing tests don't prove a test would catch the bug

| Guard | Mutation | Result |
|---|---|---|
| Tag precedence | reference rule before broad-impact | both precedence tests fail |
| Coverage requires the bar | "any scenario carrying the tag counts" | outcome-table row 2 fails |

## Notes

- **`minimatch` becomes an explicit core dependency** (glob 11 already locked 10.2.5 transitively). That propagates through the `portal:` link, so **all three** `yarn.lock` files are updated — CI runs `--immutable` and would otherwise fail in a way that looks unrelated.
- `evaluate-run-result` fails a **zero-assertion** run explicitly: no assertion failed, but none ran either, and that must not read as green.
- Both `dist` bundles are rebuilt because core is inlined into each. #750 marks them `linguist-generated`, so they should render collapsed.

No UI changes, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)