### PR TITLE
fix(wix-manage): resolve a contact label's display name to its key before tagging

### DIFF
--- a/skills/wix-manage/references/contacts/bulk-label-and-unlabel-contacts.md
+++ b/skills/wix-manage/references/contacts/bulk-label-and-unlabel-contacts.md
@@ -17,6 +17,76 @@ The job's status can be retrieved with [Get Bulk Job](https://dev.wix.com/docs/a
 
 **IMPORTANT NOTE:** When specific contacts are to be labeled, they should be filtered by id.
 
+## Resolve the label key before labeling
+
+`labelKeysToAdd` and `labelKeysToRemove` take label **keys**, not display names. A user asking to
+apply a label names it the way they see it in the dashboard ("VIP Customer"), so the display name
+has to be resolved to a key first.
+
+**Never derive the key from the display name.** A key is assigned when the label is created and
+[can't be changed afterwards](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/introduction),
+while [Update Label](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/update-label)
+renames the `displayName` — so a renamed label still carries a key derived from its original name,
+and the two do not have to correspond. Keys are also namespaced: user-defined labels sit under
+`custom.` (`custom.my-label`), system-defined ones under other namespaces
+(`contacts.contacted-me`). Always read the key out of an API response.
+
+### Adding a label: Find Or Create Label
+
+[Find Or Create Label](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/find-or-create-label)
+takes a display name and returns the label, "or creates one if it doesn't exist". One call resolves
+the key whether or not the label is already on the site, so use it for any request that adds a
+label. Do not list every label to search for a match, and do not stop to ask whether to create a
+missing label — apply the label the user asked for.
+
+`POST https://www.wixapis.com/contacts/v4/labels`
+
+```bash
+curl -X POST 'https://www.wixapis.com/contacts/v4/labels' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  --data-binary '{ "displayName": "VIP Customer" }'
+```
+
+```json
+{
+  "label": {
+    "key": "custom.vip-customer",
+    "displayName": "VIP Customer",
+    "labelType": "USER_DEFINED"
+  },
+  "newLabel": true
+}
+```
+
+Pass `label.key` to `labelKeysToAdd`. `newLabel` reports whether the label already existed, so use
+it to tell the user whether the label was created and applied or an existing one was applied.
+Requires `CONTACTS_LABELS.MODIFY`.
+
+### Removing a label: look it up without creating it
+
+Find Or Create Label would create the label being removed, so for `labelKeysToRemove` resolve the
+key read-only instead. `displayName` supports `$eq` on
+[Query Labels](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/query-labels):
+
+```bash
+curl -X POST 'https://www.wixapis.com/contacts/v4/labels/query' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  --data-binary '{ "query": { "filter": { "displayName": { "$eq": "VIP Customer" } } } }'
+```
+
+An empty `labels` array means no such label exists, so there is nothing to remove — say so rather
+than creating it. Requires `CONTACTS_LABELS.VIEW`.
+
+Two other read-only options:
+[Get Label](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/get-label)
+(`GET /contacts/v4/labels/{key}`) when the key is already known, and
+[List Labels](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/list-labels)
+(`GET /contacts/v4/labels`), which accepts `?startsWith=` to return only labels whose display names
+start with a string, and `?labelType=USER_DEFINED` to exclude system labels. Prefer the filtered
+query over listing every label on the site.
+
 ## API Endpoint
 `POST https://www.wixapis.com/contacts/v4/bulk/contacts/add-remove-labels`
 
@@ -58,10 +128,15 @@ The response includes a `jobId` which can be used to track the bulk job status:
 Use the [Get Bulk Job](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job) endpoint to check the job status.
 
 ## Permissions Required
-- `CONTACTS.MODIFY`
+- `CONTACTS.MODIFY` — the bulk label/unlabel call
+- `CONTACTS_LABELS.MODIFY` — Find Or Create Label
+- `CONTACTS_LABELS.VIEW` — Query Labels, Get Label, List Labels
 
 ## Related Documentation
 - [Bulk Label And Unlabel Contacts API Reference](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/bulk-label-and-unlabel-contacts)
 - [Query Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/contact-v4/query-contacts)
 - [Get Bulk Job](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts/bulk-job/get-bulk-job)
 - [Labels API Reference](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/introduction)
+- [Find Or Create Label](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/find-or-create-label)
+- [Query Labels](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/query-labels)
+- [Contact Labels: Supported Filters and Sorting](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/labels/sort-and-filter)

--- a/yaml/wix-manage-evals/contacts/tag-contact-resolve-label-key.yml
+++ b/yaml/wix-manage-evals/contacts/tag-contact-resolve-label-key.yml
@@ -1,0 +1,188 @@
+---
+name: contacts/tag-contact-resolve-label-key
+description: >-
+  Verifies the agent reads the bulk-label-and-unlabel-contacts recipe and completes a
+  labeling request stated the only way a user can state it — by the label's display name.
+  The bulk endpoint takes label keys, so the display name "VIP Customer" has to be resolved
+  to a key first. The site holds 24 other labels and no "VIP Customer", so scanning every
+  label finds nothing and the agent has to create the label and read its key back rather
+  than reporting the label missing or asking whether to create it.
+triggerPrompt: >-
+  Tag my contact Jordan Lee with the VIP Customer label.
+tags: [contacts]
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      # A realistic label set, so resolving one display name is a real lookup rather than a
+      # one-item list. None of these is "VIP Customer", and none contains "VIP" or
+      # "Customer", so a display-name scan has no near-miss to latch onto and the requested
+      # label genuinely does not exist yet.
+      - label: seed label Newsletter Subscriber
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Newsletter Subscriber }
+      - label: seed label Wholesale Buyer
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Wholesale Buyer }
+      - label: seed label Trade Account
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Trade Account }
+      - label: seed label Returning Buyer
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Returning Buyer }
+      - label: seed label First Time Buyer
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: First Time Buyer }
+      - label: seed label Abandoned Cart
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Abandoned Cart }
+      - label: seed label Local Pickup
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Local Pickup }
+      - label: seed label Gift Card Holder
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Gift Card Holder }
+      - label: seed label Loyalty Member
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Loyalty Member }
+      - label: seed label Workshop Attendee
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Workshop Attendee }
+      - label: seed label Trade Show Lead
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Trade Show Lead }
+      - label: seed label Referral Partner
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Referral Partner }
+      - label: seed label Press Contact
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Press Contact }
+      - label: seed label Supplier
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Supplier }
+      - label: seed label Bulk Order
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Bulk Order }
+      - label: seed label Corporate Account
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Corporate Account }
+      - label: seed label Student Discount
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Student Discount }
+      - label: seed label Senior Discount
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Senior Discount }
+      - label: seed label Seasonal Shopper
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Seasonal Shopper }
+      - label: seed label Online Only
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Online Only }
+      - label: seed label In Store Only
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: In Store Only }
+      - label: seed label Waitlist
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Waitlist }
+      - label: seed label Review Left
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Review Left }
+      - label: seed label Support Escalation
+        method: post
+        url: https://www.wixapis.com/contacts/v4/labels
+        body: { displayName: Support Escalation }
+      - label: seed the target contact Jordan Lee
+        method: post
+        url: https://www.wixapis.com/contacts/v5/contacts
+        body:
+          contact:
+            name:
+              first: Jordan
+              last: Lee
+            email:
+              email: jordan.lee@example.com
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/bulk-label-and-unlabel-contacts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Tag my contact Jordan Lee with the VIP Customer
+      label."
+
+      Site state: the contact Jordan Lee exists. 24 contact labels exist, but none of them
+      is named "VIP Customer" — that label does not exist on the site yet. The user named
+      the label the only way they can, by the display name they would see in the dashboard.
+      The Contacts labeling endpoints address labels by *key*, not by display name, so the
+      agent has to obtain a key before it can label anyone.
+
+      Pass only if the tool-call trace shows the agent:
+      - obtained a label key for "VIP Customer" by reading it out of a Wix API response —
+        creating the label is the correct action here, and Find Or Create Label
+        (POST /contacts/v4/labels with {"displayName": "VIP Customer"}) does this in one
+        call; any successful (2xx) call that returns the label and its key is acceptable,
+        AND
+      - issued a successful (2xx) call that applied that label key to the contact Jordan
+        Lee (via Bulk Label And Unlabel Contacts with labelKeysToAdd, or Label Contact with
+        labelKeys — either is fine), AND
+      - confirmed the completed result in its final answer, referring to what the API
+        actually returned rather than to what the API would do.
+
+      Fail if the response:
+      - reports that the "VIP Customer" label does not exist and stops there, OR
+      - stops to ask whether to create the label, which label to use, or whether to
+        proceed, instead of applying the label the user named, OR
+      - passed the display name "VIP Customer" where a label key is required, OR
+      - used a label key it did not read back from an API response — for example guessing
+        "custom.vip-customer" from the display name, or reusing one of the 24 unrelated
+        seeded labels, OR
+      - applied the label to a different contact, OR
+      - left the labeling call erroring (non-2xx) at the end of the run, OR
+      - only explains how to resolve a label key and label a contact, or hands back
+        curl/API instructions, without actually performing the change, OR
+      - claims the contact was labeled with no successful labeling call in the trace.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge
+    minScore: 0
+    maxTokens: 2048
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP let the agent fulfill the
+      request. Examine the tool-call trace. Score 0-10 (10 = direct: no wasted calls, no
+      errors).
+
+      Penalize and LIST any of: a call that returned a non-2xx error even if recovered;
+      listing or paging every label on the site to hunt for one display name, where a
+      single documented call resolves it; a probing call that clearer docs would avoid; a
+      request shape or field guessed wrong then corrected (display name passed as a key,
+      labelKeys vs labelKeysToAdd); a wrong endpoint or API tried first; a dead end at the
+      point where the requested label turned out not to exist. For each issue, name the
+      likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.


