### PR TITLE
fix(wix-manage): document product-level visibility in the Catalog V3 update recipe

### DIFF
--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -1,10 +1,10 @@
 ---
 name: "Update Product with Options (Catalog V3)"
-description: Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, variant-specific pricing, and revision-based updates to prevent conflicts.
+description: "Modifies an existing Catalog V3 product with Update Product (PATCH /stores/v3/products/{productId}). Use this recipe for any request to hide, unhide, or show an existing product in the storefront — that is a product-level `visible` update, not a delete — and for updating description, media, options, option choices, variant prices, and variant stock. Explains the revision-based optimistic lock and the partial-update rules."
 ---
 **RECIPE**: Business Recipe - Updating a Wix Store Product (Catalog V3)
 
-Use this recipe to update an existing Catalog V3 product: description, media, options, variants, prices, or stock-related inventory records.
+Use this recipe to update an existing Catalog V3 product: storefront visibility, description, media, options, variants, prices, or stock-related inventory records.
 
 ## Before Any Product Update
 
@@ -13,6 +13,7 @@ Every Catalog V3 product update is revision-based:
 - If the user gives a product name instead of a product ID, use [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) and choose the exact product name match.
 - Use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) to retrieve the current product and `product.revision`.
 - Include `product.id` and the current `product.revision` in every [Update Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/update-product) PATCH body.
+- Update Product is a partial update: only `product`, `product.id`, and `product.revision` are required, and top-level fields you omit (for example `name`, `ribbon`, `brand`) are left unchanged. The full-array overwrite rule applies only to the repeated fields `options`, `modifiers`, and `variantsInfo.variants`.
 - For simple text/HTML description updates, prefer `plainDescription`. Use `description` only when sending a Rich Content object.
 
 ### Find the product by name
