### PR TITLE
Fix local delivery docs link

### DIFF
--- a/skills/wix-manage/references/ecommerce/ecom-shipping.md
+++ b/skills/wix-manage/references/ecommerce/ecom-shipping.md
@@ -29,7 +29,7 @@ Set up and tune how a store ships — what rates to charge, which regions are co
 
 > - [Set up shipping rates / rules](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-rates) — tags: `[intent:setup-rates]` · priority 0
 > - [Set up delivery regions / coverage](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-regions) — tags: `[intent:setup-regions]` · priority 0
-> - [Set up store pickup / local delivery](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-pickup-local-delivery) — tags: `[intent:setup-pickup]` · priority 0
+> - [Set up store pickup / local delivery](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/local-delivery) — tags: `[intent:setup-pickup]` · priority 0
 > - [Add free shipping over $X](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-add-free-shipping) — tags: `[intent:free-shipping]` · priority 0
 
 ### Optimize & fix

--- a/yaml/wix-manage-evals/ecommerce/shipping/ecom-shipping-setup-pickup.yml
+++ b/yaml/wix-manage-evals/ecommerce/shipping/ecom-shipping-setup-pickup.yml
@@ -8,7 +8,7 @@ siteSetup:
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-pickup-local-delivery
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/local-delivery
   - tool: ReadFullDocsArticle
     params:
       articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-api-reference


### PR DESCRIPTION
Update the pickup/local-delivery dispatcher and its eval coverage to point at the correct local-delivery docs URL. The visible label stays unchanged; only the target link was corrected.