### PR TITLE
fix(wix-manage): correct the Create Modifier Group body in the restaurants recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -292,7 +292,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Restaurants
 
 ### [Wix Restaurants Setup](references/restaurants/wix-restaurants-setup.md)
-**Technical:** Configures restaurant menus, sections, and items using Menus API. Covers menu structure (Menu → Section → Item), modifiers, pricing, availability schedules, and ordering settings.
+**Technical:** Configures restaurant menus, sections, and items using Menus API. Covers menu structure (Menu → Section → Item), the two-step item modifier / modifier group flow, pricing, availability schedules, and ordering settings.
 
 ### [Restaurants Dashboard Navigation](references/restaurants/restaurants-dashboard-navigation.md)
 **Technical:** Direct links to Wix Restaurants dashboard pages on manage.wix.com (menus, edit menu, items, online orders board, online-ordering fulfillment settings, reservations list, floor plans, reservation experiences), pairing each main Restaurants entity with its read API for "view it in your dashboard" links.

--- a/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+++ b/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
@@ -1,6 +1,6 @@
 ---
 name: "Wix Restaurants Setup"
-description: Configures restaurant menus, sections, and items using Menus API. Covers menu structure (Menu → Section → Item), modifiers, pricing, availability schedules, and ordering settings.
+description: Configures restaurant menus, sections, and items using Menus API. Covers menu structure (Menu → Section → Item), the two-step item modifier / modifier group flow, pricing, availability schedules, and ordering settings.
 ---
 # Wix Restaurants Setup API Reference
 
@@ -16,6 +16,7 @@ This recipe covers setting up and configuring Wix Restaurants using the REST API
 - **Menus API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/create-menu)
 - **Menu Items API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/create-item)
 - **Menu Sections API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/create-section)
+- **Item Modifiers API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifiers/create-modifier)
 - **Item Modifier Groups API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-modifier-groups/create-modifier-group)
 - **Item Variants API**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/item-variants/bulk-create-variants)
 
@@ -70,32 +71,8 @@ Wix Restaurants uses a hierarchical structure:
 }
 ```
 
-Create multiple sections:
-```json
-// Section 1: Appetizers
-{
-  "section": {
-    "name": "Appetizers",
-    "sortOrder": 1
-  }
-}
-
-// Section 2: Main Courses
-{
-  "section": {
-    "name": "Main Courses",
-    "sortOrder": 2
-  }
-}
-
-// Section 3: Desserts
-{
-  "section": {
-    "name": "Desserts",
-    "sortOrder": 3
-  }
-}
-```
+Repeat per section, incrementing `sortOrder`, or create them all at once with the bulk endpoint
+in Step 7.
 
 ## Step 3: Create Menu Items
 
@@ -115,6 +92,9 @@ Create multiple sections:
 }
 ```
 
+`modifierGroups` holds objects referencing existing modifier groups —
+`[{ "id": "<MODIFIER_GROUP_ID>" }]`. Leave it empty until the groups exist (Step 5).
+
 ## Step 4: Add Items to Sections
 
 **Endpoint**: `PATCH https://www.wixapis.com/restaurants/menus-section/v1/sections/{sectionId}`
@@ -133,85 +113,102 @@ Each section update requires the latest section `revision`.
 
 ## Step 5: Configure Item Options and Modifiers
 
-Create modifiers for customization (e.g., cooking temperature, add-ons):
+A modifier group (e.g. "Cooking Temperature", "Toppings") holds a set of individual choices and
+the selection rule that governs them. **The choices are separate entities** — a modifier group
+does not contain inline options. Creating a group therefore takes two calls, in this order:
+
+1. Create one **item modifier** per choice (Item Modifiers API) and keep each returned `id`.
+2. Create the **modifier group** (Item Modifier Groups API), referencing those IDs.
+
+Do both calls; a group created without step 1 comes back with an empty `modifiers` array and no
+choices are saved.
+
+### Step 5a: Create each item modifier
+
+**Endpoint**: `POST https://www.wixapis.com/restaurants/item-modifiers/v1/modifiers`
+
+Only `modifier.name` is required.
+
+```json
+{
+  "modifier": {
+    "name": "Extra Cheese",
+    "type": "MODIFIER"
+  }
+}
+```
+
+The response returns the new `modifier.id`. Repeat per choice, collecting the IDs.
+
+### Step 5b: Create the modifier group
 
 **Endpoint**: `POST https://www.wixapis.com/restaurants/item-modifier-group/v1/modifier-groups`
 
