### PR TITLE
feat(evalforge-core): per-scenario change-impact classification (CODEAI-877)

### DIFF
--- a/.github/actions/evalforge-skill-gate/README.md
+++ b/.github/actions/evalforge-skill-gate/README.md
@@ -68,6 +68,109 @@ silent false pass:
 - a scenario selection that resolves to **zero** ids — nothing would be verified;
 - a completed run with **zero assertions** — no assertion failed, but none ran either.
 
+## Change-impact comparison — what blocks
+
+> **Design, not current behaviour.** Nothing in this section is wired into the gate yet. The
+> classification logic exists (`classifyChangeImpact` in `evalforge-core`), but the gate still
+> runs exactly one eval and the comment carries no impact table. What remains is blocked on
+> where per-scenario results come from — see
+> [CODEAI-877](https://wix.atlassian.net/browse/CODEAI-877).
+
+The gate will run the selected scenarios **twice**: once with the PR's content pinned, once
+with the base content — the same thing without this diff. Same preset agent, same scenario ids,
+same repeat count. The pinned versions are the only variable, which is what makes the
+difference attributable to the diff.
+
+Only the **PR arm** decides the verdict. The base arm exists to say *who broke it* and
+*whether the change moved anything* — it can never turn a green PR red, or a red PR green.
+
+```mermaid
+flowchart TD
+    VERS[["one job, two run variants:<br/>pr-N-sha7 per changed entity<br/>pr-N-base-sha7 per changed entity"]]
+    VERS --> PRRUN[PR arm]
+    VERS --> BASERUN[base arm]
+
+    PRRUN --> USABLE{completed, with<br/>≥1 assertion?}
+    USABLE -->|"no — timed out · cancelled · nothing verified"| DECIDE
+    USABLE -->|yes| RED{any assertion<br/>failed or errored?}
+    RED -->|no| PASS([✓ check passes])
+    RED -->|yes| DECIDE{{"blocking input?"}}
+    DECIDE -->|true| BLOCK([setFailed — merge blocked])
+    DECIDE -->|false| WARN([warning + comment — passes, soak period])
+
+    BASERUN -.-> BUSABLE{base arm<br/>usable?}
+    BUSABLE -.->|no| NOATTR[attribution unavailable]
+    BUSABLE -.->|yes| CLASS["classify every scenario<br/>fixed · newly-broken<br/>still-passing · still-failing"]
+    CLASS -.-> COMMENT
+    NOATTR -.-> COMMENT[["PR comment — wording and the<br/>necessity signal, never the verdict"]]
+```
+
+Dotted edges inform the comment. Nothing on the dotted path reaches `blocking input?`, so a
+base arm that times out or errors degrades the report to "attribution unavailable" and leaves
+the gate exactly as strict as it was.
+
+| Base | PR | Class | Effect on the check |
+|---|---|---|---|
+| pass | pass | `still-passing` | silent |
+| fail | pass | `fixed` | **passes** — reported as the necessity signal |
+| pass | fail | `newly-broken` | **blocks** — this PR caused it |
+| fail | fail | `still-failing` | **blocks** — labelled pre-existing |
+| unusable | pass | — | **passes**, attribution unavailable |
+| unusable | fail | — | **blocks**, attribution unavailable |
+
+**Why `still-failing` blocks.** A scenario red on both sides tells you nothing about the
+change — it is absence of signal, not evidence of safety, and this is the one rule
+[`evalforge-yaml-gate`](../evalforge-yaml-gate) already enforces for wix-manage
+(`comparisonHasNoWinner` fails when the `llm_judge` failed in *both* runs). Blocking on it
+also keeps the gate's strictness identical to the pre-comparison behaviour: the block
+condition remains "the PR run is fully green", so adding the comparison can only add
+information, never permission to merge something that used to be rejected. The delta's
+payoff is attribution and necessity, not a looser bar.
+
+**Every scenario has a base result.** Both runs are given the same scenario ids, so a
+scenario this PR *authored* still runs against the base skill version. That is exactly the
+signal a new reference file wants: the base version has no such doc and fails, the PR version
+passes, and the scenario reports `fixed`. There is no "no counterpart in base" case to
+special-case.
+
+**A wholly `still-passing` PR is the strongest necessity signal available.** Every scenario
+green on both sides means the measured behaviour did not move — either the change is a no-op
+against the current suite, or the suite does not cover it. Neither blocks; both are worth
+saying out loud in the comment.
+
+The base version is labelled `pr-<number>-base-<base-sha7>`, sharing the `pr-<number>-` prefix
+so PR-close cleanup sweeps it with no extra code. A shared `base-<sha7>` label reused across
+PRs would store fewer versions, but then cleanup for one PR could delete a version another PR
+is still running against — capability versions are cheaper than that ownership problem.
+
+**Nothing in the comparison knows it is comparing skills.** `EvalRunInput.capabilityVersions`
+is a `Record<capabilityId, versionId>`, so an arm is just a map: one entry per **changed**
+entity, at head for the PR arm and at the base ref for the base arm. An entity the PR did not
+touch appears in neither map, so both arms resolve it to the same default version — which is
+the "hold everything else constant" property the delta depends on.
+
+Only two things are entity-typed: the per-entity path conventions used to derive tags, and the
+mapping from content to a version body (`skillContent` for a skill, `mcpContent` for an MCP,
+one case per future kind). Selection, the guard, the gate decision, classification and cleanup
+are all entity-blind.
+
+The **inputs** are still single-entity, though — `skill-dir` and `capability-id` are scalars,
+and the entity list is built from them internally with one element. Generalising the input
+surface so a rule needs no workflow change is CODEAI-880's job; what the comparison buys now is
+that none of the *logic* will have to change. Whether a rule is even expressible as a
+capability version is itself open — rules may live in agent config instead.
+
+A PR that changes two entities produces one arm pinning both, so the delta attributes to *the
+PR*, not to either entity — separating them would need one arm per subset. The comment names
+which entities an arm pinned, so the ambiguity is visible rather than implied.
+
+**Why it stops here.** `getEvalRun` returns only `aggregateMetrics` — totals, no per-scenario
+breakdown — so the classification above has no data source yet. The two candidate routes
+(extend the client, or go through the eval-pipeline service the wix-manage gate uses) differ in
+*architecture*, not just in one adapter: the pipeline resolves both arms itself from a commit
+SHA, which would mean no base version and no second run of our own. That is why the orchestration
+is unbuilt rather than merely unwired.
+
 ## `cleanup` flow
 
 ```mermaid

--- a/.github/actions/evalforge-skill-gate/README.md
+++ b/.github/actions/evalforge-skill-gate/README.md
@@ -72,9 +72,7 @@ silent false pass:
 
 > **Design, not current behaviour.** Nothing in this section is wired into the gate yet. The
 > classification logic exists (`classifyChangeImpact` in `evalforge-core`), but the gate still
-> runs exactly one eval and the comment carries no impact table. What remains is blocked on
-> where per-scenario results come from — see
-> [CODEAI-877](https://wix.atlassian.net/browse/CODEAI-877).
+> runs exactly one eval and the comment carries no impact table.
 
 The gate will run the selected scenarios **twice**: once with the PR's content pinned, once
 with the base content — the same thing without this diff. Same preset agent, same scenario ids,
@@ -156,7 +154,7 @@ are all entity-blind.
 
 The **inputs** are still single-entity, though — `skill-dir` and `capability-id` are scalars,
 and the entity list is built from them internally with one element. Generalising the input
-surface so a rule needs no workflow change is CODEAI-880's job; what the comparison buys now is
+surface so a rule needs no workflow change is follow-up work; what the comparison buys now is
 that none of the *logic* will have to change. Whether a rule is even expressible as a
 capability version is itself open — rules may live in agent config instead.
 

--- a/.github/actions/evalforge-skill-gate/dist/index.js
+++ b/.github/actions/evalforge-skill-gate/dist/index.js
@@ -30119,6 +30119,58 @@ async function assertWixAuthor(octokit, owner, repo, prNumber, log) {
 
 /***/ }),
 
+/***/ 1985:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.scenarioPassed = scenarioPassed;
+exports.classifyChangeImpact = classifyChangeImpact;
+/** Zero assertions is not a pass: nothing was verified. Errors count as failures. */
+function scenarioPassed(outcome) {
+    return outcome.totalAssertions > 0 && outcome.failed === 0 && outcome.errors === 0;
+}
+function classifyOne(prPassed, basePassed) {
+    if (prPassed)
+        return basePassed ? 'still-passing' : 'fixed';
+    return basePassed ? 'newly-broken' : 'still-failing';
+}
+function classifyChangeImpact(prOutcomes, baseOutcomes) {
+    const baseById = new Map((baseOutcomes ?? []).map(outcome => [outcome.scenarioId, outcome]));
+    const scenarios = prOutcomes.map(prOutcome => {
+        const prPassed = scenarioPassed(prOutcome);
+        const baseOutcome = baseById.get(prOutcome.scenarioId);
+        return {
+            scenarioId: prOutcome.scenarioId,
+            scenarioName: prOutcome.scenarioName,
+            // A base scenario with zero assertions was not measured, so it is not evidence the
+            // scenario was broken — scoring it as a base failure would manufacture a false `fixed`.
+            impact: baseOutcome === undefined || baseOutcome.totalAssertions === 0
+                ? 'unattributed'
+                : classifyOne(prPassed, scenarioPassed(baseOutcome)),
+            prPassed,
+            failingAssertionNames: [...prOutcome.failingAssertionNames],
+        };
+    });
+    const countOf = (impact) => scenarios.filter(scenario => scenario.impact === impact).length;
+    const fixed = countOf('fixed');
+    const newlyBroken = countOf('newly-broken');
+    return {
+        scenarios,
+        fixed,
+        newlyBroken,
+        stillPassing: countOf('still-passing'),
+        stillFailing: countOf('still-failing'),
+        unattributed: countOf('unattributed'),
+        netEffect: fixed - newlyBroken,
+        attributionAvailable: scenarios.some(scenario => scenario.impact !== 'unattributed'),
+    };
+}
+
+
+/***/ }),
+
 /***/ 4527:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -30443,6 +30495,25 @@ const MAX_QUERY_CONCURRENCY = 8;
 // here, then used as a Bearer credential against the V1 API at `baseUrl`.
 const OAUTH_TOKEN_URL = 'https://www.wixapis.com/oauth2/token';
 exports.TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'];
+function contentBody(content) {
+    if (content.kind === 'skill')
+        return { skillContent: { files: content.files } };
+    // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
+    return {
+        mcpContent: {
+            config: {
+                [MCP_CONFIG_KEY]: {
+                    url: content.url,
+                    type: 'http',
+                    headers: {
+                        Authorization: '{{wix-auth-token}}',
+                        'wix-account-id': '{{wix-auth-user-id}}',
+                    },
+                },
+            },
+        },
+    };
+}
 exports.DRAFT_PREFIX = 'draft:';
 // Human-facing EvalForge results page (distinct from the REST `baseUrl` the client calls).
 const UI_BASE = 'https://bo.wix.com/pages/evalforge';
@@ -30576,64 +30647,22 @@ class EvalForgeClient {
         url.searchParams.set('skillsPr', headSha);
         return url.toString();
     }
-    async createMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo) {
-        const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(mcpId)}/versions`, {
-            capabilityVersion: {
-                capabilityId: mcpId,
-                version: versionLabel,
-                origin: 'pr',
-                notes: `Auto-created for PR #${prNumber}`,
-                // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
-                mcpContent: {
-                    config: {
-                        [MCP_CONFIG_KEY]: {
-                            url: this.buildMcpUrl(skillsRepo, headSha),
-                            type: 'http',
-                            headers: {
-                                Authorization: '{{wix-auth-token}}',
-                                'wix-account-id': '{{wix-auth-user-id}}',
-                            },
-                        },
-                    },
-                },
-            },
-        });
-        const v = res.capabilityVersion;
-        return { id: v.id, capabilityId: v.capabilityId, version: v.version };
-    }
-    async ensureMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo) {
-        try {
-            return await this.createMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo);
-        }
-        catch (e) {
-            // A duplicate version should be 409, but the backend currently throws a plain
-            // error for "already exists" that transcodes to 500 — so recover on either by
-            // reusing the existing version, and only rethrow if it genuinely isn't there.
-            if (!isHttpError(e) || (e.status !== 409 && e.status !== 500))
-                throw e;
-            const versions = await this.listCapabilityVersions(mcpId, projectId);
-            const existing = versions.find(v => v.version === versionLabel);
-            if (!existing)
-                throw e;
-            return existing;
-        }
-    }
-    async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+    async createCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content) {
         const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
             capabilityVersion: {
                 capabilityId,
                 version: versionLabel,
                 origin: 'pr',
                 notes: `Auto-created for PR #${prNumber}`,
-                skillContent: { files },
+                ...contentBody(content),
             },
         });
         const created = res.capabilityVersion;
         return { id: created.id, capabilityId: created.capabilityId, version: created.version };
     }
