### PR TITLE
fix(wix-manage): Catalog V3 products carry `inventory`, not a `stock` field

### DIFF
--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -20,6 +20,7 @@ Use **Search Products** for text search and name-based lookup. Use **Query Produ
 | Filter by `id`, `slug`, `handle`, dates, or `visible` | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Best for exact structured criteria. |
 | Need exact name matching after text lookup | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) + client-side match | Search by the name text, then match the returned `product.name` in your own code. |
 | Find which products are out of stock | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) + client-side select | Stock lives on `inventory`, **not** `stock`, and is not filterable. See STEP 6. |
+| Find products above or below a price | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) + client-side select | Price lives on `actualPriceRange`, **not** `priceData`, and is not filterable. See STEP 7. |
 
 ### STEP 1: Search products by name or free text
 
@@ -188,6 +189,37 @@ Include `PARTIALLY_OUT_OF_STOCK` — those products do have out-of-stock variant
 **Endpoint:** `POST https://www.wixapis.com/stores/v3/inventory-items/query`
 
 It *can* filter on `availabilityStatus` (`IN_STOCK`, `OUT_OF_STOCK`, `PREORDER` — a different enum from the product's), and on `inStock`, `quantity`, `trackQuantity`, `productId`, and `product.name`. Items with `trackQuantity: true` carry a numeric `quantity`; items with `trackQuantity: false` carry a boolean `inStock` instead.
+
+---
+
+### STEP 7: Find products by price
+
+Price is on the product as **`actualPriceRange`** — there is no `priceData` field (that is Catalog V1, see Important Notes). A product with variants spans a range, so the shape is:
+
+```json
+"actualPriceRange": {
+  "minValue": { "amount": "12.00", "formattedAmount": "$12.00" },
+  "maxValue": { "amount": "19.50", "formattedAmount": "$19.50" }
+}
+```
+
+`actualPriceRange` is returned **by default** — no `fields` enum value requests it. `compareAtPriceRange` (the "was" price) has the same shape.
+
+Like `inventory`, price is **absent from STEP 4's filterable field list**, so `QueryProducts` cannot filter on it — put it in `query.filter` and the request is rejected. Answer the question in **one** query call and select in your own code:
+
+```javascript
+// products from POST /stores/v3/products/query with "fields": []
+const under20 = products.filter(
+  (p) => parseFloat(p.actualPriceRange?.minValue?.amount ?? 'NaN') < 20,
+);
+```
+
+Two things that will otherwise cost you a wrong answer:
+
+- **`amount` is a decimal string**, not a number — `"12.00"`, not `12`. Compare with `parseFloat`; a raw `<` against a string compares lexicographically and silently misorders (`"9" > "20"`).
+- **Pick the bound the question asks for.** "Under $20" on a product whose variants run $12–$25 is ambiguous: `minValue` means "has something under $20", `maxValue` means "everything is under $20". Choose deliberately and say which you used.
+
+Page until `pagingMetadata.hasNext` is `false` so no product is missed.
 
 ---
 

--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -19,6 +19,7 @@ Use **Search Products** for text search and name-based lookup. Use **Query Produ
 | List all products or page through the catalog | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Supports paging and structured filters on the fields listed below. |
 | Filter by `id`, `slug`, `handle`, dates, or `visible` | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Best for exact structured criteria. |
 | Need exact name matching after text lookup | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) + client-side match | Search by the name text, then match the returned `product.name` in your own code. |
+| Find which products are out of stock | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) + client-side select | Stock lives on `inventory`, **not** `stock`, and is not filterable. See STEP 6. |
 
 ### STEP 1: Search products by name or free text
 
@@ -54,7 +55,7 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
 }'
 ```
 
-This returns all products with their default fields (id, name, slug, visible, productType, priceData, stock, media, etc.).
+This returns all products with their default fields (`id`, `name`, `slug`, `visible`, `productType`, `inventory`, `media`, `actualPriceRange`, `createdDate`, `updatedDate`, and more).
 
 ### STEP 3: Understanding the `fields` parameter
 
@@ -142,43 +143,51 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
 }'
 ```
 