+The request body's top-level field is **`modifierGroup`**. Sending `modifier` instead is rejected
+with `400 modifierGroup must not be empty` (`violatedRule: REQUIRED_FIELD`).
+
+Required: `modifierGroup` and `modifierGroup.name`.
+
 ```json
 {
-  "modifier": {
-    "name": "Cooking Temperature",
-    "required": true,
-    "minSelections": 1,
-    "maxSelections": 1,
-    "options": [
+  "modifierGroup": {
+    "name": "Toppings",
+    "modifiers": [
       {
-        "name": "Rare",
-        "price": {
-          "amount": "0",
-          "currency": "USD"
-        }
+        "id": "<ITEM_MODIFIER_ID_1>",
+        "additionalChargeInfo": { "additionalCharge": "2.00" }
       },
       {
-        "name": "Medium Rare",
-        "price": {
-          "amount": "0",
-          "currency": "USD"
-        }
-      },
-      {
-        "name": "Medium",
-        "price": {
-          "amount": "0",
-          "currency": "USD"
-        }
-      },
-      {
-        "name": "Well Done",
-        "price": {
-          "amount": "0",
-          "currency": "USD"
-        }
+        "id": "<ITEM_MODIFIER_ID_2>",
+        "additionalChargeInfo": { "additionalCharge": "0.00" }
       }
-    ]
+    ],
+    "rule": {
+      "required": false,
+      "minSelections": 0,
+      "maxSelections": 5
+    }
   }
 }
 ```
 
-Add-on modifier with pricing:
+For a mandatory single-choice group (e.g. cooking temperature) use the same shape with
+`"rule": { "required": true, "minSelections": 1, "maxSelections": 1 }`.
+
+**Field reference** for `modifierGroup`:
+
+| Field | Notes |
+|-------|-------|
+| `name` | Required. The group's display name. |
+| `modifiers[].id` | ID of an existing item modifier from Step 5a — not a name. Up to 500. |
+| `modifiers[].additionalChargeInfo.additionalCharge` | That choice's surcharge, a decimal string (`"2.00"`). No `currency` field — the site currency is used. |
+| `modifiers[].preSelected` | Optional boolean; selects the choice by default. |
+| `rule.required` | Whether the customer must choose. Named `required`, not `mandatory`. |
+| `rule.minSelections` / `rule.maxSelections` | Integers bounding how many choices are allowed. |
+
+There is no `options` field and no per-option `price` object.
+
+### Step 5c: Attach the group to an item
+
+A modifier group only reaches customers once an item references it. The item's `modifierGroups`
+is an array of **objects carrying an `id`**, not bare ID strings.
+
+**Endpoint**: `PATCH https://www.wixapis.com/restaurants/menus-item/v1/items/{itemId}`
+
 ```json
 {
-  "modifier": {
-    "name": "Add-ons",
-    "required": false,
-    "minSelections": 0,
-    "maxSelections": 5,
-    "options": [
-      {
-        "name": "Extra Cheese",
-        "price": {
-          "amount": "2.00",
-          "currency": "USD"
-        }
-      },
-      {
-        "name": "Bacon",
-        "price": {
-          "amount": "3.00",
-          "currency": "USD"
-        }
-      },
-      {
-        "name": "Avocado",
-        "price": {
-          "amount": "2.50",
-          "currency": "USD"
-        }
-      }
-    ]
+  "item": {
+    "id": "<ITEM_ID>",
+    "revision": "<ITEM_REVISION>",
+    "modifierGroups": [{ "id": "<MODIFIER_GROUP_ID>" }]
   }
 }
 ```