-    async createOrReuseSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+    async createOrReuseCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content) {
         try {
-            return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
+            return await this.createCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content);
         }
         catch (error) {
             // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
@@ -30645,6 +30674,12 @@ class EvalForgeClient {
                 throw error;
             return existing;
         }
+    }
+    async createOrReuseSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+        return this.createOrReuseCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, { kind: 'skill', files });
+    }
+    async ensureMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo) {
+        return this.createOrReuseCapabilityVersion(mcpId, projectId, versionLabel, prNumber, { kind: 'mcp', url: this.buildMcpUrl(skillsRepo, headSha) });
     }
     // Without `names`: lists ALL scenarios via an empty-filter query (used by
     // promote / cleanup / run-all). With `names`: fetches only those scenarios —
@@ -31115,6 +31150,7 @@ __exportStar(__nccwpck_require__(3308), exports);
 __exportStar(__nccwpck_require__(8833), exports);
 __exportStar(__nccwpck_require__(3460), exports);
 __exportStar(__nccwpck_require__(5970), exports);
+__exportStar(__nccwpck_require__(1985), exports);
 
 
 /***/ }),

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34233,6 +34233,58 @@ async function assertWixAuthor(octokit, owner, repo, prNumber, log) {
 
 /***/ }),
 
+/***/ 1985:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.scenarioPassed = scenarioPassed;
+exports.classifyChangeImpact = classifyChangeImpact;
+/** Zero assertions is not a pass: nothing was verified. Errors count as failures. */
+function scenarioPassed(outcome) {
+    return outcome.totalAssertions > 0 && outcome.failed === 0 && outcome.errors === 0;
+}
+function classifyOne(prPassed, basePassed) {
+    if (prPassed)
+        return basePassed ? 'still-passing' : 'fixed';
+    return basePassed ? 'newly-broken' : 'still-failing';
+}
+function classifyChangeImpact(prOutcomes, baseOutcomes) {
+    const baseById = new Map((baseOutcomes ?? []).map(outcome => [outcome.scenarioId, outcome]));
+    const scenarios = prOutcomes.map(prOutcome => {
+        const prPassed = scenarioPassed(prOutcome);
+        const baseOutcome = baseById.get(prOutcome.scenarioId);
+        return {
+            scenarioId: prOutcome.scenarioId,
+            scenarioName: prOutcome.scenarioName,
+            // A base scenario with zero assertions was not measured, so it is not evidence the
+            // scenario was broken — scoring it as a base failure would manufacture a false `fixed`.
+            impact: baseOutcome === undefined || baseOutcome.totalAssertions === 0
+                ? 'unattributed'
+                : classifyOne(prPassed, scenarioPassed(baseOutcome)),
+            prPassed,
+            failingAssertionNames: [...prOutcome.failingAssertionNames],
+        };
+    });
+    const countOf = (impact) => scenarios.filter(scenario => scenario.impact === impact).length;
+    const fixed = countOf('fixed');
+    const newlyBroken = countOf('newly-broken');
+    return {
+        scenarios,
+        fixed,
+        newlyBroken,
+        stillPassing: countOf('still-passing'),
+        stillFailing: countOf('still-failing'),
+        unattributed: countOf('unattributed'),
+        netEffect: fixed - newlyBroken,
+        attributionAvailable: scenarios.some(scenario => scenario.impact !== 'unattributed'),
+    };
+}
+
+
+/***/ }),
+
 /***/ 4527:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -34557,6 +34609,25 @@ const MAX_QUERY_CONCURRENCY = 8;
 // here, then used as a Bearer credential against the V1 API at `baseUrl`.
 const OAUTH_TOKEN_URL = 'https://www.wixapis.com/oauth2/token';
 exports.TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'];
