### PR TITLE
fix(ecommerce): re-add checkout conversion to strategy routing cues

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -164,7 +164,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## eCommerce
 
 **Routing — pick the right entry point:**
-- **Any sales/business improvement request** (boost sales, promotions, help my business, holiday deals, improve revenue, discounts, shipping, coupons, clearance) → use [Recommend: eCommerce Strategy](references/ecommerce/recommend-ecommerce-strategy.md). This is the **default entry point** — it analyzes ALL domains (discounts, shipping) and generates cross-domain recommendations. Do NOT ask clarifying questions.
+- **Any sales/business improvement request** (boost sales, promotions, help my business, holiday deals, improve revenue, discounts, shipping, coupons, clearance, checkout conversion, cart abandonment) → use [Recommend: eCommerce Strategy](references/ecommerce/recommend-ecommerce-strategy.md). This is the **default entry point** — it analyzes ALL domains (discounts, shipping) and generates cross-domain recommendations. Do NOT ask clarifying questions.
 - **Traffic acquisition is NOT an eCommerce-strategy request** ("grow my traffic", SEO, ads, social, content) → do NOT use Recommend: eCommerce Strategy; it only converts visitors a store already has. Route these to marketing.
 - **Pricing & promotions** (coupons, discount rules, ribbons, sales) → use the [Pricing & Promotions](references/ecommerce/ecom-pricing.md) dispatcher.
 - **Shipping setup** (rates, regions, pickup, free shipping, fix coverage) → use the [Shipping](references/ecommerce/ecom-shipping.md) dispatcher.

--- a/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
+++ b/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
@@ -1,6 +1,6 @@
 ---
 name: "Recommend: eCommerce Strategy"
-description: Unified eCommerce recommendation skill — analyzes site data across ALL domains (discounts, shipping, and future domains) and generates up to 5 actionable recommendations. Entry point for requests about earning more from the visitors a store already has: sales, promotions, discounts, coupons, clearance, holiday deals, AOV, shipping. Out of scope — traffic acquisition (SEO, ads, social, content); route "grow my traffic" requests to marketing instead. Tracking is built-in.
+description: Unified eCommerce recommendation skill — analyzes site data across ALL domains (discounts, shipping, and future domains) and generates up to 5 actionable recommendations. Entry point for requests about earning more from the visitors a store already has: sales, promotions, discounts, coupons, clearance, holiday deals, AOV, shipping, checkout conversion, cart abandonment. Out of scope — traffic acquisition (SEO, ads, social, content); route "grow my traffic" requests to marketing instead. Tracking is built-in.
 layer: R
 references:
   - name: "API: Recommendation Tracking"


### PR DESCRIPTION
Two-line fix for an inconsistency I introduced in #789. Extracted from #805, which was closed — the rest of that PR was tuning against a non-deterministic gate, but this part is readable straight from the diff and doesn't depend on any eval score.

## The problem

`recommend-ecommerce-strategy.md:179` activates the SHIPPING domain on these cues:

> `| **SHIPPING** | Merchant mentions shipping, delivery, checkout conversion, cart abandonment. ...`

#789 replaced this skill's open-ended scope ("Use this for ANY business improvement request") with an explicit enumeration, in order to exclude traffic acquisition. But the enumeration omitted checkout conversion and cart abandonment:

| Location | On main today |
|---|---|
| body `:179` | shipping, delivery, **checkout conversion, cart abandonment** |
| frontmatter `description` | sales, promotions, discounts, coupons, clearance, holiday deals, AOV, shipping |
| `SKILL.md:167` | boost sales, promotions, help my business, holiday deals, improve revenue, discounts, shipping, coupons, clearance |

So the skill body handles a request type its own front door no longer advertises.

That was my error in #789. Excluding traffic acquisition was right; enumerating the in-scope list was a reasonable mechanism for it. What I got wrong was writing that list from the existing description instead of checking it against the domain-activation table in the body.

## The fix

Adds `checkout conversion` and `cart abandonment` to both cue sites. #789's traffic-acquisition exclusion is untouched — it has been green on both sides of every gate run I have seen (five consecutive), and this change does not widen scope back toward acquisition.

Description is 513 chars, within the 1024 limit.

Two files because `SKILL.md` is this skill's index entry, per CONTRIBUTING step 2.

## Coverage

Covered by the existing `yaml/wix-manage-evals/ecommerce/recommend-ecommerce-strategy.yml` and `recommend-strategy-not-traffic-growth.yml`.

Heads-up for whoever reviews: this gate has been unreliable on these scenarios. On #805, runs 4 and 5 evaluated byte-identical content and inverted on two of three scenarios ([detail](https://github.com/wix/skills/pull/805#issuecomment-5157950723)). Worth re-running before reading a single red result as a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)