### PR TITLE
fix(wix-manage): correct discount-rule request body shape in five pricing recipes

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
@@ -22,30 +22,38 @@ layer: config
 
 ## Critical: `discounts` structure
 
-**The API always returns the full normalized structure.** Never assume a simplified form. Each discount entry looks like:
+`discounts` is an **object with a `values` array** — not a plain array. Passing a plain array is rejected with `400 {"message":"Expected an object"}`.
+
+Within each entry, `discountType` and its value field (`percentage`, `fixedAmount`, `fixedPrice`) are **direct fields of the entry**, siblings of `targetType` and `specificItemsInfo`. They are *not* nested inside a `discount` object — nesting them is rejected with `400 Validation failed: ... Discount value type does not match discount value`.
+
+**The API always returns the full normalized structure.** Never assume a simplified form. A complete `discounts` field looks like:
 
 ```json
 {
-  "targetType": "SPECIFIC_ITEMS",
-  "specificItemsInfo": {
-    "scopes": [
+  "discounts": {
+    "values": [
       {
-        "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-        "type": "CATALOG_ITEM",
-        "catalogItemFilter": {
-          "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
-        }
+        "targetType": "SPECIFIC_ITEMS",
+        "specificItemsInfo": {
+          "scopes": [
+            {
+              "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "type": "CATALOG_ITEM",
+              "catalogItemFilter": {
+                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+              }
+            }
+          ]
+        },
+        "discountType": "PERCENTAGE",
+        "percentage": 20
       }
     ]
-  },
-  "discount": {
-    "discountType": "PERCENTAGE",
-    "percentage": 20
   }
 }
 ```
 
-When updating a rule, always use the `discounts` array as returned from the query/get, modifying only the specific fields you need. **Do not reconstruct from scratch unless creating a new rule.**
+When updating a rule, always use `discounts.values` as returned from the query/get, modifying only the specific fields you need. **Do not reconstruct from scratch unless creating a new rule.**
 
 ---
 
@@ -170,26 +178,26 @@ When a discount *isn't* applying as expected, see [Troubleshoot: Discount Not Ap
       "start": "2026-05-01T00:00:00.000Z",
       "end": "2026-05-03T23:59:59.000Z"
     },
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CATALOG_ITEM",
-              "catalogItemFilter": {
-                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 20
         }
-      }
-    ],
+      ]
+    },
     "settings": {
       "appliesTo": "ALL_ITEMS"
     }
@@ -203,29 +211,29 @@ When a discount *isn't* applying as expected, see [Troubleshoot: Discount Not Ap
   "discountRule": {
     "name": "Summer Collection Sale",
     "active": true,
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CUSTOM_FILTER",
-              "customFilter": {
-                "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
-                "params": {
-                  "collectionIds": ["collection-uuid-here"]
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["collection-uuid-here"]
+                  }
                 }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
         }
-      }
-    ],
+      ]
+    },
     "settings": {
       "appliesTo": "ALL_ITEMS"
     }
@@ -243,27 +251,27 @@ When a discount *isn't* applying as expected, see [Troubleshoot: Discount Not Ap
   "discountRule": {
     "name": "$5 Off Selected Items",
     "active": true,
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CATALOG_ITEM",
-              "catalogItemFilter": {
-                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
-                "catalogItemIds": ["product-uuid-here"]
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "catalogItemIds": ["product-uuid-here"]
+                }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "FIXED_AMOUNT",
           "fixedAmount": "5.00"
         }
-      }
-    ],
+      ]
+    },
     "settings": {
       "appliesTo": "ALL_ITEMS"
     }
@@ -287,26 +295,26 @@ Always fetch the rule first (via Get or Query), then modify only the fields you 
   "discountRule": {
     "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "revision": "1",
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CATALOG_ITEM",
-              "catalogItemFilter": {
-                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 25
         }
-      }
-    ]
+      ]
+    }
   },
   "mask": { "paths": ["discounts"] }
 }
@@ -330,8 +338,8 @@ Always fetch the rule first (via Get or Query), then modify only the fields you 
 
 The safe pattern for "find a rule by name and update its percentage":
 
-1. Query with name filter → get the rule's `id`, `revision`, and `discounts` array
-2. Modify only the `discount.percentage` inside each discount entry, keeping all other fields intact
+1. Query with name filter → get the rule's `id`, `revision`, and `discounts.values` array
+2. Modify only the `percentage` field on each entry in `discounts.values`, keeping all other fields intact
 3. PATCH with the modified `discounts` and `mask: { paths: ["discounts"] }`
 
 **Step 5a — Query by name**:
