### PR TITLE
fix(evalforge-core): link the run when polling fails, and stop dumping Zod

### DIFF
--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30793,6 +30793,7 @@ exports.formatGuardFailure = formatGuardFailure;
 exports.formatForeignDraftConflicts = formatForeignDraftConflicts;
 exports.formatGateResult = formatGateResult;
 exports.formatGateTimeout = formatGateTimeout;
+exports.formatGatePollFailure = formatGatePollFailure;
 exports.formatGateServiceError = formatGateServiceError;
 const evalforge_1 = __nccwpck_require__(7230);
 exports.GATE_COMMENT_MARKER = '<!-- evalforge-skill-gate-action -->';
@@ -30809,6 +30810,10 @@ function count(quantity, noun) {
 /** The API sends a fraction of a percent (26/30 arrives as 86.667); nobody needs the decimals. */
 function percent(passRate) {
     return Math.round(passRate);
+}
+/** Shared by every outcome that has a run to point at. */
+function runLine(runId, runUrl) {
+    return `**Run:** [${runId}](${runUrl})`;
 }
 function soakNote(blocking) {
     return blocking
@@ -30910,7 +30915,7 @@ function formatGateResult(input) {
         `**Pass rate:** ${percent(metrics.passRate)}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
             + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
             + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
-        `**Run:** [${input.runId}](${input.runUrl})`,
+        runLine(input.runId, input.runUrl),
     ];
     if (!verdict.passed) {
         body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
@@ -30933,8 +30938,23 @@ function formatGateTimeout(runId, runUrl, blocking) {
     return render(blocking ? '⏱' : '⚠️', 'Timed Out', [
         'The eval run did not finish within the poll window. It may still be running in EvalForge.',
         '',
-        `**Run:** [${runId}](${runUrl})`,
+        runLine(runId, runUrl),
         ...soakNote(blocking),
+    ]);
+}
+/**
+ * Polling broke after the run started. Distinct from a service error, which has no run to name:
+ * here the run exists and may well have finished, so the link is the whole point of the comment.
+ */
+function formatGatePollFailure(input) {
+    const { icon } = failIcon(input.blocking);
+    return render(icon, 'Run Status Unavailable', [
+        `The run started, but the gate could not read its status: ${input.detail}`,
+        '',
+        'Open it to see whether it finished — the gate could not verify the result either way, so treat this as unverified rather than passing.',
+        '',
+        runLine(input.runId, input.runUrl),
+        ...soakNote(input.blocking),
     ]);
 }
 /**
@@ -31759,7 +31779,19 @@ function parseScenario(raw) {
             }
         }
     }
-    return exports.ScenarioSchema.parse(parsed);
+    const result = exports.ScenarioSchema.safeParse(parsed);
+    if (result.success)
+        return result.data;
+    throw new Error(describeIssues(result.error));
+}
+/**
+ * Zod's own `message` is the serialised issue array, so it reached the PR comment as ~15 lines of
+ * JSON for a one-line problem. One `path: message` per issue instead.
+ */
+function describeIssues(error) {
+    return error.issues
+        .map(issue => (issue.path.length === 0 ? issue.message : `${issue.path.join('.')}: ${issue.message}`))
+        .join('; ');
 }
 
 
@@ -62494,9 +62526,12 @@ async function pollToCompletion(client, config, runId, runUrl, comment) {
             (0, report_1.fail)(error.message, config.isBlocking);
             return report_1.HALTED;
         }
-        core.error(`Polling the eval run failed: ${(0, report_1.describeError)(error)}`);
-        await comment((0, evalforge_core_1.formatGateServiceError)('Polling the eval run failed', config.isBlocking));
-        (0, report_1.fail)('Polling the eval run failed', config.isBlocking);
+        // Names the run: it started, it may have finished, and without the link there is no way
+        // to find out from the PR.
+        const detail = (0, report_1.describeError)(error);
+        core.error(`Polling the eval run failed: ${detail}`);
+        await comment((0, evalforge_core_1.formatGatePollFailure)({ runId, runUrl, detail, blocking: config.isBlocking }));
+        (0, report_1.fail)(`Polling the eval run failed: ${detail}`, config.isBlocking);
         return report_1.HALTED;
     }
 }

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30815,6 +30815,13 @@ function percent(passRate) {
 function runLine(runId, runUrl) {
     return `**Run:** [${runId}](${runUrl})`;
 }
+/**
+ * The three outcomes where nothing was verified and retrying is the answer. A push re-triggers the
+ * gate today; CODEAI-895 adds a `/re-eval` comment so it does not need a commit.
+ */
+function retryNote() {
+    return ['', '_Push any commit to run the gate again._'];
+}
 function soakNote(blocking) {
     return blocking
         ? []
@@ -30939,6 +30946,7 @@ function formatGateTimeout(runId, runUrl, blocking) {
         'The eval run did not finish within the poll window. It may still be running in EvalForge.',
         '',
         runLine(runId, runUrl),
+        ...retryNote(),
         ...soakNote(blocking),
     ]);
 }
@@ -30954,6 +30962,7 @@ function formatGatePollFailure(input) {
         'Open it to see whether it finished — the gate could not verify the result either way, so treat this as unverified rather than passing.',
         '',
         runLine(input.runId, input.runUrl),
+        ...retryNote(),
         ...soakNote(input.blocking),
     ]);
 }
@@ -30963,7 +30972,7 @@ function formatGatePollFailure(input) {
  */
 function formatGateServiceError(message, blocking, label = 'Service Error') {
     const { icon } = failIcon(blocking);
-    return render(icon, label, [message, ...soakNote(blocking)]);
+    return render(icon, label, [message, ...retryNote(), ...soakNote(blocking)]);
 }
 
 

--- a/.github/actions/evalforge-skill-gate/src/utils/run-eval.ts
+++ b/.github/actions/evalforge-skill-gate/src/utils/run-eval.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import {
-  EvalForgeClient, EvalRunTimeoutError, formatGateServiceError, formatGateTimeout, pollUntilDone,
+  EvalForgeClient, EvalRunTimeoutError, formatGatePollFailure, formatGateTimeout, pollUntilDone,
   type Commenter, type EvalRunCreated, type EvalRunStatus,
 } from '@wix/evalforge-core';
 import { HALTED, describeError, fail, guardedCall, type Guarded } from './report';
@@ -47,9 +47,12 @@ export async function pollToCompletion(
       fail(error.message, config.isBlocking);
       return HALTED;
     }
-    core.error(`Polling the eval run failed: ${describeError(error)}`);
-    await comment(formatGateServiceError('Polling the eval run failed', config.isBlocking));
-    fail('Polling the eval run failed', config.isBlocking);
+    // Names the run: it started, it may have finished, and without the link there is no way
+    // to find out from the PR.
+    const detail = describeError(error);
+    core.error(`Polling the eval run failed: ${detail}`);
+    await comment(formatGatePollFailure({ runId, runUrl, detail, blocking: config.isBlocking }));
+    fail(`Polling the eval run failed: ${detail}`, config.isBlocking);
     return HALTED;
   }
 }

--- a/.github/actions/evalforge-skill-gate/tests/gate-run.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/gate-run.test.ts
@@ -361,6 +361,24 @@ describe('runGate — the happy path', () => {
     expect(upsertComment).toHaveBeenCalledWith(expect.stringMatching(/timed out/i));
     expect(setFailedSpy).toHaveBeenCalled();
   });
+
+  // Seen on #773: polling died on a 403 after the run had been going six minutes, and the comment
+  // named no run at all — the cost was paid and the result was unreachable from the PR.
+  it('links the run when polling fails for any other reason', async () => {
+    const { runGate, core, evalforge } = await harness();
+    vi.mocked(evalforge.pollUntilDone).mockRejectedValue(
+      new Error('EvalForge GET /v1/projects/proj/eval-runs/run-1 → 403: '),
+    );
+    const setFailedSpy = vi.spyOn(core, 'setFailed');
+
+    await runGate();
+
+    const body = upsertComment.mock.calls.at(-1)?.[0] as string;
+    expect(body).toContain('run-1');
+    expect(body).toContain(evalforge.evalRunUrl('proj', 'run-1'));
+    expect(body).toContain('403');
+    expect(setFailedSpy).toHaveBeenCalledWith(expect.stringContaining('403'));
+  });
 });
 
 describe('runGate — sync and selection', () => {

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34907,6 +34907,7 @@ exports.formatGuardFailure = formatGuardFailure;
 exports.formatForeignDraftConflicts = formatForeignDraftConflicts;
 exports.formatGateResult = formatGateResult;
 exports.formatGateTimeout = formatGateTimeout;
+exports.formatGatePollFailure = formatGatePollFailure;
 exports.formatGateServiceError = formatGateServiceError;
 const evalforge_1 = __nccwpck_require__(7230);
 exports.GATE_COMMENT_MARKER = '<!-- evalforge-skill-gate-action -->';
@@ -34923,6 +34924,10 @@ function count(quantity, noun) {
 /** The API sends a fraction of a percent (26/30 arrives as 86.667); nobody needs the decimals. */
 function percent(passRate) {
     return Math.round(passRate);
+}
+/** Shared by every outcome that has a run to point at. */
+function runLine(runId, runUrl) {
+    return `**Run:** [${runId}](${runUrl})`;
 }
 function soakNote(blocking) {
     return blocking
@@ -35024,7 +35029,7 @@ function formatGateResult(input) {
         `**Pass rate:** ${percent(metrics.passRate)}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
             + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
             + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
-        `**Run:** [${input.runId}](${input.runUrl})`,
+        runLine(input.runId, input.runUrl),
     ];
     if (!verdict.passed) {
         body.push('', `**Why this ${input.blocking ? 'blocks' : 'would block'}:** ${verdict.reasons.join('; ')}`);
@@ -35047,8 +35052,23 @@ function formatGateTimeout(runId, runUrl, blocking) {
     return render(blocking ? '⏱' : '⚠️', 'Timed Out', [
         'The eval run did not finish within the poll window. It may still be running in EvalForge.',
         '',
-        `**Run:** [${runId}](${runUrl})`,
+        runLine(runId, runUrl),
         ...soakNote(blocking),
+    ]);
+}
+/**
+ * Polling broke after the run started. Distinct from a service error, which has no run to name:
+ * here the run exists and may well have finished, so the link is the whole point of the comment.
+ */
+function formatGatePollFailure(input) {
+    const { icon } = failIcon(input.blocking);
+    return render(icon, 'Run Status Unavailable', [
+        `The run started, but the gate could not read its status: ${input.detail}`,
+        '',
+        'Open it to see whether it finished — the gate could not verify the result either way, so treat this as unverified rather than passing.',
+        '',
+        runLine(input.runId, input.runUrl),
+        ...soakNote(input.blocking),
     ]);
 }
 /**
@@ -35873,7 +35893,19 @@ function parseScenario(raw) {
             }
         }
     }
-    return exports.ScenarioSchema.parse(parsed);
+    const result = exports.ScenarioSchema.safeParse(parsed);
+    if (result.success)
+        return result.data;
+    throw new Error(describeIssues(result.error));
+}
+/**
+ * Zod's own `message` is the serialised issue array, so it reached the PR comment as ~15 lines of
+ * JSON for a one-line problem. One `path: message` per issue instead.
+ */
+function describeIssues(error) {
+    return error.issues
+        .map(issue => (issue.path.length === 0 ? issue.message : `${issue.path.join('.')}: ${issue.message}`))
+        .join('; ');
 }
 
 

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34929,6 +34929,13 @@ function percent(passRate) {
 function runLine(runId, runUrl) {
     return `**Run:** [${runId}](${runUrl})`;
 }
+/**
+ * The three outcomes where nothing was verified and retrying is the answer. A push re-triggers the
+ * gate today; CODEAI-895 adds a `/re-eval` comment so it does not need a commit.
+ */
+function retryNote() {
+    return ['', '_Push any commit to run the gate again._'];
+}
 function soakNote(blocking) {
     return blocking
         ? []
@@ -35053,6 +35060,7 @@ function formatGateTimeout(runId, runUrl, blocking) {
         'The eval run did not finish within the poll window. It may still be running in EvalForge.',
         '',
         runLine(runId, runUrl),
+        ...retryNote(),
         ...soakNote(blocking),
     ]);
 }
@@ -35068,6 +35076,7 @@ function formatGatePollFailure(input) {
         'Open it to see whether it finished — the gate could not verify the result either way, so treat this as unverified rather than passing.',
         '',
         runLine(input.runId, input.runUrl),
+        ...retryNote(),
         ...soakNote(input.blocking),
     ]);
 }
@@ -35077,7 +35086,7 @@ function formatGatePollFailure(input) {
  */
 function formatGateServiceError(message, blocking, label = 'Service Error') {
     const { icon } = failIcon(blocking);
-    return render(icon, label, [message, ...soakNote(blocking)]);
+    return render(icon, label, [message, ...retryNote(), ...soakNote(blocking)]);
 }
 
 

--- a/packages/evalforge-core/src/format-gate-comment.ts
+++ b/packages/evalforge-core/src/format-gate-comment.ts
@@ -30,6 +30,14 @@ function runLine(runId: string, runUrl: string): string {
   return `**Run:** [${runId}](${runUrl})`;
 }
 
+/**
+ * The three outcomes where nothing was verified and retrying is the answer. A push re-triggers the
+ * gate today; CODEAI-895 adds a `/re-eval` comment so it does not need a commit.
+ */
+function retryNote(): string[] {
+  return ['', '_Push any commit to run the gate again._'];
+}
+
 function soakNote(blocking: boolean): string[] {
   return blocking
     ? []
@@ -200,6 +208,7 @@ export function formatGateTimeout(runId: string, runUrl: string, blocking: boole
     'The eval run did not finish within the poll window. It may still be running in EvalForge.',
     '',
     runLine(runId, runUrl),
+    ...retryNote(),
     ...soakNote(blocking),
   ]);
 }
@@ -221,6 +230,7 @@ export function formatGatePollFailure(input: {
     'Open it to see whether it finished — the gate could not verify the result either way, so treat this as unverified rather than passing.',
     '',
     runLine(input.runId, input.runUrl),
+    ...retryNote(),
     ...soakNote(input.blocking),
   ]);
 }