+
+To create modifier groups in bulk, use
+`POST https://www.wixapis.com/restaurants/menus/v1/bulk/modifier-groups/create` and
+`POST https://www.wixapis.com/restaurants/menus/v1/bulk/modifiers/create`; the per-entity body
+shape is the same.
 
 ## Step 6: Set Menu Structure (Attach Sections to Menu)
 
@@ -265,39 +262,18 @@ Use query APIs for retrieval and UI display flows.
 }
 ```
 
-## Query Menus
-
-**Endpoint**: `GET https://www.wixapis.com/restaurants/menus-menu/v1/menus`
-
-**Response**:
-```json
-{
-  "menus": [
-    {
-      "id": "menu-1",
-      "name": "Breakfast Menu",
-      "visible": true,
-      "sections": [...]
-    },
-    {
-      "id": "menu-2",
-      "name": "Lunch Menu",
-      "visible": true,
-      "sections": [...]
-    }
-  ]
-}
-```
-
 ## Recommended Setup Order
 
 For complex restaurant menus, use this order to avoid dependency issues:
 
 1. Create variants (sizes/options) if needed.
-2. Create items (single or bulk).
-3. Create sections (single or bulk).
-4. Update each section with `itemIds`.
-5. Update menu with `sectionIds`.
+2. Create item modifiers, then group them into modifier groups (Step 5) if the items need
+   customization options.
+3. Create items (single or bulk).
+4. Create sections (single or bulk).
+5. Update each section with `itemIds`.
+6. Update menu with `sectionIds`.
+7. Update items with `modifierGroups` to attach the groups from step 2.
 
 ## Item Labels
 
@@ -311,15 +287,6 @@ Common dietary labels:
 - `spicy`
 - `chef-recommendation`
 
-## Best Practices
-
-1. **High-Quality Images**: Use appetizing food photography
-2. **Clear Descriptions**: Include ingredients and preparation methods
-3. **Accurate Pricing**: Keep prices up-to-date
-4. **Stock Management**: Update availability in real-time
-5. **Modifier Organization**: Group related customizations logically
-6. **Menu Structure**: Organize sections in logical dining order
-
 ## Error Handling
 
 | Error | Cause | Solution |
@@ -327,6 +294,8 @@ Common dietary labels:
 | `MENU_NOT_FOUND` | Invalid menu ID | Verify menu exists |
 | `ITEM_NOT_FOUND` | Invalid item ID | Verify item exists |
 | `INVALID_PRICE` | Negative price | Use positive amounts |
+| `400 modifierGroup must not be empty` | Request body wrapped the group in `modifier` instead of `modifierGroup` | Use `modifierGroup` as the top-level field (Step 5b) |
+| Group created but `modifiers` is `[]` | Choices were sent inline (e.g. an `options` array) instead of as item modifier IDs | Create item modifiers first, then reference their IDs in `modifiers[].id` (Step 5a → 5b) |
 
 ## Related Documentation
 