-**Filter by product IDs:**
-
-```bash
-curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
--H 'Content-Type: application/json' \
--H 'Authorization: <AUTH>' \
--d '{
-  "fields": [],
-  "query": {
-    "filter": {
-      "id": {
-        "$in": [
-          "product-id-1",
-          "product-id-2"
-        ]
-      }
-    }
-  }
-}'
-```
+To filter by several product IDs, use the same shape with `"filter": {"id": {"$in": ["id-1", "id-2"]}}`.
 
 ### STEP 5: Handling pagination
 
-When there are more products than the page limit, use cursor-based or offset-based paging:
+The endpoint returns at most 100 products per request. Raise `query.paging.limit` to 100, then check the response `pagingMetadata` to determine whether more pages exist and continue paging until they are exhausted.
+
+### STEP 6: Find which products are out of stock
+
+Stock is on the product as **`inventory`**. There is **no `stock` field** on a Catalog V3 product, so `product.stock` is always `undefined` and any check on it silently matches nothing.
+
+`inventory` is returned **by default** — no `fields` enum value requests it, and none is needed:
 
 ```json
-{
-  "query": {
-    "paging": {
-      "limit": 100,
-      "offset": 0
-    }
-  }
+"inventory": {
+  "availabilityStatus": "OUT_OF_STOCK",
+  "preorderStatus": "DISABLED",
+  "preorderAvailability": "NO_VARIANTS"
 }
 ```
 
-Check the response `pagingMetadata` to determine if more pages exist.
+`inventory.availabilityStatus` is one of exactly three values:
+
+| Value | Meaning |
+| ----- | ------- |
+| `IN_STOCK` | All variants are in stock and available for purchase. |
+| `OUT_OF_STOCK` | All variants are out of stock. |
+| `PARTIALLY_OUT_OF_STOCK` | Some variants are out of stock, some are in stock. |
+
+`inventory` is **absent from STEP 4's filterable field list**, so `QueryProducts` cannot filter on it — put it in `query.filter` and the request is rejected. Answer the question in **one** query call and select in your own code:
+
+```js
+// products from POST /stores/v3/products/query with "fields": []
+const outOfStock = products.filter(
+  (p) => p.inventory?.availabilityStatus === 'OUT_OF_STOCK'
+      || p.inventory?.availabilityStatus === 'PARTIALLY_OUT_OF_STOCK',
+);
+```
+
+Include `PARTIALLY_OUT_OF_STOCK` — those products do have out-of-stock variants, and omitting them under-reports. Page until `pagingMetadata.hasNext` is `false` so no product is missed.
+
+**Only for per-variant or per-location stock detail**, use Inventory Items V3 — do not reach for it just to list out-of-stock products:
+
+**Endpoint:** `POST https://www.wixapis.com/stores/v3/inventory-items/query`
+
+It *can* filter on `availabilityStatus` (`IN_STOCK`, `OUT_OF_STOCK`, `PREORDER` — a different enum from the product's), and on `inStock`, `quantity`, `trackQuantity`, `productId`, and `product.name`. Items with `trackQuantity: true` carry a numeric `quantity`; items with `trackQuantity: false` carry a boolean `inStock` instead.
 
 ---
 
@@ -186,7 +195,8 @@ Check the response `pagingMetadata` to determine if more pages exist.
 
 - **Variant data is NOT returned** by Query Products. To get variant details, use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) for individual products.
 - **Non-visible products** require the `SCOPE.STORES.PRODUCT_READ_ADMIN` permission.
-- Default fields include: `id`, `name`, `slug`, `visible`, `productType`, `priceData`, `stock`, `media`, `createdDate`, `updatedDate`.
+- Default fields include: `id`, `name`, `slug`, `visible`, `productType`, `inventory`, `media`, `actualPriceRange`, `compareAtPriceRange`, `variantSummary`, `createdDate`, `updatedDate`.
+- There is **no `stock` field and no `priceData` field** on a Catalog V3 product. `priceData` is Catalog V1; in V3 prices are `actualPriceRange` / `compareAtPriceRange`, and stock is `inventory` (see STEP 6).
 - The `fields` parameter adds fields **on top of** the defaults — you never need to request `id` or `name` explicitly.
 
 ## Conclusion

