### PR TITLE
fix(dashboard-navigation): absolute routes.json link in the index

### DIFF
--- a/skills/wix-manage/references/dashboard-navigation/dashboard-navigation.md
+++ b/skills/wix-manage/references/dashboard-navigation/dashboard-navigation.md
@@ -59,7 +59,7 @@ For a business solution not listed yet, use the app-ID fallback URL with the sol
 
 ## Machine-Readable Route Data
 
-[routes.json](routes.json) holds the full page inventory behind these recipes — every covered app with its `appDefinitionId`, `slug`, and per page: `path` (append to `https://manage.wix.com/dashboard/{metaSiteId}/`), `title`, `inSidebar`, redirecting `legacyAliases`, and — where the page shows a single entity — `deepLink` with the ID placeholder (`bookings/services/form/{serviceId}`). Prefer the per-solution recipes for guidance (curation, entity deep links, read-API pairing); use the JSON to look up or enumerate routes programmatically:
+[routes.json](https://www.wix.com/skills/manage/references/dashboard-navigation/routes.json) holds the full page inventory behind these recipes — every covered app with its `appDefinitionId`, `slug`, and per page: `path` (append to `https://manage.wix.com/dashboard/{metaSiteId}/`), `title`, `inSidebar`, redirecting `legacyAliases`, and — where the page shows a single entity — `deepLink` with the ID placeholder (`bookings/services/form/{serviceId}`). Prefer the per-solution recipes for guidance (curation, entity deep links, read-API pairing); use the JSON to look up or enumerate routes programmatically:
 
 ```bash
 curl -s https://www.wix.com/skills/manage/references/dashboard-navigation/routes.json


### PR DESCRIPTION
Found while testing the merged #778 through the Wix MCP: `ReadFullDocsArticle` on the index shows the docs pipeline rewrites relative article links to absolute docs URLs (works beautifully across all five docsEntry families), but does NOT rewrite the relative `routes.json` file link — it renders dead in the docs context. Pointing it at the skills-registry URL, which serves the raw file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)