@@ -349,29 +357,29 @@ Extract from response: `discountRules[0].id`, `discountRules[0].revision`, `disc
 
 **Step 5b — Update percentage** (modify the returned discounts in-place):
 
-Take the `discounts` array from the query response and update only `discount.percentage` on each entry:
+Take `discounts.values` from the query response and update only `percentage` on each entry:
 ```json
 PATCH https://www.wixapis.com/ecom/v1/discount-rules/{id}
 {
   "discountRule": {
     "id": "<id from query>",
     "revision": "<revision from query>",
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": { "<scopes unchanged from query response>" },
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": { "<scopes unchanged from query response>" },
           "discountType": "PERCENTAGE",
           "percentage": 10
         }
-      }
-    ]
+      ]
+    }
   },
   "mask": { "paths": ["discounts"] }
 }
 ```
 
-> **Important**: Copy `targetType`, `specificItemsInfo.scopes` verbatim from the query response — do not reconstruct them. Only change `discount.discountType` and `discount.percentage`/`discount.fixedAmount`.
+> **Important**: Copy `targetType`, `specificItemsInfo.scopes` verbatim from the query response — do not reconstruct them. Only change `discountType` and `percentage`/`fixedAmount`.
 
 ---
 
@@ -403,11 +411,11 @@ To delete permanently:
 | `active` | Yes | Whether the rule is currently applied |
 | `activeTimeInfo.start` | No | ISO 8601 start time. Omit for immediate activation |
 | `activeTimeInfo.end` | No | ISO 8601 end time. Omit for no expiration |
-| `discounts[].targetType` | Yes | Always `"SPECIFIC_ITEMS"` for standard rules |
-| `discounts[].specificItemsInfo.scopes[]` | Yes | Array of scope objects — see Scope types below |
-| `discounts[].discount.discountType` | Yes | `"PERCENTAGE"` or `"FIXED_AMOUNT"` or `"FIXED_PRICE"` |
-| `discounts[].discount.percentage` | If PERCENTAGE | Integer 1-100 |
-| `discounts[].discount.fixedAmount` | If FIXED_AMOUNT | Decimal string (e.g., `"5.00"`) |
+| `discounts.values[].targetType` | Yes | Always `"SPECIFIC_ITEMS"` for standard rules |
+| `discounts.values[].specificItemsInfo.scopes[]` | Yes | Array of scope objects — see Scope types below |
+| `discounts.values[].discountType` | Yes | `"PERCENTAGE"` or `"FIXED_AMOUNT"` or `"FIXED_PRICE"` |
+| `discounts.values[].percentage` | If PERCENTAGE | Integer 1-100 |
+| `discounts.values[].fixedAmount` | If FIXED_AMOUNT | Decimal string (e.g., `"5.00"`) |
 | `settings.appliesTo` | Yes on create | Always `"ALL_ITEMS"` |
 | `revision` | On update/delete | Must match current value — fetch first |
 | `mask.paths[]` | On update | Recommended — list fields being changed (e.g., `["discounts"]`, `["active"]`) |
@@ -488,11 +496,11 @@ The recommendation's `scope` field maps to the API's internal scope structure. T
 
 | Recommendation `discountType` | API field to set | Value format |
 |---|---|---|
-| `PERCENTAGE` | `discount.percentage` | Integer (e.g., `15`) |
-| `FIXED_AMOUNT` | `discount.fixedAmount` | String (e.g., `"5.00"`) |
-| `FIXED_PRICE` | `discount.fixedPrice` | String (e.g., `"29.99"`) |
+| `PERCENTAGE` | `discounts.values[].percentage` | Integer (e.g., `15`) |
+| `FIXED_AMOUNT` | `discounts.values[].fixedAmount` | String (e.g., `"5.00"`) |
+| `FIXED_PRICE` | `discounts.values[].fixedPrice` | String (e.g., `"29.99"`) |
 
-All discount entries use `targetType: "SPECIFIC_ITEMS"` with the scope wrapped in `specificItemsInfo.scopes[]`.
+All discount entries live in `discounts.values[]` and use `targetType: "SPECIFIC_ITEMS"` with the scope wrapped in `specificItemsInfo.scopes[]`.
 
 ### Trigger mapping (conditions)
 

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
@@ -101,26 +101,26 @@ Filterable fields: `id`, `name`, `active`, `revision`, `created_date`, `updated_
         "start": "2026-06-01T00:00:00.000Z",
         "end": "2026-08-31T23:59:59.000Z"
       },
-      "discounts": [
-        {
-          "targetType": "SPECIFIC_ITEMS",
-          "specificItemsInfo": {
-            "scopes": [
-              {
-                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-                "type": "CATALOG_ITEM",
-                "catalogItemFilter": {
-                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+      "discounts": {
+        "values": [
+          {
+            "targetType": "SPECIFIC_ITEMS",
+            "specificItemsInfo": {
+              "scopes": [
+                {
+                  "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "type": "CATALOG_ITEM",
+                  "catalogItemFilter": {
+                    "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                  }
                 }
-              }
-            ]
-          },
-          "discount": {
+              ]
+            },
             "discountType": "PERCENTAGE",
             "percentage": 10
           }
-        }
-      ]
+        ]
+      }
     }
   ],
   "pagingMetadata": {

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md
@@ -113,21 +113,45 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
   "discountRule": {
     "name": "Buy 2+, Save 15% on Accessories",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["accessories-category-guid"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
-        },
-        "scope": {
-          "id": "accessories-category-guid",
-          "type": "COLLECTION"
         }
-      }
-    ],
-    "conditions": {
+      ]
+    },
+    "trigger": {
+      "triggerType": "ITEM_QUANTITY_RANGE",
       "itemQuantityRange": {
-        "from": 2
+        "from": 2,
+        "scopes": [
+          {
+            "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+            "type": "CUSTOM_FILTER",
+            "customFilter": {
+              "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "params": {
+                "collectionIds": ["accessories-category-guid"]
+              }
+            }
+          }
+        ]
       }
     }
   }