--- a/yaml/wix-manage-evals/stores/find-products-under-price-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/find-products-under-price-catalog-v3.yml
@@ -1,0 +1,138 @@
+# Seeds five single-variant products at distinct prices: two below $20, three above. Single
+# variant on purpose — a product whose variants span the threshold makes "under $20"
+# ambiguous, and a gate needs one right answer.
+#
+# The failure mode this covers is silent. Price on a Catalog V3 product is
+# `actualPriceRange.minValue.amount`; reading the Catalog V1 `priceData.price` yields
+# undefined rather than an error, so the filter matches nothing and the agent reports a
+# confident "no products under $20". The three above-threshold decoys mean a correct answer
+# has to be both complete and precise.
+#
+# `amount` is a decimal string ("7.25"), so a comparison that skips parseFloat orders
+# lexicographically and misreports — another way to pass the outcome only by accident.
+name: stores/find-products-under-price-catalog-v3
+description: >
+  A store owner asking which products fall under a price. Price lives on the Catalog V3
+  product as `actualPriceRange.minValue.amount` (a decimal string) and is returned by
+  default; there is no `priceData` field, and price is not filterable by Query Products.
+  Expected: one products query, then a client-side numeric comparison, naming both seeded
+  products under $20. Anti-patterns: reading a non-existent `priceData` field and reporting
+  none; sending a price filter to the products query; string-comparing the amount; omitting
+  one of the two; naming an above-threshold product.
+triggerPrompt: >
+  Which products in my store cost less than $20?
+tags: [stores, aria]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3
+  - type: llm_judge          # GATE — outcome correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Intent: the user wants the products in their Wix store priced under $20.
+
+      Ground truth for this site. Exactly two products are under $20: "Eval Price Coaster"
+      ($7.25) and "Eval Price Mug" ($12.00). Three are above: "Eval Price Tumbler" ($22.50),
+      "Eval Price Apron" ($31.00), "Eval Price Kettle" ($48.00). The agent can only know
+      these names and prices by actually querying the catalog.
+
+      Pass only if the final answer names both under-$20 products and names none of the
+      three above-$20 products as being under $20.
+
+      Fail if the answer reports that no products are under $20, or returns an empty list,
+      or states it could not determine prices. Fail if it omits either under-$20 product —
+      an incomplete list is a wrong answer here, not partial credit. Fail if it lists any
+      above-$20 product as under $20. Fail if it names products it never retrieved.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # SIGNAL — non-gating MCP friction
+    minScore: 0
+    maxTokens: 2048
+    prompt: >
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP and its docs let the agent
+      fulfill the request. Examine the tool-call trace. Score 0-10 (10 = direct: one
+      products query plus a client-side numeric comparison, no wasted calls, no errors).
+
+      Penalize and LIST any of: reading a product price field that does not exist (for
+      example `priceData`, `priceData.price`, `price.amount`) and getting undefined or an
+      empty result; a query that returned zero matches and had to be re-run; a repeat query
+      issued only to dump a product object and discover where price lives; a `filter` on a
+      price field sent to the products query, which does not support it; a 400 from
+      filtering on an unsupported field; comparing the decimal-string `amount` without
+      converting it to a number; extra documentation or API-spec searches needed to locate
+      the price field.
+
+      For each issue, name the likely MCP or docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed coaster under threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Price Coaster
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "7.25" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed mug under threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Price Mug
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed tumbler above threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Price Tumbler
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "22.50" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed apron above threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Price Apron
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "31.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed kettle above threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Price Kettle
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "48.00" } }
+                  physicalProperties: {}
+                  visible: true

