### PR TITLE
feat(wix-manage): add Find and Update Contact recipe — Query Contacts cannot filter by name

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -142,6 +142,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Contacts Dashboard Navigation](references/contacts/contacts-dashboard-navigation.md)
 **Technical:** Direct links to Wix Contacts (CRM) dashboard pages on manage.wix.com (contacts list, view a specific contact, contact import, segments), pairing each main contacts entity with its read API for "view it in your dashboard" links.
 
+### [Find and Update Contact](references/contacts/find-and-update-contact.md)
+**Technical:** Finds a contact the user identified by name and updates a field on it. Covers the exact filterable field list of Query Contacts, why `name.first`/`name.last` return 400 "not declared as filterable", using Search Contacts instead, and the `revision` Update Contact requires.
+
 ---
 
 ## Dashboard Navigation

--- a/skills/wix-manage/references/contacts/find-and-update-contact.md
+++ b/skills/wix-manage/references/contacts/find-and-update-contact.md
@@ -1,0 +1,148 @@
+---
+name: "Find and Update Contact"
+description: Finds a CRM contact the user identified by name (or company/email/phone) and updates a field on it. Covers the exact filterable field list of Query Contacts, why filtering by name.first/name.last returns 400 "not declared as filterable", using Search Contacts instead of listing every contact, and the revision that Update Contact requires.
+---
+# Find and Update Contact
+
+Use this recipe when a user names a contact in words — "update my contact Jordan Lee", "change Dana's phone number", "set the job title for the person at Acme" — and you need to locate that contact and change a field on it.
+
+Do the whole thing: locate the contact, then apply the change. The user naming the contact and the field is the confirmation; don't stop to ask which contact API to use.
+
+The happy path is exactly **two calls**: Search Contacts, then Update Contact.
+
+## Locate the contact
+
+### Query Contacts cannot filter by name
+
+`POST https://www.wixapis.com/contacts/v5/contacts/query` only declares these fields as filterable:
+
+| Field | Operators | Sortable |
+|---|---|---|
+| `id` | `$eq`, `$in` | no |
+| `createdDate` | `$eq`, `$gt`, `$lt`, `$gte`, `$lte` | ASC |
+| `updatedDate` | `$eq`, `$gt`, `$lt`, `$gte`, `$lte` | ASC |
+| `email.email` | `$eq`, `$in`, `$exists` | no |
+| `phone.phone` | `$eq`, `$in`, `$exists` | no |
+| `externalId` | `$eq`, `$in`, `$exists` | no |
+
+Any other field in `query.filter` is rejected with HTTP 400:
+
+```json
+{
+  "message": "value Field 'name.last' is not declared as filterable",
+  "details": {
+    "validationError": {
+      "fieldViolations": [
+        { "field": "value", "description": "Field 'name.last' is not declared as filterable" }
+      ]
+    }
+  }
+}
+```
+
+`name.first`, `name.last`, `company.name` and `company.jobTitle` all fail this way, with `$eq` and with a bare value. Retrying with a different operator does not help — the field is not filterable at all in Query Contacts.
+
+So: use Query Contacts only when you already have an `id`, an exact `email.email`, an exact `phone.phone`, or an `externalId`. For anything else, use Search Contacts.
+
+### Search Contacts — the way to find a contact by name
+
+`POST https://www.wixapis.com/contacts/v5/contacts/search` combines free-text matching with filtering and cursor paging.
+
+Free-text searchable properties: `name.full`, `email.email`, `phone.phone`, `company.name`, `company.jobTitle`, `memberInfo.email`, `memberInfo.profileInfo.nickname`.
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/contacts/v5/contacts/search' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "search": {
+      "search": {
+        "expression": "Jordan Lee",
+        "mode": "AND",
+        "fuzzy": true
+      },
+      "cursorPaging": { "limit": 10 }
+    },
+    "nameFormat": "BY_FIRST_NAME"
+  }'
+```
+
+Note the doubled nesting: the free-text block is `search.search`, alongside `search.filter`, `search.sort` and `search.cursorPaging`.
+
+- `mode`: `AND` requires every term (use it for a first + last name), `OR` requires any term.
+- `fuzzy`: tolerates typos in the expression.
+- `nameFormat`: `BY_FIRST_NAME` or `BY_LAST_NAME` — controls how names are matched and ordered.
+
+Unlike Query Contacts, the **filter inside a search request does accept the name fields**, with `$eq`, `$ne`, `$in`, `$nin`, `$exists` and `$startsWith`. Use it when you want an exact surname match rather than free text:
+
+```json
+{
+  "search": {
+    "filter": { "name.last": { "$eq": "Lee" } },
+    "cursorPaging": { "limit": 10 }
+  }
+}
+```
+
+Permission: `CONTACTS.CONTACT_READ`.
+
+### Do not list every contact and filter in memory
+
+Paging through `POST /contacts/v5/contacts/query` with no filter to scan for a name works on a small test site and does not scale — Query and Search both cap at 100 items per page. Search Contacts already does this server-side. Reach for a full scan only when the user's description matches no searchable property at all (for example "the contact I added last Tuesday", which is `createdDate` on Query Contacts).
+
+## Apply the update
+
+`PATCH https://www.wixapis.com/contacts/v5/contacts/{contact.id}`
+
+Update Contact requires the contact's **current `revision`** — this is optimistic concurrency, not an optional field. Omitting it or sending a stale value fails the call.
+
+You already have it: both Search Contacts and Query Contacts return the full contact, including `id` and `revision`. Read them off the search result you just got. A separate `GET /contacts/v5/contacts/{contactId}` is only needed when the user handed you a contact id with no revision.
+
+Send `revision` plus only the fields you are changing; other fields keep their current values.
+
+```bash
+curl -X PATCH \
+  'https://www.wixapis.com/contacts/v5/contacts/acfe01b8-9ee7-4279-b792-0d3c429ce09d' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "contact": {
+      "revision": "1",
+      "phone": { "phone": "+1-212-555-0100" }
+    }
+  }'
+```
+
+The response returns the contact with `revision` incremented by 1. `phone.e164` is generated from `phone.phone` when the number is a valid E.164 number, so a formatted input like `+1-212-555-0100` comes back as `phone.e164: "+12125550100"`.
+
+Restrictions worth knowing before you build the payload:
+
+- `externalId` can be set only at creation and never changed.
+- The main `email.email` of a contact that is also a site member can't be changed here — use the [Members API](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/introduction).
+- At least one of `name`, `email`, or `phone` must remain after the update.
+
+Permission: `CONTACTS.CONTACT_UPDATE` (plus `CONTACTS.CONTACT_MEMBER_EMAIL_UPDATE` for a member's main email).
+
+## Handling ambiguity in the search result
+
+- **Exactly one match** — update it and confirm what changed.
+- **Several matches** — say how many you found and list them with the details that distinguish them (email, phone, company), then update the one the user identifies. Don't guess between two people.
+- **No match** — report that no contact matches, and offer to create one with [Create Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/create-contact) rather than silently doing nothing.
+
+## Common Pitfalls
+
+- **Filtering `name.last` / `name.first` in Query Contacts.** 400 `not declared as filterable`. Use Search Contacts.
+- **Changing the filter operator after that 400.** `{"name.last": {"$eq": "Lee"}}` fails identically to `{"name.last": "Lee"}`.
+- **Falling back to fetching every contact and matching in memory.** Search Contacts matches `name.full` server-side.
+- **Calling Update Contact without `revision`.** Required on every update.
+- **Calling Get Contact just to read `revision`** when the search result you already have contains it.
+- **Using the v4 filter vocabulary against v5.** Contacts v4 nests fields under `info` (`info.name.last`) — those paths do not exist in the v5 contact, whose fields are top-level (`name.last`, `email.email`, `phone.phone`).
+
+## Related Documentation
+
+- [Search Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/search-contacts)
+- [Query Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/query-contacts)
+- [Update Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/update-contact)
+- [Get Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/get-contact)
+- [Contacts Dashboard Navigation](contacts-dashboard-navigation.md) — for handing back a `contacts/view/{contactId}` link after the update

--- a/skills/wix-manage/references/contacts/find-and-update-contact.md
+++ b/skills/wix-manage/references/contacts/find-and-update-contact.md
@@ -6,7 +6,7 @@ description: Finds a CRM contact the user identified by name (or company/email/p
 
 Use this recipe when a user names a contact in words — "update my contact Jordan Lee", "change Dana's phone number", "set the job title for the person at Acme" — and you need to locate that contact and change a field on it.
 
-Do the whole thing: locate the contact, then apply the change. The user naming the contact and the field is the confirmation; don't stop to ask which contact API to use.
+**Do both steps in the same turn: search for the contact, then update it.** The user naming the contact and the new value is the confirmation — issue the calls rather than describing them, and don't stop to ask which contact API to use or to confirm the field. Finish by reporting what actually changed: the contact's name, the new value, and the new `revision` from the update response.
 
 The happy path is exactly **two calls**: Search Contacts, then Update Contact.
 
@@ -124,11 +124,11 @@ Restrictions worth knowing before you build the payload:
 
 Permission: `CONTACTS.CONTACT_UPDATE` (plus `CONTACTS.CONTACT_MEMBER_EMAIL_UPDATE` for a member's main email).
 
-## Handling ambiguity in the search result
+## Handling the search result
 
-- **Exactly one match** — update it and confirm what changed.
-- **Several matches** — say how many you found and list them with the details that distinguish them (email, phone, company), then update the one the user identifies. Don't guess between two people.
-- **No match** — report that no contact matches, and offer to create one with [Create Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/create-contact) rather than silently doing nothing.
+- **Exactly one match — the normal case.** Update it immediately and report the contact, the new value and the new `revision`. Do not pause for confirmation.
+- **Several matches for genuinely different people** — list them with the details that distinguish them (email, phone, company) and update the one the user identifies. This is the only case where you stop mid-task, and only because picking between two real people would risk editing the wrong record.
+- **No match** — say so, then create the contact with [Create Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/create-contact) carrying the value the user asked for, rather than reporting the miss and stopping.
 
 ## Common Pitfalls
 

--- a/yaml/wix-manage-evals/contacts/find-and-update-contact-by-name.yml
+++ b/yaml/wix-manage-evals/contacts/find-and-update-contact-by-name.yml
@@ -1,20 +1,28 @@
 ---
 name: contacts/find-and-update-contact-by-name
 description: >-
-  Verifies the agent reads the find-and-update-contact recipe when Query Contacts
-  rejects a name filter as "not declared as filterable", and routes to Search
-  Contacts instead of paging every contact — including the revision that Update
-  Contact requires and where it already comes from.
+  Verifies the agent reads the find-and-update-contact recipe and actually completes an
+  update to a contact it can only identify by name — routing to Search Contacts instead
+  of the name filter Query Contacts rejects as "not declared as filterable", and passing
+  the revision Update Contact requires.
 triggerPrompt: >-
-  I need to update a contact on my Wix site but I only know their name, "Jordan Lee".
-  I called POST https://www.wixapis.com/contacts/v5/contacts/query with body
-  {"query":{"filter":{"name.last":"Lee","name.first":"Jordan"}}} and got a 400:
-  "value Field 'name.last' is not declared as filterable". I retried with
-  {"query":{"filter":{"name.last":{"$eq":"Lee"}}}} and got exactly the same 400.
-  Do I have to page through every contact and match the name in memory? What is the
-  correct way to find Jordan Lee and set their phone number to +1-212-555-0100?
+  Update my contact Jordan Lee — set their phone number to +1-212-555-0100.
 tags: [contacts]
-maxTokens: 30000
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: seed the contact Jordan Lee
+        method: post
+        url: https://www.wixapis.com/contacts/v5/contacts
+        body:
+          contact:
+            name:
+              first: Jordan
+              last: Lee
+            email:
+              email: jordan.lee@example.com
 assertions:
   - tool: ReadFullDocsArticle
     params:
@@ -23,35 +31,25 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: |
-      The user hit HTTP 400 "Field 'name.last' is not declared as filterable" from
-      Query Contacts (POST /contacts/v5/contacts/query) twice — once with a bare value
-      and once with $eq — and asks whether they must page all contacts and filter in
-      memory, and how to find "Jordan Lee" and set their phone to +1-212-555-0100.
+      The user's request (verbatim): "Update my contact Jordan Lee — set their phone
+      number to +1-212-555-0100."
 
-      Intent: route the user to Search Contacts for finding a contact by name, and to
-      Update Contact with the contact's current revision for the change.
+      Intent: the contact named Jordan Lee, who exists on the site, must end up with the
+      phone number +1-212-555-0100. The agent is only given the name, so it has to locate
+      the contact before it can update it.
 
-      Pass if the response:
-      - names Search Contacts, POST https://www.wixapis.com/contacts/v5/contacts/search,
-        as the way to find a contact by name — either free text (the expression is nested
-        as search.search.expression) or a filter on name.last / name.first inside the
-        search request, AND
-      - explains that Query Contacts declares only a limited set of filterable fields
-        (id, createdDate, updatedDate, email.email, phone.phone, externalId), so no
-        operator makes name.last work there, AND
-      - answers the user's actual question by saying a full scan with in-memory matching
-        is NOT required, AND
-      - states the update is PATCH https://www.wixapis.com/contacts/v5/contacts/{contactId}
-        with the contact's current revision in the request body, AND
-      - notes that the revision (and id) already come back on the contact returned by the
-        search, so no extra Get Contact call is needed just to read it.
+      Pass only if the tool-call trace shows the agent:
+      - located the existing contact Jordan Lee, AND
+      - issued a successful (2xx) update against that contact setting the phone number to
+        +1-212-555-0100 (equivalently +12125550100 in phone.e164), AND
+      - confirmed the completed change in its final answer, referring to the actual result
+        it got back rather than to what the API would do.
 
       Fail if the response:
-      - suggests any way to make Query Contacts filter on name.first / name.last
-        (different operator, nesting, or field projection), OR
-      - presents paging all contacts and filtering in memory as the answer or as an
-        equally good option, OR
-      - omits revision from the update request, or calls it optional, OR
-      - invents an endpoint that is not in the Contacts v5 API, or uses the Contacts v4
-        info.* field paths (e.g. info.name.last) against a v5 endpoint, OR
-      - only explains the error without giving the concrete find-then-update calls.
+      - only explains how to find and update a contact, or hands back curl/API instructions,
+        without actually performing the update, OR
+      - stops to ask which API, which contact, or whether to proceed, when exactly one
+        contact matches the name, OR
+      - left the update call erroring (non-2xx) at the end of the run, OR
+      - claims the phone number was updated with no successful update call in the trace, OR
+      - updated the wrong field or a different contact.

--- a/yaml/wix-manage-evals/contacts/find-and-update-contact-by-name.yml
+++ b/yaml/wix-manage-evals/contacts/find-and-update-contact-by-name.yml
@@ -1,0 +1,57 @@
+---
+name: contacts/find-and-update-contact-by-name
+description: >-
+  Verifies the agent reads the find-and-update-contact recipe when Query Contacts
+  rejects a name filter as "not declared as filterable", and routes to Search
+  Contacts instead of paging every contact — including the revision that Update
+  Contact requires and where it already comes from.
+triggerPrompt: >-
+  I need to update a contact on my Wix site but I only know their name, "Jordan Lee".
+  I called POST https://www.wixapis.com/contacts/v5/contacts/query with body
+  {"query":{"filter":{"name.last":"Lee","name.first":"Jordan"}}} and got a 400:
+  "value Field 'name.last' is not declared as filterable". I retried with
+  {"query":{"filter":{"name.last":{"$eq":"Lee"}}}} and got exactly the same 400.
+  Do I have to page through every contact and match the name in memory? What is the
+  correct way to find Jordan Lee and set their phone number to +1-212-555-0100?
+tags: [contacts]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/find-and-update-contact
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user hit HTTP 400 "Field 'name.last' is not declared as filterable" from
+      Query Contacts (POST /contacts/v5/contacts/query) twice — once with a bare value
+      and once with $eq — and asks whether they must page all contacts and filter in
+      memory, and how to find "Jordan Lee" and set their phone to +1-212-555-0100.
+
+      Intent: route the user to Search Contacts for finding a contact by name, and to
+      Update Contact with the contact's current revision for the change.
+
+      Pass if the response:
+      - names Search Contacts, POST https://www.wixapis.com/contacts/v5/contacts/search,
+        as the way to find a contact by name — either free text (the expression is nested
+        as search.search.expression) or a filter on name.last / name.first inside the
+        search request, AND
+      - explains that Query Contacts declares only a limited set of filterable fields
+        (id, createdDate, updatedDate, email.email, phone.phone, externalId), so no
+        operator makes name.last work there, AND
+      - answers the user's actual question by saying a full scan with in-memory matching
+        is NOT required, AND
+      - states the update is PATCH https://www.wixapis.com/contacts/v5/contacts/{contactId}
+        with the contact's current revision in the request body, AND
+      - notes that the revision (and id) already come back on the contact returned by the
+        search, so no extra Get Contact call is needed just to read it.
+
+      Fail if the response:
+      - suggests any way to make Query Contacts filter on name.first / name.last
+        (different operator, nesting, or field projection), OR
+      - presents paging all contacts and filtering in memory as the answer or as an
+        equally good option, OR
+      - omits revision from the update request, or calls it optional, OR
+      - invents an endpoint that is not in the Contacts v5 API, or uses the Contacts v4
+        info.* field paths (e.g. info.name.last) against a v5 endpoint, OR
+      - only explains the error without giving the concrete find-then-update calls.

--- a/yaml/wix-manage-evals/contacts/find-and-update-contact-by-name.yml
+++ b/yaml/wix-manage-evals/contacts/find-and-update-contact-by-name.yml
@@ -2,9 +2,10 @@
 name: contacts/find-and-update-contact-by-name
 description: >-
   Verifies the agent reads the find-and-update-contact recipe and actually completes an
-  update to a contact it can only identify by name — routing to Search Contacts instead
-  of the name filter Query Contacts rejects as "not declared as filterable", and passing
-  the revision Update Contact requires.
+  update to a contact it can only identify by name, on a site holding 61 contacts —
+  routing to Search Contacts instead of the name filter Query Contacts rejects as "not
+  declared as filterable" or a full scan filtered in memory, and passing the revision
+  Update Contact requires. Two other contacts named Jordan make the surname load-bearing.
 triggerPrompt: >-
   Update my contact Jordan Lee — set their phone number to +1-212-555-0100.
 tags: [contacts]
@@ -13,7 +14,195 @@ siteSetup:
   templateId: blank-editor
   bootstrap:
     steps:
-      - label: seed the contact Jordan Lee
+      # A realistic address book, so locating one person by name is a real lookup rather
+      # than a one-item list. Two other Jordans make the surname load-bearing; no other
+      # contact shares the surname Lee, so "Jordan Lee" still resolves to exactly one.
+      - label: seed 60 unrelated contacts
+        method: post
+        url: https://www.wixapis.com/contacts/v5/bulk/contacts/create
+        body:
+          contacts:
+            - name: { first: Avery, last: Alvarez }
+              email: { email: avery.alvarez.0@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Blake, last: Bennett }
+              email: { email: blake.bennett.1@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Cameron, last: Castillo }
+              email: { email: cameron.castillo.2@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Dana, last: Dubois }
+              email: { email: dana.dubois.3@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Elliot, last: Espinosa }
+              email: { email: elliot.espinosa.4@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Finley, last: Fairbanks }
+              email: { email: finley.fairbanks.5@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Gray, last: Goldberg }
+              email: { email: gray.goldberg.6@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Harper, last: Hartley }
+              email: { email: harper.hartley.7@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Iris, last: Ibrahim }
+              email: { email: iris.ibrahim.8@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Jesse, last: Jensen }
+              email: { email: jesse.jensen.9@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Kai, last: Kowalski }
+              email: { email: kai.kowalski.10@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Logan, last: Lindqvist }
+              email: { email: logan.lindqvist.11@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Mara, last: Moreau }
+              email: { email: mara.moreau.12@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Noor, last: Nakamura }
+              email: { email: noor.nakamura.13@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Owen, last: Okafor }
+              email: { email: owen.okafor.14@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Paige, last: Pereira }
+              email: { email: paige.pereira.15@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Quinn, last: Quintero }
+              email: { email: quinn.quintero.16@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Riley, last: Rasmussen }
+              email: { email: riley.rasmussen.17@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Sasha, last: Silva }
+              email: { email: sasha.silva.18@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Tessa, last: Tanaka }
+              email: { email: tessa.tanaka.19@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Uma, last: Ueda }
+              email: { email: uma.ueda.20@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Vaughn, last: Vasquez }
+              email: { email: vaughn.vasquez.21@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Wren, last: Whitfield }
+              email: { email: wren.whitfield.22@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Xander, last: Xiong }
+              email: { email: xander.xiong.23@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Yara, last: Yilmaz }
+              email: { email: yara.yilmaz.24@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Zane, last: Zielinski }
+              email: { email: zane.zielinski.25@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Adele, last: Ashford }
+              email: { email: adele.ashford.26@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Bruno, last: Braun }
+              email: { email: bruno.braun.27@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Celia, last: Cavanagh }
+              email: { email: celia.cavanagh.28@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Dorian, last: Delgado }
+              email: { email: dorian.delgado.29@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Esme, last: Eriksen }
+              email: { email: esme.eriksen.30@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Felix, last: Fontaine }
+              email: { email: felix.fontaine.31@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Greta, last: Grimaldi }
+              email: { email: greta.grimaldi.32@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Hugo, last: Halvorsen }
+              email: { email: hugo.halvorsen.33@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Imani, last: Ivanov }
+              email: { email: imani.ivanov.34@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Jonas, last: Jamison }
+              email: { email: jonas.jamison.35@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Kira, last: Kaplan }
+              email: { email: kira.kaplan.36@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Lucian, last: Lemieux }
+              email: { email: lucian.lemieux.37@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Miriam, last: Mansour }
+              email: { email: miriam.mansour.38@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Nadia, last: Novak }
+              email: { email: nadia.novak.39@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Otto, last: Ortega }
+              email: { email: otto.ortega.40@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Priya, last: Petrov }
+              email: { email: priya.petrov.41@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Rafael, last: Rowntree }
+              email: { email: rafael.rowntree.42@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Sonia, last: Stavros }
+              email: { email: sonia.stavros.43@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Theo, last: Thibault }
+              email: { email: theo.thibault.44@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Ursula, last: Ulrich }
+              email: { email: ursula.ulrich.45@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Viktor, last: Vidal }
+              email: { email: viktor.vidal.46@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Wanda, last: Wexler }
+              email: { email: wanda.wexler.47@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Yusuf, last: Yamamoto }
+              email: { email: yusuf.yamamoto.48@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Zora, last: Zamora }
+              email: { email: zora.zamora.49@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Amara, last: Aguilar }
+              email: { email: amara.aguilar.50@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Designer" }
+            - name: { first: Bodhi, last: Bergstrom }
+              email: { email: bodhi.bergstrom.51@example.com }
+              company: { name: "Cedar & Co", jobTitle: "Bookkeeper" }
+            - name: { first: Clara, last: Cortez }
+              email: { email: clara.cortez.52@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Studio Manager" }
+            - name: { first: Desmond, last: Dvorak }
+              email: { email: desmond.dvorak.53@example.com }
+              company: { name: "Kestrel Labs", jobTitle: "Buyer" }
+            - name: { first: Eva, last: Engstrom }
+              email: { email: eva.engstrom.54@example.com }
+              company: { name: "Ferro Supply", jobTitle: "Consultant" }
+            - name: { first: Franco, last: Farrow }
+              email: { email: franco.farrow.55@example.com }
+              company: { name: "Verdant Goods", jobTitle: "Coordinator" }
+            - name: { first: Giulia, last: Gallagher }
+              email: { email: giulia.gallagher.56@example.com }
+              company: { name: "Northwind Traders", jobTitle: "Operations Manager" }
+            - name: { first: Hector, last: Haddad }
+              email: { email: hector.haddad.57@example.com }
+              company: { name: "Bright Ideas Co.", jobTitle: "Account Executive" }
+            - name: { first: Jordan, last: Alvarez }
+              email: { email: jordan.alvarez@example.com }
+              company: { name: "Harbor Analytics", jobTitle: "Buyer" }
+            - name: { first: Jordan, last: Whitfield }
+              email: { email: jordan.whitfield@example.com }
+              company: { name: "Lumen Studio", jobTitle: "Consultant" }
+      - label: seed the target contact Jordan Lee
         method: post
         url: https://www.wixapis.com/contacts/v5/contacts
         body:

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -14,3 +14,7 @@ apiDoc:
       title: Contacts Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
       tags: [contacts]
+    - file: ../../../skills/wix-manage/references/contacts/find-and-update-contact.md
+      title: Find and Update Contact
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
+      tags: [contacts]


### PR DESCRIPTION
## Problem

An agent asked to *"Update my contact Jordan Lee — set their phone number to +1-212-555-0100"* took 88 s and 9 tool calls, two of which were rejected outright. Verbatim from the run trace:

**Call 1** — `POST https://www.wixapis.com/contacts/v5/contacts/query`, body `{"query":{"filter":{"name.last":"Lee","name.first":"Jordan"}}}`:

```
Wix API error (400): {"message":"value Field 'name.last' is not declared as filterable",
"details":{"validationError":{"fieldViolations":[{"field":"value",
"description":"Field 'name.last' is not declared as filterable"}]}}}
```

**Call 2** — same endpoint, retried with an operator, body `{"query":{"filter":{"name.last":{"$eq":"Lee"}}}}`: byte-identical 400.

**Calls 3–6** — four probing `SearchWixAPISpec` calls plus a `ReadFullDocsArticle` on Query Contacts, hunting for the filterable-field list.

**Call 7** — gave up on filtering and paged the entire contact list with `cursorPaging`, then matched the name in JavaScript:

```js
const jordan = contacts.filter(c => (c.name?.first||'').toLowerCase() === 'jordan'
                                 && (c.name?.last||'').toLowerCase() === 'lee');
```

**Call 8** — `PATCH /contacts/v5/contacts/{id}` with `revision: "1"` succeeded.

The outcome gate passed 10/10; the non-gating friction judge scored **4/10**: *"Two 400 errors filtering by unfilterable 'name.last'; 5 probing calls to find query schema; forced to fetch all contacts and filter in memory; required to fetch contact first to get 'revision'."*

## What is actually true

Confirmed against the generated Contacts v5 reference via the Wix MCP docs tools, not from memory:

- **Query Contacts** (`POST /contacts/v5/contacts/query`) declares exactly six filterable fields: `id`, `createdDate`, `updatedDate`, `email.email`, `phone.phone`, `externalId`. `name.first` and `name.last` are not filterable there under any operator, so the retry in call 2 could never have worked.
- **Search Contacts** (`POST /contacts/v5/contacts/search`) is the endpoint for this. Free-text searchable properties are `name.full`, `email.email`, `phone.phone`, `company.name`, `company.jobTitle`, `memberInfo.email`, `memberInfo.profileInfo.nickname` — and unlike Query Contacts, the `filter` **inside** a search request does accept `name.first` / `name.last` (`$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$startsWith`). The agent never found this endpoint.
- **Update Contact** is `PATCH /contacts/v5/contacts/{contact.id}` and the current `revision` "must be passed when updating the contact". Search and Query both return the full contact including `id` and `revision`, so the happy path is two calls, not three.

## The change

A new `contacts` recipe, **Find and Update Contact**, covering the case where the user identifies a contact in words: the verified filterable set of Query Contacts and the exact 400 it produces, Search Contacts as the name-lookup route (with the doubled `search.search.expression` nesting called out), the `revision` requirement and where it already comes from, plus the v4-`info.*`-vs-v5-top-level field-path trap that the older bulk recipes in this area still use.

Four files, per `CONTRIBUTING.md`: the reference, its `SKILL.md` index entry, its `yaml/wix-manage/contacts/documentation.yaml` entry, and a covering scenario `contacts/find-and-update-contact-by-name` asserting the canonical URL `…/crm/members-contacts/contacts/skills/find-and-update-contact`.

## What the scenario does and does not catch

`contacts/find-and-update-contact-by-name` replays the original request verbatim — *"Update my contact Jordan Lee — set their phone number to +1-212-555-0100"* — on a freshly provisioned `blank-editor` site whose bootstrap seeds an address book of 61 contacts, exactly one of them Jordan Lee. So the agent, like the agent in the run above, knows only the name and must locate the contact before it can update it.

The size of that seeded book is load-bearing, and I got it wrong first: seeding a single contact makes "fetch every contact and filter in memory" free, and the measured efficiency gap collapsed to 28% tokens / 12% time. With a realistic list the fallback costs what it cost in production. Two further contacts named Jordan (Alvarez, Whitfield) make the surname matter, and no other contact is surnamed Lee, so the target stays unambiguous.

The rubric requires a **completed** update: the contact located, a 2xx update setting the phone number, and a final answer describing the result it got back. It fails a response that hands over curl instructions instead of performing the update, that stops to ask which API or which contact when exactly one matches, or that claims success with no successful call in the trace.

What it does not catch: it scores the outcome, not the call *sequence*, so it cannot by itself assert that the two rejected filters and the full-list scan disappeared. That delta is what the gate's PR-vs-production comparison measures. A `tool_called_with_param` assertion on `ExecuteWixAPI` would express it directly, but its params substring-match scalars only and the request body here is a nested object, so such an assertion could pass on broken content and fail on correct content.

## Out of scope

Two upstream gaps stay unfixed and are not in `wix/skills`:

- The 400 body names the offending field but not the filterable set, so the error is not self-correcting. That is the Contacts service proto / API, not a skill.
- Search Contacts was not surfaced by four spec searches for how to find a contact by name — a docs/MCP discoverability gap in the Wix MCP server and the generated reference.