+function contentBody(content) {
+    if (content.kind === 'skill')
+        return { skillContent: { files: content.files } };
+    // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
+    return {
+        mcpContent: {
+            config: {
+                [MCP_CONFIG_KEY]: {
+                    url: content.url,
+                    type: 'http',
+                    headers: {
+                        Authorization: '{{wix-auth-token}}',
+                        'wix-account-id': '{{wix-auth-user-id}}',
+                    },
+                },
+            },
+        },
+    };
+}
 exports.DRAFT_PREFIX = 'draft:';
 // Human-facing EvalForge results page (distinct from the REST `baseUrl` the client calls).
 const UI_BASE = 'https://bo.wix.com/pages/evalforge';
@@ -34690,64 +34761,22 @@ class EvalForgeClient {
         url.searchParams.set('skillsPr', headSha);
         return url.toString();
     }
-    async createMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo) {
-        const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(mcpId)}/versions`, {
-            capabilityVersion: {
-                capabilityId: mcpId,
-                version: versionLabel,
-                origin: 'pr',
-                notes: `Auto-created for PR #${prNumber}`,
-                // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
-                mcpContent: {
-                    config: {
-                        [MCP_CONFIG_KEY]: {
-                            url: this.buildMcpUrl(skillsRepo, headSha),
-                            type: 'http',
-                            headers: {
-                                Authorization: '{{wix-auth-token}}',
-                                'wix-account-id': '{{wix-auth-user-id}}',
-                            },
-                        },
-                    },
-                },
-            },
-        });
-        const v = res.capabilityVersion;
-        return { id: v.id, capabilityId: v.capabilityId, version: v.version };
-    }
-    async ensureMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo) {
-        try {
-            return await this.createMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo);
-        }
-        catch (e) {
-            // A duplicate version should be 409, but the backend currently throws a plain
-            // error for "already exists" that transcodes to 500 — so recover on either by
-            // reusing the existing version, and only rethrow if it genuinely isn't there.
-            if (!isHttpError(e) || (e.status !== 409 && e.status !== 500))
-                throw e;
-            const versions = await this.listCapabilityVersions(mcpId, projectId);
-            const existing = versions.find(v => v.version === versionLabel);
-            if (!existing)
-                throw e;
-            return existing;
-        }
-    }
-    async createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+    async createCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content) {
         const res = await this.request('POST', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions`, {
             capabilityVersion: {
                 capabilityId,
                 version: versionLabel,
                 origin: 'pr',
                 notes: `Auto-created for PR #${prNumber}`,
-                skillContent: { files },
+                ...contentBody(content),
             },
         });
         const created = res.capabilityVersion;
         return { id: created.id, capabilityId: created.capabilityId, version: created.version };
     }