--- a/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
@@ -1,0 +1,204 @@
+# Seeds nine products through /stores/v3/products-with-inventory so each one gets a real
+# inventory item: four are created with inventoryItem.inStock = false and five with
+# inStock = true. A plain POST /stores/v3/products creates NO inventory item, so the
+# product would come back untracked/available and could never surface as out of stock —
+# hence products-with-inventory here. The seeded names are the ground truth: they are
+# knowable only by querying the catalog.
+#
+# The mix matters. Reading the stock flag off a field that does not exist on a Catalog V3
+# product yields an empty result set rather than an error, so a wrong field name produces a
+# confident "everything is in stock" answer. Five in-stock decoys mean a correct answer has
+# to be both complete (all four) and precise (none of the five).
+name: stores/list-out-of-stock-products-catalog-v3
+description: >
+  A store owner asking which of their products are out of stock. Stock lives on the Catalog
+  V3 product as `inventory.availabilityStatus` (IN_STOCK / OUT_OF_STOCK /
+  PARTIALLY_OUT_OF_STOCK) and is returned by default with no `fields` request; there is no
+  `stock` field on the product. Expected: one products query, then select on
+  `inventory.availabilityStatus` client-side, and report all four seeded out-of-stock
+  products by name. Anti-patterns: reading a non-existent `stock` field and reporting zero
+  out-of-stock products; omitting some of them; naming in-stock products as out of stock;
+  answering without querying.
+triggerPrompt: >
+  Which of my store products are out of stock?
+tags: [stores, aria]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3
+  - type: llm_judge          # GATE — outcome correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Intent: the user wants the list of products in their Wix store that are out of stock.
+
+      Ground truth for this site. Exactly four products are out of stock: "Eval Stock
+      Kettle", "Eval Stock Tumbler", "Eval Stock Apron", "Eval Stock Coaster Set". Five
+      products are in stock: "Eval Stock Mug", "Eval Stock Teapot", "Eval Stock Strainer",
+      "Eval Stock Caddy", "Eval Stock Whisk". The agent can only know these names by
+      actually querying the catalog.
+
+      Pass only if the final answer names all four out-of-stock products and names none of
+      the five in-stock products as out of stock.
+
+      Fail if the answer reports that no products are out of stock, or reports an empty
+      list, or states it could not determine stock status. Fail if it omits any of the four
+      out-of-stock products — an incomplete list is a wrong answer here, not a partial
+      credit. Fail if it labels any of the five in-stock products as out of stock. Fail if
+      it lists products it never retrieved (invented names, or names not among the nine
+      above).
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # SIGNAL — non-gating MCP friction
+    minScore: 0
+    maxTokens: 2048
+    prompt: >
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP and its docs let the agent
+      fulfill the request. Examine the tool-call trace. Score 0-10 (10 = direct: one
+      products query plus a client-side selection, no wasted calls, no errors).
+
+      Penalize and LIST any of: reading or filtering on a product field that does not
+      exist (for example `stock`, `stock.inventoryStatus`, `priceData`) and getting an
+      empty or undefined result; a query that returned zero matches and had to be re-run;
+      a repeat query issued only to dump a product object and discover where stock lives;
+      a `filter` on `inventory.availabilityStatus` sent to the products query, which does
+      not support it; a guessed endpoint that 404'd (for example
+      `/stores/v3/inventory/query`); a 400 from filtering on an unsupported field; extra
+      documentation or API-spec searches needed to locate the stock field or the inventory
+      endpoint; falling back to Inventory Items V3 and then needing further calls to map
+      product IDs back to names.
+
+      For each issue, name the likely MCP or docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed out-of-stock kettle
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Kettle
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "48.00" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: false }
+      - label: seed out-of-stock tumbler
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Tumbler
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "22.50" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: false }
+      - label: seed out-of-stock apron
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Apron
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "31.00" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: false }
+      - label: seed out-of-stock coaster set
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Coaster Set
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "17.25" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: false }
+      - label: seed in-stock mug
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Mug
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "14.00" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: true }
+      - label: seed in-stock teapot
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Teapot
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "39.90" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: true }
+      - label: seed in-stock strainer
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Strainer
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "9.50" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: true }
+      - label: seed in-stock caddy
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Caddy
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "26.75" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: true }
+      - label: seed in-stock whisk
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Stock Whisk
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "11.40" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: true }

--- a/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
@@ -1,5 +1,5 @@
-# Seeds nine products through /stores/v3/products-with-inventory so each one gets a real
-# inventory item: four are created with inventoryItem.inStock = false and five with
+# Seeds six products through /stores/v3/products-with-inventory so each one gets a real
+# inventory item: three are created with inventoryItem.inStock = false and three with
 # inStock = true. A plain POST /stores/v3/products creates NO inventory item, so the
 # product would come back untracked/available and could never surface as out of stock —
 # hence products-with-inventory here. The seeded names are the ground truth: they are