@@ -169,41 +193,49 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
   "discountRule": {
     "name": "Bundle 3 Best Sellers, Save 10%",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "catalogItemIds": [
+                        "product-uuid-1",
+                        "product-uuid-2",
+                        "product-uuid-3"
+                  ]
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 10
-        },
-        "scope": {
-          "id": "product-uuid-1",
-          "type": "SPECIFIC_PRODUCTS"
         }
-      },
-      {
-        "discount": {
-          "discountType": "PERCENTAGE",
-          "percentage": 10
-        },
-        "scope": {
-          "id": "product-uuid-2",
-          "type": "SPECIFIC_PRODUCTS"
-        }
-      },
-      {
-        "discount": {
-          "discountType": "PERCENTAGE",
-          "percentage": 10
-        },
-        "scope": {
-          "id": "product-uuid-3",
-          "type": "SPECIFIC_PRODUCTS"
-        }
-      }
-    ],
-    "conditions": {
+      ]
+    },
+    "trigger": {
+      "triggerType": "ITEM_QUANTITY_RANGE",
       "itemQuantityRange": {
-        "from": 3
+        "from": 3,
+        "scopes": [
+          {
+            "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+            "type": "CATALOG_ITEM",
+            "catalogItemFilter": {
+              "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "catalogItemIds": [
+                    "product-uuid-1",
+                    "product-uuid-2",
+                    "product-uuid-3"
+              ]
+            }
+          }
+        ]
       }
     }
   }

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md
@@ -166,21 +166,45 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
     "revision": "1",
     "name": "Buy 2+, Save 15% on Accessories",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["accessories-category-guid"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
-        },
-        "scope": {
-          "id": "accessories-category-guid",
-          "type": "COLLECTION"
         }
-      }
-    ],
-    "conditions": {
+      ]
+    },
+    "trigger": {
+      "triggerType": "ITEM_QUANTITY_RANGE",
       "itemQuantityRange": {
-        "from": 2
+        "from": 2,
+        "scopes": [
+          {
+            "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+            "type": "CUSTOM_FILTER",
+            "customFilter": {
+              "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "params": {
+                "collectionIds": ["accessories-category-guid"]
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-seasonal-promotion.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-seasonal-promotion.md
@@ -200,18 +200,29 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
       "start": "2026-11-23T00:00:00.000Z",
       "end": "2026-12-01T23:59:59.000Z"
     },
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["electronics-category-guid"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 20
-        },
-        "scope": {
-          "id": "electronics-category-guid",
-          "type": "COLLECTION"
         }
-      }
-    ]
+      ]
+    }
   }
 }
 ```

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-seasonal-promotion.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-seasonal-promotion.md
@@ -161,18 +161,29 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
       "start": "2026-11-23T00:00:00.000Z",
       "end": "2026-12-01T23:59:59.000Z"
     },
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["electronics-category-guid"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 20
-        },
-        "scope": {
-          "id": "electronics-category-guid",
-          "type": "COLLECTION"
         }
-      }
-    ]
+      ]
+    }
   }
 }
 ```
@@ -215,18 +226,26 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
       "start": "2026-02-10T00:00:00.000Z",
       "end": "2026-02-16T23:59:59.000Z"
     },
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
-        },
-        "scope": {
-          "id": "catalog",
-          "type": "CATALOG"
         }
-      }
-    ]
+      ]
+    }
   }
 }
 ```

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
@@ -150,38 +150,31 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
     "revision": "1",
     "name": "Clearance - Overstock Items 20% Off",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "catalogItemIds": [
+                        "slow-mover-product-uuid-1",
+                        "slow-mover-product-uuid-2",
+                        "slow-mover-product-uuid-3"
+                  ]
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 20
-        },
-        "scope": {
-          "id": "slow-mover-product-uuid-1",
-          "type": "SPECIFIC_PRODUCTS"
         }
-      },
-      {
-        "discount": {
-          "discountType": "PERCENTAGE",
-          "percentage": 20
-        },
-        "scope": {
-          "id": "slow-mover-product-uuid-2",
-          "type": "SPECIFIC_PRODUCTS"
-        }
-      },
-      {
-        "discount": {
-          "discountType": "PERCENTAGE",
-          "percentage": 20
-        },
-        "scope": {
-          "id": "slow-mover-product-uuid-3",
-          "type": "SPECIFIC_PRODUCTS"
-        }
-      }
-    ]
+      ]
+    }
   }
 }
 ```

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
@@ -113,38 +113,31 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
   "discountRule": {
     "name": "Clearance - Overstock Items 20% Off",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "catalogItemIds": [
+                        "slow-mover-product-uuid-1",
+                        "slow-mover-product-uuid-2",
+                        "slow-mover-product-uuid-3"
+                  ]
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 20
-        },
-        "scope": {
-          "id": "slow-mover-product-uuid-1",
-          "type": "SPECIFIC_PRODUCTS"
         }
