### PR TITLE
[throwaway] e2e D: covered tag, full flow

### DIFF
--- a/skills/wix-app/references/DASHBOARD_PAGE.md
+++ b/skills/wix-app/references/DASHBOARD_PAGE.md
@@ -325,3 +325,5 @@ Wizard pages guide users through setting up a product or feature. They split com
 - `<Layout />` - Grid layout container
 - `<MarketingPageLayout />` - Marketing page wrapper
 - `<Card />` - Content container with 24px gaps between cards
+
+<!-- e2e throwaway marker: PR-only content, proves the version came from this PR. Do not merge. -->


### PR DESCRIPTION
Throwaway. `references/DASHBOARD_PAGE.md` derives `dashboard-page`, carried by `employee-shift-dashboard`, which meets the bar. So coverage passes and the gate should create a PR capability version and start a run.

**The run is expected to fail** — the scenario's `templateId` points at a deleted EvalForge template. That is the point: confirming a dead template degrades *visibly* (a comment naming the failure) rather than silently reporting green.