### PR TITLE
fix(evalforge-core): make the coverage comment actionable

### DIFF
--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30850,10 +30850,12 @@ function formatNoGatedChanges(unmapped) {
         ...unmappedSection(unmapped),
     ]);
 }
-function violationLine(violation) {
+function violationLine(violation, scenarioDir) {
     switch (violation.kind) {
-        case 'UNCOVERED_TAG':
-            return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under the scenario directory tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+        case 'UNCOVERED_TAG': {
+            const where = scenarioDir === '' ? 'the scenario directory' : `\`${scenarioDir}/\``;
+            return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under ${where} tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+        }
         case 'WEAK_TAG':
             return `- **\`${violation.tag}\`** is carried only by scenarios below the quality bar (${violation.scenarios.map(name => `\`${name}\``).join(', ')}). Strengthen one of them, or add a scenario that meets the bar.`;
         case 'WEAK_TOUCHED_SCENARIO':
@@ -30862,10 +30864,15 @@ function violationLine(violation) {
 }
 function formatGuardFailure(input) {
     const { icon, label } = failIcon(input.blocking);
+    // Only when something here is actually about quality. On a bare uncovered tag there is no
+    // scenario to be below the bar, and leading with it reads as though one was too weak.
+    const aboutQuality = input.violations.some(violation => violation.kind !== 'UNCOVERED_TAG')
+        || input.warnings.length > 0;
     return render(icon, `Coverage ${label}`, [
-        'The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.',
-        '',
-        ...input.violations.map(violationLine),
+        ...(aboutQuality
+            ? ['The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.', '']
+            : []),
+        ...input.violations.map(violation => violationLine(violation, input.scenarioDir)),
         '',
         '_No eval run was started — a coverage failure is caught before any run cost._',
         ...warningSection(input.warnings),
@@ -31075,11 +31082,23 @@ __exportStar(__nccwpck_require__(5970), exports);
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.scenarioDirFromGlob = scenarioDirFromGlob;
 exports.loadScenarios = loadScenarios;
 const node_fs_1 = __nccwpck_require__(3024);
 const node_path_1 = __nccwpck_require__(6760);
 const glob_1 = __nccwpck_require__(2311);
 const schema_1 = __nccwpck_require__(3540);
+/**
+ * The directory a scenario glob covers, so an author can be told where to add one: the leading
+ * wildcard-free prefix of the pattern. With no wildcard at all the last segment is a filename,
+ * so it is dropped. See the tests for the concrete patterns.
+ */
+function scenarioDirFromGlob(globPattern) {
+    const segments = globPattern.split('/');
+    const firstWildcard = segments.findIndex(segment => /[*?{[]/.test(segment));
+    const directory = firstWildcard === -1 ? segments.slice(0, -1) : segments.slice(0, firstWildcard);
+    return directory.join('/');
+}
 function loadScenarios(root, globPattern) {
     const found = glob_1.glob.sync(globPattern, {
         cwd: root,
@@ -62106,7 +62125,11 @@ async function runCoverageGuard(derived, headScenarios, touchedPaths, config, co
     });
     if (guard.violations.length === 0)
         return { ok: true, value: guard };
-    await comment((0, evalforge_core_1.formatGuardFailure)({ ...guard, blocking: config.isBlocking }));
+    await comment((0, evalforge_core_1.formatGuardFailure)({
+        ...guard,
+        blocking: config.isBlocking,
+        scenarioDir: (0, evalforge_core_1.scenarioDirFromGlob)(config.evalsGlob),
+    }));
     (0, report_1.fail)(`Eval coverage guard failed: ${guard.violations.length} violation(s)`, config.isBlocking);
     return report_1.HALTED;
 }

--- a/.github/actions/evalforge-skill-gate/src/utils/gate-scope.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/gate-scope.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import {
   collectSkillFiles, deriveTags, formatGuardFailure, formatNoGatedChanges, formatYamlErrors,
-  getChangedFiles, guardScenarios, loadScenarios, touchedScenarioPaths,
+  getChangedFiles, guardScenarios, loadScenarios, scenarioDirFromGlob, touchedScenarioPaths,
   type ChangedFile, type Commenter, type DerivedTags, type GuardViolation, type GuardWarning,
   type LoadedScenario, type SkillFileContent,
 } from '@wix/evalforge-core';
@@ -104,7 +104,11 @@ async function runCoverageGuard(
     touchedScenarioPaths: touchedPaths,
   });
   if (guard.violations.length === 0) return { ok: true, value: guard };
-  await comment(formatGuardFailure({ ...guard, blocking: config.isBlocking }));
+  await comment(formatGuardFailure({
+    ...guard,
+    blocking: config.isBlocking,
+    scenarioDir: scenarioDirFromGlob(config.evalsGlob),
+  }));
   fail(`Eval coverage guard failed: ${guard.violations.length} violation(s)`, config.isBlocking);
   return HALTED;
 }

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34964,10 +34964,12 @@ function formatNoGatedChanges(unmapped) {
         ...unmappedSection(unmapped),
     ]);
 }
-function violationLine(violation) {
+function violationLine(violation, scenarioDir) {
     switch (violation.kind) {
-        case 'UNCOVERED_TAG':
-            return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under the scenario directory tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+        case 'UNCOVERED_TAG': {
+            const where = scenarioDir === '' ? 'the scenario directory' : `\`${scenarioDir}/\``;
+            return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under ${where} tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+        }
         case 'WEAK_TAG':
             return `- **\`${violation.tag}\`** is carried only by scenarios below the quality bar (${violation.scenarios.map(name => `\`${name}\``).join(', ')}). Strengthen one of them, or add a scenario that meets the bar.`;
         case 'WEAK_TOUCHED_SCENARIO':
@@ -34976,10 +34978,15 @@ function violationLine(violation) {
 }
 function formatGuardFailure(input) {
     const { icon, label } = failIcon(input.blocking);
+    // Only when something here is actually about quality. On a bare uncovered tag there is no
+    // scenario to be below the bar, and leading with it reads as though one was too weak.
+    const aboutQuality = input.violations.some(violation => violation.kind !== 'UNCOVERED_TAG')
+        || input.warnings.length > 0;
     return render(icon, `Coverage ${label}`, [
-        'The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.',
-        '',
-        ...input.violations.map(violationLine),
+        ...(aboutQuality
+            ? ['The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.', '']
+            : []),
+        ...input.violations.map(violation => violationLine(violation, input.scenarioDir)),
         '',
         '_No eval run was started — a coverage failure is caught before any run cost._',
         ...warningSection(input.warnings),
@@ -35189,11 +35196,23 @@ __exportStar(__nccwpck_require__(5970), exports);
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.scenarioDirFromGlob = scenarioDirFromGlob;
 exports.loadScenarios = loadScenarios;
 const node_fs_1 = __nccwpck_require__(3024);
 const node_path_1 = __nccwpck_require__(6760);
 const glob_1 = __nccwpck_require__(2311);
 const schema_1 = __nccwpck_require__(3540);
+/**
+ * The directory a scenario glob covers, so an author can be told where to add one: the leading
+ * wildcard-free prefix of the pattern. With no wildcard at all the last segment is a filename,
+ * so it is dropped. See the tests for the concrete patterns.
+ */
+function scenarioDirFromGlob(globPattern) {
+    const segments = globPattern.split('/');
+    const firstWildcard = segments.findIndex(segment => /[*?{[]/.test(segment));
+    const directory = firstWildcard === -1 ? segments.slice(0, -1) : segments.slice(0, firstWildcard);
+    return directory.join('/');
+}
 function loadScenarios(root, globPattern) {
     const found = glob_1.glob.sync(globPattern, {
         cwd: root,

--- a/packages/evalforge-core/src/format-gate-comment.ts
+++ b/packages/evalforge-core/src/format-gate-comment.ts
@@ -69,10 +69,12 @@ export function formatNoGatedChanges(unmapped: string[]): string {
   ]);
 }
 
-function violationLine(violation: GuardViolation): string {
+function violationLine(violation: GuardViolation, scenarioDir: string): string {
   switch (violation.kind) {
-    case 'UNCOVERED_TAG':
-      return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under the scenario directory tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+    case 'UNCOVERED_TAG': {
+      const where = scenarioDir === '' ? 'the scenario directory' : `\`${scenarioDir}/\``;
+      return `- **\`${violation.tag}\`** has no eval scenario at all. Add one under ${where} tagged \`${violation.tag}\`, or add that tag to a scenario that already exercises the area.`;
+    }
     case 'WEAK_TAG':
       return `- **\`${violation.tag}\`** is carried only by scenarios below the quality bar (${violation.scenarios.map(name => `\`${name}\``).join(', ')}). Strengthen one of them, or add a scenario that meets the bar.`;
     case 'WEAK_TOUCHED_SCENARIO':
@@ -84,12 +86,19 @@ export function formatGuardFailure(input: {
   violations: GuardViolation[];
   warnings: GuardWarning[];
   blocking: boolean;
+  /** Named in the fix instructions, so an author is not left guessing where scenarios live. */
+  scenarioDir: string;
 }): string {
   const { icon, label } = failIcon(input.blocking);
+  // Only when something here is actually about quality. On a bare uncovered tag there is no
+  // scenario to be below the bar, and leading with it reads as though one was too weak.
+  const aboutQuality = input.violations.some(violation => violation.kind !== 'UNCOVERED_TAG')
+    || input.warnings.length > 0;
   return render(icon, `Coverage ${label}`, [
-    'The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.',
-    '',
-    ...input.violations.map(violationLine),
+    ...(aboutQuality
+      ? ['The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.', '']
+      : []),
+    ...input.violations.map(violation => violationLine(violation, input.scenarioDir)),
     '',
     '_No eval run was started — a coverage failure is caught before any run cost._',
     ...warningSection(input.warnings),

--- a/packages/evalforge-core/src/load-scenarios.ts
+++ b/packages/evalforge-core/src/load-scenarios.ts
@@ -6,6 +6,18 @@ import { parseScenario, type Scenario } from './schema';
 export type LoadedScenario = { path: string; scenario: Scenario };
 export type LoadError = { path: string; message: string };
 
+/**
+ * The directory a scenario glob covers, so an author can be told where to add one: the leading
+ * wildcard-free prefix of the pattern. With no wildcard at all the last segment is a filename,
+ * so it is dropped. See the tests for the concrete patterns.
+ */
+export function scenarioDirFromGlob(globPattern: string): string {
+  const segments = globPattern.split('/');
+  const firstWildcard = segments.findIndex(segment => /[*?{[]/.test(segment));
+  const directory = firstWildcard === -1 ? segments.slice(0, -1) : segments.slice(0, firstWildcard);
+  return directory.join('/');
+}
+
 export function loadScenarios(root: string, globPattern: string): {
   scenarios: Map<string, LoadedScenario>;
   errors: LoadError[];

--- a/packages/evalforge-core/tests/format-gate-comment.test.ts
+++ b/packages/evalforge-core/tests/format-gate-comment.test.ts
@@ -29,7 +29,7 @@ describe('every gate comment', () => {
     for (const body of [
       formatYamlErrors([{ path: 'a.yml', message: 'bad' }]),
       formatNoGatedChanges([]),
-      formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true }),
+      formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true, scenarioDir: 'd' }),
       formatForeignDraftConflicts([{ kind: 'FOREIGN_DRAFT', name: 'n', foreignTags: ['draft:o/r#1'] }], true),
       formatGateResult(baseResult),
       formatGateTimeout('run-1', 'https://x', false),
@@ -63,7 +63,7 @@ describe('formatGuardFailure', () => {
   it('names an uncovered tag and says a scenario is needed', () => {
     const body = formatGuardFailure({
       violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
-      warnings: [], blocking: true,
+      warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
     });
     expect(body).toContain('backend-api');
     expect(body).toMatch(/scenario/i);
@@ -72,7 +72,7 @@ describe('formatGuardFailure', () => {
   it('distinguishes a weak tag from an uncovered one, naming the weak scenarios', () => {
     const body = formatGuardFailure({
       violations: [{ kind: 'WEAK_TAG', tag: 'dashboard-page', scenarios: ['thin'] }],
-      warnings: [], blocking: true,
+      warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
     });
     expect(body).toContain('dashboard-page');
     expect(body).toContain('thin');
@@ -84,7 +84,7 @@ describe('formatGuardFailure', () => {
         kind: 'WEAK_TOUCHED_SCENARIO', name: 'thin',
         path: 'yaml/wix-app-evals/thin.yml', reasons: ['has 1 assertion (needs at least 3)'],
       }],
-      warnings: [], blocking: true,
+      warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
     });
     expect(body).toContain('yaml/wix-app-evals/thin.yml');
     expect(body).toContain('has 1 assertion');
@@ -92,14 +92,14 @@ describe('formatGuardFailure', () => {
 
   it('states that the run was skipped, since a guard failure costs no run', () => {
     const body = formatGuardFailure({
-      violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true,
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
     });
     expect(body).toMatch(/no eval run|skipped|not run/i);
   });
 
   it('renders as a warning rather than a failure when not blocking', () => {
-    const blocked = formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true });
-    const soaking = formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: false });
+    const blocked = formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true, scenarioDir: 'd' });
+    const soaking = formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: false, scenarioDir: 'd' });
     expect(blocked).not.toBe(soaking);
     expect(soaking).toContain('⚠️');
     expect(blocked).toContain('❌');
@@ -112,7 +112,7 @@ describe('formatGuardFailure', () => {
         kind: 'WEAK_UNTOUCHED_SCENARIO', name: 'old', path: 'yaml/wix-app-evals/old.yml',
         tags: ['dashboard-page'], reasons: ['has no llm_judge assertion'],
       }],
-      blocking: true,
+      blocking: true, scenarioDir: 'yaml/wix-app-evals',
     });
     expect(body).toContain('old');
     expect(body).toContain('llm_judge');
@@ -234,5 +234,51 @@ describe('formatGateSkipped', () => {
 
   it('spells out that green does not mean the scenarios passed', () => {
     expect(formatGateSkipped('reason')).toMatch(/did not run, not because the scenarios passed/);
+  });
+  it('names the scenario directory, so the author knows where to add the file', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
+      warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
+    });
+    expect(body).toContain('`yaml/wix-app-evals/`');
+  });
+
+  it('falls back to generic wording rather than an empty path', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
+      warnings: [], blocking: true, scenarioDir: '',
+    });
+    expect(body).toContain('the scenario directory');
+    expect(body).not.toContain('`/`');
+  });
+
+  // An uncovered tag has no scenario, so nothing can be below the bar. Leading with the bar read
+  // as though an existing scenario was too weak.
+  it('omits the quality bar note when nothing is about quality', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
+      warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
+    });
+    expect(body).not.toContain('quality bar');
+  });
+
+  it('keeps the quality bar note for a weak tag', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'WEAK_TAG', tag: 'dashboard-page', scenarios: ['thin'] }],
+      warnings: [], blocking: true, scenarioDir: 'yaml/wix-app-evals',
+    });
+    expect(body).toContain('quality bar');
+  });
+
+  it('keeps the quality bar note when only the carried-forward warnings concern quality', () => {
+    const body = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 'backend-api' }],
+      warnings: [{
+        kind: 'WEAK_UNTOUCHED_SCENARIO', name: 'old', path: 'yaml/wix-app-evals/old.yml',
+        tags: ['dashboard-page'], reasons: ['has no llm_judge assertion'],
+      }],
+      blocking: true, scenarioDir: 'yaml/wix-app-evals',
+    });
+    expect(body).toContain('quality bar');
   });
 });

--- a/packages/evalforge-core/tests/load-scenarios.test.ts
+++ b/packages/evalforge-core/tests/load-scenarios.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadScenarios } from '../src/load-scenarios';
+import { loadScenarios, scenarioDirFromGlob } from '../src/load-scenarios';
 
 const GLOB = 'evals/*/**/*.{yml,yaml}';
 const yaml = (name: string) => `name: ${name}\ndescription: d\ntriggerPrompt: a long enough trigger prompt\ntags: [dashboard-page]\nassertions:\n  - type: llm_judge\n    prompt: p\n    minScore: 7\n`;
@@ -45,5 +45,23 @@ describe('loadScenarios', () => {
     const greedy = loadScenarios(dir, '**/*.{yml,yaml}');
     expect(greedy.errors).toHaveLength(0);
     expect([...greedy.scenarios.keys()]).toEqual(['area/a']);
+  });
+});
+
+describe('scenarioDirFromGlob', () => {
+  it('strips the wildcard tail from a scenario glob', () => {
+    expect(scenarioDirFromGlob('yaml/wix-app-evals/**/*.{yml,yaml}')).toBe('yaml/wix-app-evals');
+  });
+
+  it('handles a single-level glob', () => {
+    expect(scenarioDirFromGlob('yaml/wix-app-evals/*.yml')).toBe('yaml/wix-app-evals');
+  });
+
+  it('drops the filename when the pattern has no wildcard', () => {
+    expect(scenarioDirFromGlob('yaml/wix-app-evals/one.yml')).toBe('yaml/wix-app-evals');
+  });
+
+  it('returns empty rather than a bare slash for a wildcard-only pattern', () => {
+    expect(scenarioDirFromGlob('**/*.yml')).toBe('');
   });
 });


### PR DESCRIPTION
Two bugs in the coverage comment, both visible in what the gate posted on #767 — the first real-CI run of the merged gate.

### 1. The fix instruction never named the directory

> Add one under **the scenario directory** tagged `backend-api`

The comment's whole job is telling the author what to do, and it omitted the one thing they need. The path was known at the call site all along (`evals-glob`), just never passed to the formatter.

`scenarioDirFromGlob` derives it from the glob, so it stays a single source rather than a second hardcoded copy. `docs/skill-evaluation.md` already named the path correctly, which made the comment the weakest copy of the instruction.

### 2. The quality-bar sentence led every coverage failure

> The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.

For an uncovered tag there is no scenario at all, so nothing can be below the bar — it read as though something existing was too weak. Now conditional on a violation or warning that is actually about quality.

### Before / after, uncovered tag

Before (what #767 got):
```
## ⚠️ EvalForge Skill Gate: Coverage Warning

The quality bar is **at least 3 assertions including one `llm_judge`** — a scenario below it would run, pass, and verify nothing.

- **`backend-api`** has no eval scenario at all. Add one under the scenario directory tagged `backend-api`, or ...
```

After:
```
## ⚠️ EvalForge Skill Gate: Coverage Warning

- **`backend-api`** has no eval scenario at all. Add one under `yaml/wix-app-evals/` tagged `backend-api`, or ...
```

The weak-tag case keeps the bar note — covered by a test either way.

### Tests

core 257 → 266. New: the directory appears in the message, empty `scenarioDir` falls back to the old generic wording rather than rendering `` `/` ``, the bar note is omitted for a bare uncovered tag and kept for a weak tag or a carried-forward warning, plus four for `scenarioDirFromGlob`.

yaml-gate 76 and skill-gate 87 unchanged. Both dists rebuilt.