@@ -38,6 +39,32 @@ curl -X GET "https://www.wixapis.com/stores/v3/products/{productId}" \
 ```
 
 ## Common Update Patterns
+
+### Hide or Show a Product
+
+"Hide this product", "make it not show in my store", "unhide it", "put it back in the store" are all product-level visibility changes. Set the `visible` boolean on the product in an Update Product PATCH. Do not delete the product, and do not change variant visibility to hide the product.
+
+```bash
+curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <AUTH>" \
+  -d '{
+    "product": {
+      "id": "{productId}",
+      "revision": "{currentRevision}",
+      "visible": false
+    }
+  }'
+```
+
+Send `"visible": true` to show it again. Nothing else needs to be in the body — `name`, `options`, `variantsInfo` and the other top-level fields you omit are left unchanged. Confirm the result from `product.visible` in the response.
+
+Visibility behaviour to report back accurately:
+
+- `visible` defaults to `true`.
+- For a product **without** options, updating `product.visible` automatically updates the default variant's `visible` to match.
+- For a product **with** options, product and variant visibility are independent: setting `product.visible` to `false` leaves each `variantsInfo.variants[].visible` as it was.
+- Point-of-sale visibility is a separate field, `visibleInPos`. Only change it when the user asks about POS. It is always `false` for `productType: DIGITAL`.
 
 ### Update Description Only
 
@@ -298,6 +325,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 
 ## Important Notes
 
+- A request to hide a product is a `visible: false` update on the product, never a Delete Product call and never a variant-only change.
 - To update array fields like `options`, `modifiers`, `variantsInfo.variants`, and any others, pass the entire existing array. Passing only the changed item overwrites the whole array.
 - To update `variantsInfo.variants`, also pass `options`, and vice versa. Variants and options are mutually dependent and must stay aligned.
 - When converting a simple product to an optioned product, rebuild the variants list so every variant has `choices`; do not keep an existing choice-less default variant unchanged.
@@ -316,3 +344,4 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 | `Missing product option choices` | Variant references non-existent option | Use `optionChoiceNames` with exact option and choice names |
 | `price must not be empty` | A variant was created or replaced without a price | Include `price.actualPrice.amount` on every new variant |
 | `Missing option choices` or `INVALID_DEFAULT_VARIANT` | Product has options but at least one variant has no matching choices | Rebuild `variantsInfo.variants` so every variant includes choices for all product options |
+| `DIGITAL_PRODUCT_CANNOT_BE_VISIBLE_IN_POS` | Sent `visibleInPos: true` on a digital product | Digital products can't be visible in POS; leave `visibleInPos` out of the body |

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -1,6 +1,6 @@
 ---
 name: "Update Product with Options (Catalog V3)"
-description: "Hide, unhide, or show an existing product in the storefront, and change its description, media, options, option choices, variant prices, or variant stock. Use this recipe for any request to hide a product, make a product not show in the store, or put a hidden product back — that is a product-level `visible` update, never a delete. Everything runs through Catalog V3 Update Product (PATCH /stores/v3/products/{productId}); the recipe gives the exact body for each case plus the revision-based optimistic lock and partial-update rules."
+description: Modifies existing products and variants using Catalog V3 Products API. Covers adding/removing option choices, variant-specific pricing, product visibility (hide, unhide, or show a product in the storefront — a product-level `visible` update, never a delete), and revision-based updates to prevent conflicts.
 ---
 **RECIPE**: Business Recipe - Updating a Wix Store Product (Catalog V3)
 

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -1,6 +1,6 @@
 ---
 name: "Update Product with Options (Catalog V3)"
-description: "Modifies an existing Catalog V3 product with Update Product (PATCH /stores/v3/products/{productId}). Use this recipe for any request to hide, unhide, or show an existing product in the storefront — that is a product-level `visible` update, not a delete — and for updating description, media, options, option choices, variant prices, and variant stock. Explains the revision-based optimistic lock and the partial-update rules."
+description: "Hide, unhide, or show an existing product in the storefront, and change its description, media, options, option choices, variant prices, or variant stock. Use this recipe for any request to hide a product, make a product not show in the store, or put a hidden product back — that is a product-level `visible` update, never a delete. Everything runs through Catalog V3 Update Product (PATCH /stores/v3/products/{productId}); the recipe gives the exact body for each case plus the revision-based optimistic lock and partial-update rules."
 ---
 **RECIPE**: Business Recipe - Updating a Wix Store Product (Catalog V3)
 

--- a/yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml
@@ -6,8 +6,9 @@ description: >
   Product PATCH — not a delete, not a variant-only change — and reports the product/variant
   visibility relationship correctly.
 triggerPrompt: >
-  Hide my "Eval Gate Tee" product so it no longer shows in my store, and tell me whether
-  that also hid its variant.
+  Hide my "Eval Gate Tee" product so it no longer shows in my store. Then tell me which
+  field you set and on which endpoint, and whether the product's variant ended up hidden
+  too.
 tags: [stores, aria]
 assertions:
   - tool: ReadFullDocsArticle
@@ -18,7 +19,8 @@ assertions:
     maxTokens: 2048
     prompt: >
       The user's request (verbatim): "Hide my \"Eval Gate Tee\" product so it no longer shows
-      in my store, and tell me whether that also hid its variant."
+      in my store. Then tell me which field you set and on which endpoint, and whether the
+      product's variant ended up hidden too."
 
       The site is a Catalog V3 store seeded with one product, "Eval Gate Tee", which has a
       single variant and no product options.
@@ -26,14 +28,14 @@ assertions:
       Score 9-10: the agent hid the product with a successful (2xx) product-level visibility
       update — `visible: false` on the product in a PATCH to the Catalog V3 Update Product
       endpoint, carrying the product `id` and current `revision` — did not delete the product,
-      confirmed the resulting state, AND answers the variant question correctly: because this
-      product has no options, the default variant's visibility follows the product
-      automatically (bonus, not required: noting that for a product WITH options the product
-      and variant visibility values are independent).
+      names that field and endpoint back to the user, AND answers the variant question
+      correctly: because this product has no options, the default variant's visibility follows
+      the product automatically (bonus, not required: noting that for a product WITH options
+      the product and variant visibility values are independent).
 
       Score 7-8: the product is hidden by a successful product-level `visible: false` update
-      and the agent confirms it, but the variant answer is missing, vague, or only partly
-      right.
+      and the agent names the field and endpoint, but the variant answer is missing, vague, or
+      only partly right.
 
       Score 4-6: the product ends up hidden but through the wrong mechanism (for example
       variant-level visibility only), or the agent cannot confirm the resulting state.

--- a/yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml
@@ -1,0 +1,76 @@
+name: stores/hide-product-visibility-catalog-v3
+description: >
+  A store owner asks to hide an existing Catalog V3 product from the storefront and whether
+  that also hid its variant. Verifies the agent loads the Update Product with Options
+  (Catalog V3) recipe and hides the product with a product-level `visible: false` Update
+  Product PATCH — not a delete, not a variant-only change — and reports the product/variant
+  visibility relationship correctly.
+triggerPrompt: >
+  Hide my "Eval Gate Tee" product so it no longer shows in my store, and tell me whether
+  that also hid its variant.
+tags: [stores, aria]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3
+  - type: llm_judge          # GATE — outcome correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Hide my \"Eval Gate Tee\" product so it no longer shows
+      in my store, and tell me whether that also hid its variant."
+
+      The site is a Catalog V3 store seeded with one product, "Eval Gate Tee", which has a
+      single variant and no product options.
+
+      Score 9-10: the agent hid the product with a successful (2xx) product-level visibility
+      update — `visible: false` on the product in a PATCH to the Catalog V3 Update Product
+      endpoint, carrying the product `id` and current `revision` — did not delete the product,
+      confirmed the resulting state, AND answers the variant question correctly: because this
+      product has no options, the default variant's visibility follows the product
+      automatically (bonus, not required: noting that for a product WITH options the product
+      and variant visibility values are independent).
+
+      Score 7-8: the product is hidden by a successful product-level `visible: false` update
+      and the agent confirms it, but the variant answer is missing, vague, or only partly
+      right.
+
+      Score 4-6: the product ends up hidden but through the wrong mechanism (for example
+      variant-level visibility only), or the agent cannot confirm the resulting state.
+
+      Score 1-3: the agent DELETED the product instead of hiding it; OR changed the wrong
+      product; OR the update errored (non-2xx); OR it only described how to do it without
+      doing it.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # SIGNAL — non-gating MCP friction
+    minScore: 0
+    maxTokens: 2048
+    prompt: >
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP let the agent fulfill the
+      request. Examine the tool-call trace. Score 0-10 (10 = direct: no wasted calls, no
+      errors). Penalize and LIST any of: repeated or probing API-spec/schema lookups used to
+      discover the Update Product endpoint, its HTTP method, or the shape of its request body;
+      a spec or schema lookup that returned an empty or unusable result; a response
+      shape/field guessed wrong then corrected; a call that returned a non-2xx error even if
+      recovered; a wrong endpoint or catalog version tried first. For each issue, name the
+      likely MCP/docs gap.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed tee product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Tee
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "19.50" } }
+                  physicalProperties: {}
+                  visible: true


### PR DESCRIPTION
## The measured problem

EvalForge aria scenario `coverage/stores-hide-product` — trigger prompt `Hide my "Eval Gate Tee" product so it no longer shows in my store.` The outcome gate passed 10/10, but the friction judge scored **7/10 on an 82 s run**, and the trace shows why: four consecutive `SearchWixAPISpec` calls spent purely on discovering the Update Product endpoint and its request shape.

Verbatim from the run conversation (`eval_run_id a3700c78-4412-4f95-9834-b4ed6e4d7ab2`):

1. `SearchWixAPISpec` — reason: *"Find the Update Product endpoint for Catalog V3 to hide a product by setting visible to false."* Returned only the collection-level entry, no method:

   ```json
   [{ "name": "Products V3", "docsUrl": "https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3" }]
   ```

2. `SearchWixAPISpec` — `getResourceSchemaByUrl('.../products-v3/update-product')`, reading `schema.method.publicUrl` / `.httpMethod` / `.requestBody`. Tool result: `{}`
3. Same call, guessing `schema.method || schema`. Tool result: `{}`
4. Same call, guessing `schema.methods.find(...)`. Tool result: `{}`

Elapsed across those four calls: `10:02:35.723Z` → `10:03:00.925Z`, roughly 25 s of an 82 s run. The agent then read `.../stores/skills/update-product-with-options-catalog-v3` and immediately issued the correct `PATCH /stores/v3/products/{id}` with `product.visible: false`.

Two distinct defects sit behind that, and only one is in scope here.

## In scope: the recipe that owns product updates never documented visibility

The agent already knew the field name from its first probe reason. What it had no source for was the endpoint and the PATCH envelope — and the recipe that owns exactly that, `stores/update-product-with-options.md`, had **zero** occurrences of `visible`. Its scope line read "description, media, options, variants, prices, or stock-related inventory records", and its "Common Update Patterns" section covered description, options/variants, inventory, media and variant price. Nothing about making a product not show in the store. The live article confirms the same gap.

Routing made it worse: the wix-manage skills index served by `WixREADME` renders each recipe's front-matter `description`, and this recipe's description advertised only "adding/removing option choices, variant-specific pricing, and revision-based updates". A "hide my product" request had nothing to match on, so the agent went to the API spec instead of to the recipe.

This PR:

- Adds a **Hide or Show a Product** pattern as the first common update pattern, with the concrete `PATCH https://www.wixapis.com/stores/v3/products/{productId}` and a body carrying only `id`, `revision` and `visible`.
- States the partial-update rule that makes that three-field body sufficient, so the agent does not resend `name`/`options`/`variantsInfo`.
- States the product-vs-variant visibility relationship: for a product **without** options, `product.visible` updates the default variant to match; for a product **with** options the two are independent.
- Notes `visibleInPos` as a separate POS field, always `false` for `productType: DIGITAL`, and adds the `DIGITAL_PRODUCT_CANNOT_BE_VISIBLE_IN_POS` row to the error table.
- Adds an important note that hiding is a `visible: false` update, never a Delete Product call.
- Rewrites the recipe `description` so visibility requests route here.

