### PR TITLE
🦞 igor-claw: add Uninstall App recipe covering HAS_EDITOR_PRESENCE

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -29,6 +29,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [List Installed Apps](references/app-installation/list-installed-apps.md)
 **Technical:** Lists all apps installed on a site using Apps Installer API. Useful for verifying app installations before making API calls and diagnosing authorization errors.
 
+### [Uninstall App](references/app-installation/uninstall-app.md)
+**Technical:** Uninstalls a Wix app from a site using the Apps Installer API. Covers the HAS_EDITOR_PRESENCE precondition failure and why blind retries never resolve it.
+
 ---
 
 ## Analytics

--- a/skills/wix-manage/references/app-installation/uninstall-app.md
+++ b/skills/wix-manage/references/app-installation/uninstall-app.md
@@ -1,0 +1,80 @@
+---
+name: "Uninstall App"
+description: Uninstalls a Wix app from a site using the Apps Installer API. Covers the HAS_EDITOR_PRESENCE precondition failure and why blind retries never resolve it.
+---
+# Uninstall an App from a Site
+
+This recipe guides you through uninstalling a Wix app from a site using the Apps Installer REST API, and how to diagnose the most common failure.
+
+## Prerequisites
+
+- Site ID for the site
+- `appDefId` of the app to uninstall (use the [List Installed Apps](list-installed-apps.md) recipe if you only know the app by name)
+
+## Required APIs
+
+- **Apps Installer API**: [Uninstall App](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/uninstall-app)
+
+---
+
+## Uninstall the App
+
+**Endpoint**: `POST https://www.wixapis.com/apps-installer-service/v1/app-instance/uninstall`
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/apps-installer-service/v1/app-instance/uninstall' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tenant": {
+      "tenantType": "SITE",
+      "id": "<SITE_ID>"
+    },
+    "appDefId": "<APP_DEF_ID>"
+  }'
+```
+
+A successful call returns `{}`.
+
+---
+
+## Error Handling
+
+### 428 FAILED_PRECONDITION — `UNINSTALL_FAILED`
+
+The response body's description embeds the real reason as `reason on MetaSite [<reason>]`. The reason is one of:
+
+- **`APP_NOT_FOUND`** — the app was already uninstalled, or never existed on this tenant. Nothing to do.
+- **`HAS_EDITOR_PRESENCE`** — the app has pages, widgets, or other components placed in the site's Wix Editor, and can't be uninstalled through this API alone.
+- **`ERROR`** — an unexpected internal error. Safe to retry once; if it persists, report the request ID.
+
+### `HAS_EDITOR_PRESENCE`: do NOT blind-retry
+
+**This is not a live editor session lock and it does not expire.** It is a persisted flag on the app's installation state, set because the app has components living in the site's Editor document (e.g. Wix Bookings' `/book-online` page and its widgets). It is only cleared by an actual Wix Editor session removing those components and saving — never by the passage of time.
+
+Concretely:
+- Retrying the identical uninstall call will fail identically, no matter how many times or how long you wait.
+- Asking the user to close the Wix Editor tab does **nothing** — closing a browser tab isn't the event that clears the flag.
+- There is currently **no API** to inspect or force-clear this flag, and no API to remove an app's Editor-placed components on the user's behalf.
+
+**Correct remediation**: the site owner needs to open the site in the actual Wix Editor, delete the app's page(s)/widget(s) from the Editor itself, and save. Only then will an API-level uninstall (or a Dashboard "Remove App" click) succeed. Tell the user this directly instead of retrying — repeated identical retries waste turns and give false hope that the issue is transient.
+
+If the app being removed is not actually needed by site visitors (e.g. all its services/items are hidden), removing it from the Editor may still require going through the Editor's own UI for that app type — there's no cross-app-type generic "detach from Editor" endpoint.
+
+---
+
+## Next Steps
+
+After uninstalling:
+- Confirm removal with the [List Installed Apps](list-installed-apps.md) recipe.
+- Note that uninstalling and reinstalling the same app doesn't create a new app instance — `status` flips between `INSTALLED`/`UNINSTALLED` and `instanceId` is preserved.
+
+---
+
+## Common Pitfalls
+
+- **Retrying `HAS_EDITOR_PRESENCE` in a loop** — it will never clear on its own; see above.
+- **Assuming the error means "someone has the editor open right now"** — it doesn't; it's about the app's Editor-placed components, not a live session.
+- **Confusing this with the app just being hidden/unused** — an app can have zero visible pages (e.g. all services marked `hidden: true`) and still have `HAS_EDITOR_PRESENCE`, because the flag tracks Editor component presence, not visibility.

--- a/yaml/wix-manage-evals/app-installation/uninstall-app.yml
+++ b/yaml/wix-manage-evals/app-installation/uninstall-app.yml
@@ -1,0 +1,42 @@
+name: app-installation/uninstall-app
+description: >-
+  Verifies the agent reads the uninstall-app skill and, when the Uninstall App call
+  fails with HAS_EDITOR_PRESENCE, explains the real remediation instead of blindly
+  retrying or telling the user to just close the editor and wait.
+triggerPrompt: >-
+  I called the Wix Uninstall App endpoint to remove Wix Bookings from my site (tenant
+  SITE, appDefId 13d21c63-b5ec-5912-8397-c3a5ddb27a97). It failed with 428
+  FAILED_PRECONDITION, code UNINSTALL_FAILED, reason "HAS_EDITOR_PRESENCE" on the
+  MetaSite. I already closed the Wix Editor and waited 5 minutes, then retried, and got
+  the exact same error again. What's going on and what should I do?
+tags: [app-installation]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/uninstall-app
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user hit HAS_EDITOR_PRESENCE on Uninstall App, already closed the editor and
+      waited, and retried with an identical failure.
+
+      Intent: explain that HAS_EDITOR_PRESENCE is a persisted flag on the app's install
+      state (the app has components placed in the site's Wix Editor), not a live/expiring
+      editor session lock, and that closing the editor tab and waiting does not clear it.
+
+      Pass if the response:
+      - explains HAS_EDITOR_PRESENCE means the app has pages/widgets/components placed in
+        the site's Editor, not that someone currently has an editor session open, AND
+      - explicitly says closing the editor and/or waiting will not clear this and retrying
+        the same call will keep failing identically, AND
+      - gives the correct remediation: open the site in the actual Wix Editor, remove the
+        app's components there, and save (or otherwise use the Editor UI itself) before the
+        uninstall can succeed, AND
+      - does not recommend simply retrying the API call again or waiting longer as a fix.
+
+      Fail if the response:
+      - suggests retrying the identical call, waiting longer, or re-closing the editor as a
+        plausible fix, OR
+      - describes HAS_EDITOR_PRESENCE as a live session/lock that should expire on its own, OR
+      - has no concrete remediation at all.

--- a/yaml/wix-manage/app-installation/documentation.yaml
+++ b/yaml/wix-manage/app-installation/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: List Installed Apps
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
       tags: [app-installation]
+    - file: ../../../skills/wix-manage/references/app-installation/uninstall-app.md
+      title: Uninstall App
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
+      tags: [app-installation]


### PR DESCRIPTION
## Gap

`WixREADME`'s app-installation section only had recipes for **Install Wix Apps** and **List Installed Apps** — nothing for uninstalling. An agent asked to uninstall an app has zero pre-curated guidance and has to discover the endpoint and its failure modes cold via generic doc search.

That's exactly what happened in the linked feedback: an agent uninstalling Wix Bookings hit `428 UNINSTALL_FAILED` / `HAS_EDITOR_PRESENCE`, and — with nothing telling it otherwise — retried the identical call 6 times over 10+ minutes (including a dedicated 5-minute wait, closing the Wix Editor each time), because it read the error as a live, expiring session lock. It isn't.

## Root cause (confirmed by reading `wix-private/meta-site` source + empirical test)

`HAS_EDITOR_PRESENCE` reflects a **persisted flag** on the app's install state (`DefaultLifecycle.scala`'s `Presence.Editor`), set when a hybrid app has components placed in the site's Wix Editor (pages/widgets). It's only cleared by an actual Wix Editor session removing those components and saving — there is no TTL, no heartbeat, nothing that clears it by waiting or by closing a browser tab. Confirmed empirically: uninstalling Bookings from a site where it was only ever installed via API (never touched through a live Editor) succeeds immediately.

See the paired API-reference fix: a `wix.api.error` proto annotation added in `wix-private/dev-center-platform` so this shows up in the public docs too (that PR has the full source trace).

## Fix

Adds `skills/wix-manage/references/app-installation/uninstall-app.md`:
- The Uninstall App request/response.
- The three `UNINSTALL_FAILED` reasons (`APP_NOT_FOUND`, `HAS_EDITOR_PRESENCE`, `ERROR`).
- An explicit "do NOT blind-retry `HAS_EDITOR_PRESENCE`" section with the correct remediation (remove the app's components via the actual Wix Editor and save).

Registered in `documentation.yaml` and `SKILL.md` per CONTRIBUTING.md, with a covering eval scenario (`yaml/wix-manage-evals/app-installation/uninstall-app.yml`) asserting the agent explains the real fix instead of recommending another retry/wait.

## Context

Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching Wix MCP feedback here: https://wix.slack.com/archives/C08P5DKLJR5/p1785293981114789