### PR TITLE
fix(evalforge-core): four defects found by rendering every gate comment

### DIFF
--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30803,6 +30803,13 @@ function render(icon, label, body) {
 function failIcon(blocking) {
     return blocking ? { icon: '❌', label: 'Failed' } : { icon: '⚠️', label: 'Warning' };
 }
+function count(quantity, noun) {
+    return `${quantity} ${noun}${quantity === 1 ? '' : 's'}`;
+}
+/** The API sends a fraction of a percent (26/30 arrives as 86.667); nobody needs the decimals. */
+function percent(passRate) {
+    return Math.round(passRate);
+}
 function soakNote(blocking) {
     return blocking
         ? []
@@ -30826,11 +30833,13 @@ function warningSection(warnings) {
         ...warnings.map(warning => `- \`${warning.path}\` (\`${warning.name}\`, tagged ${warning.tags.map(tag => `\`${tag}\``).join(', ')}) — ${warning.reasons.join('; ')}`),
     ];
 }
-function formatYamlErrors(errors) {
-    return render('❌', 'Invalid Scenario YAML', [
+function formatYamlErrors(errors, blocking) {
+    const { icon } = failIcon(blocking);
+    return render(icon, 'Invalid Scenario YAML', [
         'These scenario files did not parse against the schema:',
         '',
         ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+        ...soakNote(blocking),
     ]);
 }
 /**
@@ -30898,7 +30907,7 @@ function formatGateResult(input) {
     const { metrics, verdict, selection } = input;
     const { icon, label } = verdict.passed ? { icon: '✅', label: 'Passed' } : failIcon(input.blocking);
     const body = [
-        `**Pass rate:** ${metrics.passRate}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
+        `**Pass rate:** ${percent(metrics.passRate)}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
             + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
             + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
         `**Run:** [${input.runId}](${input.runUrl})`,
@@ -30907,8 +30916,8 @@ function formatGateResult(input) {
         body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
     }
     body.push('', input.broadImpact
-        ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${selection.selected.length} scenario(s) ran.`
-        : `**Scope:** ${selection.selected.length} scenario(s) ran.`, '', ...selection.selected.map(name => `- \`${name}\``));
+        ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${count(selection.selected.length, 'scenario')} ran.`
+        : `**Scope:** ${count(selection.selected.length, 'scenario')} ran.`, '', ...selection.selected.map(name => `- \`${name}\``));
     if (selection.dropped.length > 0) {
         body.push('', `**Capped at \`max-scenarios: ${input.maxScenarios}\`** — these were not run:`, ...selection.dropped.map(name => `- \`${name}\``));
     }
@@ -30928,8 +30937,12 @@ function formatGateTimeout(runId, runUrl, blocking) {
         ...soakNote(blocking),
     ]);
 }
