### PR TITLE
[throwaway] e2e C: ignored path, no gated changes

### DIFF
--- a/skills/wix-app/scripts/generate-auto-patterns.js
+++ b/skills/wix-app/scripts/generate-auto-patterns.js
@@ -508,3 +508,5 @@ console.log(
     outputDir: resolvedOutput,
   }),
 );
+
+# e2e throwaway comment. Do not merge.


### PR DESCRIPTION
Throwaway. Touches only `skills/wix-app/scripts/**`, which is in `ignore-globs` — a generator change arrives with its regenerated docs anyway.

The workflow should trigger (the path is under `skills/wix-app/**`) but derive no tags, so expect **No Gated Changes** with a green check and no run.