### PR TITLE
fix(wix-manage): document how to archive a pricing plan

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -280,7 +280,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Pricing Plans
 
 ### [Create and Update Pricing Plans](references/pricing-plans/create-and-update-pricing-plans.md)
-**Technical:** Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, and plan visibility.
+**Technical:** Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, plan visibility, and how to archive, hide, or delete a plan that should no longer be sold.
 
 ### [Pricing Plans Bookings Integration](references/pricing-plans/pricing-plans-bookings-integration.md)
 **Technical:** Links Pricing Plans to Bookings services using the Benefit Programs API. Enables package deals and memberships that grant booking access.

--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -1,6 +1,6 @@
 ---
 name: "Create and Update Pricing Plans"
-description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, and plan visibility.
+description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, plan visibility, and how to archive, hide, or delete a plan that should no longer be sold.
 ---
 # Technical Step-by-Step Instructions: Creating or Updating a Wix Pricing Plans (Real-World, API-First)
 
@@ -149,8 +149,33 @@ Each item in the request for this endpoint must adhere to these rules:
 - `itemSetId` must set to the created pool definition benefit item set id.
 - `externalId` must be set to the integrating app entity id, example: booking service id or blog post id.
 
+### 3. Stop selling a plan (archive, hide, or delete)
+
+Plans V3 has **no archive method**. Its methods are Create, Get, Update, Delete, Bulk Update,
+Query, Search and Count — there is no `ArchivePlan` and no settable `archived` field. Pick by what
+the user actually wants:
+
+| Goal | Call | Effect |
+| --- | --- | --- |
+| Stop offering it to new customers, keep existing buyers | `PATCH /pricing-plans/v3/plans/{plan.id}` with `plan.visibility: "PRIVATE"` | Hidden from the plan list. **Still purchasable by anyone with a direct link.** Existing buyers keep their benefits. |
+| Archive it — no longer purchasable at all | `POST /pricing-plans/v2/plans/{id}/archive` (empty body) | Sets the plan's `public` to `false`. Archived plans can't be purchased or reactivated. Existing orders keep their perks and payment schedule. |
+| Remove it entirely | `DELETE /pricing-plans/v3/plans/{planId}` | Deletion, not archiving. Do not use this when the user says "archive". |
+
+Two traps that cost several failed calls each:
+
+- **A plan you `GET` shows `archived`, `status` and `primary`, none of which are in the V3 Plan
+  schema and none of which are settable through Update Plan.** Reading them back and trying to
+  `PATCH` `archived: true` or `status: "ARCHIVED"` does not archive the plan. `visibility` is the
+  only state field on the V3 plan, and its only values are `PUBLIC` and `PRIVATE`.
+- **The archive endpoint is on the V2 resource, which is labelled deprecated.** It is still the
+  only call that archives, and its documented replacement (`UpdatePlan`) does not expose the
+  field. Use it, and treat the V3 `visibility` route as the alternative when "stop selling"
+  rather than "archive" is what was meant.
+
 ## Pricing plans REST API Documentation Reference
 - [Create plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan)
+- [Archive plan (V2)](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-deprecated/archive-plan)
+- [Delete plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/delete-plan)
 - [Get plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/get-plan)
 - [Update plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/update-plan)
 - [Query Plans](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/query-plans)

--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -161,16 +161,9 @@ the user actually wants:
 | Archive it — no longer purchasable at all | `POST /pricing-plans/v2/plans/{id}/archive` (empty body) | Sets the plan's `public` to `false`. Archived plans can't be purchased or reactivated. Existing orders keep their perks and payment schedule. |
 | Remove it entirely | `DELETE /pricing-plans/v3/plans/{planId}` | Deletion, not archiving. Do not use this when the user says "archive". |
 
-Two traps that cost several failed calls each:
-
-- **A plan you `GET` shows `archived`, `status` and `primary`, none of which are in the V3 Plan
-  schema and none of which are settable through Update Plan.** Reading them back and trying to
-  `PATCH` `archived: true` or `status: "ARCHIVED"` does not archive the plan. `visibility` is the
-  only state field on the V3 plan, and its only values are `PUBLIC` and `PRIVATE`.
-- **The archive endpoint is on the V2 resource, which is labelled deprecated.** It is still the
-  only call that archives, and its documented replacement (`UpdatePlan`) does not expose the
-  field. Use it, and treat the V3 `visibility` route as the alternative when "stop selling"
-  rather than "archive" is what was meant.
+A plan returned by `GET` carries `archived`, `status` and `primary`. None of them is settable —
+`PATCH`ing `archived: true` or `status: "ARCHIVED"` does not archive a plan. `visibility` is the
+only state field you can write, and it does not archive.
 
 ## Pricing plans REST API Documentation Reference
 - [Create plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan)