@@ -231,5 +241,5 @@ export function formatGatePollFailure(input: {
  */
 export function formatGateServiceError(message: string, blocking: boolean, label = 'Service Error'): string {
   const { icon } = failIcon(blocking);
-  return render(icon, label, [message, ...soakNote(blocking)]);
+  return render(icon, label, [message, ...retryNote(), ...soakNote(blocking)]);
 }

--- a/packages/evalforge-core/src/format-gate-comment.ts
+++ b/packages/evalforge-core/src/format-gate-comment.ts
@@ -25,6 +25,11 @@ function percent(passRate: number): number {
   return Math.round(passRate);
 }
 
+/** Shared by every outcome that has a run to point at. */
+function runLine(runId: string, runUrl: string): string {
+  return `**Run:** [${runId}](${runUrl})`;
+}
+
 function soakNote(blocking: boolean): string[] {
   return blocking
     ? []
@@ -152,7 +157,7 @@ export function formatGateResult(input: {
     `**Pass rate:** ${percent(metrics.passRate)}% — ${metrics.passed}/${metrics.totalAssertions} assertions passed`
     + (metrics.failed > 0 ? `, ${metrics.failed} failed` : '')
     + (metrics.errors > 0 ? `, ${metrics.errors} errored` : ''),
-    `**Run:** [${input.runId}](${input.runUrl})`,
+    runLine(input.runId, input.runUrl),
   ];
 
   if (!verdict.passed) {
@@ -194,8 +199,29 @@ export function formatGateTimeout(runId: string, runUrl: string, blocking: boole
   return render(blocking ? '⏱' : '⚠️', 'Timed Out', [
     'The eval run did not finish within the poll window. It may still be running in EvalForge.',
     '',
-    `**Run:** [${runId}](${runUrl})`,
+    runLine(runId, runUrl),
     ...soakNote(blocking),
+  ]);
+}
+
+/**
+ * Polling broke after the run started. Distinct from a service error, which has no run to name:
+ * here the run exists and may well have finished, so the link is the whole point of the comment.
+ */
+export function formatGatePollFailure(input: {
+  runId: string;
+  runUrl: string;
+  detail: string;
+  blocking: boolean;
+}): string {
+  const { icon } = failIcon(input.blocking);
+  return render(icon, 'Run Status Unavailable', [
+    `The run started, but the gate could not read its status: ${input.detail}`,
+    '',
+    'Open it to see whether it finished — the gate could not verify the result either way, so treat this as unverified rather than passing.',
+    '',
+    runLine(input.runId, input.runUrl),
+    ...soakNote(input.blocking),
   ]);
 }
 

--- a/packages/evalforge-core/src/schema.ts
+++ b/packages/evalforge-core/src/schema.ts
@@ -214,5 +214,17 @@ export function parseScenario(raw: string): Scenario {
       }
     }
   }
-  return ScenarioSchema.parse(parsed);
+  const result = ScenarioSchema.safeParse(parsed);
+  if (result.success) return result.data;
+  throw new Error(describeIssues(result.error));
+}
+
+/**
+ * Zod's own `message` is the serialised issue array, so it reached the PR comment as ~15 lines of
+ * JSON for a one-line problem. One `path: message` per issue instead.
+ */
+function describeIssues(error: z.ZodError): string {
+  return error.issues
+    .map(issue => (issue.path.length === 0 ? issue.message : `${issue.path.join('.')}: ${issue.message}`))
+    .join('; ');
 }

--- a/packages/evalforge-core/tests/format-gate-comment.test.ts
+++ b/packages/evalforge-core/tests/format-gate-comment.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   GATE_COMMENT_MARKER, formatYamlErrors, formatNoGatedChanges, formatGuardFailure,
-  formatForeignDraftConflicts, formatGateResult, formatGateTimeout, formatGateServiceError, formatGateSkipped,
+  formatForeignDraftConflicts, formatGateResult, formatGatePollFailure, formatGateTimeout,
+  formatGateServiceError, formatGateSkipped,
 } from '../src/format-gate-comment';
 import type { EvalRunStatus } from '../src/evalforge';
 
@@ -341,5 +342,43 @@ describe('formatGateServiceError', () => {
     const body = formatGateServiceError('nothing was verified', false, 'Nothing Verified');
     expect(body).toContain('Nothing Verified');
     expect(body).not.toContain('Service Error');
+  });
+});
+
+describe('formatGatePollFailure', () => {
+  const input = {
+    runId: '1a3d3e51-4fd3-4838-94fa-57f213d9c3b5',
+    runUrl: 'https://bo.wix.com/pages/evalforge/proj/results?runId=1a3d3e51',
+    detail: 'EvalForge GET /v1/projects/proj/eval-runs/1a3d3e51 → 403: ',
+    blocking: false,
+  };
+
+  // Seen on #773: the run had been executing for six minutes and the comment named nothing, so
+  // there was no way to reach it from the PR.
+  it('links the run, since that is the whole point of the comment', () => {
+    const body = formatGatePollFailure(input);
+    expect(body).toContain(input.runId);
+    expect(body).toContain(input.runUrl);
+  });
+
+  it('carries the underlying error, so the reader knows what broke', () => {
+    expect(formatGatePollFailure(input)).toContain('403');
+  });
+
+  it('says the result is unverified rather than passing', () => {
+    expect(formatGatePollFailure(input)).toMatch(/unverified|could not verify/i);
+  });
+
+  it('is distinguishable from a timeout, which is a different outcome', () => {
+    const polled = formatGatePollFailure(input);
+    const timedOut = formatGateTimeout(input.runId, input.runUrl, input.blocking);
+    expect(polled).not.toBe(timedOut);
+    expect(polled).toContain('Run Status Unavailable');
+    expect(timedOut).toContain('Timed Out');
+  });
+
+  it('respects soak, like every other failure path', () => {
+    expect(formatGatePollFailure(input)).toContain('soak period');
+    expect(formatGatePollFailure({ ...input, blocking: true })).not.toContain('soak period');
   });
 });