-    async createOrReuseSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+    async createOrReuseCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content) {
         try {
-            return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
+            return await this.createCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content);
         }
         catch (error) {
             // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
@@ -34759,6 +34788,12 @@ class EvalForgeClient {
                 throw error;
             return existing;
         }
+    }
+    async createOrReuseSkillVersion(capabilityId, projectId, versionLabel, prNumber, files) {
+        return this.createOrReuseCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, { kind: 'skill', files });
+    }
+    async ensureMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo) {
+        return this.createOrReuseCapabilityVersion(mcpId, projectId, versionLabel, prNumber, { kind: 'mcp', url: this.buildMcpUrl(skillsRepo, headSha) });
     }
     // Without `names`: lists ALL scenarios via an empty-filter query (used by
     // promote / cleanup / run-all). With `names`: fetches only those scenarios —
@@ -35229,6 +35264,7 @@ __exportStar(__nccwpck_require__(3308), exports);
 __exportStar(__nccwpck_require__(8833), exports);
 __exportStar(__nccwpck_require__(3460), exports);
 __exportStar(__nccwpck_require__(5970), exports);
+__exportStar(__nccwpck_require__(1985), exports);
 
 
 /***/ }),

--- a/packages/evalforge-core/src/classify-change-impact.ts
+++ b/packages/evalforge-core/src/classify-change-impact.ts
@@ -1,0 +1,87 @@
+export type ScenarioOutcome = {
+  scenarioId: string;
+  scenarioName: string;
+  totalAssertions: number;
+  failed: number;
+  errors: number;
+  failingAssertionNames: string[];
+};
+
+export type ImpactClass =
+  | 'fixed'
+  | 'newly-broken'
+  | 'still-passing'
+  | 'still-failing'
+  | 'unattributed';
+
+export type ScenarioImpact = {
+  scenarioId: string;
+  scenarioName: string;
+  impact: ImpactClass;
+  prPassed: boolean;
+  failingAssertionNames: string[];
+};
+
+export type ChangeImpact = {
+  scenarios: ScenarioImpact[];
+  fixed: number;
+  newlyBroken: number;
+  stillPassing: number;
+  stillFailing: number;
+  unattributed: number;
+  /** `fixed - newlyBroken` — the necessity signal. */
+  netEffect: number;
+  /** False when the base arm produced nothing at all. */
+  attributionAvailable: boolean;
+};
+
+/** Zero assertions is not a pass: nothing was verified. Errors count as failures. */
+export function scenarioPassed(outcome: ScenarioOutcome): boolean {
+  return outcome.totalAssertions > 0 && outcome.failed === 0 && outcome.errors === 0;
+}
+
+function classifyOne(prPassed: boolean, basePassed: boolean): ImpactClass {
+  if (prPassed) return basePassed ? 'still-passing' : 'fixed';
+  return basePassed ? 'newly-broken' : 'still-failing';
+}
+
+export function classifyChangeImpact(
+  prOutcomes: ScenarioOutcome[],
+  baseOutcomes: ScenarioOutcome[] | undefined,
+): ChangeImpact {
+  const baseById = new Map((baseOutcomes ?? []).map(outcome => [outcome.scenarioId, outcome]));
+
+  const scenarios: ScenarioImpact[] = prOutcomes.map(prOutcome => {
+    const prPassed = scenarioPassed(prOutcome);
+    const baseOutcome = baseOutcomes === undefined
+      ? undefined
+      : baseById.get(prOutcome.scenarioId);
+
+    return {
+      scenarioId: prOutcome.scenarioId,
+      scenarioName: prOutcome.scenarioName,
+      impact: baseOutcome === undefined
+        ? 'unattributed'
+        : classifyOne(prPassed, scenarioPassed(baseOutcome)),
+      prPassed,
+      failingAssertionNames: prOutcome.failingAssertionNames,
+    };
+  });
+
+  const countOf = (impact: ImpactClass): number =>
+    scenarios.filter(scenario => scenario.impact === impact).length;
+
+  const fixed = countOf('fixed');
+  const newlyBroken = countOf('newly-broken');
+
+  return {
+    scenarios,
+    fixed,
+    newlyBroken,
+    stillPassing: countOf('still-passing'),
+    stillFailing: countOf('still-failing'),
+    unattributed: countOf('unattributed'),
+    netEffect: fixed - newlyBroken,
+    attributionAvailable: baseOutcomes !== undefined && baseOutcomes.length > 0,
+  };
+}

--- a/packages/evalforge-core/src/classify-change-impact.ts
+++ b/packages/evalforge-core/src/classify-change-impact.ts
@@ -31,7 +31,7 @@ export type ChangeImpact = {
   unattributed: number;
   /** `fixed - newlyBroken` — the necessity signal. */
   netEffect: number;
-  /** False when the base arm produced nothing at all. */
+  /** True when at least one scenario was actually classified against a measured base outcome. */
   attributionAvailable: boolean;
 };
 
