### PR TITLE
fix(wix-manage): give classes a real availability endpoint in the booking flow

### DIFF
--- a/skills/wix-manage/references/bookings/end-to-end-booking-flow.md
+++ b/skills/wix-manage/references/bookings/end-to-end-booking-flow.md
@@ -17,7 +17,7 @@ Step-by-step flow for implementing a complete booking experience using REST APIs
 ## Required APIs
 
 - **Services API**: [Query Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services)
-- **Time Slots V2 API**: [List Availability Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots)
+- **Time Slots V2 API**: [List Availability Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots) for appointments, [List Event Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots) for classes
 - **Bookings API**: [Create Booking](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/create-booking), [Confirm Booking](https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-writer-v2/confirm-booking)
 - **eCommerce API**: [Create Checkout](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/checkout/create-checkout)
 
@@ -60,6 +60,10 @@ Step-by-step flow for implementing a complete booking experience using REST APIs
 **Endpoint**: `POST https://www.wixapis.com/_api/service-availability/v2/time-slots`
 
 > **Important**: The old Availability Calendar API (`/bookings/v2/availability/query`) is deprecated. Always use Time Slots V2.
+>
+> Class availability does **not** come from the calendar or schedule APIs either. `/bookings/v2/calendar/sessions/query`
+> and `/bookings/v1/schedules/sessions/query` are not the route to it — use the class endpoint in
+> [For Classes](#for-classes) below.
 
 ```json
 {
@@ -96,7 +100,46 @@ Dates **must** be in `YYYY-MM-DDThh:mm:ss` format (local datetime). Plain dates 
 
 ### For Classes
 
-Use [List Event Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots) instead. Each class session has an `eventId` — save it for the booking.
+Classes use a **different endpoint**. The appointment call above returns no slots for a class service.
+
+**Endpoint**: `POST https://www.wixapis.com/_api/service-availability/v2/time-slots/event`
+
+```json
+{
+  "serviceIds": ["<SERVICE_ID>"],
+  "fromLocalDate": "2024-06-15T00:00:00",
+  "toLocalDate": "2024-06-30T23:59:59",
+  "timeZone": "America/New_York"
+}
+```
+
+| Parameter            | Required | Description                                                                                      |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `fromLocalDate`      | Yes      | Start of range in `YYYY-MM-DDThh:mm:ss` format. Required unless paging with `cursorPaging.cursor` |
+| `toLocalDate`        | Yes      | End of range, same format. Required unless paging with `cursorPaging.cursor`                      |
+| `serviceIds`         | No       | **Array** of service GUIDs (max 100). Omit to return slots for every service                     |
+| `timeZone`           | No       | IANA timezone. Defaults to the business time zone                                                |
+| `includeNonBookable` | No       | Default `true`. Set `false` for bookable sessions only                                           |
+| `maxSlotsPerDay`     | No       | Requires `toLocalDate` no more than 1 month after `fromLocalDate`                                 |
+
+Two parameter names differ from the appointment call above. Check them before treating an empty or
+over-broad result as a data problem:
+
+- `serviceIds` is an **array**, not the singular `serviceId` used above. Omit it and slots for
+  every service are returned.
+- `includeNonBookable` replaces `bookable`. Pass `includeNonBookable: false` for bookable
+  sessions only.
+
+### Save from each class time slot
+
+- `eventInfo.eventId` — the session id, and the only field Create Booking needs for a class (see Step 3)
+- `localStartDate`, `localEndDate` — session times
+- `bookableCapacity` — spots customers can actually book (`remainingCapacity` minus waitlist reservations)
+- `nonBookableReasons` — why a returned slot is unbookable: `noRemainingCapacity`,
+  `violatesBookingPolicy`, `reservedForWaitingList`, `eventCancelled`
+
+An empty `timeSlots` array means the class has no sessions scheduled in that range. That is a valid
+answer to "when can customers book this?", not an error.
 
 ---
 

--- a/yaml/wix-manage-evals/bookings/end-to-end-booking-flow-class-availability.yml
+++ b/yaml/wix-manage-evals/bookings/end-to-end-booking-flow-class-availability.yml
@@ -1,0 +1,69 @@
+name: bookings/end-to-end-booking-flow-class-availability
+description: >-
+  Verifies the agent can report when customers can book a CLASS service, reading
+  the end-to-end-booking-flow recipe and reaching a successful class-session
+  availability read rather than dead-ending or answering from business hours.
+triggerPrompt: >-
+  I have a class on my Wix Bookings site. Tell me when customers can book it —
+  which sessions are scheduled and how many spots are open on each. Don't change
+  anything on my site, just tell me what's there.
+tags: [bookings]
+siteSetup:
+  mode: template
+  templateId: bookings-editor
+  bootstrap:
+    steps:
+      - label: Seed one free in-person CLASS service (classes need no staff)
+        method: post
+        url: https://www.wixapis.com/bookings/v2/bulk/services/create
+        body:
+          returnEntity: true
+          services:
+            - name: Sunrise Yoga Class
+              type: CLASS
+              onlineBooking:
+                enabled: true
+              payment:
+                rateType: NO_FEE
+                options:
+                  online: false
+                  inPerson: true
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/end-to-end-booking-flow
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The site has one CLASS service, "Sunrise Yoga Class", just created and with no sessions
+      scheduled yet. The owner asked which sessions are scheduled and how many spots are open,
+      and explicitly asked for no changes.
+
+      Class availability comes from a class-specific time-slots read, NOT from business working
+      hours and NOT from the appointment availability call. "No sessions are scheduled yet" is
+      the correct answer here — the point is whether the agent established that from an actual
+      successful read of the class's sessions.
+
+      Pass if ALL of these are true:
+        1. The agent named the actual service it found ("Sunrise Yoga Class").
+        2. It made a successful (2xx) read of the class's sessions/time slots and based its
+           answer on that response.
+        3. It reported that no sessions are currently scheduled — or, if the read did return
+           sessions, reported their times and open spots consistently with the response.
+
+      Fail if ANY of these are true:
+        - The agent created or modified anything (service, session, event, booking, schedule).
+          The request was read-only.
+        - It never reached a successful class-session read: it gave up, said it could not
+          determine availability or could not find the right API, or told the owner to check
+          the Bookings dashboard instead.
+        - It answered from the site's business working hours, or from the service's general
+          settings, without reading the class's actual sessions — business hours are when the
+          business is open, not when a class session runs.
+        - It reported specific session times or spot counts that its own API reads did not
+          return (fabrication).
+        - It claimed the site has no class service even though a services read returned
+          "Sunrise Yoga Class".
+
+      Judge only the points above. Do not require pricing, policy, or booking-flow commentary.


### PR DESCRIPTION
## What's wrong

Step 2 of the booking-flow recipe ("Check Availability") specifies the appointment call completely — endpoint, request body, and a required/optional parameter table with the date-format rule. Classes got one sentence:

> Use [List Event Time Slots](https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots) instead. Each class session has an `eventId` — save it for the booking.

No endpoint path, no request body, no parameters. And this was the **only** mention of class availability anywhere under `skills/wix-manage/references/bookings/`.

The asymmetry matters because Step 3 already tells the reader that a class booking needs `serviceId` + `eventId` — while nothing told them how to obtain an `eventId`.

## What agents actually do with it

Two eval runs of a "list my booking services and tell me when customers can book each one" prompt against a site seeded with a single CLASS service. Both read this recipe (`sourceDocUrls` on the execute calls names it), and both had to discover the call themselves.

Run `0bbf48ae-cc3f-4864-88cc-8f6212282cc9` — 101 s, 4 failed tool calls:

- guessed `/event-time-slots` and `/event-time-slots/list` → 404
- fell back to spec search, which returned `Search error: Invalid resourceId` (reason on the call: *"Find the List Event Time Slots endpoint URL for CLASS booking services."*)
- a schedule read via a v1 route returned `"schedule": {"error": "Wix API error (404): "}`

Run `650ed144-4c21-4919-b10d-2be7a1eee235` — 112 s:

- `/bookings/v2/calendar/sessions/query` → `Wix API error (400): {"message":"fromDate and toDate must be given","details":{"applicationError":{"code":"INVALID_QUERY_FILTER"}}}`
- `/bookings/v1/schedules/sessions/query` → 404
- then reached `POST .../service-availability/v2/time-slots/event` — passing `serviceId` and `bookable`, neither of which is a parameter of that method

Both runs eventually produced a correct answer, so both **passed** their outcome gate at 10/10. The cost shows up only as friction, scored 4/10 and 5/10, with the endpoint gap named explicitly in both diagnostics.

## The fix

Step 2's class section now matches the depth of the appointment section, taken from the generated List Event Time Slots reference:

- `POST https://www.wixapis.com/_api/service-availability/v2/time-slots/event`
- `fromLocalDate` / `toLocalDate` — required unless paging by cursor
- `serviceIds` is an **array**, where the appointment call above takes a singular `serviceId`; `includeNonBookable` takes the place of `bookable`. These are the two parameter names that differ between the two calls, and the second run got both wrong
- what to keep from each slot: `eventInfo.eventId`, `localStartDate` / `localEndDate`, `bookableCapacity`, `nonBookableReasons`
- an empty `timeSlots` array means no sessions are scheduled — a valid answer, not an error

The deprecation callout now also names `/bookings/v2/calendar/sessions/query` and `/bookings/v1/schedules/sessions/query` as not being the route to class availability, because that is where both runs went. `List Event Time Slots` is added to Required APIs.

## Eval coverage

**No scenario asserted this recipe's article URL**, so it had no coverage at all — meaning the coverage check would fail on any change to it. `bookings/end-to-end-booking-flow-class-availability` provisions a bookings site, seeds one CLASS service with no sessions, and asks when customers can book it.

The judge requires the answer to rest on a successful class-session read, and fails the two ways a run can look plausible without one:

- **dead-ending** — "I couldn't determine availability", or deferring the owner to the Bookings dashboard
- **answering from business working hours** — which are when the business is open, not when a class session runs

It also asserts read-only behaviour, since the prompt asks for no changes.

The seed reuses a `bookings/v2/bulk/services/create` call already known to provision a CLASS service successfully. Classes need no staff, so it is a single bootstrap call with no id chaining.

**Measured against production docs.** The gate runs the scenario twice — once with this PR's
content, once against what's live — and compares. Same 10/10 judge verdict both times, so the
outcome is unchanged, which is expected: an agent recovers from a missing endpoint by searching.
The cost of that recovery is the finding:

| | This PR | Production |
|---|---|---|
| `ReadFullDocsArticle` assertion | pass | **fail** |
| LLM judge | 10/10 | 10/10 |
| Time | **45.0 s** | 104.3 s |
| Cost | **$0.493** | $1.290 |
| Tokens | **239.6K** | 631.0K |

2.3x faster and 2.6x cheaper, verdict `required`, pairwise judge awards it to the PR on
efficiency. The 104.3 s production run also lines up with the 101 s and 112 s measured on the
historical runs above, which is a useful corroboration that those weren't outliers.

The tool assertion failing on production is worth noting on its own: against the current docs the
agent does not end up reading this recipe at the asserted URL, and with the fix it does.

## Separate defect, not fixed here

Spec search failed outright in the first run: `Search error: Invalid resourceId`, on a call whose stated purpose was finding this very endpoint. That belongs to the MCP server rather than this repo, so it is out of scope for this PR, but it is worth someone's attention — it removes the fallback that a reader is supposed to have when a recipe is incomplete.

## Validation

All 50 scenario files in the tree were validated by executing `ScenarioSchema` from `packages/evalforge-core/src/schema.ts` — 50 files, 50 unique names, 0 failures.

The gate's first attempt failed after 38 s on `Could not start eval pipeline comparison: The operation was aborted due to timeout`, with the scenario already registered. That was an infrastructure timeout rather than anything in this PR; a re-run completed in 2 m 57 s with the results above.

