### PR TITLE
[throwaway] e2e B: uncovered tag

### DIFF
--- a/skills/wix-app/references/BACKEND_API.md
+++ b/skills/wix-app/references/BACKEND_API.md
@@ -231,3 +231,5 @@ src/pages/api/
 - Include `Content-Type: application/json` header on JSON responses.
 - Include `statusText` in error responses.
 - Validate input parameters and request bodies.
+
+<!-- e2e throwaway: derives the uncovered `backend-api` tag. Do not merge. -->


### PR DESCRIPTION
Throwaway. `backend-api` has no scenario, so coverage fails before any EvalForge call.

Checking #768's fix: the instruction should now name `yaml/wix-app-evals/` instead of "the scenario directory", and the quality-bar sentence should be **absent** (there is no scenario to be below the bar).