### PR TITLE
fix(wix-manage): correct the discount-rule request structure

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md
@@ -22,7 +22,13 @@ layer: config
 
 ## Critical: `discounts` structure
 
-**The API always returns the full normalized structure.** Never assume a simplified form. Each discount entry looks like:
+**`discounts` is an object with a `values` array — not an array.** Sending an array is rejected with `400 {"message":"Expected an object"}`.
+
+`discountType` and `percentage`/`fixedAmount` are **top-level fields of each `values[]` entry**. There is no nested `discount` sub-object; wrapping them in one is rejected with `400 Validation failed: discount_rule.customer_gets.specific_items_discount Discount value type does not match discount value`.
+
+**Send scalars as plain JSON.** The generated reference types several fields as `StringValue`/`BoolValue` (`name`, `active`, `subtotalRange.from`, `percentage`). Those are protobuf wrapper types and are serialized as bare values — `"name": "Flash Sale"`, not `"name": {"value": "Flash Sale"}`. The wrapped form is rejected with `400 {"message":"Unexpected value for StringValue"}`.
+
+**The API always returns the full normalized structure.** Never assume a simplified form. Each entry inside `discounts.values` looks like:
 
 ```json
 {
@@ -38,14 +44,12 @@ layer: config
       }
     ]
   },
-  "discount": {
-    "discountType": "PERCENTAGE",
-    "percentage": 20
-  }
+  "discountType": "PERCENTAGE",
+  "percentage": 20
 }
 ```
 
-When updating a rule, always use the `discounts` array as returned from the query/get, modifying only the specific fields you need. **Do not reconstruct from scratch unless creating a new rule.**
+When updating a rule, always send `discounts` back as returned from the query/get (the object with its `values` array), modifying only the specific fields you need. **Do not reconstruct from scratch unless creating a new rule.**
 
 ---
 
@@ -93,26 +97,26 @@ Filterable fields: `id`, `name`, `active`, `revision`, `created_date`, `updated_
         "start": "2026-06-01T00:00:00.000Z",
         "end": "2026-08-31T23:59:59.000Z"
       },
-      "discounts": [
-        {
-          "targetType": "SPECIFIC_ITEMS",
-          "specificItemsInfo": {
-            "scopes": [
-              {
-                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-                "type": "CATALOG_ITEM",
-                "catalogItemFilter": {
-                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+      "discounts": {
+        "values": [
+          {
+            "targetType": "SPECIFIC_ITEMS",
+            "specificItemsInfo": {
+              "scopes": [
+                {
+                  "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "type": "CATALOG_ITEM",
+                  "catalogItemFilter": {
+                    "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                  }
                 }
-              }
-            ]
-          },
-          "discount": {
+              ]
+            },
             "discountType": "PERCENTAGE",
             "percentage": 10
           }
-        }
-      ]
+        ]
+      }
     }
   ],
   "pagingMetadata": {
@@ -170,26 +174,26 @@ When a discount *isn't* applying as expected, see [Troubleshoot: Discount Not Ap
       "start": "2026-05-01T00:00:00.000Z",
       "end": "2026-05-03T23:59:59.000Z"
     },
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CATALOG_ITEM",
-              "catalogItemFilter": {
-                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 20
         }
-      }
-    ],
+      ]
+    },
     "settings": {
       "appliesTo": "ALL_ITEMS"
     }
@@ -203,29 +207,31 @@ When a discount *isn't* applying as expected, see [Troubleshoot: Discount Not Ap
   "discountRule": {
     "name": "Summer Collection Sale",
     "active": true,
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CUSTOM_FILTER",
-              "customFilter": {
-                "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
-                "params": {
-                  "collectionIds": ["collection-uuid-here"]
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "collections_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CUSTOM_FILTER",
+                "customFilter": {
+                  "appId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "params": {
+                    "collectionIds": [
+                      "collection-uuid-here"
+                    ]
+                  }
                 }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 15
         }
-      }
-    ],
+      ]
+    },
     "settings": {
       "appliesTo": "ALL_ITEMS"
     }
@@ -243,27 +249,29 @@ When a discount *isn't* applying as expected, see [Troubleshoot: Discount Not Ap
   "discountRule": {
     "name": "$5 Off Selected Items",
     "active": true,
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CATALOG_ITEM",
-              "catalogItemFilter": {
-                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
-                "catalogItemIds": ["product-uuid-here"]
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "specific_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                  "catalogItemIds": [
+                    "product-uuid-here"
+                  ]
+                }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "FIXED_AMOUNT",
           "fixedAmount": "5.00"
         }
-      }
-    ],
+      ]
+    },
     "settings": {
       "appliesTo": "ALL_ITEMS"
     }
@@ -287,28 +295,32 @@ Always fetch the rule first (via Get or Query), then modify only the fields you 
   "discountRule": {
     "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "revision": "1",
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": {
-          "scopes": [
-            {
-              "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
-              "type": "CATALOG_ITEM",
-              "catalogItemFilter": {
-                "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": {
+            "scopes": [
+              {
+                "id": "all_215238eb-22a5-4c36-9e7b-e7c08025e04e",
+                "type": "CATALOG_ITEM",
+                "catalogItemFilter": {
+                  "catalogAppId": "215238eb-22a5-4c36-9e7b-e7c08025e04e"
+                }
               }
-            }
-          ]
-        },
-        "discount": {
+            ]
+          },
           "discountType": "PERCENTAGE",
           "percentage": 25
         }
-      }
-    ]
+      ]
+    }
   },
-  "mask": { "paths": ["discounts"] }
+  "mask": {
+    "paths": [
+      "discounts"
+    ]
+  }
 }
 ```
 