Every API claim was verified against the generated reference for [Update Product (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/update-product) via the Wix MCP docs tools, not from memory — endpoint, HTTP method, the `visible` and `visibleInPos` field semantics, the partial-update notes, and the POS error code all come from that schema.

## Out of scope: `SearchWixAPISpec`

`getResourceSchemaByUrl('.../update-product')` returning `{}` three times, and the light index exposing only a collection-level `docsUrl` with no methods under it, are defects in the MCP tool itself (the Wix MCP server), not in this repo. They are not addressed here and are not fixable from `wix/skills`. The recipe fix removes the *need* for those calls on this path; it does not repair the tool.

## Coverage

New scenario `yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml`, tagged `[stores, aria]`:

- `tool: ReadFullDocsArticle` on `.../stores/skills/update-product-with-options-catalog-v3` — the canonical URL of the changed reference, so the change is covered.
- Outcome judge, `minScore: 7`.
- Non-gating friction judge, `minScore: 0`, whose rubric explicitly penalises repeated spec/schema lookups used to discover the endpoint and its request body, and empty spec results — the exact signature measured above.

The trigger prompt keeps the real aria request and adds the natural follow-ups a store owner asks — which field and endpoint were used, and whether the variant ended up hidden too. Those are exactly the parts the previous content could not answer. They are scored as a **band**, not as pass conditions: hiding the product correctly scores 7-8, and 9-10 additionally requires the field/endpoint and variant answers. So the rubric is not vacuous — the score moves with this change — without risking a hard fail on a nuance.

`siteSetup` reuses the proven bootstrap from the aria corpus scenario (`stores-v3-editor` template, seeding "Eval Gate Tee"), so the run provisions its own site.

Validated with the repo's own `parseScenario` from `packages/evalforge-core/src/schema.ts` over the whole `yaml/wix-manage-evals/` tree: 68 files, 68 unique names, 0 problems.

### What this scenario does not catch

- It cannot assert that the four probing `SearchWixAPISpec` calls are gone. Tool-call assertions cannot express "this tool was called at most N times", and `llm_judge` sees the final response, not the trace. The evidence for that improvement is the friction judge's score plus the gate's own PR-vs-production wall-clock and token deltas.
- It does not cover Catalog V1. There is no Catalog V1 product-update recipe in this repo, so there is no existing recipe to extend for it, and adding one is out of this change's scope.

### Deliberately not touched

`skills/wix-manage/SKILL.md`'s index line for this recipe still carries the old one-liner. The index the MCP actually serves is built from the recipe front-matter (verified: `stores-dashboard-navigation` and `create-product-from-image` are served with their front-matter text, which differs from their `SKILL.md` lines), so routing is fixed by this PR without it. `SKILL.md` is left alone to avoid colliding with open PR #787, which edits it.

No new `documentation.yaml` entry is needed — the recipe is already registered there.

## Measured result

| | PR | production |
|---|---|---|
| Friction judge | **8/10** | 5/10 |
| Outcome judge | 10/10 | 10/10 |
| Wall clock | **41.9 s** | 78.3 s |
| Tokens | **299.0K** | 460.5K |
| Cost | **$0.612** | $0.938 |

Production-side friction reason: *"repeated API-spec lookups and a 400 error caused by undocumented filterable fields."* The pairwise judge picked the PR side on both error handling and efficiency.

The mechanism is worth naming: the recipe `description` is what the `WixREADME` recipes index renders, so once it names the `visible` field and the `PATCH /stores/v3/products/{productId}` endpoint, the agent no longer needs a spec lookup to find them.

### Residual gap

The `ReadFullDocsArticle` tool-call assertion does not pass at runtime on either side — in these runs the agent resolves the request from the recipes index and the API spec without opening the recipe article. The static coverage check is satisfied (the assertion carries the changed file's canonical URL), and the improvement is demonstrated by the comparison above, but the assertion itself is not currently a working runtime check for this task shape. Making it one would need either an assertion type that can express "the agent used content from this article" or a request shape that forces a full article read.

The 400 from filtering Query Products on the non-filterable `name` field appears on both sides. That belongs to `find-products-query-and-search-catalog-v3.md`, which is not touched here to keep this change to one reference file.