### PR DESCRIPTION
> **Reopened.** This was closed because the eval comparison returned `not-required`. That was the
> wrong reason to drop it: `not-required` means the gate could not *measure* the change, not that the
> defect is imaginary. The friction is real and reproducible, the content below is verified against
> the generated reference, and the corpus scenario that surfaced it explicitly penalises this exact
> gap. What is true is that **this fix is not demonstrable through the gate** — see "Why the gate
> cannot score this" below. Reviewing it on merit rather than on the verdict.

## Closing: the eval comparison shows this change is not needed

Opened from a measured friction finding, then closed on the strength of what the gate's own
pairwise comparison measured. Recording the evidence here so the next person does not redo it.

### The original finding

A recorded run transcript for a labeling request ("Tag my contact Jordan Lee with the VIP Customer
label") showed the agent read this recipe, then had to spend an extra call listing every label on
the site to turn the display name "VIP Customer" into the key `custom.vip-customer`, because
`labelKeysToAdd` takes keys and this recipe never said how to obtain one. The outcome was correct;
the friction score was 8/10.

### What the comparison actually measured

The gate ran the scenario against this branch's content and against live content. Result:
**`not-required`** — the change is not needed for the scenario to pass.

| | this branch | live content |
| --- | --- | --- |
| Outcome judge | **10**/7 | **10**/7 |
| Friction judge (non-gating) | 7 | 6 |
| Tokens | 626,270 | 516,301 |
| Wall clock | 76.9 s | 60.1 s |
| `ReadFullDocsArticle` on this recipe | **not called** | **not called** |

Three findings, in order of how much they matter:

1. **Neither run read this recipe.** Both went `WixREADME` → `SearchWixAPISpec` and resolved the
   API from the spec index, never loading a recipe at all. The doc-coverage assertion therefore
   failed on *both* sides. Whatever this branch says, no run in the comparison could see it — so
   the scenario measures nothing about the change.
2. **Live content already gets the right answer.** Both sides scored 10/10: each discovered Find Or
   Create Label unaided and applied the resolved key successfully. There is no wrong result for a
   fix to correct.
3. **The efficiency delta runs the wrong way and is noise.** This branch was 22 % slower and used
   18 % more tokens, and the pairwise judge picked live content as the winner. With the recipe
   unread on both sides, that spread is pure exploration variance, not an effect of the change.

A friction finding where production already produces the correct result can only earn `required`
through a large efficiency delta, and that delta is run-to-run noise. This one is squarely in that
category, so the honest call is not to ship it.

### The residual friction is real, but it is not in this repo

Both runs did hit friction — just not friction this recipe can fix:

- **Create Label body nesting.** This branch's run got a 400 on step 8 by sending
  `{ "label": { "displayName": … } }`; the endpoint wants `displayName` at the top level. That is a
  request-shape ambiguity on the Labels reference.
- **Spec-search probing.** The live-content run spent seven `SearchWixAPISpec` calls locating
  endpoints and schemas, two of which errored outright.

Both live in the Wix MCP server and the generated API reference, not in this repo, so they are out
of scope here and are reported separately rather than papered over in a recipe.

### A structural note for anyone editing this recipe next

The gate requires every changed `.md` to be covered by a scenario asserting its canonical URL via a
`ReadFullDocsArticle` tool-call assertion. The gate's agent currently resolves contacts-labeling
requests through the API spec index and never calls `ReadFullDocsArticle`, so that assertion fails
on both sides no matter what the recipe says. Until the agent reads recipes for this request again,
**a change to this file cannot be demonstrated through this gate** — which is the second reason this
PR is being closed rather than reworked.

### What was verified and is worth keeping if anyone wants it

The API facts below were confirmed against the generated Labels reference and are correct
independently of the eval result, in case someone wants to land the documentation on its own merits:

- **Find Or Create Label** — `POST /contacts/v4/labels`, body `{"displayName": "…"}` (top level, not
  nested), returns `label.key` plus `newLabel`. Its reference states it "Retrieves a label with a
  specified name, or creates one if it doesn't exist", so it resolves a key in one call whether or
  not the label exists. Requires `CONTACTS_LABELS.MODIFY`.
- **Query Labels** — `POST /contacts/v4/labels/query` filtering `displayName: {"$eq": "…"}` is the
  read-only lookup to use when removing a label, since Find Or Create Label would create the label
  being removed. `displayName` is confirmed `$eq`-filterable by *Contact Labels: Supported Filters
  and Sorting*. Requires `CONTACTS_LABELS.VIEW`.
- **A key must never be derived from a display name.** The Labels introduction states "Label keys
  can't be changed once created", while Update Label renames `displayName` — so a renamed label
  keeps a key derived from its original name and the two can diverge. Keys are namespaced:
  `custom.*` for user-defined labels, other namespaces (e.g. `contacts.contacted-me`) for
  system-defined ones.

No merge, no review requested.



## Why the gate cannot score this

Recorded plainly so nobody re-litigates it from the verdict alone:

- **Production already produces the right answer.** Both sides scored 10/10 — each discovered Find Or
  Create Label unaided. There is no wrong result for a decision assertion to catch, and a wrong
  result is the only route to `required` that reproduces.
- **Neither side opened the recipe.** The doc-read assertion failed on the PR side *and* on
  production: both went `WixREADME` → spec search → execute. So no edit to this file could have
  changed either run. The nightly sweep run *did* read it, which is why the finding exists at all.
- **The efficiency delta runs backwards** — the PR side measured slower and more expensive on the run
  in question. With the recipe unread on both sides that is exploration variance, not an effect of
  this change.

So the honest claim is narrow: the label-key resolution step is real, the guidance is correct, and it
should help an agent that reads this recipe. It has not been shown to help one, and this gate cannot
show it.