@@ -330,8 +342,8 @@ Always fetch the rule first (via Get or Query), then modify only the fields you 
 
 The safe pattern for "find a rule by name and update its percentage":
 
-1. Query with name filter → get the rule's `id`, `revision`, and `discounts` array
-2. Modify only the `discount.percentage` inside each discount entry, keeping all other fields intact
+1. Query with name filter → get the rule's `id`, `revision`, and `discounts` object
+2. Modify only `percentage` inside each `discounts.values[]` entry, keeping all other fields intact
 3. PATCH with the modified `discounts` and `mask: { paths: ["discounts"] }`
 
 **Step 5a — Query by name**:
@@ -349,29 +361,29 @@ Extract from response: `discountRules[0].id`, `discountRules[0].revision`, `disc
 
 **Step 5b — Update percentage** (modify the returned discounts in-place):
 
-Take the `discounts` array from the query response and update only `discount.percentage` on each entry:
+Take `discounts.values` from the query response and update only `percentage` on each entry:
 ```json
 PATCH https://www.wixapis.com/ecom/v1/discount-rules/{id}
 {
   "discountRule": {
     "id": "<id from query>",
     "revision": "<revision from query>",
-    "discounts": [
-      {
-        "targetType": "SPECIFIC_ITEMS",
-        "specificItemsInfo": { "<scopes unchanged from query response>" },
-        "discount": {
+    "discounts": {
+      "values": [
+        {
+          "targetType": "SPECIFIC_ITEMS",
+          "specificItemsInfo": { "<scopes unchanged from query response>" },
           "discountType": "PERCENTAGE",
           "percentage": 10
         }
-      }
-    ]
+      ]
+    }
   },
   "mask": { "paths": ["discounts"] }
 }
 ```
 
-> **Important**: Copy `targetType`, `specificItemsInfo.scopes` verbatim from the query response — do not reconstruct them. Only change `discount.discountType` and `discount.percentage`/`discount.fixedAmount`.
+> **Important**: Copy `targetType`, `specificItemsInfo.scopes` verbatim from the query response — do not reconstruct them. Only change `discountType` and `percentage`/`fixedAmount`.
 
 ---
 
@@ -403,11 +415,11 @@ To delete permanently:
 | `active` | Yes | Whether the rule is currently applied |
 | `activeTimeInfo.start` | No | ISO 8601 start time. Omit for immediate activation |
 | `activeTimeInfo.end` | No | ISO 8601 end time. Omit for no expiration |
-| `discounts[].targetType` | Yes | Always `"SPECIFIC_ITEMS"` for standard rules |
-| `discounts[].specificItemsInfo.scopes[]` | Yes | Array of scope objects — see Scope types below |
-| `discounts[].discount.discountType` | Yes | `"PERCENTAGE"` or `"FIXED_AMOUNT"` or `"FIXED_PRICE"` |
-| `discounts[].discount.percentage` | If PERCENTAGE | Integer 1-100 |
-| `discounts[].discount.fixedAmount` | If FIXED_AMOUNT | Decimal string (e.g., `"5.00"`) |
+| `discounts.values[].targetType` | Yes | Always `"SPECIFIC_ITEMS"` for standard rules |
+| `discounts.values[].specificItemsInfo.scopes[]` | Yes | Array of scope objects — see Scope types below |
+| `discounts.values[].discountType` | Yes | `"PERCENTAGE"` or `"FIXED_AMOUNT"` or `"FIXED_PRICE"` |
+| `discounts.values[].percentage` | If PERCENTAGE | Integer 1-100 |
+| `discounts.values[].fixedAmount` | If FIXED_AMOUNT | Decimal string (e.g., `"5.00"`) |
 | `settings.appliesTo` | Yes on create | Always `"ALL_ITEMS"` |
 | `revision` | On update/delete | Must match current value — fetch first |
 | `mask.paths[]` | On update | Recommended — list fields being changed (e.g., `["discounts"]`, `["active"]`) |
@@ -488,8 +500,8 @@ The recommendation's `scope` field maps to the API's internal scope structure. T
 
 | Recommendation `discountType` | API field to set | Value format |
 |---|---|---|
-| `PERCENTAGE` | `discount.percentage` | Integer (e.g., `15`) |
-| `FIXED_AMOUNT` | `discount.fixedAmount` | String (e.g., `"5.00"`) |
+| `PERCENTAGE` | `discounts.values[].percentage` | Integer (e.g., `15`) |
+| `FIXED_AMOUNT` | `discounts.values[].fixedAmount` | String (e.g., `"5.00"`) |
 | `FIXED_PRICE` | `discount.fixedPrice` | String (e.g., `"29.99"`) |
 
 All discount entries use `targetType: "SPECIFIC_ITEMS"` with the scope wrapped in `specificItemsInfo.scopes[]`.

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/create-discount-rule-subtotal-threshold.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/create-discount-rule-subtotal-threshold.yml
@@ -1,0 +1,81 @@
+# Covers a plain "discount above a spend threshold" request — the shape that exercises
+# `discounts` and the subtotal-range trigger together.
+#
+# The sibling scenario (create-discount-rule.yml) checks that a recommendation object is
+# mapped onto the right fields, but passes without the create call succeeding. This one
+# requires a 2xx create, so it fails when the documented request structure is wrong.
+name: ecommerce/pricing-promotions/create-discount-rule-subtotal-threshold
+description: >
+  Verifies that an agent asked for an automatic discount above a spend threshold creates a
+  working discount rule. Success is a 2xx Create Discount Rule call and a final answer
+  reporting the rule as live. Anti-patterns: sending `discounts` as an array, nesting
+  `discountType`/`percentage` in a `discount` sub-object, or wrapping scalar fields as
+  `{ "value": ... }` — each is rejected with a 400.
+triggerPrompt: |
+  In my Wix store, set up an automatic discount: 10% off whenever a customer's order
+  subtotal is over $50. It should apply to everything in the catalog and be active now.
+tags: [ecommerce]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed a catalog product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Tee
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "19.50" } }
+                  physicalProperties: {}
+                  visible: true
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule
+
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked for an automatic discount rule: 10% off when the order subtotal exceeds
+      $50, applying to the whole catalog, active immediately.
+
+      Pass only if BOTH are true:
+        1. The trace shows a successful (2xx) create against `ecom/v1/discount-rules`.
+        2. The final answer reports the rule as created and active, describing the 10% /
+           $50-subtotal terms it actually set.
+
+      Fail if any of these are true:
+        - No successful create call appears in the trace.
+        - The agent returned curl commands or instructions instead of creating the rule.
+        - It created a coupon (a code the shopper types) instead of an automatic rule.
+        - It claimed success while every create attempt returned an error.
+        - It stopped to ask which discount mechanism to use, when the request is
+          unambiguously an automatic discount.
+
+      Recovering after an initial error still passes — this assertion scores the outcome,
+      not the route.
+
+  # Non-gating diagnostic (minScore 0 → never fails the gate): records how much the
+  # documented request shape cost. This is where a corrected structure shows up.
+  - type: llm_judge
+    minScore: 0
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how smoothly the docs let the agent create this rule.
+      Examine the tool-call trace. Score 0-10 (10 = direct: no wasted calls, no errors).
+
+      Penalize and LIST any of: a 400 `Expected an object`; a 400
+      `Discount value type does not match discount value`; a 400
+      `Unexpected value for StringValue`; repeated create attempts differing only in
+      request-body shape; probing spec/schema lookups hunting for the request structure;
+      a schema lookup that errored or returned nothing usable.
+
+      For each issue, name the likely docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected docs gap,
+      or 'clean path' if none>"}.


### PR DESCRIPTION
## Problem

An agent asked to *"set up an automatic discount: 10% off whenever a customer's order subtotal is over $50"* followed this recipe and could not create the rule. From the recorded run transcript, it took **13 create attempts** before one succeeded, cycling through three different rejections:

**Attempt 1** — the recipe's own shape, `discounts` as an array:

```
Wix API error (400): {"message":"Expected an object","details":{}}
```

**Attempt 2** — `discounts.values[]`, but keeping the recipe's nested `discount` object:

```
Wix API error (400): {"message":"Validation failed:
  discount_rule.customer_gets.specific_items_discount
  Discount value type does not match discount value", ...
  "violatedRule":"OTHER","ruleName":"DISCOUNT_TYPE_AND..."}
```

**Attempts 3–8** — the agent then guessed that scalar fields were protobuf wrappers, because that is how the generated reference types them, and wrapped `name`, `active`, `subtotalRange.from` and `percentage` as `{ "value": ... }`:

```
Wix API error (400): {"message":"Unexpected value for StringValue","details":{}}
```

It could not resolve any of this from the API spec. Every schema drill-down failed:

```
Search error: Cannot read properties of undefined (reading 'request')
```

because the request schema exposes `discountRule` as `$circular` — its fields are not expanded there. So the recipe was the only available source of the request shape, and the recipe was wrong.

## What is actually true

Confirmed against the create call that finally returned **200** and its response body — not from the spec, which cannot express this:

```json
{
  "discountRule": {
    "name": "10% Off Orders Over $50",
    "active": true,
    "trigger": {
      "triggerType": "SUBTOTAL_RANGE",
      "subtotalRange": { "from": "50", "scopes": [ /* scope */ ] }
    },
    "discounts": {
      "values": [
        {
          "targetType": "SPECIFIC_ITEMS",
          "specificItemsInfo": { "scopes": [ /* scope */ ] },
          "discountType": "PERCENTAGE",
          "percentage": 10
        }
      ]
    },
    "settings": { "appliesTo": "ALL_ITEMS" }
  }
}
```

Three corrections:

1. **`discounts` is an object with a `values` array**, not an array.
2. **`discountType` and `percentage`/`fixedAmount` are top-level fields of each `values[]` entry.** There is no nested `discount` sub-object.
3. **Scalars are sent bare.** `StringValue`/`BoolValue` in the reference are protobuf wrapper types; they serialize as plain JSON values.

## The change

`references/ecommerce/pricing-promotions/ecom-pricing-create-discount-rule.md` — the wrong shape was in every example, the field-reference table and the find-and-update flow, so all of them move together:

- 5 request/response examples rewrapped to `discounts.values`.
- 6 nested `discount` objects flattened to top-level `discountType` / `percentage` / `fixedAmount`.
- Field table rows renamed `discounts[].discount.*` → `discounts.values[].*`.
- The update flow and its "copy verbatim" note updated to match.
- The "Critical: `discounts` structure" section now states all three rules with the exact 400 each violation produces, so a reader who hits one can map it back.

No behaviour claims beyond those three were touched.

## Coverage

New scenario `ecommerce/pricing-promotions/create-discount-rule-subtotal-threshold`, tagged `[ecommerce]`, provisioning a fresh store site and seeding one product.

It exists because the sibling `create-discount-rule` scenario **cannot catch this**: that one checks the agent maps a recommendation object onto the right fields, and passes without any successful create. The new one requires a **2xx create** plus a final answer describing the terms actually set — which the old recipe's payload cannot produce.

It also carries a non-gating friction judge (`minScore: 0`) whose rubric names the three 400s and the repeated shape-guessing directly, so the cost shows up per run even when the outcome passes.

The trigger prompt is deliberately plain — it asks for the discount in business terms and says nothing about request structure, so it cannot pre-solve the ambiguity the defect exploits.

## Out of scope

Two upstream gaps, neither fixable here:

- The request schema for Create Discount Rule exposes `discountRule` as `$circular`, so the field shapes are unreadable from the spec. That is why an agent that hits a 400 has nothing to self-correct against.
- `Expected an object` and `Unexpected value for StringValue` name neither the field nor the expected shape, so neither error is actionable on its own.

---

## Gate status: blocked on #666

The eval gate cannot run yet. It fast-fails with:

```
Scenario(s) held by other PRs: ecommerce/pricing-promotions/create-discount-rule
```

#666 edits this same recipe and its new scenario asserts the same canonical URL, so it holds the shared scenario until it merges or closes.

The two changes are **complementary, not overlapping** — #666 corrects how a Stores collection ID is resolved; this one corrects the request body structure. Neither touches the other's lines, and a trial merge of the two branches produces **no conflicts**.

Happy to sequence behind #666. Once it lands I'll rerun the gate here.
