### PR TITLE
fix(wix-manage): give the pricing-plans recipe a complete Create Plan body

### DIFF
--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -26,7 +26,87 @@ Wix Pricing Plans includes Plans that allows Wix users to build a customized mem
 Before proceeding to further steps I must read the following [documentation](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/introduction) on how to form request to pricing plans API.
 
 ### 1. Create a pricing plan
-Creating a pricing plan can be done by using [create plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan) endpoint.
+Create plans with the [Create Plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan) endpoint: `POST https://www.wixapis.com/pricing-plans/v3/plans`.
+
+Prerequisites: the site must have the Wix Pricing Plans app installed, and a site currency must be
+set — Create Plan returns `404 CURRENCY_MISSING` when the currency isn't set in site settings.
+
+#### Required request fields
+
+Send all of these on every create request. Two of them are easy to miss, so check them before
+sending:
+
+| Field | Notes |
+| --- | --- |
+| `plan.status` | Set to `"ACTIVE"`. **The generated Create Plan method schema does not list this field, but the server requires it.** Omitting it returns `400` with `plan.status: value is required` (`REQUIRED_FIELD`). The code examples on the Create Plan article all include it. |
+| `plan.visibility` | `"PUBLIC"` or `"PRIVATE"`. |
+| `plan.pricingVariants[].id` | **You must generate this GUID yourself — it is not server-assigned.** This is unusual for a create call, and it's the most common cause of a failed first attempt. Omitting it returns `400` with `plan.pricingVariants[0].id: is not a valid GUID` and `must not be empty`. Generate a fresh UUID per variant. |
+| `plan.pricingVariants[].name` | Variant name, e.g. `"Monthly"` or the plan name for a single-variant plan. |
+| `plan.pricingVariants[].billingTerms.startType` | `"ON_PURCHASE"` or `"CUSTOM"`. |
+| `plan.pricingVariants[].billingTerms.endType` | `"UNTIL_CANCELLED"` or `"CYCLES_COMPLETED"`. With `CYCLES_COMPLETED`, also send `billingTerms.cyclesCompletedDetails.billingCycleCount`. |
+| `plan.pricingVariants[].pricingStrategies[]` | Exactly one strategy. Use `flatRate.amount` as a decimal **string**, e.g. `"0"` or `"5.99"`. |
+
+`pricingVariants` is currently limited to one variant per plan.
+
+#### Minimal free plan
+
+This is the complete minimal body for a free plan — copy it and change the names and the variant
+GUID:
+
+```javascript
+async function() {
+  return await wix.request({
+    method: 'POST',
+    url: 'https://www.wixapis.com/pricing-plans/v3/plans',
+    body: {
+      plan: {
+        name: 'Free Tier',
+        visibility: 'PUBLIC',
+        status: 'ACTIVE',
+        buyable: true,
+        buyerCanCancel: true,
+        pricingVariants: [
+          {
+            id: '7a3f1e2d-4b5c-6d7e-8f9a-0b1c2d3e4f5a', // generate a fresh GUID
+            name: 'Free Tier',
+            pricingStrategies: [{ flatRate: { amount: '0' } }],
+            billingTerms: {
+              startType: 'ON_PURCHASE',
+              endType: 'UNTIL_CANCELLED'
+            }
+          }
+        ]
+      }
+    }
+  });
+}
+```
+
+Do **not** add a `billingCycle` to a free plan: a free plan can't be recurring, and the server
+rejects that combination with `400 FREE_PRICING_VARIANT_IS_NOT_RECURRING`.
+
+#### Other plan types
+
+Same required fields; only `billingTerms` and the `flatRate.amount` change.
+
+| Plan type | `billingTerms` |
+| --- | --- |
+| Free, open-ended | Omit `billingCycle`; `endType: "UNTIL_CANCELLED"`. `flatRate.amount: "0"`. |
+| One-time payment, fixed duration | `billingCycle` = the duration (e.g. `{ period: 'MONTH', count: 1 }`), `endType: "CYCLES_COMPLETED"`, `cyclesCompletedDetails.billingCycleCount: 1`. |
+| Recurring, until cancelled | `billingCycle` = the recurrence (e.g. `{ period: 'MONTH', count: 1 }`), `endType: "UNTIL_CANCELLED"`. |
+
+A `billingCycle` can't be shorter than 7 days, and total plan duration can't exceed 10 years
+(`400 VALID_BILLING_CYCLE` / `400 VALID_PLAN_DURATION`).
+
+Two more optional fields worth knowing:
+
+- **Purchase caps.** In V3 these are `plan.purchaseLimits`, an array of
+  `{ type, maxCount }`. `type` is one of `PER_MEMBER_LIFETIME`, `PER_MEMBER_ACTIVE`,
+  `TOTAL_ACTIVE`, `TOTAL_SOLD`. To make a plan available only once per member, send
+  `purchaseLimits: [{ type: 'PER_MEMBER_LIFETIME', maxCount: 1 }]`. Some Create Plan examples still
+  use the V2-era `maxPurchasesPerBuyer` field; `purchaseLimits` is the V3 equivalent.
+- **Free trials.** `pricingVariants[].freeTrialDays` only applies to recurring *paid* plans — using
+  it on a free plan returns `400 FREE_TRIAL_IS_APPLICABLE`.
 
 ### 2. Attach integrating app entity to pricing plans
 

