### PR TITLE
fix(wix-app-evals): point the scenario at the current eval template

### DIFF
--- a/docs/eval-scenarios.md
+++ b/docs/eval-scenarios.md
@@ -198,7 +198,7 @@ Beyond these two, `wix-app` scenarios often add `build_passed`, and you can use 
 A `wix-app` scenario usually scaffolds its starter project from a **file template** — the top-level `templateId`, an EvalForge template (id or alias). It maps to `templateId` on the EvalForge run:
 
 ```yaml
-templateId: 8116ffa2-e212-4a74-a9f0-1738c9cbb6b1
+templateId: 33f2cb85-054e-4281-b617-3bc21ac0803f
 ```
 
 This is the **default template all wix-app runs start from**.

--- a/packages/evalforge-core/tests/schema.test.ts
+++ b/packages/evalforge-core/tests/schema.test.ts
@@ -398,8 +398,8 @@ describe('scenario templateId', () => {
   ].join('\n');
 
   it('accepts an optional top-level templateId', () => {
-    const s = parseScenario(base + '\ntemplateId: 8116ffa2-e212-4a74-a9f0-1738c9cbb6b1\n');
-    expect(s.templateId).toBe('8116ffa2-e212-4a74-a9f0-1738c9cbb6b1');
+    const s = parseScenario(base + '\ntemplateId: 33f2cb85-054e-4281-b617-3bc21ac0803f\n');
+    expect(s.templateId).toBe('33f2cb85-054e-4281-b617-3bc21ac0803f');
   });
   it('is valid without templateId (wix-manage scenarios omit it)', () => {
     const s = parseScenario(base + '\n');

--- a/yaml/wix-app-evals/employee-shift-dashboard.yml
+++ b/yaml/wix-app-evals/employee-shift-dashboard.yml
@@ -4,7 +4,7 @@ triggerPrompt: |-
   Build a dashboard page that lets store owners manage employee shifts. The page should have a table where each row is a shift with these fields: employee name, date, and hours. The store owner must be able to add new shifts to the table.
   APP_NAMESPACE: "@mirivo/my-app31ceim", Use this namespace when creating data collections (for idSuffix scoping).
   CODE_IDENTIFIER: "MirivoMyApp31ceim" When generating editor React component or function library extensions, use this identifier as the type prefix (e.g. type: 'MirivoMyApp31ceim"ComponentName').
-templateId: 8116ffa2-e212-4a74-a9f0-1738c9cbb6b1
+templateId: 33f2cb85-054e-4281-b617-3bc21ac0803f
 tags: [dashboard-page, data-collection, auto-patterns-dashboard]
 assertions:
   - type: skill_was_called


### PR DESCRIPTION
The template the scenario scaffolded from was deleted, so any run using it fails. Swaps in `33f2cb85-054e-4281-b617-3bc21ac0803f`.

| File | Why |
|---|---|
| `yaml/wix-app-evals/employee-shift-dashboard.yml` | the functional change |
| `docs/eval-scenarios.md` | the old id was the worked example — otherwise the next author copies a dead template |
| `packages/evalforge-core/tests/schema.test.ts` | fixture value is arbitrary, but shouldn't be a known-dead id |

The `templateId`s under `yaml/wix-manage-evals/**` are a **different field** despite the identical name — nested under `siteSetup`, holding a Wix site-template alias (`stores-v3-editor`). All 13 are untouched.

### This PR doubles as the e2e we couldn't run

Touching the scenario YAML makes it a *touched* scenario, so this PR exercises the parts nothing has covered in CI yet: draft-tagged sync of an edited scenario, then a run against the new template with the result comment. Watching it.

core 272 unchanged; the scenario still parses with 7 assertions and its three tags.