### PR TITLE
fix(wix-manage): carry the product-removal endpoints in the Catalog V3 find-products recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -357,7 +357,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 **Technical:** Single product creation with options using Catalog V3 Products API. Covers option types (TEXT_CHOICES, SWATCH_CHOICES), choice configuration, and automatic variant generation.
 
 ### [Find Products (Query and Search, Catalog V3)](references/stores/find-products-query-and-search-catalog-v3.md)
-**Technical:** Find, search, query, and list products from a Wix Store using Catalog V3 Search Products and Query Products endpoints. Explains when to use each endpoint, correct fields enum values, filtering, sorting, and paging.
+**Technical:** Find, search, query, and list products from a Wix Store using Catalog V3 Search Products and Query Products endpoints. Explains when to use each endpoint, correct fields enum values, filtering, sorting, and paging. Also covers resolving a product name to its product ID for a follow-up write, and the removal endpoints to call next when the user asks to remove or delete a product by name.
 
 ### [Query Products (Catalog V1)](references/stores/query-products-catalog-v1.md)
 **Technical:** Query and list products from a Wix Store using the Catalog V1 Query Products endpoint. Use this recipe when the site's catalog version is CATALOG_V1. Covers basic queries, filtering, sorting, and paging.

--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -1,6 +1,6 @@
 ---
 name: "Find Products (Query and Search, Catalog V3)"
-description: Find, search, query, and list products from a Wix Store using Catalog V3 Search Products and Query Products endpoints. Explains when to use each endpoint, correct fields enum values, filtering, sorting, and paging.
+description: Find, search, query, and list products from a Wix Store using Catalog V3 Search Products and Query Products endpoints. Explains when to use each endpoint, correct fields enum values, filtering, sorting, and paging. Also covers resolving a product name to its product ID for a follow-up write, and the removal endpoints to call next when the user asks to remove or delete a product by name.
 ---
 
 # RECIPE: Business Recipe – Find Products in a Wix Store (Query and Search, Catalog V3)
@@ -19,6 +19,7 @@ Use **Search Products** for text search and name-based lookup. Use **Query Produ
 | List all products or page through the catalog | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Supports paging and structured filters on the fields listed below. |
 | Filter by `id`, `slug`, `handle`, dates, or `visible` | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Best for exact structured criteria. |
 | Need exact name matching after text lookup | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) + client-side match | Search by the name text, then match the returned `product.name` in your own code. |