--- a/yaml/wix-manage-evals/pricing-plans/create-free-plan.yml
+++ b/yaml/wix-manage-evals/pricing-plans/create-free-plan.yml
@@ -1,0 +1,76 @@
+name: pricing-plans/create-free-plan
+description: >-
+  Verifies the agent reads the create-and-update-pricing-plans recipe and
+  assembles a valid Plans V3 create body for a free plan on the first attempt —
+  including plan.status, a caller-generated pricingVariants[].id GUID, and
+  billingTerms.startType, which the generated Create Plan schema does not
+  present as a complete required set.
+triggerPrompt: >-
+  Create a free membership plan called Free Tier.
+tags: [pricing-plans]
+siteSetup:
+  mode: template
+  templateId: bookings-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/create-and-update-pricing-plans
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Create a free membership plan called Free Tier."
+
+      Intent: create a Wix Pricing Plans plan named "Free Tier" that costs 0, via
+      POST https://www.wixapis.com/pricing-plans/v3/plans.
+
+      Examine the tool-call trace, not only the final answer.
+
+      Pass only if ALL of these are true:
+        1. A plan named "Free Tier" was created successfully (2xx) with a flat rate
+           amount of 0.
+        2. EVERY create-plan call in the trace succeeded. In particular, no
+           create-plan call was rejected with a 400 for a missing or invalid
+           required field — the field violations to watch for are
+           `plan.status` ("value is required"), `plan.pricingVariants[0].id`
+           ("is not a valid GUID" / "must not be empty"), and
+           `plan.pricingVariants[0].billingTerms.startType` ("value is required").
+        3. The agent confirmed the created plan in its final answer.
+
+      Fail if ANY of these are true:
+        - A create-plan call was rejected with a 400 naming any of `plan.status`,
+          `plan.pricingVariants[].id`, or `billingTerms.startType`, even if a later
+          retry succeeded. Recovering from this error is still a failure for this
+          scenario: the recipe is supposed to supply those fields up front.
+        - The plan was never created, or was created with a non-zero price, or with
+          a name other than "Free Tier".
+        - The agent only described how to create the plan instead of creating it.
+        - The agent used a deprecated Plans API version instead of
+          `pricing-plans/v3/plans`.
+
+      A create-plan call that failed for a reason unrelated to required fields
+      (for example CURRENCY_MISSING or the app not being installed) is a site
+      provisioning problem, not a failure of this scenario — ignore it when
+      judging criterion 2, and say so in your reason.
+  - type: llm_judge
+    minScore: 0
+    maxTokens: 2048
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP and its docs let the
+      agent create a free Pricing Plans plan. Examine the tool-call trace.
+      Score 0-10, where 10 means a direct path: no failed calls, no schema
+      guessing, no re-reading an article to recover from an error.
+
+      Penalize and LIST any of:
+        - a create-plan call that returned a non-2xx error, even if recovered
+        - required fields discovered only from a 400 response rather than from the
+          docs the agent read first (`plan.status`,
+          `plan.pricingVariants[].id`, `billingTerms.startType`)
+        - re-reading a docs article after a failed call in order to recover
+        - schema or spec lookups that did not yield a usable request body
+        - a `billingCycle` sent on a free plan, then removed
+
+      For each issue, name the likely MCP or docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and the
+      suspected MCP/docs gap, or 'clean path' if none>"}.


### PR DESCRIPTION
## What's wrong

`Create Plan` (Plans V3) rejects a create request that omits `plan.status`,
`plan.pricingVariants[].id`, or `pricingVariants[].billingTerms.startType`. The
`create-and-update-pricing-plans` recipe's create step was a bare link to the endpoint with no
request body, so an agent falls back to the generated method schema — which does not carry
`plan.status` at all — builds an incomplete body, and gets a 400 on its first attempt.

Verbatim, from an eval run of `coverage/pricing-plans-free-plan` on the prompt
*"Create a free membership plan called Free Tier."* The agent read this recipe first, then the
Create Plan schema, then sent its first create:

