### PR TITLE
🦞 igor-claw: warn that bulk delete returns 200 even when nothing was deleted

### DIFF
--- a/skills/wix-manage/references/cms/cms-data-items-crud.md
+++ b/skills/wix-manage/references/cms/cms-data-items-crud.md
@@ -355,6 +355,30 @@ curl -X DELETE \
 }
 ```
 
+**Response**:
+```json
+{
+  "results": [
+    {
+      "action": "DELETE",
+      "itemMetadata": { "id": "item-id-1", "originalIndex": 0, "success": true }
+    },
+    {
+      "action": "DELETE",
+      "itemMetadata": {
+        "id": "item-id-2",
+        "originalIndex": 1,
+        "success": false,
+        "error": { "code": "WDE0073", "description": "WDE0073: Item [item-id-2] does not exist in collection [Products]." }
+      }
+    }
+  ],
+  "bulkActionMetadata": { "totalSuccesses": 1, "totalFailures": 1 }
+}
+```
+
+> **Important**: The HTTP status is `200` even when every item fails — it only confirms the request was accepted, not that anything was deleted. Always check `bulkActionMetadata.totalFailures` and each `results[].itemMetadata.success` before treating a bulk delete as done; a stale or mistyped ID list fails silently otherwise (each failing item gets `success: false` with an error like `WDE0073`, but the overall call still returns 200). If using the `@wix/data` SDK's `items.bulkRemove()` instead of raw REST, note it doesn't throw or list not-found IDs in `result.errors` at all — check `result.removed`/`result.skipped` (and `result.skippedItemIds`, once available) instead of assuming `errors.length === 0` means everything was removed.
+
 ## Field Types Reference
 
 | Type | Description | Example Value |


### PR DESCRIPTION
## Summary

Opened automatically by an AI research agent acting on behalf of Ayal (`ayalg@wix.com`) — not personally written by them. Root-caused from a developer report in this Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1785270183960259 ("the bulk delete that returns 200 without deleting... silently corrupted seeded data and was only caught by re-querying").

**Root cause:** `POST /wix-data/v2/bulk/items/remove` returns HTTP 200 as soon as the request itself is valid — per-item outcome lives in `results[].itemMetadata.success`/`error` and `bulkActionMetadata.totalFailures`. I reproduced this directly (create collection → insert items → bulk-remove stale/nonexistent IDs): `HTTP_STATUS:200` with every item reporting `success:false` and error code `WDE0073`. `cms-data-items-crud.md`'s "Bulk Delete Items" section only showed the request body, with no response example — nothing prompts an agent following this recipe to check per-item success before treating the delete as done.

It's worse at the SDK layer: `@wix/data`'s `items.bulkRemove()` deliberately strips `WDE0073` ("item does not exist") out of `result.errors` (see the companion fix in `wix-private/wix-data`, PR #5277) — so `errors.length === 0` doesn't mean anything was actually removed there either.

**Fix:** add the response shape and an explicit warning to check `bulkActionMetadata`/`itemMetadata.success` (and, for the SDK, `result.removed`/`result.skipped`) rather than assuming a 200 or an empty `errors` array means every item was deleted.

## Test plan
- [ ] Skill lints/renders correctly (markdown only, no yaml/schema change)