### PR TITLE
fix(wix-manage): give the blog-post recipe a real way to resolve an author memberId

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -47,7 +47,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Blog
 
 ### [How to Create Blog Posts](references/blog/how-to-create-blog-posts.md)
-**Technical:** Creates and publishes blog posts using Blog Posts API. Covers Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
+**Technical:** Creates and publishes blog posts using Blog Posts API. Covers resolving the required author memberId (including creating an author member when the site has none), Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
 
 ### [Blog Dashboard Navigation](references/blog/blog-dashboard-navigation.md)
 **Technical:** Direct links to Wix Blog dashboard pages on manage.wix.com (posts list with published/draft tabs, categories, tags, writers, comments, analytics, monetization, settings), pairing each main Blog entity with its read API for "view it in your dashboard" links.

--- a/skills/wix-manage/references/blog/how-to-create-blog-posts.md
+++ b/skills/wix-manage/references/blog/how-to-create-blog-posts.md
@@ -1,6 +1,6 @@
 ---
 name: "How to Create Blog Posts"
-description: Creates and publishes blog posts using Blog Posts API. Covers Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
+description: Creates and publishes blog posts using Blog Posts API. Covers resolving the required author memberId (including creating an author member when the site has none), Ricos rich content format, image upload via Media Manager, category/tag assignment, and bulk post creation.
 ---
 
 **Article: Create and Publish Blog Posts with Rich Content and Images**
@@ -17,16 +17,40 @@ This article demonstrates how to create and immediately publish blog posts using
 
 **IMPORTANT**: When calling the Blog API as a 3rd-party app (not as the site owner), `draftPost.memberId` is **required**. The API will reject requests with "Missing post owner information" if omitted.
 