@@ -53,18 +53,18 @@ export function classifyChangeImpact(
 
   const scenarios: ScenarioImpact[] = prOutcomes.map(prOutcome => {
     const prPassed = scenarioPassed(prOutcome);
-    const baseOutcome = baseOutcomes === undefined
-      ? undefined
-      : baseById.get(prOutcome.scenarioId);
+    const baseOutcome = baseById.get(prOutcome.scenarioId);
 
     return {
       scenarioId: prOutcome.scenarioId,
       scenarioName: prOutcome.scenarioName,
-      impact: baseOutcome === undefined
+      // A base scenario with zero assertions was not measured, so it is not evidence the
+      // scenario was broken — scoring it as a base failure would manufacture a false `fixed`.
+      impact: baseOutcome === undefined || baseOutcome.totalAssertions === 0
         ? 'unattributed'
         : classifyOne(prPassed, scenarioPassed(baseOutcome)),
       prPassed,
-      failingAssertionNames: prOutcome.failingAssertionNames,
+      failingAssertionNames: [...prOutcome.failingAssertionNames],
     };
   });
 
@@ -82,6 +82,6 @@ export function classifyChangeImpact(
     stillFailing: countOf('still-failing'),
     unattributed: countOf('unattributed'),
     netEffect: fixed - newlyBroken,
-    attributionAvailable: baseOutcomes !== undefined && baseOutcomes.length > 0,
+    attributionAvailable: scenarios.some(scenario => scenario.impact !== 'unattributed'),
   };
 }

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -3,7 +3,6 @@ import { TokenProvider } from './auth';
 export type HttpError = Error & { status: number };
 
 const MCP_URL = 'https://mcp.wix.com/mcp';
-const MCP_CONFIG_KEY = 'wix-mcp-remote';
 
 // Cap on concurrent per-name scenario queries, so a PR touching many scenarios
 // doesn't fire an unbounded burst at the V1 gateway (which may rate-limit).