```
Execute error: Wix API error (400): {"message":"plan is invalid:
|-- status value is required
`-- pricingVariants [at index 0] is invalid:
    |-- id is not a valid GUID
    |-- id must not be empty
    `-- billingTerms is invalid:
       `-- startType value is required","details":{"validationError":{"fieldViolations":[
{"field":"plan.status","description":"value is required","violatedRule":"REQUIRED_FIELD"},
{"field":"plan.pricingVariants[0].id","description":"is not a valid GUID","violatedRule":"FORMAT",
 "data":{"type":"GUID"}},
{"field":"plan.pricingVariants[0].id","description":"must not be em…
```

`sourceDocUrls` on that failed call named this recipe and the Create Plan reference. The agent
recovered by re-reading the full Create Plan article and retrying, which succeeded — the outcome
gate passed 10/10 while the friction judge scored 6/10, and the run took 51 s.

## What changed

`skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md`, step 1 only:

- The required-field set for `POST /pricing-plans/v3/plans`, each row naming the 400 you get when
  it is missing.
- An explicit callout that **`pricingVariants[].id` is a GUID the caller generates** — it is not
  server-assigned. This is unusual for a create call and is what the run got wrong.
- A note that **`plan.status` is required by the server but absent from the generated Create Plan
  method schema**, so it cannot be discovered from the schema alone.
- A complete, copy-pasteable minimal free-plan body.
- The `billingTerms` shape for free / one-time / recurring plans, and why a free plan must not carry
  a `billingCycle` (`400 FREE_PRICING_VARIANT_IS_NOT_RECURRING`).
- The prerequisites: Pricing Plans app installed, site currency set (`404 CURRENCY_MISSING`).

Every field name, enum value and error code above was checked against the generated Create Plan
reference and its documented error table through the Wix MCP docs tools. `plan.status` is the one
claim the reference does not support — it is grounded in the verbatim 400 above plus the successful
retry, and the recipe says so explicitly rather than implying the schema documents it.

## Routing

The recipe is the right surface: it is what the agent read *first*, and it is the one place that can
carry a worked request body for the specific task ("create a free plan"). The two upstream defects
below live in the Pricing Plans service proto, outside `skills/wix-manage/**`, so this PR does not
touch them.

## Out of scope

Both are proto-side defects in the Plans V3 reference and want a fix from the owning team:

1. **`plan.status` is missing from the generated Create Plan schema** — from the request `Plan`
   message, from its required-parameter list, and from the response `Plan`. The server requires it
   on create and returns it on the created plan. Every code example on the article includes it, so
   only the schema is wrong; an agent that reads the schema instead of the examples cannot succeed.
2. **The Create Plan method description tells you to set `maxPurchasesPerBuyer` to `1` for a free
   plan.** That field is not in the V3 request schema; the V3 equivalent is
   `purchaseLimits: [{ type: 'PER_MEMBER_LIFETIME', maxCount: 1 }]`.

## Eval coverage

`yaml/wix-manage-evals/pricing-plans/create-free-plan.yml` — new scenario, name
`pricing-plans/create-free-plan`, tagged `[pricing-plans]`, provisioned from the `bookings-editor`
template (bundles the Pricing Plans app and has a site currency set, so `CURRENCY_MISSING` cannot
fire). Assertions:

- `ReadFullDocsArticle` on the recipe's canonical URL, so the changed reference is covered.
- Gating `llm_judge` (`minScore: 7`) that fails if **any** create-plan call was rejected with a 400
  naming `plan.status`, `pricingVariants[].id` or `billingTerms.startType` — *even when a later
  retry succeeds*. That is the discriminator: on current content the run recovers and an
  outcome-only rubric passes either way, so the rubric is written against the failed first attempt
  rather than the end state.
- Non-gating friction `llm_judge` (`minScore: 0`), matching the corpus convention.

Validated with `parseScenario` from `packages/evalforge-core/src/schema.ts` over the whole
`yaml/wix-manage-evals/` tree: 68 files, 68 unique names, 0 failures.

**What the scenario does not catch:** it asserts the consequence (no required-field 400), not the
request body itself. Tool-call assertions substring-match scalar params only, so a nested request
body is not expressible as an assertion, and which tool the agent reaches for is not deterministic.
It also cannot distinguish "the recipe supplied the fields" from "the agent guessed correctly" — the
gate's PR-vs-production comparison is what separates those.

No top-level `maxTokens` is set: the observed run used ~64k tokens, so any threshold tight enough to
be meaningful would gate model verbosity rather than the defect, and the gate's comparison already
reports the token delta against a control.

## Notes

- `SKILL.md` and `yaml/wix-manage/pricing-plans/documentation.yaml` already carry entries for this
  recipe; neither needed a change, so neither is touched.
- No confirmation step was added. The recipe's mutation is the action the user explicitly asked for,
  which CONTRIBUTING already treats as user-confirmed.