--- a/yaml/wix-manage-evals/pricing-plans/archive-a-plan.yml
+++ b/yaml/wix-manage-evals/pricing-plans/archive-a-plan.yml
@@ -1,0 +1,87 @@
+# Seeds one plan and asks for it to be archived.
+#
+# The failure this covers is a routing choice, not a payload mistake. Plans V3 has no archive
+# method, so an agent working from the V3 surface alone has three wrong-looking options and no
+# right one: PATCH a `status`/`archived` field that a GET shows but Update Plan does not accept,
+# DELETE the plan, or hunt for an endpoint that isn't there. The only call that archives is on
+# the V2 resource.
+#
+# Deleting scores zero here on purpose. It satisfies "stop selling it" and destroys the plan,
+# which is not what was asked and is not recoverable.
+name: pricing-plans/archive-a-plan
+description: >
+  A site owner retiring a plan. Plans V3 exposes no archive method and no settable `archived` or
+  `status` field — archiving is `POST /pricing-plans/v2/plans/{id}/archive` with an empty body.
+  Expected: locate the seeded plan, then archive it in one call. Anti-patterns: deleting it;
+  PATCHing `archived: true` or `status: "ARCHIVED"` against Plans V3; setting `visibility` to
+  `PRIVATE` and reporting it as archived.
+triggerPrompt: >
+  Archive my "Legacy Membership" plan — I don't want to sell it any more, but I don't want to
+  lose it either.
+tags: [pricing-plans, aria]
+assertions:
+  # If the recipe is never opened, the content fix cannot be what moved the score —
+  # surface that as a failure rather than letting it pass quietly.
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/create-and-update-pricing-plans
+  - type: llm_judge          # GATE — outcome correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Intent: the user wants the plan named "Legacy Membership" archived — no longer purchasable,
+      but still present on the site.
+
+      Pass only if the plan was archived and the final answer says so. Archiving is a successful
+      (2xx) call to POST /pricing-plans/v2/plans/{id}/archive.
+
+      Fail if the plan was deleted (DELETE on Plans V3) — the user explicitly asked not to lose
+      it. Fail if the only change was setting `visibility` to `PRIVATE`, and the answer reports
+      the plan as archived: a private plan is still purchasable through a direct link, so that
+      claim is untrue. Fail if no successful archive call was made but the answer claims the plan
+      was archived. Fail if the agent reports it cannot archive plans.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # SIGNAL — non-gating MCP friction
+    minScore: 0
+    maxTokens: 2048
+    prompt: >
+      DIAGNOSTIC, non-gating — rate how smoothly the Wix MCP and its docs let the agent fulfill
+      the request. Examine the tool-call trace. Score 0-10 (10 = direct: find the plan, one
+      archive call, no errors, no wasted searches).
+
+      Penalize and LIST any of: a PATCH against Plans V3 carrying `archived`, `status`, or any
+      field that Update Plan rejects; a 400 from such a call; a DELETE attempted and then walked
+      back; more than one documentation or API-spec search to find where archiving lives;
+      searching Plans V3 for an archive method that does not exist; confusion between the V2 and
+      V3 plan resources costing an extra call.
+
+      For each issue, name the likely MCP or docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: bookings-editor
+  bootstrap:
+    steps:
+      # Body shape per the recipe's minimal example: `status` and a caller-generated
+      # `pricingVariants[].id` are both required and both absent from the generated schema.
+      - label: seed the plan to archive
+        method: post
+        url: https://www.wixapis.com/pricing-plans/v3/plans
+        body:
+          plan:
+            name: Legacy Membership
+            visibility: PUBLIC
+            status: ACTIVE
+            buyable: true
+            buyerCanCancel: true
+            pricingVariants:
+              - id: 0f8c2b17-4e6a-4d9b-8a31-5c7e2f9d1a44
+                name: Legacy Membership
+                pricingStrategies:
+                  - flatRate:
+                      amount: "15"
+                billingTerms:
+                  startType: ON_PURCHASE
+                  endType: UNTIL_CANCELLED


### PR DESCRIPTION
## Scope

This PR is deliberately narrow: it teaches the agent **which call archives a plan**, and nothing else.

The reason archiving is hard to get right is an upstream defect, not a documentation gap — filed
as **wix-private/app-market#60578**. `Plan.status`, `Plan.archived` and `Plan.primary` are declared
in the Plans V3 proto but annotated `(.wix.api.field_exposure) = PRIVATE`, so they are stripped
from the public schema while the server still requires `status` on create, returns `archived` in
responses, and lists all three as filterable and sortable. That belongs with the owning team
(`paid-plans`), not in a recipe.

## What stays here

Even with a correct schema, an agent still has to map the word "archive" onto the right call. Plans
V3 has no archive method, so the three plausible options produce three different outcomes:

| Goal | Call | Effect |
| --- | --- | --- |
| Stop offering to new customers | `PATCH` V3 `visibility: "PRIVATE"` | Hidden, but still purchasable via direct link |
| Archive | `POST` V2 `/plans/{id}/archive` | Not purchasable or reactivatable; existing orders keep perks |
| Remove entirely | `DELETE` V3 | Deletion, not archiving |

Plus one line noting that `archived`/`status`/`primary` are readable but not settable, so `PATCH`ing
them does nothing.

19 lines in the recipe.

## Evidence

`coverage/pricing-plans-archive-plan` scores **5/10 at 195s**, the slowest scenario in the
pricing-plans cluster. The friction judge:

> confusion between V3 PATCH status, DELETE, and V2 archive endpoint leading to redundant API calls

Archiving is currently documented nowhere — the word does not appear in either pricing-plans recipe.
The recipe `description` gains archive/hide/delete additively, so the page is reachable for
"archive a plan"; it previously advertised only "plan visibility".

## Scenario

`pricing-plans/archive-a-plan` seeds one plan and asks for it to be archived.

Deleting it scores **zero** — that satisfies "stop selling it" while destroying something the user
explicitly asked to keep. Setting `visibility: PRIVATE` and calling it archived also fails, because
a private plan is still purchasable through a direct link, so the claim is untrue.

The scenario asserts the recipe is actually read. If it is not, this change cannot be what moved
the score, and that shows up as a failure rather than passing quietly.

## Sequencing

**Land [#791](https://github.com/wix/skills/pull/791) first** — it is approved and mergeable, and
covers the other four scenarios in this cluster. This PR touches the same file and will need a
rebase after it lands.

Note that #791 is itself largely a stopgap for the same upstream defect: the `plan.status` and
caller-generated-GUID facts it documents are things the generated reference should be carrying.
Worth landing anyway, since the upstream fix will take longer.