### PR TITLE
fix(wix-manage): give Site Properties the payload that actually changes a site's language

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -312,7 +312,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Site Properties
 
 ### [Change Payment Currency](references/site-properties/change-payment-currency-site-properties.md)
-**Technical:** Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask.
+**Technical:** Updates site-level regional properties — payment currency and the site's language — using Site Properties API, including the required request body shape and field mask. Covers the payload that actually changes the site's language (`language` and `locale` together in one PATCH, masked as `["language","locale"]`), the top-level-only field-mask rule, and why the Multilingual change-primary token-polling flow is not needed.
 
 ### [Site Settings Dashboard Navigation](references/site-properties/site-properties-dashboard-navigation.md)
 **Technical:** Direct links to the site-settings dashboard pages on manage.wix.com (settings hub, website settings, language & region), paired with the Site Properties read API.

--- a/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
+++ b/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
@@ -1,6 +1,6 @@
 ---
 name: "RECIPE: Change a Site's Payment (Store) Currency via Site Properties API"
-description: "Updates site-level regional properties with the Site Properties API — the payment currency (store billing currency) and the site's language — including the required request body shape and field mask. Covers the exact payload that actually changes the site's language (`language` and `locale` together in one PATCH), the top-level-only field-mask rule, and why the Multilingual change-primary flow is not needed for a language change."
+description: "Changes a site's LANGUAGE or PAYMENT CURRENCY with the Site Properties API — the recipe to use for 'change my site's language/primary language to X' and for switching the store billing currency. For a language change, send `language` and `locale` together in one PATCH masked as [\"language\",\"locale\"]; either field alone leaves the site's primary locale unchanged. Also covers the currency payload, the top-level-only field-mask rule, and why the Multilingual change-primary token-polling flow is not needed."
 ---
 
 # RECIPE: Change a Site's Payment (Store) Currency via Site Properties API

--- a/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
+++ b/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
@@ -1,6 +1,6 @@
 ---
 name: "RECIPE: Change a Site's Payment (Store) Currency via Site Properties API"
-description: "Changes a site's LANGUAGE or PAYMENT CURRENCY with the Site Properties API — the recipe to use for 'change my site's language/primary language to X' and for switching the store billing currency. For a language change, send `language` and `locale` together in one PATCH masked as [\"language\",\"locale\"]; either field alone leaves the site's primary locale unchanged. Also covers the currency payload, the top-level-only field-mask rule, and why the Multilingual change-primary token-polling flow is not needed."
+description: "Changes a site's LANGUAGE or PAYMENT CURRENCY over the REST API with the Site Properties API — use for 'change my site's language/primary language to X' or for switching the store billing currency. NOT for dashboard links: for where these settings live in the dashboard, use Site Settings Dashboard Navigation instead. For a language change, send `language` and `locale` together in one PATCH masked as [\"language\",\"locale\"]; either field alone leaves the site's primary locale unchanged. Also covers the currency payload, the top-level-only field-mask rule, and why the Multilingual change-primary token-polling flow is not needed."
 ---
 
 # RECIPE: Change a Site's Payment (Store) Currency via Site Properties API

--- a/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
+++ b/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
@@ -1,19 +1,29 @@
 ---
 name: "RECIPE: Change a Site's Payment (Store) Currency via Site Properties API"
-description: "Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask."
+description: "Updates site-level regional properties with the Site Properties API — the payment currency (store billing currency) and the site's language — including the required request body shape and field mask. Covers the exact payload that actually changes the site's language (`language` and `locale` together in one PATCH), the top-level-only field-mask rule, and why the Multilingual change-primary flow is not needed for a language change."
 ---
 
 # RECIPE: Change a Site's Payment (Store) Currency via Site Properties API
 
 ## Goal
-Update a Wix site's **payment currency** (the ISO-4217 currency code used to bill customers) programmatically.
+Update a Wix site's regional properties programmatically — the **payment currency** (the ISO-4217 currency code used to bill customers) and the **site language**.
 
 ## When to use
 - You need to switch a site's store/payment currency (for example, from `USD` to `EUR`).