@@ -21,6 +20,17 @@ export type CapabilityVersion = { id: string; capabilityId: string; version: str
 
 /** One file of a skill capability version; `path` is relative to the skill root. */
 export type SkillFileContent = { path: string; content: string };
+
+/** The entity-typed content of a capability version — the seam shared by skills, mcp, and (later) rules/tools. */
+export type CapabilityContent =
+  | { kind: 'skill'; files: SkillFileContent[] }
+  | { kind: 'mcp'; url: string };
+
+function contentBody(content: CapabilityContent): Record<string, unknown> {
+  return content.kind === 'skill'
+    ? { skillContent: { files: content.files } }
+    : { mcpContent: { url: content.url } };
+}
 
 import type { EvalForgeBody } from './evalforge-mapper';
 
@@ -221,71 +231,12 @@ export class EvalForgeClient {
     return url.toString();
   }
 
-  async createMcpVersion(
-    mcpId: string,
-    projectId: string,
-    versionLabel: string,
-    prNumber: number,
-    headSha: string,
-    skillsRepo: string,
-  ): Promise<CapabilityVersion> {
-    const res = await this.request<{ capabilityVersion: RawCapabilityVersion }>(
-      'POST',
-      `/projects/${enc(projectId)}/capabilities/${enc(mcpId)}/versions`,
-      {
-        capabilityVersion: {
-          capabilityId: mcpId,
-          version: versionLabel,
-          origin: 'pr',
-          notes: `Auto-created for PR #${prNumber}`,
-          // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
-          mcpContent: {
-            config: {
-              [MCP_CONFIG_KEY]: {
-                url: this.buildMcpUrl(skillsRepo, headSha),
-                type: 'http',
-                headers: {
-                  Authorization: '{{wix-auth-token}}',
-                  'wix-account-id': '{{wix-auth-user-id}}',
-                },
-              },
-            },
-          },
-        },
-      },
-    );
-    const v = res.capabilityVersion;
-    return { id: v.id, capabilityId: v.capabilityId, version: v.version };
-  }
-
-  async ensureMcpVersion(
-    mcpId: string,
-    projectId: string,
-    versionLabel: string,
-    prNumber: number,
-    headSha: string,
-    skillsRepo: string,
-  ): Promise<CapabilityVersion> {
-    try {
-      return await this.createMcpVersion(mcpId, projectId, versionLabel, prNumber, headSha, skillsRepo);
-    } catch (e) {
-      // A duplicate version should be 409, but the backend currently throws a plain
-      // error for "already exists" that transcodes to 500 — so recover on either by
-      // reusing the existing version, and only rethrow if it genuinely isn't there.
-      if (!isHttpError(e) || (e.status !== 409 && e.status !== 500)) throw e;
-      const versions = await this.listCapabilityVersions(mcpId, projectId);
-      const existing = versions.find(v => v.version === versionLabel);
-      if (!existing) throw e;
-      return existing;
-    }
-  }
-
-  private async createSkillVersion(
+  private async createCapabilityVersion(
     capabilityId: string,
     projectId: string,
     versionLabel: string,
     prNumber: number,
-    files: SkillFileContent[],
+    content: CapabilityContent,
   ): Promise<CapabilityVersion> {
     const res = await this.request<{ capabilityVersion: RawCapabilityVersion }>(
       'POST',
@@ -296,12 +247,31 @@ export class EvalForgeClient {
           version: versionLabel,
           origin: 'pr',
           notes: `Auto-created for PR #${prNumber}`,
-          skillContent: { files },
+          ...contentBody(content),
         },
       },
     );
     const created = res.capabilityVersion;
     return { id: created.id, capabilityId: created.capabilityId, version: created.version };
+  }
+
+  async createOrReuseCapabilityVersion(
+    capabilityId: string,
+    projectId: string,
+    versionLabel: string,
+    prNumber: number,
+    content: CapabilityContent,
+  ): Promise<CapabilityVersion> {
+    try {
+      return await this.createCapabilityVersion(capabilityId, projectId, versionLabel, prNumber, content);
+    } catch (error) {
+      // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
+      if (!isHttpError(error) || (error.status !== 409 && error.status !== 500)) throw error;
+      const versions = await this.listCapabilityVersions(capabilityId, projectId);
+      const existing = versions.find(candidate => candidate.version === versionLabel);
+      if (!existing) throw error;
+      return existing;
+    }
   }
 
   async createOrReuseSkillVersion(
@@ -311,16 +281,23 @@ export class EvalForgeClient {
     prNumber: number,
     files: SkillFileContent[],
   ): Promise<CapabilityVersion> {
-    try {
-      return await this.createSkillVersion(capabilityId, projectId, versionLabel, prNumber, files);
-    } catch (error) {
-      // Duplicate labels should be 409, but the backend transcodes "already exists" to 500.
-      if (!isHttpError(error) || (error.status !== 409 && error.status !== 500)) throw error;
-      const versions = await this.listCapabilityVersions(capabilityId, projectId);
-      const existing = versions.find(candidate => candidate.version === versionLabel);
-      if (!existing) throw error;
-      return existing;
-    }
+    return this.createOrReuseCapabilityVersion(
+      capabilityId, projectId, versionLabel, prNumber, { kind: 'skill', files },
+    );
+  }
+
+  async ensureMcpVersion(
+    mcpId: string,
+    projectId: string,
+    versionLabel: string,
+    prNumber: number,
+    headSha: string,
+    skillsRepo: string,
+  ): Promise<CapabilityVersion> {
+    return this.createOrReuseCapabilityVersion(
+      mcpId, projectId, versionLabel, prNumber,
+      { kind: 'mcp', url: this.buildMcpUrl(skillsRepo, headSha) },
+    );
   }
 
   // Without `names`: lists ALL scenarios via an empty-filter query (used by

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -1,4 +1,5 @@
 import { TokenProvider } from './auth';
+import type { EvalForgeBody } from './evalforge-mapper';
 
 export type HttpError = Error & { status: number };
 
@@ -27,7 +28,20 @@ export type CapabilityContent =
   | { kind: 'skill'; files: SkillFileContent[] }
   | { kind: 'mcp'; url: string };
 
-function contentBody(content: CapabilityContent): Record<string, unknown> {
+/** One entry of an MCP capability version's remote config, keyed by `MCP_CONFIG_KEY`. */
+type McpRemoteConfigEntry = {
+  url: string;
+  type: 'http';
+  headers: {
+    Authorization: string;
+    'wix-account-id': string;
+  };
+};
+
+type SkillContentBody = { skillContent: { files: SkillFileContent[] } };
+type McpContentBody = { mcpContent: { config: Record<string, McpRemoteConfigEntry> } };
+
+function contentBody(content: CapabilityContent): SkillContentBody | McpContentBody {
   if (content.kind === 'skill') return { skillContent: { files: content.files } };
   // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
   return {
@@ -45,8 +59,6 @@ function contentBody(content: CapabilityContent): Record<string, unknown> {
     },
   };
 }
-
-import type { EvalForgeBody } from './evalforge-mapper';
 
 export type RemoteScenario = { id: string; name: string; tags: string[] };
 export type ScenarioBody = EvalForgeBody;

--- a/packages/evalforge-core/src/evalforge.ts
+++ b/packages/evalforge-core/src/evalforge.ts
@@ -3,6 +3,7 @@ import { TokenProvider } from './auth';
 export type HttpError = Error & { status: number };
 
 const MCP_URL = 'https://mcp.wix.com/mcp';
+const MCP_CONFIG_KEY = 'wix-mcp-remote';
 
 // Cap on concurrent per-name scenario queries, so a PR touching many scenarios
 // doesn't fire an unbounded burst at the V1 gateway (which may rate-limit).
@@ -27,9 +28,22 @@ export type CapabilityContent =
   | { kind: 'mcp'; url: string };
 
 function contentBody(content: CapabilityContent): Record<string, unknown> {
-  return content.kind === 'skill'
-    ? { skillContent: { files: content.files } }
-    : { mcpContent: { url: content.url } };
+  if (content.kind === 'skill') return { skillContent: { files: content.files } };
+  // V1 capability content is a oneof — MCP capabilities use `mcpContent`.
+  return {
+    mcpContent: {
+      config: {
+        [MCP_CONFIG_KEY]: {
+          url: content.url,
+          type: 'http',
+          headers: {
+            Authorization: '{{wix-auth-token}}',
+            'wix-account-id': '{{wix-auth-user-id}}',
+          },
+        },
+      },
+    },
+  };
 }
 
 import type { EvalForgeBody } from './evalforge-mapper';

--- a/packages/evalforge-core/src/index.ts
+++ b/packages/evalforge-core/src/index.ts
@@ -17,3 +17,4 @@ export * from './guard-scenarios';
 export * from './select-scenarios';
 export * from './evaluate-run-result';
 export * from './format-gate-comment';
+export * from './classify-change-impact';

--- a/packages/evalforge-core/tests/classify-change-impact.test.ts
+++ b/packages/evalforge-core/tests/classify-change-impact.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { classifyChangeImpact, type ScenarioOutcome } from '../src/classify-change-impact';
+
+const outcome = (
+  scenarioId: string,
+  passed: boolean,
+  overrides: Partial<ScenarioOutcome> = {},
+): ScenarioOutcome => ({
+  scenarioId,
+  scenarioName: `scenario ${scenarioId}`,
+  totalAssertions: 3,
+  failed: passed ? 0 : 1,
+  errors: 0,
+  failingAssertionNames: passed ? [] : ['judge'],
+  ...overrides,
+});
+
+describe('classifyChangeImpact', () => {
+  it('classifies green-on-both as still-passing', () => {
+    const impact = classifyChangeImpact([outcome('a', true)], [outcome('a', true)]);
+    expect(impact.scenarios[0].impact).toBe('still-passing');
+    expect(impact.stillPassing).toBe(1);
+  });
+
+  it('classifies base-red PR-green as fixed', () => {
+    const impact = classifyChangeImpact([outcome('a', true)], [outcome('a', false)]);
+    expect(impact.scenarios[0].impact).toBe('fixed');
+    expect(impact.fixed).toBe(1);
+  });
+
+  it('classifies base-green PR-red as newly-broken', () => {
+    const impact = classifyChangeImpact([outcome('a', false)], [outcome('a', true)]);
+    expect(impact.scenarios[0].impact).toBe('newly-broken');
+    expect(impact.newlyBroken).toBe(1);
+  });
+
+  it('classifies red-on-both as still-failing', () => {
+    const impact = classifyChangeImpact([outcome('a', false)], [outcome('a', false)]);
+    expect(impact.scenarios[0].impact).toBe('still-failing');
+    expect(impact.stillFailing).toBe(1);
+  });
+
+  it('treats an absent base arm as wholly unattributed', () => {
+    const impact = classifyChangeImpact([outcome('a', true), outcome('b', false)], undefined);
+    expect(impact.scenarios.map(scenario => scenario.impact))
+      .toEqual(['unattributed', 'unattributed']);
+    expect(impact.attributionAvailable).toBe(false);
+  });
+
+  it('degrades per scenario when the base arm is missing just one', () => {
+    const impact = classifyChangeImpact(
+      [outcome('a', true), outcome('b', true)],
+      [outcome('a', true)],
+    );
+    expect(impact.scenarios[0].impact).toBe('still-passing');
+    expect(impact.scenarios[1].impact).toBe('unattributed');
+    expect(impact.attributionAvailable).toBe(true);
+    expect(impact.unattributed).toBe(1);
+  });
+
+  it('counts an errored assertion as a failure, not a pass', () => {
+    const prOutcome = outcome('a', true, { errors: 1, failingAssertionNames: ['build'] });
+    const impact = classifyChangeImpact([prOutcome], [outcome('a', true)]);
+    expect(impact.scenarios[0].impact).toBe('newly-broken');
+  });
+
+  it('does not count a zero-assertion scenario as passing', () => {
+    const empty = outcome('a', true, { totalAssertions: 0 });
+    const impact = classifyChangeImpact([empty], [outcome('a', true)]);
+    expect(impact.scenarios[0].impact).toBe('newly-broken');
+  });
+
+  it('ignores base scenarios that the PR arm did not run', () => {
+    const impact = classifyChangeImpact([outcome('a', true)], [outcome('a', true), outcome('z', false)]);
+    expect(impact.scenarios).toHaveLength(1);
+  });
+
+  it('reports a net effect of fixed minus newly-broken', () => {
+    const impact = classifyChangeImpact(
+      [outcome('a', true), outcome('b', false)],
+      [outcome('a', false), outcome('b', true)],
+    );
+    expect(impact.netEffect).toBe(0);
+  });
+});

--- a/packages/evalforge-core/tests/classify-change-impact.test.ts
+++ b/packages/evalforge-core/tests/classify-change-impact.test.ts
@@ -82,4 +82,25 @@ describe('classifyChangeImpact', () => {
     );
     expect(impact.netEffect).toBe(0);
   });
+
+  it('treats a zero-assertion base scenario as unattributed, not fixed', () => {
+    const unmeasuredBase = outcome('a', false, { totalAssertions: 0 });
+    const impact = classifyChangeImpact([outcome('a', true)], [unmeasuredBase]);
+    expect(impact.scenarios[0].impact).toBe('unattributed');
+    expect(impact.fixed).toBe(0);
+    expect(impact.netEffect).toBe(0);
+  });
+
+  it('reports attributionAvailable false when base ids are disjoint from PR ids', () => {
+    const impact = classifyChangeImpact([outcome('a', true)], [outcome('z', false)]);
+    expect(impact.scenarios[0].impact).toBe('unattributed');
+    expect(impact.attributionAvailable).toBe(false);
+  });
+
+  it('treats an empty base arm the same as an unmeasured one', () => {
+    const impact = classifyChangeImpact([outcome('a', true), outcome('b', false)], []);
+    expect(impact.scenarios.map(scenario => scenario.impact))
+      .toEqual(['unattributed', 'unattributed']);
+    expect(impact.attributionAvailable).toBe(false);
+  });
 });

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -360,6 +360,32 @@ describe('EvalForgeClient (V1) — ensureMcpVersion idempotency', () => {
     const c = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
     await expect(c.ensureMcpVersion('M', 'P', 'pr-1-abc', 1, 'abc1234', 'wix/skills')).rejects.toMatchObject({ status: 500 });
   });