+| Remove, delete, or hide a product the user named | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) first, then the write in [After the lookup](#after-the-lookup-acting-on-the-product-you-found) | Every product write takes a product ID, so the name lookup always comes first. Do not stop at the lookup — carry out the write in the same task. |
 
 ### STEP 1: Search products by name or free text
 
@@ -36,6 +37,27 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/search' \
 ```
 
 For exact name matching, search with the user-provided text and then compare the returned `product.name` values in your own code.
+
+#### Return only the fields you need when you are resolving a name to an ID
+
+Search Products returns **every default field of every match** — media, variants, price ranges, inventory, categories. A single product runs to dozens or hundreds of lines of JSON depending on its media and variants, and the search is fuzzy, so a query for one product name commonly matches several others. Returned raw from a sandboxed execution, that response can exceed the tool response size limit and be truncated — cutting off the very `id` you were looking for.
+
+When the goal is a product ID for a follow-up write, reduce the response to `id` and `name` **before returning it**:
+
+```js
+async function() {
+  const { products } = await wix.request({
+    method: 'POST',
+    url: 'https://www.wixapis.com/stores/v3/products/search',
+    siteId: '<SITE_ID>',
+    body: { search: { expression: 'Blue Shirt' } },
+  });
+  // Return the minimum you need — never the raw product objects.
+  return products.map(p => ({ id: p.id, name: p.name, visible: p.visible }));
+}
+```
+
+Then pick the product whose `name` matches what the user asked for, and use its `id` in the write.
 
 ### STEP 2: Query products with structured filters, sorting, or paging
 
@@ -182,6 +204,54 @@ Check the response `pagingMetadata` to determine if more pages exist.
 
 ---
 
+## After the lookup: acting on the product you found
+
+Every Catalog V3 product write is keyed by **product ID**, and neither Search nor Query accepts a name as an exact filter (`name` is not in the filterable list in STEP 4). So a request that names a product is always a two-call flow: look the name up, then write with the ID. Once you have the ID, go straight to the write — the request shapes below are complete, and no further schema lookup is needed.
+
+**Catalog V3 has no "archive" operation for products.** "Removing" a product means one of exactly two different things, and the user's wording tells you which:
+
+| The user says | What they mean | Do this |
+| ------------- | -------------- | ------- |
+| remove, delete, get rid of, take it out of my store/catalog | Permanent deletion | **Delete Product** — below |
+| hide, unpublish, take it off the storefront, stop showing it to shoppers | Keep the product, stop displaying it | Set `visible: false` — see [Update Product with Options (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3) |
+
+Match the request to a row and carry that operation out — a user who names a product and asks for it to be removed has already authorised the change, so do not stop to re-confirm. Do confirm the list first when the request is a broad clear-out that would delete products the user never named. The API exposes no restore or undelete for a deleted product, so mention that deletion is permanent when you report back.
+
+### Delete one product
+
+**Endpoint:** `DELETE https://www.wixapis.com/stores/v3/products/{productId}` — takes no request body.
+
+```bash
+curl -X DELETE 'https://www.wixapis.com/stores/v3/products/PRODUCT_ID' \
+-H 'Authorization: <AUTH>'
+```
+
+A 2xx response with an empty body means the product was deleted.
+
+### Delete several products at once
+
+**Endpoint:** `POST https://www.wixapis.com/stores/v3/bulk/products/delete`
+
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v3/bulk/products/delete' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "productIds": [
+    "product-id-1",
+    "product-id-2"
+  ]
+}'
+```
+
+`productIds` is required, 1–100 IDs per request. The response carries a per-product `results[].itemMetadata.success` plus `bulkActionMetadata.totalSuccesses` / `totalFailures` — a 200 does **not** mean every ID succeeded, so check them.
+
+### Deleting everything that matches a filter
+
+`POST https://www.wixapis.com/stores/v3/bulk/products/delete-by-filter` takes a required `filter` (plus an optional fuzzy `search`) and returns only a `jobId` to poll via [Get Async Job](https://dev.wix.com/docs/api-reference/business-management/async-job/introduction) — the deletion is asynchronous, so nothing is confirmed by the response itself. It deletes **every** match, and search matching is fuzzy, so never use it to satisfy a request about one named product; resolve that product's ID and use Delete Product instead. Reserve delete-by-filter for an explicit bulk clear-out.
+
+---
+
 ## Important Notes
 
 - **Variant data is NOT returned** by Query Products. To get variant details, use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) for individual products.
@@ -191,4 +261,4 @@ Check the response `pagingMetadata` to determine if more pages exist.
 
 ## Conclusion
 
-To find products by name or free text, use `POST https://www.wixapis.com/stores/v3/products/search`. To list, page, sort, or structurally filter products, use `POST https://www.wixapis.com/stores/v3/products/query`. Use `fields: []` for defaults, or pass valid enum values like `DESCRIPTION`, `URL`, `ALL_CATEGORIES_INFO` for additional data. Never pass property names as field values.
+To find products by name or free text, use `POST https://www.wixapis.com/stores/v3/products/search`. To list, page, sort, or structurally filter products, use `POST https://www.wixapis.com/stores/v3/products/query`. Use `fields: []` for defaults, or pass valid enum values like `DESCRIPTION`, `URL`, `ALL_CATEGORIES_INFO` for additional data. Never pass property names as field values. When the lookup exists to feed a write, reduce the response to the fields you need and then act on the ID: `DELETE https://www.wixapis.com/stores/v3/products/{productId}` to remove a product, or `visible: false` to hide one.

