### PR TITLE
🦞 igor-claw: Site Import NOT_ENABLED should not tell users to contact Wix support

### DIFF
--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -230,10 +230,16 @@ the user has no way to open a file.
 - Never invent a `deployUrl` — only report the one returned with `DEPLOYED`.
 - Treat `NEEDS_INPUT` and `AUTH_EXPIRED` as normal conversation turns, not
   errors.
-- **Site Import is in limited rollout.** If Start returns `404` or `403` with
-  `"code": "NOT_ENABLED"`, tell the user plainly that site import isn't
-  supported on their account yet and they can contact Wix support — then stop.
-  Do not retry or fall back to another site-creation tool.
+- **Site Import is in limited rollout, with no self-service enablement path.**
+  If Start returns `404` or `403` with `"code": "NOT_ENABLED"`, tell the user
+  plainly that site import isn't available on their account yet — then stop.
+  **Do not tell them to "contact Wix support"**: this API is unlisted and
+  ALPHA, Wix Support has no visibility into it or way to grant access, and the
+  public "importing a site created outside of Wix" help-center article is an
+  unrelated, long-stalled feature-request page — sending a user to either is a
+  dead end. If a Wix feedback tool is available in your environment, you may
+  offer to send feedback noting their interest; that is the only channel that
+  reaches the team. Do not retry or fall back to another site-creation tool.
 - Any other `403` on Start means the caller is not authorized — tell the user
   and stop. Do not probe other endpoints to diagnose this. A `400` means a
   required field is missing (`request`/`message` must be 1–20000 chars).


### PR DESCRIPTION
## Summary
- Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching MCP feedback in this Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1785700567846739
- The `site-import` skill's `NOT_ENABLED` handling rule told the client agent to tell blocked users "they can contact Wix support" to get Site Import enabled. Reproduced: this account is enabled (Start succeeds), but the reporting account got a clean `403 { code: "NOT_ENABLED" }` — confirming per-account gradual rollout, not an outage.
- Root cause of the dead end: Site Import's rollout is gated purely by an internal Conductor/Releases experiment (`replatformSiteImport`), see `wix-private/replatform-sb` `packages/bix-site-import/src/shared/releaseGate.ts` + `specs/0004-id-minimal-protocol-and-rollout-gate.md`. There is no support-facing runbook, ticket queue, or self-service enablement flow tied to it — Wix Support has no lever to grant access. The only public help-center hit for "importing a site into Wix" is an unrelated, long-stalled feature-request/voting page, not this AI migration agent (confirmed via web search — this ALPHA API has zero public documentation).
- Fix: stop promising a support escalation that doesn't exist. Tell the user plainly it isn't available yet, and — if a Wix feedback tool is available in the agent's environment — offer to send feedback noting interest, since that's the one channel that actually reaches the owning team.

## Test plan
- [x] Reproduced Start success on an enabled account and a clean `403 NOT_ENABLED` shape via docs/code review of the release gate
- [x] Confirmed via web search that there is no public documentation or support path for this feature
- N/A automated tests — this is a client-facing instruction/wording change in a skill markdown file, not code

🤖 This PR was opened automatically by an AI research agent acting on behalf of Ayal (ayalg@wix.com), not written by them personally.