+
+  it('posts the nested mcpContent config wix-mcp-remote expects, with type and header placeholders', async () => {
+    let captured: unknown;
+    mockFetch(({ url, method, body }) => {
+      if (url.includes('/capabilities/M/versions') && method === 'POST') {
+        captured = body;
+        return { status: 200, body: { capabilityVersion: { id: 'ver-1', capabilityId: 'M', version: 'pr-1-abc' } } };
+      }
+      return { status: 404 };
+    });
+    const c = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+    await c.ensureMcpVersion('M', 'P', 'pr-1-abc', 1, 'abc1234', 'wix/skills');
+
+    expect((captured as { capabilityVersion: { mcpContent: unknown } }).capabilityVersion.mcpContent).toEqual({
+      config: {
+        'wix-mcp-remote': {
+          url: 'https://mcp.wix.com/mcp?skillsRepo=wix%2Fskills&skillsPr=abc1234',
+          type: 'http',
+          headers: {
+            Authorization: '{{wix-auth-token}}',
+            'wix-account-id': '{{wix-auth-user-id}}',
+          },
+        },
+      },
+    });
+  });
 });
 
 describe('EvalForgeClient (V1) — skill capability versions', () => {
@@ -463,8 +489,18 @@ describe('createOrReuseCapabilityVersion', () => {
       kind: 'mcp', url: 'https://example.test/mcp',
     });
 
-    expect((captured as { capabilityVersion: { mcpContent: unknown } }).capabilityVersion.mcpContent)
-      .toEqual({ url: 'https://example.test/mcp' });
+    expect((captured as { capabilityVersion: { mcpContent: unknown } }).capabilityVersion.mcpContent).toEqual({
+      config: {
+        'wix-mcp-remote': {
+          url: 'https://example.test/mcp',
+          type: 'http',
+          headers: {
+            Authorization: '{{wix-auth-token}}',
+            'wix-account-id': '{{wix-auth-user-id}}',
+          },
+        },
+      },
+    });
   });
 
   it('reuses the existing version when the label already exists', async () => {

--- a/packages/evalforge-core/tests/evalforge.test.ts
+++ b/packages/evalforge-core/tests/evalforge.test.ts
@@ -430,3 +430,54 @@ describe('EvalForgeClient (V1) — skill capability versions', () => {
     await expect(client.createOrReuseSkillVersion('C', 'P', 'L', 42, files)).rejects.toMatchObject({ status: 400 });
   });
 });