-      },
-      {
-        "discount": {
-          "discountType": "PERCENTAGE",
-          "percentage": 20
-        },
-        "scope": {
-          "id": "slow-mover-product-uuid-2",
-          "type": "SPECIFIC_PRODUCTS"
-        }
-      },
-      {
-        "discount": {
-          "discountType": "PERCENTAGE",
-          "percentage": 20
-        },
-        "scope": {
-          "id": "slow-mover-product-uuid-3",
-          "type": "SPECIFIC_PRODUCTS"
-        }
-      }
-    ]
+      ]
+    }
   }
 }
 ```
@@ -199,18 +192,29 @@ If scope is CATEGORY, call `getCategoryIds` to convert category names to GUIDs.
   "discountRule": {
     "name": "Clearance - Winter Collection 15% Off",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["winter-collection-category-guid"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
-        },
-        "scope": {
-          "id": "winter-collection-category-guid",
-          "type": "COLLECTION"
         }
-      }
-    ]
+      ]
+    }
   }
 }
 ```

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md
@@ -104,21 +104,45 @@ Max 3 categoryIds per discount rule.
   "discountRule": {
     "name": "Spend $195+, Get 15% Off",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["category-guid-here"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
-        },
-        "scope": {
-          "id": "category-guid-here",
-          "type": "COLLECTION"
         }
-      }
-    ],
-    "conditions": {
+      ]
+    },
+    "trigger": {
+      "triggerType": "SUBTOTAL_RANGE",
       "subtotalRange": {
-        "from": "195.00"
+        "from": "195.00",
+        "scopes": [
+          {
+            "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+            "type": "CUSTOM_FILTER",
+            "customFilter": {
+              "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "params": {
+                "collectionIds": ["category-guid-here"]
+              }
+            }
+          }
+        ]
       }
     }
   }
@@ -160,21 +184,39 @@ Max 3 categoryIds per discount rule.
   "discountRule": {
     "name": "Spend $175+, Get 10% Off Everything",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 10
-        },
-        "scope": {
-          "id": "catalog",
-          "type": "CATALOG"
         }
-      }
-    ],
-    "conditions": {
+      ]
+    },
+    "trigger": {
+      "triggerType": "SUBTOTAL_RANGE",
       "subtotalRange": {
-        "from": "175.00"
+        "from": "175.00",
+        "scopes": [
+          {
+            "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+            "type": "CATALOG_ITEM",
+            "catalogItemFilter": {
+              "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+            }
+          }
+        ]
       }
     }
   }

--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md
@@ -157,21 +157,45 @@ Max 3 categoryIds per discount rule.
     "revision": "1",
     "name": "Spend $195+, Get 15% Off",
     "active": true,
-    "discounts": [
-      {
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": ["category-guid-here"]
+                  }
+                }
+              }
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
-        },
-        "scope": {
-          "id": "category-guid-here",
-          "type": "COLLECTION"
         }