--- a/packages/evalforge-core/tests/format-gate-comment.test.ts
+++ b/packages/evalforge-core/tests/format-gate-comment.test.ts
@@ -382,3 +382,30 @@ describe('formatGatePollFailure', () => {
     expect(formatGatePollFailure({ ...input, blocking: true })).not.toContain('soak period');
   });
 });
+
+describe('retry guidance', () => {
+  const run = { runId: 'run-1', runUrl: 'https://example.com/run-1', blocking: false };
+
+  // Nothing was verified in any of these, so the reader needs to know how to get a verdict.
+  it('tells the reader how to re-run, on every outcome that verified nothing', () => {
+    expect(formatGatePollFailure({ ...run, detail: '403' })).toMatch(/run the gate again/i);
+    expect(formatGateTimeout(run.runId, run.runUrl, false)).toMatch(/run the gate again/i);
+    expect(formatGateServiceError('Could not reach EvalForge', false)).toMatch(/run the gate again/i);
+  });
+
+  // A verdict exists in these, so re-running is not the next step.
+  it('does not suggest re-running when the gate actually reached a verdict', () => {
+    const passed = formatGateResult({
+      metrics: metrics(), verdict: { passed: true, reasons: [] },
+      runId: 'run-1', runUrl: 'https://example.com/run-1', maxScenarios: 25,
+      selection: { ids: ['i'], selected: ['one'], dropped: [], missingIds: [] },
+      warnings: [], unmapped: [], broadImpact: false, blocking: false,
+    });
+    const guard = formatGuardFailure({
+      violations: [{ kind: 'UNCOVERED_TAG', tag: 't' }], warnings: [],
+      blocking: false, scenarioDir: 'yaml/wix-app-evals',
+    });
+    expect(passed).not.toMatch(/run the gate again/i);
+    expect(guard).not.toMatch(/run the gate again/i);
+  });
+});