-function formatGateServiceError(message, blocking) {
-    const { icon, label } = failIcon(blocking);
+/**
+ * `label` defaults to a service failure, the common case. The zero-selection guard passes its own:
+ * nothing broke there, the gate simply had nothing to run, and that deserves saying in the heading.
+ */
+function formatGateServiceError(message, blocking, label = 'Service Error') {
+    const { icon } = failIcon(blocking);
     return render(icon, label, [message, ...soakNote(blocking)]);
 }
 
@@ -62102,7 +62115,7 @@ async function loadHeadScenarios(workspace, config, comment) {
     const { scenarios, errors } = (0, evalforge_core_1.loadScenarios)(workspace, config.evalsGlob);
     if (errors.length === 0)
         return { ok: true, value: scenarios };
-    await comment((0, evalforge_core_1.formatYamlErrors)(errors));
+    await comment((0, evalforge_core_1.formatYamlErrors)(errors, config.isBlocking));
     (0, report_1.fail)(`Invalid scenario YAML or duplicate names: ${errors.length}`, config.isBlocking);
     return report_1.HALTED;
 }
@@ -62402,7 +62415,7 @@ async function resolveScenarioIds(config, scope, nameToId, comment) {
         return { ok: true, value: selection };
     // A gate that resolved nothing to run must not report a green check.
     const message = 'No eval scenarios could be resolved to run, so nothing was verified';
-    await comment((0, evalforge_core_1.formatGateServiceError)(message, config.isBlocking));
+    await comment((0, evalforge_core_1.formatGateServiceError)(message, config.isBlocking, 'Nothing Verified'));
     (0, report_1.fail)(message, config.isBlocking);
     return report_1.HALTED;
 }

--- a/.github/actions/evalforge-skill-gate/src/utils/gate-scope.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/gate-scope.ts
@@ -68,7 +68,7 @@ async function loadHeadScenarios(
 ): Promise<Guarded<Map<string, LoadedScenario>>> {
   const { scenarios, errors } = loadScenarios(workspace, config.evalsGlob);
   if (errors.length === 0) return { ok: true, value: scenarios };
-  await comment(formatYamlErrors(errors));
+  await comment(formatYamlErrors(errors, config.isBlocking));
   fail(`Invalid scenario YAML or duplicate names: ${errors.length}`, config.isBlocking);
   return HALTED;
 }

--- a/.github/actions/evalforge-skill-gate/src/utils/run-and-report.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/run-and-report.ts
@@ -70,7 +70,7 @@ async function resolveScenarioIds(
 
   // A gate that resolved nothing to run must not report a green check.
   const message = 'No eval scenarios could be resolved to run, so nothing was verified';
-  await comment(formatGateServiceError(message, config.isBlocking));
+  await comment(formatGateServiceError(message, config.isBlocking, 'Nothing Verified'));
   fail(message, config.isBlocking);
   return HALTED;
 }

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34917,6 +34917,13 @@ function render(icon, label, body) {
 function failIcon(blocking) {
     return blocking ? { icon: '❌', label: 'Failed' } : { icon: '⚠️', label: 'Warning' };
 }
+function count(quantity, noun) {
+    return `${quantity} ${noun}${quantity === 1 ? '' : 's'}`;
+}
+/** The API sends a fraction of a percent (26/30 arrives as 86.667); nobody needs the decimals. */
+function percent(passRate) {
+    return Math.round(passRate);
+}
 function soakNote(blocking) {
     return blocking
         ? []
@@ -34940,11 +34947,13 @@ function warningSection(warnings) {
         ...warnings.map(warning => `- \`${warning.path}\` (\`${warning.name}\`, tagged ${warning.tags.map(tag => `\`${tag}\``).join(', ')}) — ${warning.reasons.join('; ')}`),
     ];
 }
-function formatYamlErrors(errors) {
-    return render('❌', 'Invalid Scenario YAML', [
+function formatYamlErrors(errors, blocking) {
+    const { icon } = failIcon(blocking);
+    return render(icon, 'Invalid Scenario YAML', [
         'These scenario files did not parse against the schema:',
         '',
         ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+        ...soakNote(blocking),
     ]);
 }
 /**
@@ -35012,7 +35021,7 @@ function formatGateResult(input) {
     const { metrics, verdict, selection } = input;
     const { icon, label } = verdict.passed ? { icon: '✅', label: 'Passed' } : failIcon(input.blocking);
     const body = [
-        `**Pass rate:** ${metrics.passRate}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
+        `**Pass rate:** ${percent(metrics.passRate)}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
             + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
             + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
         `**Run:** [${input.runId}](${input.runUrl})`,
@@ -35021,8 +35030,8 @@ function formatGateResult(input) {
         body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
     }
     body.push('', input.broadImpact
-        ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${selection.selected.length} scenario(s) ran.`
-        : `**Scope:** ${selection.selected.length} scenario(s) ran.`, '', ...selection.selected.map(name => `- \`${name}\``));
+        ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${count(selection.selected.length, 'scenario')} ran.`
+        : `**Scope:** ${count(selection.selected.length, 'scenario')} ran.`, '', ...selection.selected.map(name => `- \`${name}\``));
     if (selection.dropped.length > 0) {
         body.push('', `**Capped at \`max-scenarios: ${input.maxScenarios}\`** — these were not run:`, ...selection.dropped.map(name => `- \`${name}\``));
     }
@@ -35042,8 +35051,12 @@ function formatGateTimeout(runId, runUrl, blocking) {
         ...soakNote(blocking),
     ]);
 }
