### PR TITLE
fix(dashboard-navigation): index description names all covered solutions

### DIFF
--- a/skills/wix-manage/references/dashboard-navigation/dashboard-navigation.md
+++ b/skills/wix-manage/references/dashboard-navigation/dashboard-navigation.md
@@ -1,6 +1,6 @@
 ---
 name: "Dashboard Navigation"
-description: "Entry point for building direct links into a site's Wix dashboard (manage.wix.com). Documents the shared URL structure for all dashboard pages and routes to the per-business-solution recipes (Bookings, Stores) that list each solution's page routes and pair entities with their read APIs. Use when the user asks where to manage something in the Wix dashboard, wants a dashboard link, or after an API operation to hand back a 'view it in your dashboard' link."
+description: "Entry point for building direct links into a site's Wix dashboard (manage.wix.com). Documents the shared URL structure for all dashboard pages (site and account level, app-ID fallback, entity deep links, machine-readable routes.json) and routes to a per-business-solution recipe for every covered solution — bookings, stores/ecommerce, blog, pricing plans, restaurants, CMS, contacts, forms, marketing, get paid, analytics, google ads, app management, site settings, sites, and domains. Use when the user asks where to manage something in the Wix dashboard, wants a dashboard link, or after an API operation to hand back a 'view it in your dashboard' link."
 ---
 
 # Dashboard Navigation


### PR DESCRIPTION
The index's frontmatter `description` is rendered verbatim in agent-facing catalogs (WixREADME) and still said "(Bookings, Stores)" from the first commit — later batches updated the body table but never the frontmatter. Now enumerates all 16 covered solutions: the description is the intent-matching surface for MCP routing, so naming them helps agents pick this doc.

Process fix landing in the meta-skill (wix-private/meta-skills#9): updating the index frontmatter description is now part of the add-a-solution checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)