### PR TITLE
🦞 igor-claw: document page-504/runtime-unreachable known gap

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -353,6 +353,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Sites Dashboard Navigation](references/sites/sites-dashboard-navigation.md)
 **Technical:** Direct links to the account-level My Sites list (manage.wix.com/account/websites) and per-site dashboard homes, paired with the Query Sites read API.
 
+### [Diagnosing a Live Page Returning 504 / "Runtime is unreachable" — Known Gap](references/sites/diagnosing-page-504-runtime-unreachable.md)
+**Technical:** A Velo-enabled site's non-home pages return HTTP 504 "Runtime is unreachable" — Wix's Velo runtime supervisor's own signal for an unreachable backend pod, not a content/publish/routing problem. Republishing doesn't fix it, `ListSitemapPages` cannot diagnose it (it only covers dynamic items, never static pages), and there's no public API to check or restart the runtime. Read this before spending multiple tool calls chasing it.
+
 ---
 
 ## Stores

--- a/skills/wix-manage/references/sites/diagnosing-page-504-runtime-unreachable.md
+++ b/skills/wix-manage/references/sites/diagnosing-page-504-runtime-unreachable.md
@@ -1,0 +1,65 @@
+---
+name: "Diagnosing a Live Page Returning 504 / 'Runtime is unreachable' — Known Gap"
+description: A published, Velo-enabled site's non-home pages return HTTP 504 with body "Runtime is unreachable" while the home page works. Republishing does not fix it, ListSitemapPages cannot diagnose it, and there is no public API to check or restart the site's Velo runtime. Read this before spending multiple tool calls hunting for a fix.
+---
+
+# Diagnosing a Live Page Returning 504 / "Runtime is unreachable" — Known Gap
+
+## The symptom
+
+A site owner reports that some or all pages of a **Published, Velo-enabled** site fail to
+load, with the browser showing an error like "runtime is unreachable" and DevTools showing
+`Failed to load resource: the server responded with a status of 504`. Often the home page
+loads fine while other pages (About, Contact, etc.) fail — because the home page is more
+likely to already be warm/cached, not because those other pages are special.
+
+## Root cause: this is a Velo backend runtime signal, not a content/publish problem
+
+The literal string **"Runtime is unreachable"**, paired with HTTP **504**, is Wix's own Velo
+platform's canned response for exactly this condition — it comes from the Kore Supervisor
+(`wix-private/velo-platform-golang`, `kore/kore-supervisor`), the reverse proxy in front of
+every Velo-enabled site's backend runtime container. When the supervisor can't dial the
+runtime (connection refused, EOF, or an unexplained fast timeout — see
+`handleRuntimeUnreachable` in `kore-supervisor/handlers/proxy_factory.go`), it returns
+`504` with body `"Runtime is unreachable"` verbatim. This is an **infrastructure-level
+signal that the site's Velo runtime pod is unreachable or crashed** — it has nothing to do
+with the page's content, its publish status, or its routing configuration.
+
+This explains two things a diagnostic session will otherwise misread as separate bugs:
+
+- **Republishing does not fix it.** `Publish Site` (Site Actions API) publishes content/routing
+  changes; it does not touch Velo runtime pod lifecycle at all. A successful `publish-site`
+  call with the 504s persisting afterward is expected, not a sign the publish itself is broken.
+- **There is no public API to check or restart the runtime.** There is no REST/MCP surface to
+  read a site's Velo runtime health or force a restart. If a site is stuck in this state, the
+  only path is to escalate to Wix support/infra — do not keep spending tool calls probing
+  content or routing APIs looking for a fix here.
+
+## Don't use `ListSitemapPages` to check whether the site's pages are "registered"
+
+A natural next diagnostic step is checking whether the affected pages are known to Wix's
+backend at all — via the Headless Sitemap Entry V1 API's `ListSitemapPages`
+(`GET /v1/list-sitemap-pages`). **This will not tell you that.** Its `itemType` enum only
+covers dynamic, repeater-generated business-solution items (`STORES_PRODUCT`, `BLOG_POST`,
+`BOOKINGS_SERVICE`, etc.) — there is no value for a site's static/main pages (classic Editor
+"Home", "About", "Contact", ...). An empty `pages` result is the **expected, unrelated**
+response for any site whose pages are all static — it is not evidence those pages are
+unpublished or unregistered, and it should not feed into a 504 root-cause hypothesis.
+
+There is also no other public API to list a classic/Editorless site's own static page
+routes for verification: `List Published Site URLs` (Site URLs API) only returns
+domain-level URLs (primary/secondary/multilingual subdomains), not per-page routes. This is
+the same underlying theme as the page-editing gap documented in
+[[editing-existing-site-pages-menus-and-homepage.md]] — site *creation* APIs are rich, site
+*introspection* of the actual page/runtime state is not.
+
+## What to do instead
+
+1. Confirm the symptom directly (fetch the failing page URL, or ask the user to check
+   DevTools) rather than relying on `ListSitemapPages` or any other content API — it won't
+   confirm or refute this.
+2. If confirmed, state plainly that this is a Velo backend runtime issue on Wix's
+   infrastructure side, not something fixable via the Wix MCP or any public API — republishing
+   will not help. Direct the user to Wix Support for the underlying runtime pod issue.
+3. Don't loop on `publish-site`, sitemap, or SEO/routing APIs expecting one of them to
+   surface or fix this — none of them touch Velo runtime pod health.

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -22,3 +22,7 @@ apiDoc:
       title: Sites Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
       tags: [sites]
+    - file: ../../../skills/wix-manage/references/sites/diagnosing-page-504-runtime-unreachable.md
+      title: Diagnosing a Live Page Returning 504 / "Runtime is unreachable" — Known Gap
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites/site-actions
+      tags: [sites, gap]


### PR DESCRIPTION
## What's missing

Feedback report (Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1785786776810269): a user's Published, Velo-enabled site returned HTTP 504 "Runtime is unreachable" on every page except the home page. The agent's diagnostic session burned several tool calls on `list-sitemap-pages` (came back empty, wrongly read as "pages might not be registered") and `publish-site` (succeeded, didn't fix anything), with no path to the actual explanation.

## Root cause (confirmed by reading source)

"Runtime is unreachable" + HTTP 504 is the literal, verbatim response Wix's Velo runtime supervisor (Kore Supervisor, `wix-private/velo-platform-golang:kore/kore-supervisor/handlers/proxy_factory.go`, `handleRuntimeUnreachable`) returns when it can't reach a site's Velo backend runtime pod (connection refused / EOF / unexplained fast timeout). This is an infra-level signal, unrelated to page content, publish status, or routing — which is why republishing doesn't help, and why there's no REST/MCP API to check or restart it.

Separately, confirmed `list-sitemap-pages`'s `itemType` enum only covers dynamic business-solution items (products, blog posts, etc.) — no value exists for a site's static/main pages, so an empty result there is expected and unrelated to the 504s (companion fix: wix-private/promote-seo#14836 clarifies this in the proto).

## The fix

New recipe `skills/wix-manage/references/sites/diagnosing-page-504-runtime-unreachable.md`, registered in `SKILL.md` + `yaml/wix-manage/sites/documentation.yaml`: explains the Velo-runtime root cause, states plainly that no public API can diagnose or fix it, and tells the next agent not to spend tool calls on `list-sitemap-pages`/`publish-site` chasing it.

---
Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com), researching Wix MCP user feedback.