--- a/packages/evalforge-core/tests/schema.test.ts
+++ b/packages/evalforge-core/tests/schema.test.ts
@@ -406,3 +406,34 @@ describe('scenario templateId', () => {
     expect(s.templateId).toBeUndefined();
   });
 });
+
+describe('parse error messages', () => {
+  // Seen on #770: ZodError.message is the serialised issue array, so the PR comment carried ~15
+  // lines of JSON for a one-line problem.
+  const bad = 'name: x\ndescription: d\ntriggerPrompt: build a dashboard page\ntags: [t]\nassertions: []\n';
+
+  it('names the field and the problem in one line', () => {
+    expect(() => parseScenario(bad)).toThrow('assertions: Array must contain at least 1 element(s)');
+  });
+
+  it('does not leak the raw Zod issue objects', () => {
+    try {
+      parseScenario(bad);
+      throw new Error('expected parseScenario to throw');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).not.toContain('too_small');
+      expect(message).not.toContain('"code"');
+      expect(message).not.toContain('\n');
+    }
+  });
+
+  it('joins multiple issues rather than dumping an array', () => {
+    const message = (() => {
+      try { parseScenario('name: x\n'); return ''; } catch (error) { return (error as Error).message; }
+    })();
+    expect(message).toContain('description: Required');
+    expect(message).toContain('assertions: Required');
+    expect(message).not.toContain('[');
+  });
+});