-      }
-    ],
-    "conditions": {
+      ]
+    },
+    "trigger": {
+      "triggerType": "SUBTOTAL_RANGE",
       "subtotalRange": {
-        "from": "195.00"
+        "from": "195.00",
+        "scopes": [
+          {
+            "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+            "type": "CUSTOM_FILTER",
+            "customFilter": {
+              "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+              "params": {
+                "collectionIds": ["category-guid-here"]
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.yml
@@ -37,9 +37,12 @@ assertions:
         1. The agent loaded the `pricing-create-discount-rule` recipe (NOT create-coupon — no code is involved).
         2. The create payload maps recommendation fields: `percentage: 25`, name "Summer Clearance", scoped to the "summer-clearance" category (SPECIFIC scope, not CATALOG-wide).
         3. The active period is bounded to July 1–31 2026.
+        4. The rule was actually **created on the site** and the agent reports it as live/active — not merely described, drafted, or proposed as a payload the user should send themselves.
 
       Fail if ANY of these are true:
         - The agent routed to create-coupon or added a coupon code.
         - Scope is CATALOG-wide instead of the specific category.
         - The agent invented endpoints outside `ecom/v1/discount-rules`.
         - The agent ignored the recommendation fields and invented its own parameters.
+        - The agent only explains how to create the rule, or hands back a request body, without creating it.
+        - The agent reports success while also reporting that the create call failed or was rejected, or claims success without ever having made a successful create call.

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.yml
@@ -1,0 +1,38 @@
+name: ecommerce/pricing-promotions/flow-bundle-and-save-create
+description: Verifies the BUNDLE_AND_SAVE flow actually creates a discount rule whose quantity threshold is configured on the rule itself, exercising the `trigger` / `itemQuantityRange` request shape.
+triggerPrompt: |
+  For my Wix store I want a multi-buy deal to get people adding more to their cart: when a shopper has 2 or more items in the cart, take 15% off.
+
+  Set this up as an automatic discount on my store — I don't want a coupon code. Create it, don't just tell me how.
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-bundle-and-save
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The merchant asked for an automatic multi-buy discount: 15% off once the cart holds 2 or more items. The agent was told to create it, not just explain it.
+
+      This scenario exists to prove the quantity threshold is configured **on the created rule**. A rule created without its threshold would silently discount every order — the failure this scenario must catch.
+
+      Pass if ALL of these are true:
+        1. The agent created an automatic **discount rule** on the site (Discount Rules API, `ecom/v1/discount-rules`) and reports it as live/active — not merely described or proposed.
+        2. The discount is 15% off.
+        3. The agent states that the discount applies **only** once the cart reaches the 2-item threshold, and presents that threshold as part of the rule it created — i.e. the rule itself is conditional.
+
+      Fail if ANY of these are true:
+        - No rule was created: the agent only explains the steps, or hands back a request body for the user to send.
+        - The agent created a **coupon** or introduced a coupon code.
+        - The rule discounts unconditionally — the 2-item threshold is missing from the created rule, or the agent mentions the threshold only as the merchant's intent while the rule it created applies to every order regardless of quantity.
+        - The agent reports that the create call failed or was rejected, or claims success without a successful create.
+        - The discount percentage is not 15%.
+
+      Judge only the four points above. Do not require a specific category or product scope — catalog-wide is correct for "2 or more items in the cart". Do not require margin or stacking guardrail commentary.

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.yml
@@ -1,0 +1,39 @@
+name: ecommerce/pricing-promotions/flow-upsell-boost-create
+description: Verifies the UPSELL_BOOST flow actually creates a discount rule whose subtotal threshold is configured on the rule itself, exercising the `trigger` / `subtotalRange` request shape.
+triggerPrompt: |
+  For my Wix store I want to push up my average order value: once a shopper's cart subtotal reaches $175, give them 10% off the whole order.
+
+  Set this up as an automatic store-wide discount — no coupon code. Please actually create it rather than describing the steps.
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-upsell-boost
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The merchant asked for an automatic store-wide discount: 10% off once the cart subtotal reaches $175. The agent was told to create it, not just describe it.
+
+      This scenario exists to prove the subtotal threshold is configured **on the created rule**. A rule created without its threshold would silently discount every order — the failure this scenario must catch.
+
+      Pass if ALL of these are true:
+        1. The agent created an automatic **discount rule** on the site (Discount Rules API, `ecom/v1/discount-rules`) and reports it as live/active — not merely described or proposed.
+        2. The discount is 10% off.
+        3. The agent states that the discount applies **only** once the cart subtotal reaches $175, and presents that threshold as part of the rule it created — i.e. the rule itself is conditional.
+        4. The rule is store-wide / catalog-wide, not limited to one category or product.
+
+      Fail if ANY of these are true:
+        - No rule was created: the agent only explains the steps, or hands back a request body for the user to send.
+        - The agent created a **coupon** or introduced a coupon code.
+        - The rule discounts unconditionally — the $175 subtotal threshold is missing from the created rule, or the agent mentions it only as the merchant's intent while the rule it created applies to every order regardless of subtotal.
+        - The agent reports that the create call failed or was rejected, or claims success without a successful create.
+        - The discount percentage is not 10%.
+
+      Judge only the points above. Do not require margin or stacking guardrail commentary.


### PR DESCRIPTION
## What's wrong

Five e-commerce pricing recipes document the `POST /ecom/v1/discount-rules` request body in a shape the API rejects. Two independent errors:

1. **`discounts` is documented as a plain array.** The API requires an **object with a `values` array**.
2. **Each entry nests `discount: { discountType, percentage }`.** Those are **direct fields of the entry**, siblings of `targetType` and `specificItemsInfo`.

The correct shape:

```json
"discounts": {
  "values": [
    {
      "targetType": "SPECIFIC_ITEMS",
      "specificItemsInfo": { "scopes": [ … ] },
      "discountType": "PERCENTAGE",
      "percentage": 15
    }
  ]
}
```

## Evidence — a real eval run

From the EvalForge run `coverage/stores-create-discount-rule` (364 s, friction 3/10). The agent followed `pricing-create-discount-rule`, sent a plain array with a nested `discount`, and got, verbatim:

```
Execute error: Wix API error (400): {"message":"Expected an object","details":{}}
```

It retried with `discounts: { values: [ … ] }` but kept the nested `discount`, and got, verbatim:

```
Wix API error (400): {"message":"Validation failed: discount_rule.customer_gets.specific_items_discount Discount value type does not match discount value", … "field":"discount_rule.customer_gets.specific_items_discount"}
```

Two round-trips burned on a shape the docs got wrong. That is most of the 364 s.

## These pages contradict the generated API reference

The generated reference for **Create Discount Rule** — produced from the proto, and already correct — documents `discounts (Discounts)` → `values (Array<Discount>)` with `discountType` as a direct field of `Discount`, and its REST example shows `"values": [ { "discountType": "PERCENTAGE", "percentage": 15, … } ]`. These recipes have been contradicting it. Every shape in this PR was matched against that reference, including its field ordering (`targetType`, `specificItemsInfo`, `discountType`, then the value field).

## The two errors were not sufficient

The four `flow-*` recipes were further off-contract, and fixing only the two errors above would still have produced a 400. They also used:

- **a `scope` field** on each discount entry (`{"id": …, "type": "SPECIFIC_PRODUCTS" | "COLLECTION" | "CATALOG"}`) — no such field exists on `Discount`; scopes belong in `specificItemsInfo.scopes[]`, and the valid `type` values are `CATALOG_ITEM` / `CUSTOM_FILTER`;
- **a `conditions` field** (`{"itemQuantityRange": …}` / `{"subtotalRange": …}`) — the API field is `trigger`, with a `triggerType` discriminator and a `scopes` array inside the range;
- **one discount entry per product** (3 entries for 3 products) — the reference notes only one discount can be defined per discount rule; multiple products belong in one entry's `catalogItemFilter.catalogItemIds`.

These were corrected using the scope and trigger conventions **already documented in `ecom-pricing-create-discount-rule.md` itself** ("Scope types" table, "Trigger mapping" section) plus the generated reference. This makes the diff larger than a pure shape fix — flagging it explicitly so it gets reviewed as such rather than skimmed.

## What changed

| File | Request bodies | Response examples | Other |
|---|---|---|---|
| `ecom-pricing-create-discount-rule.md` | 5 | 1 | `## Critical: discounts structure` section rewritten; 12 prose/table references corrected |
| `ecom-pricing-flow-stock-mover.md` | 2 | 1 | `scope` → `specificItemsInfo`; 3 entries → 1 |
| `ecom-pricing-flow-bundle-and-save.md` | 2 | 1 | `scope`, `conditions` → `trigger`; 3 entries → 1 |
| `ecom-pricing-flow-upsell-boost.md` | 2 | 1 | `scope`, `conditions` → `trigger` |
| `ecom-pricing-flow-seasonal-promotion.md` | 2 | 1 | `scope` → `specificItemsInfo` |

The `## Critical: discounts structure` section asserted the nested form as canonical, so it drove the error rather than merely repeating it. It now states both rules and quotes the 400 each violation produces.

Prose corrected from `discounts[].discount.percentage` → `discounts.values[].percentage` and similar throughout, including the "find by name and update" walkthrough that told readers to copy `discounts` out of a query response and change `discount.percentage`.

**Three commits, deliberately separable:**

- `a2f1b24` — request bodies and request-describing prose.
- `1356088` — eval scenarios (see below).
- `e404d4b` — **response** examples. The generated reference documents the response `discountRule.discounts` as the identical `Discounts` type and its own response JSON shows `values` with a direct `discountType`, so these were wrong too. It matters because the update walkthrough tells readers to copy `discounts.values` out of the query response and PATCH it back — left wrong, the response example keeps regenerating the rejected request. **Drop this commit if you disagree; the first commit stands alone.**

Verification: every ` ```json ` block in all five files was extracted and re-parsed with `json.loads` — zero failures. Zero occurrences of `"discounts": [`, `"discount": {`, `"conditions": {`, or an entry-level `"scope": {` remain.

## Why this repo

`wix/skills` is the **source** for skill/recipe pages. The same content is visible in `wix-private/igor-docs`, but that repo is a **read-only mirror, re-synced hourly** from the Docs API (`.github/workflows/sync-docs.yml`, `cron: '0 * * * *'`); its README states that everything under `packages/wix-api-docs/docs/**` is generated output, that edits there are "lost within the hour and never reach the real documentation", and "do not open PRs that change doc content here". Its routing table points skill/recipe fixes back here.

Further copies in `coding-agents-plugins`, `wix-headless-better-skill`, `member-roles-on-headless-via-cms`, `ecom-apps-for-specific-users` and `ecom-ai-agents` were **deliberately not touched** — they are downstream copies and would reintroduce drift if edited independently.

All edits are confined to `skills/wix-manage/**`.

## Eval scenarios added

Commit `1356088` adds two scenarios and tightens one, under `yaml/wix-manage-evals/ecommerce/pricing-promotions/`:

| Scenario | Exercises |
|---|---|
| `ecommerce/pricing-promotions/flow-bundle-and-save-create` (new) | Creates a rule with an `ITEM_QUANTITY_RANGE` trigger — 2+ items → 15% off |
| `ecommerce/pricing-promotions/flow-upsell-boost-create` (new) | Creates a rule with a `SUBTOTAL_RANGE` trigger — $175+ → 10% off |
| `ecommerce/pricing-promotions/create-discount-rule` (strengthened) | Now requires the rule was actually created and reported live |

**Why new scenarios rather than only strengthening.** The four flow recipes were already *covered* for gate purposes by their sibling `goal-*` scenarios, but those judge recommendation classification, targeting and tracking — **none of them ever creates a discount rule.** The request bodies this PR corrects were therefore never exercised by any scenario. The two new ones close that gap for exactly the two `conditions` → `trigger` conversions in the diff, and both judge that the threshold is configured **on the created rule**: a rule built from the old `conditions` field would discount every order unconditionally, which these rubrics fail. Each pairs two `ReadFullDocsArticle` assertions (the flow page and the create-discount-rule mechanics page) with an `llm_judge`, per `docs/eval-scenarios.md`, and provisions a fresh site via `siteSetup`.

I did not add scenarios for `flow-stock-mover` or `flow-seasonal-promotion`: their edits are the same `scope` → `specificItemsInfo.scopes[]` conversion the two new scenarios already exercise, and four extra agent runs per gate execution seemed disproportionate for a docs fix. Say the word and I'll add them.

**The previous rubric scored 10/10 against the broken docs** — verdict: "The agent perfectly executed the conversion … mapping all fields exactly as required." It never required a rule to exist. It now fails an agent that only hands back a payload, or claims success after a rejected create.

### No `time_limit`, and the measurement that decided it

I queried this scenario's own history rather than importing the aria-corpus numbers. Across its **15 completed runs** (per-scenario `results[].duration`), **all of which ran against the broken docs currently in `main`**:

```
19, 43, 47, 52, 59, 64, 66, 66, 67, 74, 79, 82, 96, 137, 169   (seconds)
min 19s · median 66s · max 169s
```

There is no threshold that separates a broken run from a clean one here: broken-docs runs already finish in 19–169 s. A ceiling above 169 s would never fire; below it, it would fail runs that pass today. The 364 s figure belongs to a *different* scenario (`coverage/stores-create-discount-rule`) with a different prompt, so it can't ground a threshold for this one. The new scenarios have no history at all yet. So `time_limit` is omitted rather than invented — it can be added later once these scenarios have a clean baseline.

### What these scenarios do and don't catch

**Do catch:** a rule that is never created; a rule created without its quantity/subtotal threshold (the direct consequence of the old `conditions` field); routing to a coupon; a wrong percentage; an agent that returns a payload instead of acting; an agent that claims success after a rejected create.

**Don't catch:** the `discounts` wrapper shape itself. Three measured reasons, from the same 15 runs:

1. `conversation` is empty on **15/15** results — the judge receives only `outputText`, the agent's final prose summary.
2. `outputText` contains `"Expected an object"`, `"400"` or `"Validation failed"` in **0/15** runs. The 400s are simply not in what the judge sees, so no rubric can score them. This is an information-availability limit, not a rubric-quality one.
3. `"values"` appears in **0/15** outputs (`discountType` appears in 10/15). Demanding the response echo `discounts.values[]` would therefore fail correct runs, which is worse than not asserting it.

And an agent that hits a 400 can recover by consulting the generated API reference, then report a correct result — so even a body-level assertion would pass on broken docs whenever recovery succeeds. The honest position: these scenarios prove the *created rule* is right, and prove it pre-merge on this PR; they do not prove the documented wire shape, whose only reliable signature is recovery cost, which for this scenario sits inside normal variance. `api_call` remains the way to close that last gap — see below.

## Eval coverage

All five changed pages are covered. Per `docs/skill-evaluation.md`, the wix-manage gate's coverage check requires "at least one scenario under `yaml/wix-manage-evals/<area>/` asserting on its doc URL" — coverage is keyed on the **asserted `articleUrl`**, not on a scenario file named after the page:

| Changed page | Doc URL slug | Covered by |
|---|---|---|
| `ecom-pricing-create-discount-rule.md` | `pricing-create-discount-rule` | `create-discount-rule`, `flow-bundle-and-save-create`, `flow-upsell-boost-create` |
| `ecom-pricing-flow-stock-mover.md` | `flow-stock-mover` | `run-a-sale-clearance` |
| `ecom-pricing-flow-bundle-and-save.md` | `flow-bundle-and-save` | `run-a-sale-drive-cross-sells`, `flow-bundle-and-save-create` |
| `ecom-pricing-flow-upsell-boost.md` | `flow-upsell-boost` | `run-a-sale-increase-sales`, `flow-upsell-boost-create` |
| `ecom-pricing-flow-seasonal-promotion.md` | `flow-seasonal-promotion` | `run-a-sale-seasonal` |

Checked against the gate's own implementation (`.github/actions/evalforge-yaml-gate/src/utils/coverage.ts` + `doc-url.ts`): canonical URLs recomputed from each page's `documentation.yaml` entry with the same `slugify`, normalised the same way, matched within the same first-segment area (`ecommerce`). All five resolve, so `cov.uncovered` is empty.

`SKILL.md` index entries and `yaml/wix-manage/ecommerce/documentation.yaml` entries already existed for all five files — verified, not assumed — so of AGENTS.md's four-file rule only the eval scenarios needed work.

All 51 scenario files in the tree were validated by **executing** `ScenarioSchema` from `packages/evalforge-core/src/schema.ts` itself — `parseScenario` run over every file, including its `.strict()` no-extra-keys behaviour and the `name` pattern. 51 files, 51 unique names, 0 failures.

Note the "at least 3 assertions including an `llm_judge`" quality bar in `CONTRIBUTING.md` applies to the **wix-app** gate; the wix-manage gate's only coverage-related failure is `uncovered.length > 0`.

## What the gate will and won't prove

Two honest caveats:

1. **The gate skips drafts.** The workflow is guarded by `if: ${{ !github.event.pull_request.draft && … }}`, so it will not run while this PR is a draft. Whether it blocks merge is controlled by the `EVAL_BLOCK_MERGE` repo variable (defaulting to `false` if unset), which I can't read.

2. **No *pre-existing* scenario would have caught this defect. The two added here catch its consequence, but not the documented wire shape itself.** The new scenarios fail a rule created without its quantity/subtotal threshold — the direct consequence of the old `conditions` field. What stays unasserted is the `discounts` wrapper shape on the wire, and the rest of this section is why. `ecom-pricing-create-discount-rule.yml`, **as it stood before this PR**, asserted only that `ReadFullDocsArticle` was called plus an `llm_judge` at `minScore: 7` whose criteria are all *semantic mapping* — `percentage: 25`, the name, a category-specific rather than catalog-wide scope, and the July window. **Nothing asserts the create call succeeded, and nothing inspects the request body.** The run above eventually produced a correct rule after two 400s and satisfies every one of those criteria; the broken shape surfaced only as 364 s and friction 3/10, neither of which is scored. The four `goal-*` scenarios are weaker still for this purpose — their judges assess recommendation classification, targeting and tracking, and never exercise a discount-rule create at all.

   I deliberately did **not** paper over this with a judge criterion that would pass either way. Here is what I evaluated against the assertion types in `docs/eval-scenarios.md`, and why each falls short — **your call on which to pursue**:

   - **`api_call`** is the right mechanism ("end-to-end state checks") and is the one I'd recommend: query the rule after the run and assert the persisted `discounts.values[]`. Two things block me from writing it blind. It needs site auth, and the only token pattern in this repo (`{{wix-auth-token}}`, in `evalforge-core/src/evalforge.ts`) is used for **MCP capability headers** — whether EvalForge substitutes run variables inside *assertion params* is implemented server-side in `wix-private/evalforge` and isn't documented here. And `expectedResponse` matching semantics (exact vs. subset) are likewise server-side; if it's whole-body equality it can never match a response carrying generated ids, revisions and dates. `api_call` also has **zero usages anywhere in this repo**. Guessing wrong turns your gate red for reasons unrelated to this fix. You own that integration and can confirm both behaviours in minutes.
   - **A tool-call assertion on the execution tool** could work via substring matching, but only for `ExecuteWixAPI`, where the body is embedded in the `code` string param. If the agent instead uses `CallWixSiteAPI`, the body is a nested **object**, and `ParamValueSchema` permits only scalars and arrays of scalars — so the shape isn't expressible. Which tool the agent picks isn't deterministic, so this assertion would fail intermittently on correct docs. A flaky merge gate is worse than a missing one.
   - **`time_limit`** would exploit the real signature (two wasted round-trips), but the measurement above rules it out here: this scenario's own 15 broken-docs runs span 19–169 s, so no ceiling separates a broken run from a clean one. See "No `time_limit`, and the measurement that decided it".
   - **Strengthening the `llm_judge`** can't help: per `docs/eval-scenarios.md` the judge scores the agent's *response*, and the same doc warns it "can pass on a fabricated response that never touched the skill at all" — so it cannot see the 400s. That is precisely the assertion that would pass either way.

   Happy to add the `api_call` assertion in a follow-up once you confirm run-variable substitution and `expectedResponse` matching, or to take a pointer to a scenario that already does it.

## Follow-ups for this team

- **`setup-discount-rules` has no source here.** The portal serves `…/e-commerce/skills/setup-discount-rules` with the identical defect, but there is no corresponding file under `skills/wix-manage/**` — it appears to be a separate portal article (byte-identical to this recipe apart from front matter, the H1, and a missing "Guardrails" section). It is outside this repo's `wix-manage` tree, so I did not widen the change; it still needs fixing wherever it is authored, or de-duplicating against this recipe so the two cannot drift.
- **`subtotalRange.from` wrapper mismatch** — the schema advertises a `StringValue` wrapper (`{"value": "50"}`) but the API rejects it and wants a plain string `"50"`. These recipes already use the plain string, so nothing changed here; the defect is upstream in the schema/proto.
- **`SearchWixAPISpec` throws `Cannot read properties of undefined`** — surfaced by the same eval run. Unrelated to these docs.
- **`settings.appliesTo`** — `ecom-pricing-create-discount-rule.md` marks it required on create and the reference lists an error for it being undefined, yet the reference's own valid request examples omit `settings` entirely, as do the flow recipes. Left alone; the contradiction is unresolved.
- **`{"scope": …}` illustrative fragments** in the "Recommendation → API Mapping" section (3 occurrences) are labelled examples of a *scope object*, not request bodies, so they were left as-is — but the key name echoes the bogus `scope` field that made the flow recipes wrong, and renaming it would remove a trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