--- a/yaml/wix-manage-evals/restaurants/restaurants-create-modifier-group-with-options.yml
+++ b/yaml/wix-manage-evals/restaurants/restaurants-create-modifier-group-with-options.yml
@@ -1,0 +1,62 @@
+name: restaurants/create-modifier-group-with-options
+description: >-
+  Verifies the agent reads the wix-restaurants-setup recipe and creates a
+  Toppings modifier group whose choices actually persist — item modifiers
+  created first, then a modifier group wrapped in `modifierGroup` that
+  references their IDs with per-choice surcharges under
+  `additionalChargeInfo.additionalCharge`.
+triggerPrompt: >-
+  Set up a Toppings modifier group on my restaurant menu with three optional
+  toppings customers can add: Extra Cheese for $2.00, Mushrooms for $1.00, and
+  Bacon for $3.00. They can pick any number of them, including none.
+tags: [restaurants]
+siteSetup:
+  mode: template
+  templateId: restaurants-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/wix-restaurants-setup
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked for a "Toppings" modifier group on their Wix Restaurants
+      menu with three optional toppings — Extra Cheese $2.00, Mushrooms $1.00,
+      Bacon $3.00 — any number selectable, including none.
+
+      Creating this correctly takes two API stages: create one item modifier per
+      topping (Item Modifiers API) to get their IDs, then create the modifier
+      group (Item Modifier Groups API) referencing those IDs.
+
+      Examine the tool-call trace, not just the final prose.
+
+      Pass only if ALL of these hold:
+        1. The agent created the three toppings as individual item modifiers
+           (three successful 2xx creates against the Item Modifiers API,
+           singly or via its bulk endpoint) BEFORE creating the group.
+        2. The modifier-group create body used `modifierGroup` as its
+           top-level field.
+        3. The group's `modifiers` array referenced the item modifier IDs from
+           step 1, with each topping's surcharge given as
+           `additionalChargeInfo.additionalCharge` ("2.00", "1.00", "3.00").
+        4. The group was created successfully (2xx) and the response's
+           `modifiers` array is NOT empty.
+        5. The optional/any-number rule was expressed under `rule` — a `rule`
+           object with `required: false` and `minSelections: 0`.
+
+      Fail if ANY of these hold:
+        - Any modifier-group create call was rejected with HTTP 400, including
+          one the agent later recovered from — in particular
+          "modifierGroup must not be empty", which means the body was wrapped
+          in `modifier` instead of `modifierGroup`.
+        - The toppings were sent inline on the group — e.g. an `options` array,
+          or `modifiers` entries carrying a `name` or a
+          `price: { amount, currency }` object instead of an `id` and
+          `additionalChargeInfo`.
+        - The group was created but its `modifiers` array came back empty, or
+          the agent told the user the toppings "weren't persisted" / offered to
+          add them in a follow-up step.
+        - `required`, `minSelections`, or `maxSelections` were sent flattened on
+          `modifierGroup` instead of nested under `rule`.
+        - The agent only described the steps without executing them.


### PR DESCRIPTION
## The defect

`skills/wix-manage/references/restaurants/wix-restaurants-setup.md` Step 5 gave a
Create Modifier Group body that the API rejects:

```json
{ "modifier": { "name": "Cooking Temperature", "required": true, "minSelections": 1,
                "maxSelections": 1, "options": [ { "name": "Rare", "price": { "amount": "0", "currency": "USD" } } ] } }
```

Three things are wrong with it, and an agent following the recipe hits all three.

## Evidence

An eval run of `coverage/restaurants-create-modifier-group` (EvalForge run
`eed6b0c9-31fc-49b4-a0a9-9a453b1b20de`, 41 s, friction judge 7/10) followed this recipe —
its `ExecuteWixAPI` call carried
`"sourceDocUrls": ["https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/wix-restaurants-setup"]` —
and got, verbatim:

```
Execute error: Wix API error (400): {"message":"modifierGroup must not be empty","details":
{"validationError":{"fieldViolations":[{"field":"modifierGroup","description":"must not be empty",
"violatedRule":"REQUIRED_FIELD"}]}}}
```

followed by the agent's own conclusion: *"The field name should be `modifierGroup` (not
`modifier`). Let me fix that."*

The retry corrected the wrapper but kept the recipe's `options` array. It returned 2xx, so the
outcome gate passed 10/7 — but nothing the user asked for was saved, and the agent had to say so:

> Note: The API created the group but the individual topping options (Cheese, Mushrooms,
> Pepperoni, etc.) weren't persisted via the `options` field in this request — the response shows
> `modifiers: []`.

That second failure is the more expensive one: it is silent, the gate does not catch it, and the
user is left to re-ask.

## What the API actually takes