### PR DESCRIPTION
Two defects the throwaway e2e PRs surfaced in real CI.

### 1. Polling failure named no run — #773

The gate created a version, started a run, polled it successfully 12 times over six minutes, then hit a 403 and posted:

```
## ⚠️ EvalForge Skill Gate: Service Error
Polling the eval run failed
```

The run existed, had been executing for six minutes, and may well have finished — and the PR offered no way to reach it. `formatGateTimeout` already links the run for the neighbouring case; this path had no parameter for it.

`formatGatePollFailure` is a distinct outcome from both:
- **vs. `formatGateServiceError`** — that one by definition has no run to name (auth, file list, version creation).
- **vs. `formatGateTimeout`** — "did not finish in the window" and "could not read the status" tell the reader different things.

```
## ⚠️ EvalForge Skill Gate: Run Status Unavailable

The run started, but the gate could not read its status: EvalForge GET /v1/projects/…/eval-runs/… → 403

Open it to see whether it finished — the gate could not verify the result either way, so treat this
as unverified rather than passing.

**Run:** [1a3d3e51-…](https://bo.wix.com/pages/evalforge/…/results?runId=1a3d3e51-…)

_The gate is in its soak period (`blocking: false`), so this check still passes._
```

### 2. Raw Zod dump in YAML errors — #770

`parseScenario` surfaced `ZodError.message`, which *is* the serialised issue array, so the comment carried ~15 lines of JSON:

```
- `…/broken.yml`: [ { "code": "too_small", "minimum": 1, "type": "array", … "path": [ "assertions" ] } ]
```

Now:
```
- `…/broken.yml`: triggerPrompt: String must contain at least 10 character(s); assertions: Array must contain at least 1 element(s)
```

Fixed in `parseScenario`, not in the formatter, so the merge-time sync and the wix-manage yaml-gate get it too. That's why yaml-gate's `dist` moves here.

### Deliberately not changed

The `401`-only retry in `request`. The 403 correlated with the **deleted** eval template rather than a rejected token — the same code, credentials and polling loop ran to completion against the live template on #774 (5m55s, 7/7). Widening the retry would be guessing at a cause we have evidence against.

### Tests

core 272 → 280, skill-gate 87 → 88. The new integration test asserts the poll-failure comment contains the run id, the run URL and the underlying error — it fails against the old behaviour. yaml-gate 76 unchanged. All three suites green, both dists rebuilt.