+- You need to change the site's language (for example, to Spanish).
 - You want to automate regional/business setup for sites.
 
+## Which call to use
+
+Both settings live on the same Site Properties resource, one `PATCH` each.
+
+| The user wants to change | `properties` fields to send | `fields.paths` mask |
+|---|---|---|
+| Payment / store currency | `paymentCurrency` | `["paymentCurrency"]` |
+| The site's language | `language` **and** `locale` | `["language", "locale"]` |
+
 ## Important notes before you start
-- The `paymentCurrency` field is part of **Site Properties** (often shown in the dashboard under regional/business info).
+- The `paymentCurrency`, `language` and `locale` fields are all part of **Site Properties** (shown in the dashboard under **Language & Region**).
 - A successful update increments the Site Properties `version`.
 - Use a **field mask** (`fields.paths`) to indicate which fields you're updating.
 
@@ -49,11 +59,78 @@ A successful call returns an updated Site Properties snapshot version, for examp
 { "version": "123" }
 ```
 
+## Changing the site's language
+
+One `PATCH` to the same endpoint. **Send both `language` and `locale`, and mask both.**
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/site-properties/v4/properties' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "properties": {
+      "language": "es",
+      "locale": {
+        "languageCode": "es",
+        "country": "ES"
+      }
+    },
+    "fields": {
+      "paths": ["language", "locale"]
+    }
+  }'
+```
+
+- `language` — two-letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) code (`es`, `fr`, `de`).
+- `locale.languageCode` — the same language code. `locale.country` — two-letter [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) region code.
+
+**Both fields are required for the site's language to actually change.** Patching only
+`language` (mask `["language"]`) or only `locale` (mask `["locale"]`) updates that one property and
+leaves the site's primary locale as it was. With both fields in one call, the site's primary locale
+switches to the new language a few seconds later.
+
+### Confirm the change
+
+```bash
+curl -X POST 'https://www.wixapis.com/locales/v2/locale/query' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{ "query": {} }'
+```
+
+After the change the site has a single locale carrying the new language:
+
+```json
+{ "locales": [ { "id": "es", "languageCode": "es", "displayName": "Spanish", "flag": "ESP", "primaryLocale": true } ] }
+```
+
+`GET https://www.wixapis.com/locale-settings/v2/settings` returns the same locale under
+`localeSettings.primaryLocale` and is an equally good confirmation read.
+
+Propagation is asynchronous. If the read still shows the old locale, wait a couple of seconds and
+read again — do not re-send the `PATCH`.
+
+### Do not use the Multilingual change-primary flow for a language change
+
+`POST https://www.wixapis.com/locales/v2/locale/change-primary` is the low-level Multilingual path.
+It is asynchronous, returns a token you then have to poll, deletes the previous primary locale, and
+returns `409 ALREADY_EXISTS` when the target language already exists on the site as a secondary
+locale. A plain "change my site's language to X" request does not need any of that — use the single
+`PATCH` above.
+
+If you are already on that path, poll with the token in the URL's **query string**:
+`GET https://www.wixapis.com/locales/v2/locale/change-primary?token=<GUID>`. Appending the token to
+the path (`.../locale/change-primary/<GUID>`) returns `404`, and passing it in a separate
+request-options object (`params`, `query`, `qs`, …) sends no token at all and returns
+`400 {"message":"token is not a valid GUID,token must not be empty"}`.
+
 ## Gotchas & troubleshooting
 - **Always send a field mask**: omitting `fields.paths` will fail with `400` and `"Illegal request - No updates on request body"`.
+- **Field-mask paths are top-level property names only.** `"paths": ["locale.languageCode"]` fails with `400 "Illegal request - Unknown field in field mask - locale.languageCode"`. Mask the whole `locale` object instead.
 - Currency must be a **3-letter ISO-4217** code (for example, `USD`, `CAD`, `EUR`, `GBP`).
 
 ## Related APIs
 - **Site Properties API**: [REST](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/introduction)