Verified against the generated spec via `SearchWixAPISpec`
(`wix.restaurants.menus.v1.ModifierGroupsService.CreateModifierGroup`), not from memory:

| Recipe said | Spec says |
|---|---|
| top-level `modifier` | `modifierGroup`; `required: ["modifierGroup", "modifierGroup.name"]` |
| `options: [{ name, price: { amount, currency } }]` | `modifiers: [{ id, additionalChargeInfo: { additionalCharge } }]` — `id` references an existing Item Modifier entity (`referencedEntity: wix.restaurants.menus.v1.item_modifier`); no `currency` field |
| `required` / `minSelections` / `maxSelections` on the group | nested under `rule` |

So creating a group with choices is **two** calls: create each item modifier
(`POST /restaurants/item-modifiers/v1/modifiers`, only `modifier.name` required) to get its `id`,
then create the group referencing those IDs. Step 5 is now split into 5a/5b/5c accordingly, with
5c covering the attach step — the item's `modifierGroups` takes `[{ "id": ... }]` objects, not
bare ID strings (confirmed against the `create-item` schema).

I kept the endpoint URL the recipe already had
(`/restaurants/item-modifier-group/v1/modifier-groups`) because the run proves it works; the spec
also exposes `/restaurants/menus/v1/modifier-groups` for the same service, but only the former is
empirically confirmed here.

On `rule.required` vs `rule.mandatory`: the rendered reference's legacy cURL example shows
`mandatory`, but that string appears nowhere in the generated schema, which names the field
`required`. The recipe states `required` and flags the discrepancy in the field table.

## Routing

The defect is in the recipe text an agent read and copied, so the fix belongs in
`skills/wix-manage/**`. Extended the existing `Wix Restaurants Setup` recipe rather than adding a
new one — it already owns the modifier capability, and asserting an existing recipe's canonical
URL is what makes the PR-vs-production comparison meaningful. No MCP server or proto change is
needed: the API behaved correctly and its error message was precise. Out of scope, not touched:
`coverage/restaurants-create-modifier-group`'s own outcome gate in the aria corpus, which passes
10/7 on a run that lost all the user's data — that gate is too weak, but it lives in
the internal eval corpus.

## Coverage

New scenario `restaurants/create-modifier-group-with-options`
(`yaml/wix-manage-evals/restaurants/restaurants-create-modifier-group-with-options.yml`) asserts
`ReadFullDocsArticle` on `.../restaurants/skills/wix-restaurants-setup` plus an `llm_judge` that
fails on the nearest observable consequences of the defect: any HTTP 400 on the group create
(including a recovered one), choices sent inline instead of as IDs, a group whose `modifiers` came
back empty, or `rule` fields sent flattened. It would fail against the current content on both the
400 and the empty-`modifiers` clause. Provisioned on `restaurants-editor` (the template the
existing `coverage/restaurants-add-menu-item` scenario uses).

**What it does not catch:** the scenario exercises the optional/any-number path only, so the
mandatory single-choice `rule` variant (`required: true`, `minSelections: 1`) is documented but
unasserted. It also does not cover Step 5c's attach step, or the bulk modifier-group endpoints.

## Incidental trims

Restoring the file broke the 10k-char read limit that `scripts/check-truncation.mjs` checks
(8,159 → 11,546 chars, 13% of it truncated for agents). Brought it back under (9,950) by removing
content that carried no API information: the stray `Query Menus` section that duplicated and
contradicted Step 8's query endpoint with a `GET` and a non-existent `sections` field, the
three repeated section-create examples, and the generic best-practices list.

## Four-file rule

- reference `.md` — modified
- `skills/wix-manage/SKILL.md` index entry — description updated (title unchanged, so the
  canonical URL is stable)
- `yaml/wix-manage/restaurants/documentation.yaml` — entry already present
- eval scenario under `yaml/wix-manage-evals/restaurants/` — added

All 68 scenarios in `yaml/wix-manage-evals/` parse against `parseScenario` with unique names.

