### PR TITLE
docs(wix-vibe-headless): harden manage-banner wrap-up step; App.jsx edit-don't-rewrite on Base44

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -137,6 +137,12 @@ source of truth for how the client app is built. To save time, prefer copying re
 the `wix-vibe-headless` skill provides (e.g. the Wix client setup) and adapting them over
 re-generating them from scratch.
 
+**`src/App.jsx`: edit surgically, never rewrite.** On Base44 it carries required platform auth
+scaffolding (the `AuthProvider` / `useAuth` imports and wrappers from `@/lib/AuthContext`) — a
+full-file rewrite drops them and the platform validator rejects the write, costing you a redo.
+Wire your routes/imports in with targeted `find_replace` edits and leave the rest of the file
+as-is.
+
 ## STEP 4 — Manage and seed the business
 
 Seed the site with real content by following the **`wix-headless` skill**'s
@@ -182,7 +188,9 @@ one-by-one, to finish faster.
 
 Once the site is built and seeded:
 
-1. **Add the dev-only manage banner** (links the app to its Wix back office): copy the
+1. **Add the dev-only manage banner** (links the app to its Wix back office) — this is a
+   required wrap-up step, not optional polish; do NOT skip it because the build "feels done"
+   (hand-rolled dashboard links in the UI are not a substitute). Copy the
    `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
    `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
    `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
@@ -192,7 +200,9 @@ Once the site is built and seeded:
    down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
    banner — offset such a header by the banner's height.
 2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
-   you were given): `https://manage.wix.com/dashboard/{metaSiteId}`
+   you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since the banner
+   from step 1 is mounted, also tell them: *in dev builds the site shows a slim banner at the
+   top linking straight to this Wix dashboard (dismissible; never shown in production).*
 
 ## Later admin requests
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -10,11 +10,11 @@ the Wix client setup.
 
 Follow the steps below exactly:
 
-1. **Install the Wix skills locally**
+1. **Install the Wix skills locally** (and pin their location in AGENTS.md)
 2. **(optional) Brief doesn't say what to build? Read the site**
 3. **Build the client**
 4. **Manage and seed the business** (run in parallel with 3)
-5. **Wrap up**
+5. **Wrap up** (required: mount the dev-only manage banner + point the user to the Wix dashboard)
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -188,9 +188,7 @@ one-by-one, to finish faster.
 
 Once the site is built and seeded:
 
-1. **Add the dev-only manage banner** (links the app to its Wix back office) — this is a
-   required wrap-up step, not optional polish; do NOT skip it because the build "feels done"
-   (hand-rolled dashboard links in the UI are not a substitute). Copy the
+1. **Add the dev-only manage banner** (required) (links the app to its Wix back office): copy the
    `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
    `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
    `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
@@ -199,10 +197,11 @@ Once the site is built and seeded:
    shows the banner (no dev flag → no banner at all). Also verify it really pushes the site
    down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
    banner — offset such a header by the banner's height.
-2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
-   you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since the banner
-   from step 1 is mounted, also tell them: *in dev builds the site shows a slim banner at the
-   top linking straight to this Wix dashboard (dismissible; never shown in production).*
+2. **Ask the user to open** this URL to complete the setup in Wix (required; substitute the
+   metasite id you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since
+   the banner from step 1 is mounted, also tell them: *in dev builds the site shows a slim
+   banner at the top linking straight to this Wix dashboard (dismissible; never shown in
+   production).*
 
 ## Later admin requests
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -7,6 +7,7 @@ and metasite id, are given in your initial prompt. Follow the steps below:
 2. **(optional) Brief doesn't say what to build? Ask, or read the site**
 3. **Build the client**
 4. **Seed and manage the business** (run in parallel with 3)
+5. **When done** (required: mount the dev-only manage banner + point the user to the Wix dashboard)
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -111,9 +112,7 @@ back to the `wix-docs` skill where the operation isn't documented there.
 
 After the site is built and seeded:
 
-1. **Add the dev-only manage banner** (links the app to its Wix back office) — this is a
-   required wrap-up step, not optional polish; do NOT skip it because the build "feels done"
-   (hand-rolled dashboard links in the UI are not a substitute). Copy the
+1. **Add the dev-only manage banner** (required) (links the app to its Wix back office): copy the
    `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
    `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
    `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
@@ -122,7 +121,8 @@ After the site is built and seeded:
    shows the banner (no dev flag → no banner at all). Also verify it really pushes the site
    down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
    banner — offset such a header by the banner's height.
-2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
-   you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since the banner
-   from step 1 is mounted, also tell them: *in dev builds the site shows a slim banner at the
-   top linking straight to this Wix dashboard (dismissible; never shown in production).*
+2. **Ask the user to open** this URL to complete the setup in Wix (required; substitute the
+   metasite id you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since
+   the banner from step 1 is mounted, also tell them: *in dev builds the site shows a slim
+   banner at the top linking straight to this Wix dashboard (dismissible; never shown in
+   production).*

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -111,7 +111,9 @@ back to the `wix-docs` skill where the operation isn't documented there.
 
 After the site is built and seeded:
 
-1. **Add the dev-only manage banner** (links the app to its Wix back office): copy the
+1. **Add the dev-only manage banner** (links the app to its Wix back office) — this is a
+   required wrap-up step, not optional polish; do NOT skip it because the build "feels done"
+   (hand-rolled dashboard links in the UI are not a substitute). Copy the
    `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
    `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
    `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
@@ -121,4 +123,6 @@ After the site is built and seeded:
    down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
    banner — offset such a header by the banner's height.
 2. **Ask the user to open** this URL to complete the setup in Wix (substitute the metasite id
-   you were given): `https://manage.wix.com/dashboard/{metaSiteId}`
+   you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since the banner
+   from step 1 is mounted, also tell them: *in dev builds the site shows a slim banner at the
+   top linking straight to this Wix dashboard (dismissible; never shown in production).*


### PR DESCRIPTION
# Feedback

Live run ("Soft Jurassic", dino-pillow storefront on Base44, built with the current docs incl. #806's STEP 1b):

1. **Manage banner skipped.** The doc already numbers it (STEP 5.1 / "When done" 1, from #744), the installed bundle had it, and the run still skipped it — it wrapped up, hand-rolled `manage.wix.com/dashboard/...` links into the UI instead, and never copied/mounted `wix-manage-banner.js`. Another run with the same doc (DinoPillow) did mount it — coin-flip compliance on a step the agent treats as polish once the build "feels done".

2. **App.jsx rewrite rejected.** The agent rewrote `src/App.jsx` wholesale, dropping the required Base44 platform auth scaffolding (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); the platform validator rejected the write ("your edit removed required platform authentication code") and it redid the file.

## Change

- **base44.md + generic.md, wrap-up step 1:** state the banner is a *required* wrap-up step, not optional polish, and that hand-rolled dashboard links are not a substitute.
- **base44.md + generic.md, wrap-up step 2:** when asking the user to open the Wix dashboard, also tell them about the dev banner (slim top banner linking to that dashboard, dismissible, dev-only).
- **base44.md STEP 3 (Base44-specific):** edit `src/App.jsx` surgically with `find_replace`, never rewrite — it carries required platform auth scaffolding that a rewrite drops and the validator rejects.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)