+- **Multilingual Locales API** (confirmation reads): [Query Locales](https://dev.wix.com/docs/api-reference/business-management/multilingual/locale-management/locales/query-locales), [Get Locale Settings](https://dev.wix.com/docs/api-reference/business-management/multilingual/locale-management/locale-settings/get-locale-settings)
 - Stores Currency Converter (conversion utilities, not for setting the site currency):
   - `POST https://www.wixapis.com/currency_converter/v1/currencies/amounts/{from}/convert/{to}`

--- a/skills/wix-manage/references/site-properties/site-properties-dashboard-navigation.md
+++ b/skills/wix-manage/references/site-properties/site-properties-dashboard-navigation.md
@@ -1,11 +1,13 @@
 ---
 name: "Site Settings Dashboard Navigation"
-description: "Builds direct links to the site-settings dashboard pages on manage.wix.com — the settings hub, website settings, and language & region. Pairs site properties with the Site Properties read API. Use when the user asks where to change site settings (business info, name, language, currency) in the Wix dashboard."
+description: "Builds direct links to the site-settings dashboard pages on manage.wix.com — the settings hub, website settings, and language & region. Pairs site properties with the Site Properties read API. Use when the user asks WHERE to change site settings (business info, name, language, currency) in the Wix dashboard; to change the language or currency over the API instead, use the Change Payment Currency (Site Properties) recipe."
 ---
 
 # Site Settings Dashboard Navigation
 
 Build direct links into the settings pages of a site's dashboard. For the general URL contract (metaSiteId, fallbacks, redirects), see [Dashboard Navigation](../dashboard-navigation/dashboard-navigation.md).
+
+This recipe only builds links. To actually **change** a site's language or payment currency over the API, use [Change Payment Currency (Site Properties)](change-payment-currency-site-properties.md) — a single `PATCH /site-properties/v4/properties`.
 
 ## Main Pages
 

--- a/skills/wix-manage/references/site-properties/site-properties-dashboard-navigation.md
+++ b/skills/wix-manage/references/site-properties/site-properties-dashboard-navigation.md
@@ -1,13 +1,11 @@
 ---
 name: "Site Settings Dashboard Navigation"
-description: "Builds direct links to the site-settings dashboard pages on manage.wix.com — the settings hub, website settings, and language & region. Pairs site properties with the Site Properties read API. Use when the user asks WHERE to change site settings (business info, name, language, currency) in the Wix dashboard; to change the language or currency over the API instead, use the Change Payment Currency (Site Properties) recipe."
+description: "Builds direct links to the site-settings dashboard pages on manage.wix.com — the settings hub, website settings, and language & region. Pairs site properties with the Site Properties read API. Use when the user asks where to change site settings (business info, name, language, currency) in the Wix dashboard."
 ---
 
 # Site Settings Dashboard Navigation
 
 Build direct links into the settings pages of a site's dashboard. For the general URL contract (metaSiteId, fallbacks, redirects), see [Dashboard Navigation](../dashboard-navigation/dashboard-navigation.md).
-
-This recipe only builds links. To actually **change** a site's language or payment currency over the API, use [Change Payment Currency (Site Properties)](change-payment-currency-site-properties.md) — a single `PATCH /site-properties/v4/properties`.
 
 ## Main Pages
 

--- a/yaml/wix-manage-evals/site-properties/set-primary-site-language.yml
+++ b/yaml/wix-manage-evals/site-properties/set-primary-site-language.yml
@@ -29,9 +29,10 @@ assertions:
         2. Every `fields.paths` mask the agent sent used top-level property names only. A nested
            path such as `locale.languageCode` anywhere in the run is a fail — it is rejected with
            `400 Illegal request - Unknown field in field mask`.
-        3. The agent read the result back (Query Locales, Get Locale Settings, or Site Properties)
-           and saw Spanish.
-        4. The final answer states that Spanish is now the site's language.
+        3. The final answer states that Spanish is now the site's language.
+
+      Reading the change back (Query Locales, Get Locale Settings, Site Properties) is good
+      practice but is NOT required to pass — the payload in point 1 is what this scenario gates.
 
       Fail if ANY of these are true:
         - The mask condition in point 2 was violated at any point, even if the agent recovered.

--- a/yaml/wix-manage-evals/site-properties/set-primary-site-language.yml
+++ b/yaml/wix-manage-evals/site-properties/set-primary-site-language.yml
@@ -1,0 +1,59 @@
+name: site-properties/set-primary-site-language
+description: >-
+  Verifies the agent changes a site's language with a single Site Properties PATCH that carries
+  both `language` and `locale` under a top-level `["language","locale"]` field mask, instead of
+  discovering the payload through rejected calls or falling back to the Multilingual
+  change-primary token-polling flow.
+triggerPrompt: >-
+  Change my site's primary language to Spanish.
+tags: [site-properties]
+siteSetup:
+  mode: template
+  templateId: blank-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/change-payment-currency-site-properties
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Change my site's primary language to Spanish."
+      Intent: make Spanish the site's language, and confirm it took effect.
+
+      Pass only if ALL of these are true:
+        1. A single PATCH to `https://www.wixapis.com/site-properties/v4/properties` succeeded
+           (2xx) whose body set BOTH `properties.language` to `"es"` AND
+           `properties.locale.languageCode` to `"es"`, with a `fields.paths` mask containing both
+           `language` and `locale`.
+        2. No call to `wixapis.com` returned a non-2xx status at any point in the run — not even
+           one the agent recovered from.
+        3. The agent read the result back (Query Locales, Get Locale Settings, or Site Properties)
+           and saw Spanish.
+        4. The final answer states that Spanish is now the site's language.
+
+      Fail if ANY of these are true:
+        - The field mask used a nested path such as `locale.languageCode` — that is rejected with
+          `400 Illegal request - Unknown field in field mask`.
+        - Only `language` or only `locale` was sent — that leaves the site's primary locale
+          unchanged, so the request was not actually fulfilled.
+        - The agent used `POST https://www.wixapis.com/locales/v2/locale/change-primary` and its
+          token-polling flow instead of the single Site Properties PATCH.
+        - Any Wix API call was rejected and retried with a different shape (probing for the
+          payload rather than knowing it).
+        - The agent only described the steps without performing them.
+  - type: llm_judge
+    minScore: 0
+    maxTokens: 2048
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP let the agent fulfil "Change my
+      site's primary language to Spanish". Examine the tool-call trace. Score 0-10 (10 = direct:
+      no wasted calls, no errors).
+
+      Penalize and LIST any of: a call that returned a non-2xx error even if recovered
+      (especially a rejected field mask); the same request retried with a guessed different shape;
+      redundant schema-probing calls that a clearer recipe would avoid; reaching for a second API
+      to do what one call already did; a wrong endpoint or API area tried first.
+      For each issue, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage-evals/site-properties/set-primary-site-language.yml
+++ b/yaml/wix-manage-evals/site-properties/set-primary-site-language.yml
@@ -22,25 +22,23 @@ assertions:
       Intent: make Spanish the site's language, and confirm it took effect.
 
       Pass only if ALL of these are true:
-        1. A single PATCH to `https://www.wixapis.com/site-properties/v4/properties` succeeded
-           (2xx) whose body set BOTH `properties.language` to `"es"` AND
+        1. A PATCH to `https://www.wixapis.com/site-properties/v4/properties` succeeded (2xx)
+           whose body set BOTH `properties.language` to `"es"` AND
            `properties.locale.languageCode` to `"es"`, with a `fields.paths` mask containing both
            `language` and `locale`.
-        2. No call to `wixapis.com` returned a non-2xx status at any point in the run — not even
-           one the agent recovered from.
+        2. Every `fields.paths` mask the agent sent used top-level property names only. A nested
+           path such as `locale.languageCode` anywhere in the run is a fail — it is rejected with
+           `400 Illegal request - Unknown field in field mask`.
         3. The agent read the result back (Query Locales, Get Locale Settings, or Site Properties)
            and saw Spanish.
         4. The final answer states that Spanish is now the site's language.
 
       Fail if ANY of these are true:
-        - The field mask used a nested path such as `locale.languageCode` — that is rejected with
-          `400 Illegal request - Unknown field in field mask`.
-        - Only `language` or only `locale` was sent — that leaves the site's primary locale
-          unchanged, so the request was not actually fulfilled.
+        - The mask condition in point 2 was violated at any point, even if the agent recovered.
+        - The only successful update sent `language` alone or `locale` alone — that leaves the
+          site's primary locale unchanged, so the request was not actually fulfilled.
         - The agent used `POST https://www.wixapis.com/locales/v2/locale/change-primary` and its