@@ -7,15 +7,16 @@
 #
 # The mix matters. Reading the stock flag off a field that does not exist on a Catalog V3
 # product yields an empty result set rather than an error, so a wrong field name produces a
-# confident "everything is in stock" answer. Five in-stock decoys mean a correct answer has
-# to be both complete (all four) and precise (none of the five).
+# confident "everything is in stock" answer. The three in-stock decoys mean a correct answer
+# has to be both complete (all three out-of-stock products) and precise (none of the three
+# in-stock ones).
 name: stores/list-out-of-stock-products-catalog-v3
 description: >
   A store owner asking which of their products are out of stock. Stock lives on the Catalog
   V3 product as `inventory.availabilityStatus` (IN_STOCK / OUT_OF_STOCK /
   PARTIALLY_OUT_OF_STOCK) and is returned by default with no `fields` request; there is no
   `stock` field on the product. Expected: one products query, then select on
-  `inventory.availabilityStatus` client-side, and report all four seeded out-of-stock
+  `inventory.availabilityStatus` client-side, and report all three seeded out-of-stock
   products by name. Anti-patterns: reading a non-existent `stock` field and reporting zero
   out-of-stock products; omitting some of them; naming in-stock products as out of stock;
   answering without querying.
@@ -32,20 +33,19 @@ assertions:
     prompt: >
       Intent: the user wants the list of products in their Wix store that are out of stock.
 
-      Ground truth for this site. Exactly four products are out of stock: "Eval Stock
-      Kettle", "Eval Stock Tumbler", "Eval Stock Apron", "Eval Stock Coaster Set". Five
-      products are in stock: "Eval Stock Mug", "Eval Stock Teapot", "Eval Stock Strainer",
-      "Eval Stock Caddy", "Eval Stock Whisk". The agent can only know these names by
-      actually querying the catalog.
+      Ground truth for this site. Exactly three products are out of stock: "Eval Stock
+      Kettle", "Eval Stock Tumbler", "Eval Stock Apron". Three products are in stock: "Eval
+      Stock Mug", "Eval Stock Teapot", "Eval Stock Strainer". The agent can only know these
+      names by actually querying the catalog.
 
-      Pass only if the final answer names all four out-of-stock products and names none of
-      the five in-stock products as out of stock.
+      Pass only if the final answer names all three out-of-stock products and names none of
+      the three in-stock products as out of stock.
 
       Fail if the answer reports that no products are out of stock, or reports an empty
-      list, or states it could not determine stock status. Fail if it omits any of the four
+      list, or states it could not determine stock status. Fail if it omits any of the three
       out-of-stock products — an incomplete list is a wrong answer here, not a partial