--- a/yaml/wix-manage-evals/stores/remove-product-by-name-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/remove-product-by-name-catalog-v3.yml
@@ -1,0 +1,143 @@
+# A merchant naming one product to remove. The catalog is seeded with sibling products that share
+# the "Eval Gate" prefix so the fuzzy name search returns several full product objects — that makes
+# both frictions this scenario targets expensive: an oversized search response, and the absence of
+# the removal endpoint from the recipe that owns the name lookup.
+name: stores/remove-product-by-name-catalog-v3
+description: >
+  A store owner asks to remove one product, naming it. Catalog V3 keys every product write by
+  product ID and cannot filter by name, so the agent must resolve the name to an ID and then
+  delete by ID. Expected: the agent loads the Find Products (Catalog V3) recipe, resolves
+  "Eval Gate Mug" to its ID, and deletes that product with a successful call — without a
+  separate API-spec lookup to discover the delete endpoint, and without the raw search response
+  being truncated. Anti-patterns: deleting or hiding the wrong product; hiding instead of
+  deleting; describing the steps without doing them.
+triggerPrompt: >
+  Remove my "Eval Gate Mug" product from the store.
+tags: [stores]
+assertions:
+  # Coverage + routing: the recipe that owns the name lookup is also the one that must carry the
+  # removal endpoint, so the whole flow is one article read.
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3
+
+  # DISCRIMINATOR: with the delete endpoint absent from the recipe, the agent has to probe the API
+  # spec to find it. With it documented, the recipe alone is enough.
+  - tool: SearchWixAPISpec
+    negate: true
+
+  - type: llm_judge          # GATE — outcome correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Remove my \"Eval Gate Mug\" product from the store."
+      The store also contains "Eval Gate Tote", "Eval Gate Cap", "Eval Gate Poster",
+      "Eval Gate Notebook" and "Eval Gate Sticker Pack", which must be left alone.
+
+      Pass only if the trace shows the agent (a) resolved the name "Eval Gate Mug" to a
+      product ID, and (b) deleted that product via a successful (2xx) Wix Stores Catalog V3
+      call — DELETE on the product ID, or a bulk delete carrying only that product's ID —
+      and confirmed the removal.
+
+      Fail if the agent deleted or modified any of the other "Eval Gate" products; OR merely
+      hid the product (set it not visible) instead of deleting it; OR the delete call errored
+      (non-2xx); OR it only described how to remove the product without doing it.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+
+  - type: llm_judge          # SIGNAL — non-gating MCP friction
+    minScore: 0
+    maxTokens: 2048
+    prompt: >
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP and its docs let the agent
+      fulfil the request. Examine the tool-call trace. Score 0-10 (10 = direct: no wasted
+      calls, no errors, no truncated responses). Penalize and LIST any of: a tool response
+      that came back truncated or over its size limit because the call returned more data
+      than was needed; a call made only to discover an endpoint, URL, or request shape that a
+      recipe should already have supplied; a call that returned a non-2xx error even if
+      recovered; a response shape or field guessed wrong then corrected; a wrong endpoint or
+      catalog version tried first. For each issue, name the likely MCP/docs gap.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed target mug product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Mug
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed decoy tote
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Tote
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "24.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed decoy cap
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Cap
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "18.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed decoy poster
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Poster
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "9.50" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed decoy notebook
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Notebook
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "14.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed decoy sticker pack
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Sticker Pack
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "6.00" } }
+                  physicalProperties: {}
+                  visible: true


### PR DESCRIPTION
## What this fixes

A merchant asking to remove one product by name costs the agent two avoidable round-trips, because the recipe that owns the name lookup stops at the lookup.

Measured on EvalForge scenario `coverage/stores-archive-product` (run `f7ea29ef-a3ff-4e79-9b24-bd12989dcfc6`, Sonnet 4.6, 47 s wall-clock, friction judge 8/10 — outcome gate passed 10/7). Trigger prompt: *"Remove my Eval Gate Mug product from the store."* The agent loaded **Find Products (Query and Search, Catalog V3)**, searched by name, and then had to go looking for the delete endpoint on its own:

```
{"role": "assistant", "content": [{"type": "tool_use",
  "input": {"code": "async function() {\n  const results = lightIndex.filter(r => r.docsUrl && r.docsUrl.includes('stores') && r.methods);\n  const deleteMethods = [];\n ... }",
            "reason": "Find the delete product endpoint for Catalog V3."},
  "toolName": "mcp__wix-mcp-remote__SearchWixAPISpec"}]}
```

A second, separate friction in the same run: the name→id search returned the raw product objects and blew the tool response limit —

```
--- TRUNCATED ---
Response was ~17,504 tokens (limit: 6,000). Refine your code to return less data.
```

Both are gaps in the one recipe the agent already loads, so both are fixed there.

## What "archive"/"remove" actually maps to

Verified against the generated Catalog V3 reference through the Wix MCP docs tools (`SearchWixAPISpec` over `lightIndex`, `ReadFullDocsMethodSchema`), not from memory:

- **There is no archive operation for products.** Sweeping all 390 indexed resources for `archive`/`unarchive`/`restore`/`undelete`/`trash` returns nothing for Stores.
- There is no product-level visibility endpoint either — `UpdateCategoryVisibility` exists for *categories* only. Hiding a product is the `visible` field on the product entity.
- So "remove" resolves to exactly two distinct operations, and the recipe now routes on the merchant's wording:
  - **delete** → `DELETE https://www.wixapis.com/stores/v3/products/{productId}` (`wix.stores.catalog.v3.CatalogApi.DeleteProduct`, no request body) — this is what the run did and what the outcome judge scored 10.
  - **hide** → `visible: false`, cross-linked to the existing Update Product with Options recipe.
- `BulkDeleteProducts` → `POST /stores/v3/bulk/products/delete`, body `{"productIds": [...]}`, 1–100 ids, per-item `results[].itemMetadata.success` (a 200 is not per-item success).
- `BulkDeleteProductsByFilter` → `POST /stores/v3/bulk/products/delete-by-filter` does accept a fuzzy `search.expression`, so the friction judge's "there is no delete-by-query/name endpoint" is not quite right — but it is asynchronous (returns only a `jobId`) and deletes *every* match, so it is documented with an explicit warning against using it for a single named product.

The residual name→id round-trip is inherent: `name` is not in `QueryProducts`' filterable set, so an id is genuinely required. That call is not what this PR removes.

## Changes

- `skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md`
  - new **After the lookup: acting on the product you found** section — the delete/hide decision table keyed on the merchant's wording, `DELETE /stores/v3/products/{productId}`, `POST /stores/v3/bulk/products/delete`, and the delete-by-filter caveat.
  - new **Return only the fields you need when you are resolving a name to an ID** subsection — projects the search response down to `id`/`name` so it cannot be truncated.
  - routing row in STEP 0 and an updated frontmatter `description` so a "remove product X" request lands on this recipe.
- `skills/wix-manage/SKILL.md` — index entry description kept in sync with the frontmatter.
- `yaml/wix-manage-evals/stores/remove-product-by-name-catalog-v3.yml` — new covering scenario.

## The scenario, and what it does and does not catch

`stores/remove-product-by-name-catalog-v3` seeds six products sharing an "Eval Gate" prefix, so the fuzzy name search returns several full product objects and both defects cost something. Assertions:

- `ReadFullDocsArticle` on `…/stores/skills/find-products-query-and-search-catalog-v3` — coverage for the changed reference.
- **`SearchWixAPISpec` with `negate: true`** — the discriminator. Production has to probe the spec for the delete endpoint; with the endpoint in the recipe it should not.
- outcome `llm_judge` (`minScore: 7`) — the named product deleted by id, the five decoys untouched, hiding does not count as removing.
- friction `llm_judge` (`minScore: 0`) — penalises truncated responses and endpoint-discovery calls specifically, so it can differ from the 8/10 the current content scores.

Not caught: the scenario cannot assert *why* a spec probe happened, so a probe made for a response shape rather than for the delete endpoint would fail the negated assertion just the same. It also does not verify the delete-by-filter or bulk-delete guidance — neither path is exercised by a single-product request.

## Out of scope

The tool response size limit that truncated the search result lives in the Wix MCP server, not here; this PR works within it rather than changing it.