-function formatGateServiceError(message, blocking) {
-    const { icon, label } = failIcon(blocking);
+/**
+ * `label` defaults to a service failure, the common case. The zero-selection guard passes its own:
+ * nothing broke there, the gate simply had nothing to run, and that deserves saying in the heading.
+ */
+function formatGateServiceError(message, blocking, label = 'Service Error') {
+    const { icon } = failIcon(blocking);
     return render(icon, label, [message, ...soakNote(blocking)]);
 }
 

--- a/packages/evalforge-core/src/format-gate-comment.ts
+++ b/packages/evalforge-core/src/format-gate-comment.ts
@@ -16,6 +16,15 @@ function failIcon(blocking: boolean): { icon: string; label: string } {
   return blocking ? { icon: '❌', label: 'Failed' } : { icon: '⚠️', label: 'Warning' };
 }
 
+function count(quantity: number, noun: string): string {
+  return `${quantity} ${noun}${quantity === 1 ? '' : 's'}`;
+}
+
+/** The API sends a fraction of a percent (26/30 arrives as 86.667); nobody needs the decimals. */
+function percent(passRate: number): number {
+  return Math.round(passRate);
+}
+
 function soakNote(blocking: boolean): string[] {
   return blocking
     ? []
@@ -42,11 +51,13 @@ function warningSection(warnings: GuardWarning[]): string[] {
   ];
 }
 
-export function formatYamlErrors(errors: LoadError[]): string {
-  return render('❌', 'Invalid Scenario YAML', [
+export function formatYamlErrors(errors: LoadError[], blocking: boolean): string {
+  const { icon } = failIcon(blocking);
+  return render(icon, 'Invalid Scenario YAML', [
     'These scenario files did not parse against the schema:',
     '',
     ...errors.map(error => `- \`${error.path}\`: ${error.message}`),
+    ...soakNote(blocking),
   ]);
 }
 
@@ -138,7 +149,7 @@ export function formatGateResult(input: {
   const { icon, label } = verdict.passed ? { icon: '✅', label: 'Passed' } : failIcon(input.blocking);
 
   const body: string[] = [
-    `**Pass rate:** ${metrics.passRate}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
+    `**Pass rate:** ${percent(metrics.passRate)}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
     + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
     + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
     `**Run:** [${input.runId}](${input.runUrl})`,
@@ -151,8 +162,8 @@ export function formatGateResult(input: {
   body.push(
     '',
     input.broadImpact
-      ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${selection.selected.length} scenario(s) ran.`
-      : `**Scope:** ${selection.selected.length} scenario(s) ran.`,
+      ? `**Scope:** a cross-cutting file changed, so the whole suite was in play — ${count(selection.selected.length, 'scenario')} ran.`
+      : `**Scope:** ${count(selection.selected.length, 'scenario')} ran.`,
     '',
     ...selection.selected.map(name => `- \`${name}\``),
   );
@@ -188,7 +199,11 @@ export function formatGateTimeout(runId: string, runUrl: string, blocking: boole
   ]);
 }
 
-export function formatGateServiceError(message: string, blocking: boolean): string {
-  const { icon, label } = failIcon(blocking);
+/**
+ * `label` defaults to a service failure, the common case. The zero-selection guard passes its own:
+ * nothing broke there, the gate simply had nothing to run, and that deserves saying in the heading.
+ */
+export function formatGateServiceError(message: string, blocking: boolean, label = 'Service Error'): string {
+  const { icon } = failIcon(blocking);
   return render(icon, label, [message, ...soakNote(blocking)]);
 }

--- a/packages/evalforge-core/tests/format-gate-comment.test.ts
+++ b/packages/evalforge-core/tests/format-gate-comment.test.ts
@@ -27,7 +27,7 @@ const baseResult = {
 describe('every gate comment', () => {
   it('carries the marker so the upserter can find and edit it', () => {
     for (const body of [
-      formatYamlErrors([{ path: 'a.yml', message: 'bad' }]),
+      formatYamlErrors([{ path: 'a.yml', message: 'bad' }], true),
       formatNoGatedChanges([]),
       formatGuardFailure({ violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [], blocking: true, scenarioDir: 'd' }),
       formatForeignDraftConflicts([{ kind: 'FOREIGN_DRAFT', name: 'n', foreignTags: ['draft:o/r#1'] }], true),
@@ -42,9 +42,24 @@ describe('every gate comment', () => {
 
 describe('formatYamlErrors', () => {
   it('lists each offending file and message', () => {
-    const body = formatYamlErrors([{ path: 'yaml/wix-app-evals/a.yml', message: 'tags required' }]);
+    const body = formatYamlErrors([{ path: 'yaml/wix-app-evals/a.yml', message: 'tags required' }], true);
     expect(body).toContain('yaml/wix-app-evals/a.yml');
     expect(body).toContain('tags required');
+  });
+
+  // It used to render ❌ unconditionally while `fail` only warned, so a soaking PR showed a hard
+  // failure next to a green check with nothing explaining the mismatch.
+  it('renders as a warning and says why the check is green when soaking', () => {
+    const body = formatYamlErrors([{ path: 'a.yml', message: 'bad' }], false);
+    expect(body).toContain('⚠️');
+    expect(body).not.toContain('❌');
+    expect(body).toContain('soak period');
+  });
+
+  it('renders as a hard failure with no soak note when blocking', () => {
+    const body = formatYamlErrors([{ path: 'a.yml', message: 'bad' }], true);
+    expect(body).toContain('❌');
+    expect(body).not.toContain('soak period');
   });
 });
 
@@ -280,5 +295,51 @@ describe('formatGateSkipped', () => {
       blocking: true, scenarioDir: 'yaml/wix-app-evals',
     });
     expect(body).toContain('quality bar');
+  });
+});
+
+describe('gate result presentation', () => {
+  const verdict = { passed: true, reasons: [] };
+  const base = {
+    runId: 'run-1', runUrl: 'https://example.com/run-1', maxScenarios: 25,
+    warnings: [], unmapped: [], broadImpact: false, blocking: false, verdict,
+  };
+
+  // The API sends a fraction of a percent — 26/30 arrives as 86.667, which rendered in full.
+  it('rounds the pass rate rather than printing the API fraction', () => {
+    const body = formatGateResult({
+      ...base,
+      metrics: metrics({ totalAssertions: 30, passed: 26, failed: 4, passRate: 86.667 }),
+      selection: { ids: ['i'], selected: ['one'], dropped: [], missingIds: [] },
+    });
+    expect(body).toContain('87%');
+    expect(body).not.toContain('86.667');
+  });
+
+  it('says "1 scenario" and "2 scenarios", not "scenario(s)"', () => {
+    const one = formatGateResult({
+      ...base, metrics: metrics(),
+      selection: { ids: ['i'], selected: ['one'], dropped: [], missingIds: [] },
+    });
+    const two = formatGateResult({
+      ...base, metrics: metrics(),
+      selection: { ids: ['i', 'j'], selected: ['one', 'two'], dropped: [], missingIds: [] },
+    });
+    expect(one).toContain('1 scenario ran');
+    expect(two).toContain('2 scenarios ran');
+    expect(one + two).not.toContain('scenario(s)');
+  });
+});
+
+describe('formatGateServiceError', () => {
+  it('names the stage rather than heading a bare "Failed"', () => {
+    expect(formatGateServiceError('Could not reach EvalForge', true)).toContain('Service Error');
+  });
+
+  // Nothing broke in the zero-selection case; the gate just had nothing to run.
+  it('takes a caller label, so "nothing verified" does not read as a service outage', () => {
+    const body = formatGateServiceError('nothing was verified', false, 'Nothing Verified');
+    expect(body).toContain('Nothing Verified');
+    expect(body).not.toContain('Service Error');
   });
 });


### PR DESCRIPTION
Follow-up to #768. I rendered all 13 comments the gate can post and read them as an author would. Four more defects — three of them reachable before merge, and I didn't look. Root cause on my side: the pre-merge e2e checked *behaviour* (right path, no cost, comment appeared) and never audited the artifact.

### 1. `formatYamlErrors` ignored `blocking`

It rendered ❌ unconditionally, while `gate-scope.ts` calls `fail(msg, isBlocking)` — a `core.warning` during soak. So a soaking PR saw a hard failure next to a **green check**, with nothing explaining the mismatch. Exactly the hazard the skip and zero-selection comments were written to avoid.

It was the only failure path not taking `blocking`, which is also why no unit test caught it: there was no contract to assert against.

Before / after (soak):
```
## ❌ EvalForge Skill Gate: Invalid Scenario YAML     →     ## ⚠️ EvalForge Skill Gate: Invalid Scenario YAML
(no soak note)                                              _The gate is in its soak period (`blocking: false`), so this check still passes._
```

### 2. The pass rate printed the API value raw

`passRate` arrives as a fraction of a percent — 26/30 is `86.667` — so a real comment read **"Pass rate: 86.667%"**. Now rounded, matching how `evalforge.ts` already renders it for the scheduled-run summary.

Why the e2e missed it: the three pre-merge runs produced 100 and 75. Both integers, so the output looked clean. I had seen `86.667` in the API samples pulled while diagnosing the ×100 bug and never crossed it with the comment's own formatting.

### 3. `1 scenario(s) ran`

On the most-read line of the most-read comment. Now `1 scenario` / `2 scenarios`.

### 4. `formatGateServiceError` headed a bare `Failed` / `Warning`

Siblings name the stage — "Coverage Warning", "Timed Out". This one didn't, and the **zero-selection guard used it too** — so the case that matters most, the gate refusing to report green having verified nothing, got the vaguest heading of any comment.

```
## ⚠️ EvalForge Skill Gate: Warning        →   ## ⚠️ EvalForge Skill Gate: Nothing Verified
## ⚠️ EvalForge Skill Gate: Warning        →   ## ⚠️ EvalForge Skill Gate: Service Error
```

### Verified clean

Everything else in the audit held up: both skip variants explain why green ≠ pass; no-gated-changes; foreign-draft tags resolve to real PR URLs; timeout; and the capped / missing-id / unmapped / carried-forward-warning sections all render and compose correctly.

### Tests

core 266 → 272, each new test failing against the old behaviour. yaml-gate 76 and skill-gate 87 unchanged. Both dists rebuilt.