### PR TITLE
[throwaway] e2e: gate should block on an uncovered tag

### DIFF
--- a/skills/wix-app/references/BACKEND_API.md
+++ b/skills/wix-app/references/BACKEND_API.md
@@ -231,3 +231,5 @@ src/pages/api/
 - Include `Content-Type: application/json` header on JSON responses.
 - Include `statusText` in error responses.
 - Validate input parameters and request bodies.
+
+<!-- e2e throwaway: derives the uncovered `backend-api` tag. Do not merge. -->


### PR DESCRIPTION
Throwaway PR verifying the merged wix-app eval gate end to end in real CI.

Touches `references/BACKEND_API.md`, which derives the `backend-api` tag. The only scenario in `yaml/wix-app-evals/` carries `[dashboard-page, data-collection, auto-patterns-dashboard]`, so coverage should fail **before any EvalForge call** — comment posted, zero cost, and exit 0 because the gate is in soak (`blocking: false`).

Will be closed without merging.