### PR TITLE
[throwaway] e2e A: invalid scenario YAML

### DIFF
--- a/yaml/wix-app-evals/e2e-throwaway-broken.yml
+++ b/yaml/wix-app-evals/e2e-throwaway-broken.yml
@@ -1,0 +1,5 @@
+name: e2e-throwaway-broken
+description: Deliberately invalid — assertions must be a non-empty array. Throwaway.
+triggerPrompt: build something
+tags: [dashboard-page]
+assertions: []


### PR DESCRIPTION
Throwaway. Empty `assertions` fails the schema, so the gate should comment **before** the guard and before any EvalForge call.

Checking #769's fix: this used to render ❌ with no soak note while the check went green. Expect ⚠️ plus the soak line.