-      credit. Fail if it labels any of the five in-stock products as out of stock. Fail if
-      it lists products it never retrieved (invented names, or names not among the nine
+      credit. Fail if it labels any of the three in-stock products as out of stock. Fail if
+      it lists products it never retrieved (invented names, or names not among the six
       above).
 
       Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
@@ -118,20 +118,6 @@ siteSetup:
                   physicalProperties: {}
                   visible: true
                   inventoryItem: { inStock: false }
-      - label: seed out-of-stock coaster set
-        method: post
-        url: https://www.wixapis.com/stores/v3/products-with-inventory
-        body:
-          product:
-            name: Eval Stock Coaster Set
-            productType: PHYSICAL
-            physicalProperties: {}
-            variantsInfo:
-              variants:
-                - price: { actualPrice: { amount: "17.25" } }
-                  physicalProperties: {}
-                  visible: true
-                  inventoryItem: { inStock: false }
       - label: seed in-stock mug
         method: post
         url: https://www.wixapis.com/stores/v3/products-with-inventory
@@ -171,34 +157,6 @@ siteSetup:
             variantsInfo:
               variants:
                 - price: { actualPrice: { amount: "9.50" } }
-                  physicalProperties: {}
-                  visible: true
-                  inventoryItem: { inStock: true }
-      - label: seed in-stock caddy
-        method: post
-        url: https://www.wixapis.com/stores/v3/products-with-inventory
-        body:
-          product:
-            name: Eval Stock Caddy
-            productType: PHYSICAL
-            physicalProperties: {}
-            variantsInfo:
-              variants:
-                - price: { actualPrice: { amount: "26.75" } }
-                  physicalProperties: {}
-                  visible: true
-                  inventoryItem: { inStock: true }
-      - label: seed in-stock whisk
-        method: post
-        url: https://www.wixapis.com/stores/v3/products-with-inventory
-        body:
-          product:
-            name: Eval Stock Whisk
-            productType: PHYSICAL
-            physicalProperties: {}
-            variantsInfo:
-              variants:
-                - price: { actualPrice: { amount: "11.40" } }
                   physicalProperties: {}
                   visible: true
                   inventoryItem: { inStock: true }


### PR DESCRIPTION
## What this fixes

The **Find Products (Query and Search, Catalog V3)** recipe names a product field that does not exist. It said, twice, that the default fields returned by `POST /stores/v3/products/query` include `stock`:

> This returns all products with their default fields (id, name, slug, visible, productType, priceData, **stock**, media, etc.)

> Default fields include: `id`, `name`, `slug`, `visible`, `productType`, `priceData`, **`stock`**, `media`, `createdDate`, `updatedDate`.

There is no `stock` field on a Catalog V3 product. This is the worst shape a wrong field name can take, because it does not fail loudly: `product.stock` is `undefined`, a filter or comparison on it matches nothing, and the API returns 200. An agent asked "which products are out of stock" gets an empty result set and can reasonably conclude that everything is in stock.

That is what happened. On a recorded run of a "list out-of-stock products" task whose source docs named this very recipe, the agent read `p.stock`, tested `stock.inventoryStatus === 'OUT_OF_STOCK'`, got **zero results**, ran a second query purely to dump `p.stock`, and observed verbatim:

> The stock field wasn't included in the response

It then needed a further documentation search to find `inventory-items/query`. Other runs of the same task guessed `POST /stores/v3/inventory/query` and got a 404, or sent a `filter` on `availabilityStatus` to the products query and got a 400.

## Verified against the generated Catalog V3 reference

Every claim below was checked through the Wix MCP docs tools against `wix.stores.catalog.v3.product` and `wix.stores.catalog.v3.CatalogApi.QueryProducts`, not from memory.

- **`stock` does not exist.** The Product object's property set is `id, revision, createdDate, updatedDate, name, slug, url, description, plainDescription, visible, visibleInPos, media, seoData, taxGroupId, options, modifiers, brand, infoSections, ribbon, directCategoriesInfo, allCategoriesInfo, mainCategoryId, costRange, inventory, productType, handle, currency, breadcrumbsInfo, actualPriceRange, compareAtPriceRange, variantsInfo, purchaseEligibility, additionalRibbons, extendedFields, tags, subscriptionDetails, variantSummary`. No `stock`.
- **The field is `inventory`**, and `inventory.availabilityStatus` is one of exactly three values: `IN_STOCK` ("All variants are in stock and available for purchase"), `OUT_OF_STOCK` ("All variants are out of stock"), `PARTIALLY_OUT_OF_STOCK` ("Some variants are out of stock and some are in stock and available for purchase").
- **It is returned by default.** The reference's own `QueryProducts` example sends `"fields": []` and the response carries `"inventory": {"preorderAvailability": "NO_VARIANTS", "availabilityStatus": "OUT_OF_STOCK", "preorderStatus": "DISABLED"}` — and no `stock` key. There is also no `fields` enum value that would request it, so nothing needs to be asked for.
- **`inventory` is not filterable.** `QueryProducts`' queryable-field map is exactly `id`, `handle`, `options.id`, `slug`, `createdDate`, `updatedDate`, `visible` — which matches the recipe's own STEP 4 table, and `inventory` is absent from both. So the recipe now says to select client-side rather than filter, which is what makes the one-call answer possible.
- **`priceData` does not exist either**, and was sitting in the same two lists. It is a Catalog V1 field name; in V3 prices are `actualPriceRange` / `compareAtPriceRange`. Both corrected lists drop it.
- **Inventory Items V3** is `POST https://www.wixapis.com/stores/v3/inventory-items/query` (`InventoryService.QueryInventoryItems`). It *can* filter on `availabilityStatus`, `inStock`, `quantity`, `trackQuantity`, `productId` and `product.name`. Its `availabilityStatus` enum is `IN_STOCK | OUT_OF_STOCK | PREORDER` — deliberately **not** the same enum as the product's, which is why the recipe states both. `trackQuantity: true` items carry a numeric `quantity`; `trackQuantity: false` items carry a boolean `inStock` instead. It is documented only as the per-variant / per-location path, so the recipe does not push a whole-catalog question down it.

## Changes

- `skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md`
  - both "default fields" lists corrected — `stock` → `inventory`, `priceData` → `actualPriceRange` / `compareAtPriceRange`, plus an explicit note that neither `stock` nor `priceData` exists on a V3 product.
  - new **STEP 6: Find which products are out of stock** — the three `availabilityStatus` values, the fact that `inventory` comes back by default, why it cannot go in `query.filter`, a client-side selection that answers the question in one query call, the instruction to include `PARTIALLY_OUT_OF_STOCK` products, and Inventory Items V3 for per-variant detail only.
  - routing row in STEP 0 so the question lands on STEP 6.
- `yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml` — new covering scenario.

The recipe's `SKILL.md` index entry and its `yaml/wix-manage/stores/documentation.yaml` entry both already exist and are unchanged, so no index churn was needed.

### Truncation budget

The recipe was 7,664 characters and the additions took it to 10,260. Two pieces of content with no API value were removed anyway, bringing that step of the change to **9,963**:

- the second `QueryProducts` curl block ("Filter by product IDs"), which repeated the preceding block with a different `filter` value; the one `$in` shape it demonstrated is now a single inline sentence, and STEP 4's table already documents `$in` on `id`.
- STEP 5's paging JSON block, which restated the `paging` object already shown in STEP 4's example; the surviving sentence keeps the 100-per-request limit and the `pagingMetadata` instruction.

**Correction on the size budget.** An earlier revision of this description called 10,000 characters a hard limit that truncates reference files. That is not right: nothing in CI enforces it, and 35 of the 96 `wix-manage` recipes are already above it. The limit that does bind is the MCP's ~6,000-token response cap, and this file — now 11,812 characters, about 2,950 tokens — sits well inside it. The trimming above was still worth doing, but it was not paying down a ceiling.

## The scenario, and what it does and does not catch

`stores/list-out-of-stock-products-catalog-v3` provisions a fresh Stores site and seeds **six** products through `/stores/v3/products-with-inventory` — three with `inventoryItem.inStock: false` and three with `inStock: true`. The mix is the point: because reading a non-existent field returns nothing rather than erroring, the wrong field name yields a confident "nothing is out of stock", and the in-stock decoys mean a correct answer has to be complete *and* precise. A plain `POST /stores/v3/products` creates no inventory item at all, so the seed has to use `products-with-inventory` or nothing would ever be out of stock. (A first attempt seeded nine products and timed out with a 504 during site provisioning on both sides of the comparison, so neither run reached its assertions; six provisions reliably and is sufficient to expose the defect.)

Assertions:

- `ReadFullDocsArticle` on `…/stores/skills/find-products-query-and-search-catalog-v3` — coverage for the changed reference.
- outcome `llm_judge` (`minScore: 7`) — the decision assertion. It carries the three out-of-stock and three in-stock names as ground truth, and **fails** on reporting zero out-of-stock products, on an empty list, on omitting any of the three, and on labelling any of the in-stock products as out of stock. An incomplete list is scored as a wrong answer, not partial credit. This is the assertion the `stock` field cannot satisfy on its first pass.
- friction `llm_judge` (`minScore: 0`, non-gating) — enumerates the specific frictions seen in the recorded runs: reading a non-existent field and getting `undefined`, a zero-match query that had to be re-run, a repeat query issued only to discover where stock lives, a `filter` on `inventory.availabilityStatus` sent to the products query, the guessed `/stores/v3/inventory/query` 404, and the extra doc searches needed to reach the inventory endpoint.

### Measured result

The gate ran the scenario against this branch's content and against what is live, and the two sides separate cleanly on every axis:

| | this branch | live |
| --- | --- | --- |
| Outcome judge (gating) | **passed, 10/10** | **failed, 0/10** — "incorrectly included 'Hydrating Eye Serum' in the out-of-stock list" |
| `ReadFullDocsArticle` on the recipe | passed | failed |
| Friction judge (non-gating) | **10/10** — clean path | **4/10** — "struggled with discovering the correct inventory field, guessing a non-existent field and requiring multiple API spec searches and object dumps to find the correct path" |
| Tokens | 190,396 | 515,075 |
| Wall-clock | 39.5 s | 84.9 s |
| Cost | $0.3869 | $1.0519 |

The gating outcome judge failing on the live content and passing here is the discriminator: this is not an efficiency delta that could be exploration variance. The friction judge's reasoning independently names the defect this PR fixes — a guessed non-existent field, then spec searches and object dumps to locate the real one.

**What it does not catch.** The outcome judge sees the agent's final response, not the trace. An agent that reads `stock`, gets zero results, notices, and recovers through extra searches and a fallback to Inventory Items V3 can still arrive at the right answer and pass; when that happens the discriminating signal is the friction score and the efficiency delta rather than the gating assertion. The Inventory Items V3 guidance is documented but not directly exercised, since a whole-catalog question should not go down that path.

## Notes and out of scope

- **Overlapping PR.** #798 also edits this recipe, in different regions of the file (STEP 0's table and a new post-lookup section). Scenario names differ and neither branch's scenario exists in the other, so there is no scenario hold either way, but whichever merges second will hit a small textual conflict in STEP 0 and will need to re-check the file size.
- **Two further inaccuracies in this file, left alone deliberately** to keep this change tight rather than to leave them unreported. STEP 3's `fields` enum table lists `MIN_VARIANT_PRICE_INFO` and `DIRECT_CATEGORY_IDS`, neither of which is in the `RequestedFields` enum that `QueryProducts` accepts, and it omits `MIN_PRICE_VARIANT`, `PRODUCT_CHOICES_DISPLAY_IMAGE` and `DISCOUNT_INFO`, which are. Separately, the paging examples use `paging: {limit, offset}` while the `QueryProductsRequest` schema is a `CursorQuery` whose paging member is `cursorPaging`. Both are worth a follow-up; neither is on the path this scenario measures.


---

## Added: where price lives (STEP 7)

Removing `priceData` from the default-field list fixed the negative half only — nothing said where price *is*, or that it cannot be filtered. A recorded run shows what that costs: the agent read `priceData.price`, got an empty result, re-queried purely to dump a whole product object, found `actualPriceRange.minValue.amount`, and only then answered. **Friction 5/10 on a 60 s run**, outcome correct.

STEP 7 mirrors STEP 6:

- price is `actualPriceRange.minValue` / `.maxValue`, returned by default — no `fields` value requests it
- it is **absent from STEP 4's filterable list**, so the question is one query plus a client-side selection, not a `query.filter`
- `amount` is a **decimal string**; compare with `parseFloat`, because a raw `<` on strings orders lexicographically and silently misreports (`"9" > "20"`)
- `minValue` vs `maxValue` is a real choice when a product's variants span the threshold — "has something under $20" is not "everything is under $20"

Plus a STEP 0 routing row, so the recipe answers this at the top rather than 150 lines in.

**Covering scenario** `stores/find-products-under-price-catalog-v3`: five single-variant products, two under $20 and three above. Single-variant deliberately — a product straddling the threshold has no single right answer. Reading the wrong price field returns undefined rather than an error, so the agent produces a confident "nothing under $20"; the three decoys are what make that fail.

Verified against Query Products' own description, which states it "supports a narrow set of filterable and sortable fields" and that unsupported ones return `Field '<fieldName>' is not declared as filterable`. No price field appears in that set, and Search Products does not document price filtering either — so client-side selection is the correct route, not a workaround.