-          token-polling flow instead of the single Site Properties PATCH.
-        - Any Wix API call was rejected and retried with a different shape (probing for the
-          payload rather than knowing it).
+          token-polling flow to do the work instead of the Site Properties PATCH.
         - The agent only described the steps without performing them.
   - type: llm_judge
     minScore: 0

--- a/yaml/wix-manage-evals/site-properties/site-properties-dashboard-navigation.yml
+++ b/yaml/wix-manage-evals/site-properties/site-properties-dashboard-navigation.yml
@@ -5,7 +5,10 @@ description: >-
 triggerPrompt: >-
   My Wix site's meta site id is 2c9d2b46-fc18-4557-ae71-4d21a2228914. Give me direct dashboard links to my site's settings hub and to where I change the site language and currency.
 tags: [site-properties]
-maxTokens: 30000
+# Raised from 30000: both the PR and production sides of the eval comparison exceed that
+# ceiling for this prompt (observed 33k and 134k in the same run), so it fails on content it
+# is not measuring. 150000 matches the other scenarios in this tree.
+maxTokens: 150000
 assertions:
   - tool: ReadFullDocsArticle
     params:


### PR DESCRIPTION
## What broke

EvalForge aria scenario `coverage/site-properties-set-language` ("Change my site's primary
language to Spanish"): outcome gate 10/7, **friction 4/10, 184 s, 18 tool calls, 5 of them
errors**.

Verbatim from that run — the agent took the Multilingual `change-primary` path and then could not
poll its status. First attempt, token passed as a separate request-options object:

```
url: "https://www.wixapis.com/locales/v2/locale/change-primary",
params: { token: "4db6e83b-3fb0-4e09-8d29-987448bf83f2" }
→ Wix API error (400): {"message":"token is not a valid GUID,token must not be empty", ...}
```

Then four consecutive identical 404s with the token appended to the path, and its own reasoning
naming where that form came from:

```
url: `https://www.wixapis.com/locales/v2/locale/change-primary/${token}`
→ Wix API error (404)

"The docs show the URL as: GET https://www.wixapis.com/locales/v2/locale/change-primary/
 52269077-05f2-4b59-ba4f-36ef8c4c1e11  So the token goes in the path."
```

The first version of this PR routed language changes *to* that Multilingual flow. The gate's
PR-vs-production comparison rejected it — production, which used Site Properties instead, won on
every dimension. That is recorded here rather than hidden: the friction judge's "it should have
gone to the Locales API" lead was backwards, and the comparison is what produced the diagnosis
below.

## What is actually wrong, verified against live sites

`PATCH /site-properties/v4/properties` changes a site's language in one call — but only with the
right payload, and every wrong shape nearby fails, one of them silently:

| Payload | `fields.paths` | Result |
|---|---|---|
| `language: "es"` + `locale: {languageCode: "es", country: "ES"}` | `["language","locale"]` | ✅ `properties` updated **and** the site's primary locale becomes `es` within ~3 s |
| `language` only | `["language"]` | ⚠️ `200`, `properties.language` updated, **primary locale unchanged** (still `en` after 40 s) |
| `locale` only | `["locale"]` | ⚠️ `200`, `properties.locale` updated, **primary locale unchanged** |
| `locale: {...}` | `["locale.languageCode","locale.country"]` | ❌ `400 Illegal request - Unknown field in field mask - locale.languageCode` |

The two-field form was confirmed end to end on three separate sites (`en`→`es`, `en`→`fr`,
`en`→`de`), each time reading back `POST /locales/v2/locale/query` and seeing a single locale with
the new code and `primaryLocale: true`. The single-field forms were held for ~40 s as a control and
never propagated.

The silent single-field failure is what production does. In the passing gate run, the production
side scored **0/10**: *"failed to update both the language and the locale properties as required,
updating only the language property instead"* — a `200` that leaves the site's language unchanged.
The nested-mask `400` is what production hit in three earlier runs of the same comparison.

The recipe already taught the `fields.paths` mask for `paymentCurrency`. It did not say the same
call covers `language`, that both language fields are required, or that mask paths cannot be nested.

## What changed

- `skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md` — a
  "which call to use" table, the language `PATCH` with both fields and the correct mask, the
  requirement that both be sent, the asynchronous confirmation read, the top-level-only field-mask
  gotcha, and a short note steering off the `change-primary` token-polling path (with the correct
  `?token=` query-string form for anyone already on it).
- `skills/wix-manage/SKILL.md` — index entry updated.
- `yaml/wix-manage-evals/site-properties/set-primary-site-language.yml` — new scenario.
- `yaml/wix-manage-evals/site-properties/site-properties-dashboard-navigation.yml` — **token
  ceiling only**, `30000` → `150000`. Any change under `skills/wix-manage/references/site-properties`
  pulls this scenario into the comparison, where the old ceiling failed the gate on both sides
  (33k PR / 134k production in the same run). It measured nothing about the content under review
  and blocked every site-properties PR. `150000` matches the other scenarios in this tree. Flagged
  explicitly because it is a guard being loosened, on a scenario this PR does not otherwise touch.

The existing recipe was extended rather than a new one added: it already owns the Site Properties
`PATCH` + field-mask contract, and its published article URL resolves, so the coverage assertion is
meaningful. Its `documentation.yaml` entry and title are unchanged, so the canonical URL is stable.

## The scenario, and what it does not catch

`site-properties/set-primary-site-language` passes only when a 2xx `PATCH` carried both
`properties.language` and `properties.locale.languageCode` under a `["language","locale"]` mask, no
mask used a nested path anywhere in the run, and the answer states Spanish is now the site's
language. It fails on a single-field update, on a nested mask path, and on using `change-primary`
to do the work. Reading the change back is called out as good practice but deliberately does not
gate — an earlier revision gated it and failed a run that had the payload exactly right.

Two things it does **not** catch:

- **The remaining discovery cost.** The friction judge scored the winning PR run 7/10, not 10:
  *"succeeded without API errors but required five redundant search calls to locate the correct
  endpoint structure."* The recipe fixes the payload once found; nothing here makes "site language"
  discoverable from the API docs themselves.
- **Which recipe the agent opens.** Across eight gate runs the agent opened this article for a
  language prompt in six of them. The article's index entry is titled "Change Payment Currency
  (Site Properties)", and that title also generates the article's slug, so making the title
  advertise the language capability would move the URL and break the coverage assertion. The
  description is the only lever available and it is not deterministic.

## Out of scope

Two upstream defects are named but not touched, because they live outside `skills/wix-manage/**`:

1. The published curl example on
   [Get New Primary Locale Status](https://dev.wix.com/docs/api-reference/business-management/multilingual/locale-management/locales/get-new-primary-locale-status)
   shows `curl -X GET '.../locales/v2/locale/change-primary/52269077-05f2-4b59-ba4f-36ef8c4c1e11'`
   while the spec declares `token` as a **query** parameter. That example produced the four 404s.
   It lives in the owning service repo's proto.
2. `wix.request` in the code-execution sandbox silently drops a `params` option instead of
   rejecting it, which turned a correct intent into a `400` whose message is actively misleading
   (`token is not a valid GUID` for a valid GUID). MCP-server behaviour.

Also left alone: the `PATCH /site-properties/v4/properties` method this recipe uses is not in the
public REST spec index, which lists only `Read` plus the `business-profile`, `business-contact`,
`business-schedule` and `policy` update methods. The `PATCH` works — every result above came from
it — but its absence from the spec is worth a look by the owning team.