+
+describe('createOrReuseCapabilityVersion', () => {
+  it('posts skillContent for a skill entity', async () => {
+    let captured: unknown;
+    mockFetch(({ method, body }) => {
+      expect(method).toBe('POST');
+      captured = body;
+      return { status: 200, body: { capabilityVersion: { id: 'v1', capabilityId: 'C', version: 'pr-42-abc1234' } } };
+    });
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+
+    await client.createOrReuseCapabilityVersion('C', 'P', 'pr-42-abc1234', 42, {
+      kind: 'skill', files: [{ path: 'SKILL.md', content: '# skill' }],
+    });
+
+    expect((captured as { capabilityVersion: { skillContent: unknown } }).capabilityVersion.skillContent).toEqual({
+      files: [{ path: 'SKILL.md', content: '# skill' }],
+    });
+  });
+
+  it('posts mcpContent for an mcp entity', async () => {
+    let captured: unknown;
+    mockFetch(({ method, body }) => {
+      expect(method).toBe('POST');
+      captured = body;
+      return { status: 200, body: { capabilityVersion: { id: 'v2', capabilityId: 'M', version: 'pr-42-abc1234' } } };
+    });
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+
+    await client.createOrReuseCapabilityVersion('M', 'P', 'pr-42-abc1234', 42, {
+      kind: 'mcp', url: 'https://example.test/mcp',
+    });
+
+    expect((captured as { capabilityVersion: { mcpContent: unknown } }).capabilityVersion.mcpContent)
+      .toEqual({ url: 'https://example.test/mcp' });
+  });
+
+  it('reuses the existing version when the label already exists', async () => {
+    mockFetch(({ method }) => {
+      if (method === 'POST') return { status: 409 };
+      return { status: 200, body: { capabilityVersions: [{ id: 'v-existing', capabilityId: 'C', version: 'pr-42-abc1234' }] } };
+    });
+    const client = new EvalForgeClient(URL_BASE, CLIENT_ID, CLIENT_SECRET);
+
+    const version = await client.createOrReuseCapabilityVersion('C', 'P', 'pr-42-abc1234', 42, {
+      kind: 'skill', files: [{ path: 'SKILL.md', content: '# skill' }],
+    });
+
+    expect(version.id).toBe('v-existing');
+  });
+});


### PR DESCRIPTION
Phase 2 of the codegen auto-eval initiative ([CODEAI-877](https://wix.atlassian.net/browse/CODEAI-877), parent CODEAI-497). This is the **first two steps** of a nine-step plan, not the whole phase — see *Deliberately not included* below.

## What this adds

**One create-or-reuse path behind a content union** (`b9abbff`). `createOrReuseSkillVersion` and `ensureMcpVersion` each carried their own copy of the same create-then-reuse-on-409/500 dance. Both are now three-line delegates to `createOrReuseCapabilityVersion(…, content: CapabilityContent)`, where `CapabilityContent` is `{ kind: 'skill', files }` | `{ kind: 'mcp', url }`. Net −62 lines of duplicated retry logic, and both cases are live from day one.

This is also the seam that lets the same eval flow later evaluate **rules and tools**, not just skills: adding an entity kind becomes one case in `contentBody`.

**`classifyChangeImpact`** (`e31c96a`, corrected in `27c1199`). A pure function comparing two eval runs — the PR's content vs the base content — labelling each scenario `fixed` / `newly-broken` / `still-passing` / `still-failing` / `unattributed`, plus `netEffect` (`fixed - newlyBroken`) as the "was this change necessary" signal. No imports, no EvalForge types, 13 behavioural tests, zero mocks.

**Docs** (`6038b6c`). The decision graph and the reasoning for what blocks, explicitly marked as design rather than current behaviour.

## The design decision worth reviewing

**Only the PR arm decides the verdict.** The base arm attributes failures and produces the necessity signal; it can never turn a green PR red or a red PR green. If it errors or times out, the report degrades to "attribution unavailable" and the gate stays exactly as strict.

This means `still-failing` **blocks**, which reverses what CODEAI-877 originally specified. Three reasons, and the ticket has been updated to match:

1. A scenario red on both sides is *absence of signal*, not evidence of safety.
2. It is the rule the wix-manage gate already enforces (`comparisonHasNoWinner` fails when the `llm_judge` failed in *both* runs).
3. It keeps the block condition identical to today's "PR run is fully green", so adding the comparison can only add information — never permission to merge something that used to be rejected. A non-blocking `still-failing` would have been a *weakening* of the gate shipped as a reporting improvement.

## Deliberately not included

`classifyChangeImpact` has **no production caller yet**, and the gate still runs exactly one eval. The remaining seven tasks (base-version minting, dual-arm orchestration, comment rendering) were cut from this pass because the open question — where per-scenario results come from — changes their *architecture*, not just one adapter.

That question now has an answer, found while reviewing this branch: wix-manage's eval-pipeline returns a **`runId` per scenario per arm** (`eval-pipeline.ts:19`, logged at `gate.ts:232-233`), meaning it runs one eval run per scenario. Per-scenario results are therefore obtainable with today's `getEvalRun` and no new API surface, at a cost of 2N runs instead of 2. That shapes the follow-up PR.

## Two bugs caught in review, both worth knowing about

**The plan flattened the MCP wire body.** The first implementation followed the plan text and posted `mcpContent: { url }` instead of the real nested `mcpContent.config['wix-mcp-remote']` carrying `url`, `type: 'http'` and the `{{wix-auth-*}}` header placeholders. Inside a change framed as a pure refactor, that would have altered what EvalForge receives for **every MCP version the live wix-manage gate creates**. No test asserted that body, which is why it went unnoticed. `a2704bd` restores it byte-for-byte and adds the missing regression test, asserting the whole nested object with `toEqual` — a partial assertion would not have caught the original bug either.

**A zero-assertion base scenario manufactured a false `fixed`.** Sending the base outcome through `scenarioPassed` meant `totalAssertions === 0` read as `basePassed === false`, so a green PR scenario was labelled `fixed` — corrupting the one signal the phase exists to produce. Zero assertions on the base side means *we did not measure it*, not *it was broken*. Fixed in `27c1199`; it is now `unattributed`.

Note the asymmetry is intentional: on the **PR** side, zero assertions stays not-a-pass, mirroring `evaluate-run-result.ts`. Relatedly, `skipped` is deliberately not consulted anywhere — the run-level rule ignores it, and diverging would let a green check carry `newly-broken` labels.

## Verification

- `evalforge-core` 306 tests, `evalforge-skill-gate` 138, `evalforge-yaml-gate` 76 — all green
- `dist/` rebuilt for both actions (`f89dd01`); the `ci.yml:203` stale-`dist` check reproduced locally and passes
- `ensureMcpVersion`'s signature is unchanged and its caller at `.github/actions/evalforge-yaml-gate/src/utils/gate.ts:107` is untouched

`createMcpVersion` was removed rather than kept as a delegate: its only caller was `ensureMcpVersion`, and the similarly-named method in `.github/actions/skill-eval/` belongs to a separate legacy client with a different body shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)