-1. Query site members to get a valid member ID using [List Members](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/list-members):
+A `memberId` is the `id` of a **site member** (Wix Members). Only the Members API produces one. Run the two steps below in order and stop as soon as you have an id — do not go looking for an author id anywhere else (see [What is not a memberId](#what-is-not-a-memberid)).
+
+1. Query site members using [List Members](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/list-members):
 
    ```bash
    curl -X GET "https://www.wixapis.com/members/v1/members?fieldsets=PUBLIC&paging.limit=1" \
      -H "Authorization: <AUTH>"
    ```
 
-2. Use the `id` field from the response as `draftPost.memberId` when creating the blog post. This member will be the post author.
+   If the response contains a member, use `members[0].id` as `draftPost.memberId` and skip step 2. That member becomes the post author.
 
-   > **Note**: The member ID must belong to an existing site member or collaborator. If the members query returns no results, you may need to create a member first or use the site owner's member ID.
+2. **If the site has no members yet** — the response is `{"members": [], "metadata": {"count": 0, "total": 0, ...}}` — create the author member yourself with [Create Member](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/create-member). This is the normal case on a new site or a site that only has Blog installed: nobody has signed up, so there is no member to reuse. Creating the author is a prerequisite of the post the user asked for, not a separate decision — create it, then say so in your summary.
+
+   ```bash
+   curl -X POST "https://www.wixapis.com/members/v1/members" \
+     -H "Authorization: <AUTH>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "member": {
+         "loginEmail": "blogauthor@example.com",
+         "contact": { "firstName": "Blog", "lastName": "Author" }
+       }
+     }'
+   ```
+
+   Use `member.id` from the response as `draftPost.memberId`. The new member comes back with `status: "APPROVED"`, and its `profile.nickname` is derived from the contact name. That nickname is the author name the blog displays, so pass the name the user wants shown (or set `member.profile.nickname` explicitly). If the user named an author, use their name; otherwise a generic author like the example above is fine.
+
+#### What is not a memberId
+
+These are the wrong places to look, and probing them costs a round trip each:
+
+- **Site collaborators / contributors are Wix *users*, not site members.** The [Contributors API](https://dev.wix.com/docs/api-reference/account-level/user-management/sites/contributors/introduction) returns account and user ids, which the Blog API will not accept as a `memberId`.
+- **A contact is not a member.** Querying [Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/introduction) returns contact ids; only members have a `memberId`. On a site with no members the contacts query is usually empty too.
+- **`GET https://www.wixapis.com/identity/v1/users` returns 404.** There is no site-scoped identity endpoint to read the site owner from. Do not try it.
 
 ### Part 1: Import External Images to Wix Media Manager
 
@@ -264,7 +288,7 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 - Never mock blog posts or media IDs - always use the APIs to import images and create posts
 - Always read the full documentation of methods before implementation
 - External images MUST be imported via Import File API before use in blog posts - direct external URLs will not work
-- For 3rd-party app integrations, `memberId` is mandatory - use the [List Members](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/list-members) API if needed to get member ID
+- For 3rd-party app integrations, `memberId` is mandatory - get it from [List Members](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/list-members), and if the site has no members yet, create one with [Create Member](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/create-member) (see Part 0). Never substitute a contact id, a collaborator/contributor id, or a Wix user id for a `memberId`
 - Use ONLY the file ID (without `wix:image://v1/` prefix) for both cover images and embedded images
 - Rich content IMAGE nodes require both `width` and `height` properties in the `image` object
 - Images with `"operationStatus": "PENDING"` from import can be used immediately in blog posts
@@ -290,6 +314,7 @@ The natural intuition is "the bulk endpoint reuses the single-post `{draftPost: 
 | Error                                      | Cause                       | Solution                                                            |
 | ------------------------------------------ | --------------------------- | ------------------------------------------------------------------- |
 | "Missing post owner information"           | `memberId` not provided     | Add `draftPost.memberId` - see Part 0 for how to get one            |
-| "memberIds ... do not exist"               | Invalid member ID           | Query members first using List Members API to get valid IDs         |
+| "memberIds ... do not exist"               | Invalid member ID           | The id is not a site member's id (e.g. a contact, contributor, or Wix user id). Re-resolve it with Part 0 |
+| List Members returns `"total": 0`          | Site has no members yet     | Create the author member with Create Member - Part 0, step 2. Do not query contacts, contributors, or identity endpoints instead |
 | "Expected a paragraph node but found TEXT" | Invalid Ricos structure     | Wrap TEXT nodes in PARAGRAPH nodes (see structure rules above)      |
 | Image not displaying                       | Using external URL directly | Import image via Media Manager first, then use the returned file ID |

--- a/yaml/wix-manage-evals/blog/create-post-author-member-id.yml
+++ b/yaml/wix-manage-evals/blog/create-post-author-member-id.yml
@@ -1,0 +1,79 @@
+name: blog/create-post-author-member-id
+description: >-
+  Creating a blog post needs a site-member id for draftPost.memberId. On a site
+  with Blog installed and no members yet, List Members comes back empty, and the
+  recipe must send the agent straight to Create Member instead of leaving it to
+  hunt for an author id in the contributors, contacts, or identity APIs.
+triggerPrompt: >-
+  Write a blog post titled "Welcome to Our Blog" and save it as a draft.
+tags: [blog]
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: Install the Wix Blog app so the site has a blog to post to
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 14bcded7-0066-7c35-14d7-466cb3f09103
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Write a blog post titled \"Welcome to Our Blog\" and save it as a draft."
+
+      The site is freshly provisioned with only the Wix Blog app installed, so it
+      has NO site members. Creating a draft post requires `draftPost.memberId`,
+      which is the id of a Wix site member — so the agent must notice the site has
+      no members and create one with Create Member
+      (POST https://www.wixapis.com/members/v1/members), then use the returned
+      `member.id` as `draftPost.memberId`.
+
+      Judge the tool-call trace and the final answer together. Score:
+
+      - 9-10: the draft post titled "Welcome to Our Blog" was created successfully
+        (2xx), and the author id was resolved using the Members API only — a List
+        Members call (GET /members/v1/members) that came back empty, followed
+        directly by Create Member (POST /members/v1/members). No other API was
+        consulted to look for an author id.
+      - 7-8: the post was created and the author id came from the Members API, but
+        there was one extra exploratory call along the way.
+      - 3-4: the post was created, but the agent probed non-Members surfaces for an
+        author id before getting there — for example a contributors or
+        collaborators API, a Contacts query used to hunt for an author, a docs/spec
+        search for "collaborator"/"contributor", or
+        GET https://www.wixapis.com/identity/v1/users (which returns 404). Two or
+        more such probes score 3.
+      - 0-2: the draft post was not created, or the create call failed (non-2xx,
+        including "Missing post owner information", "memberIds ... do not exist",
+        app-not-installed / no blog instanceId), or the title is wrong, or the
+        agent only explained how instead of doing it, or it stopped to ask the user
+        a question instead of acting.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence naming the calls used to
+      resolve the author id>"}.
+  - type: llm_judge
+    minScore: 0
+    maxTokens: 2048
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP and its docs let the
+      agent fulfill the request. Examine the tool-call trace. Score 0-10 (10 =
+      direct: no wasted calls, no errors).
+
+      Penalize and LIST any of: a call that returned a non-2xx error even if the
+      agent recovered from it; a probing call for an author/member id outside the
+      Members API; a docs or spec search that produced nothing usable; a request
+      body shape guessed wrong then corrected. For each issue, name the likely
+      MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected
+      MCP/docs gap, or 'clean path' if none>"}.


### PR DESCRIPTION
## The defect

Measured on the aria scenario `coverage/blog-create-post` (EvalForge run `cdf3fe3c-b2ae-4e03-b206-7cb765adb801`): the outcome gate passed 10/10, but the run took **79 s** and the friction judge scored **5/10**. The agent read this recipe, then spent three extra round trips hunting for a value the recipe told it it needed but not where to get.

The recipe was the source the agent followed — its first API call carries
`sourceDocUrls: ["https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts"]`.

Part 0 said, verbatim:

> **Note**: The member ID must belong to an existing site member or collaborator. If the members query returns no results, you may need to create a member first or use the site owner's member ID.

The site (blank editor + Blog app) had no members, so `List Members` returned, verbatim from the conversation:

```json
{ "members": [], "metadata": { "count": 0, "offset": 0, "total": 0, "tooManyToCount": false } }
```

The agent then said, verbatim: *"No members exist on this site. I'll try listing collaborators to get a valid member ID, then create the draft post."* — following the recipe's own mention of "collaborator". What followed:

1. a spec search for `collaborator` / `contributor` / `member`;
2. `POST /contacts/v4/contacts/query` → `{"contacts": [], "pagingMetadata": {"total": 0}}`;
3. `GET https://www.wixapis.com/identity/v1/users` → **`Wix API error (404)`**.

Only then did it reach `POST /members/v1/members`, which returned 200 with `member.id` and `status: "APPROVED"`, and that id worked as `draftPost.memberId`. So the fix is exactly the step the recipe left out.

## The change

Part 0 is now a deterministic two-step with real endpoints:

1. `GET /members/v1/members?fieldsets=PUBLIC&paging.limit=1` — if a member comes back, use `members[0].id`.
2. If the response is empty (the normal case on a new or Blog-only site), create the author with [Create Member](https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/create-member) — `POST /members/v1/members` — and use `member.id`. The recipe tells the agent to **do this and report it**, not to stop and ask, since the author is a prerequisite of the post the user already asked for.

Plus a "What is not a memberId" list — contributors/collaborators are Wix *users*, a contact is not a member, and `GET /identity/v1/users` 404s — and two troubleshooting rows (empty `List Members`; `"memberIds ... do not exist"`).

API details verified against the generated reference via the Wix MCP docs tools (`ReadFullDocsMethodSchema` on Create Member for the endpoint, body shape and `member.id` response field; the Contributors and User Management articles for the user-vs-member distinction), and cross-checked against the request body that actually succeeded in the run.

## Routing rationale

The `memberId` prerequisite is documented correctly in each individual API reference — Blog's `draftPost.memberId` and the Members API both describe themselves accurately. What was missing is the *cross-API orchestration*: which API produces a `memberId`, and what to do when the obvious query returns nothing. That is agent-orchestration guidance the portal reference pages cannot express, and the page the agent actually read is this recipe's own `…/blog/skills/how-to-create-blog-posts` URL, whose only upstream source is `skills/wix-manage/references/blog/`. No proto comment or `developer-docs` article is wrong here, so there is nothing to fix upstream.

## Out of scope

Two of the three frictions the judge named are not fixable in this repo and are **not** addressed here:

- **`SearchWixAPISpec` crashed** with `TypeError: cannot read properties of undefined (reading 'toLowerCase')` on a filter over `lightIndex` — an MCP server defect in the Wix MCP server, not a docs or skill problem. Worth a separate issue on that repo: the tool should not throw on records whose `displayName` is undefined.
- **`GET /identity/v1/users` returning 404** was the agent guessing an endpoint, not a documented API being wrong. This PR removes the reason it went guessing; it does not change any API.

## Coverage

New scenario `blog/create-post-author-member-id` (`yaml/wix-manage-evals/blog/create-post-author-member-id.yml`), reusing the same trigger prompt and the same proven `siteSetup` bootstrap as the aria scenario that surfaced this — `blank-editor` plus the Blog app install — so `List Members` is genuinely empty and the fixed step is the one under test. It asserts `ReadFullDocsArticle` on the recipe's canonical URL, plus a gating judge that grades how the author id was resolved (Members API only = 9-10; probing contributors/contacts/identity = 3-4), plus the corpus-standard non-gating friction judge.

The gating rubric is written to fail against the current content: the run above probed three non-Members surfaces, which scores 3.

**What it does not catch:** the rubric reads the tool-call trace, and which tool the agent reaches for is not fully deterministic — an agent that happens to skip the probing on production content would pass both sides. The reliable signal for this fix is the gate's own pairwise wall-clock/token delta between PR and production content, which is why no `time_limit` is asserted (a constant threshold would gate model and provisioning latency rather than the defect). No assertion covers the `SearchWixAPISpec` crash, since that is server-side.

Scenario validated by executing this repo's own `parseScenario` from `packages/evalforge-core/src/schema.ts` over the whole `yaml/wix-manage-evals/` tree: 68 files, 68 unique names, 0 failures.

