### PR TITLE
🦞 igor-claw: fix Create Form recipe's identifier guidance for choice/date fields

### DIFF
--- a/skills/wix-manage/references/forms/create-form.md
+++ b/skills/wix-manage/references/forms/create-form.md
@@ -214,7 +214,7 @@ Verify the form in the dashboard: `https://manage.wix.com/dashboard/{siteId}/for
 
 - All `id` fields (for `formFields`, `steps`) and all `fieldId` references in the layout **must be valid UUIDs**. Generate fresh UUIDs for each form you create — do not reuse the example UUIDs above.
 - Each field needs a unique `id` and a unique `target` value. The `target` is used to map submissions to contact fields.
-- **CRITICAL: The `identifier` must be a recognized Wix value.** Custom identifiers like `"product_name"` or `"color_preference"` will cause the field to be silently dropped from the form — no error is thrown. For any generic/custom text field, use `"TEXT_INPUT"` as the identifier and set the display name via the `label` property in `textInputOptions`.
+- **CRITICAL: `identifier` must match the field's `componentType`, not just be "any recognized value".** The API silently derives the field's rendered type from `identifier` on every read — it ignores `componentType` for this purpose. Custom identifiers like `"product_name"` or `"color_preference"` cause the field to be silently dropped from the form (no error thrown). Using `identifier: "TEXT_INPUT"` for a non-text field (e.g. `RADIO_GROUP`, `DROPDOWN`, `DATE_INPUT`) does **not** just fail to drop it — it makes the field come back with `componentType: "TEXT_INPUT"` too, silently discarding its options/date config. For a generic/custom text field use `identifier: "TEXT_INPUT"` (set the display name via `label`); for every other `componentType`, set `identifier` to that exact same string (e.g. `identifier: "RADIO_GROUP"` for a `RADIO_GROUP` field, `identifier: "DATE_INPUT"` for a `DATE_INPUT` field) — see § "Choice fields" and § "Date fields" below.
 - For plain text fields, use `"format": "UNKNOWN_FORMAT"`. For email fields, use `"format": "EMAIL"`. For phone fields, use `"format": "PHONE"`. Valid format values: `UNKNOWN_FORMAT`, `DATE`, `TIME`, `DATE_TIME`, `EMAIL`, `URL`, `UUID`, `PHONE`, `URI`, `HOSTNAME`, `COLOR_HEX`, `CURRENCY`, `LANGUAGE`, `DATE_OPTIONAL_TIME`.
 - The submit button is a `DISPLAY` field with `identifier: "SUBMIT_BUTTON"`.
 - **Build the complete form in one call — do not create throwaway "test" forms to probe field shapes.** A site has a **low form cap (~4 forms)**; iterative probing hits the cap (`maximum number of forms reached`), forcing you to `GET` the form list and `DELETE` the test forms before the real create can succeed. Assemble all fields (including any RADIO_GROUP/DROPDOWN per § "Choice fields") and POST once.
@@ -229,25 +229,28 @@ Verify the form in the dashboard: `https://manage.wix.com/dashboard/{siteId}/for
 | `CONTACTS_EMAIL` | `TEXT_INPUT` | `EMAIL` | Contact email |
 | `CONTACTS_PHONE` | `TEXT_INPUT` | `PHONE` | Contact phone |
 | `SUBMIT_BUTTON` | N/A (`DISPLAY` field) | N/A | Submit button |
-| `TEXT_INPUT` | `RADIO_GROUP` | `UNKNOWN_FORMAT` | Single-choice from a fixed list (radio buttons) — see § "Choice fields" |
-| `TEXT_INPUT` | `DROPDOWN` | `UNKNOWN_FORMAT` | Single-choice from a fixed list (dropdown) — same shape as RADIO_GROUP |
+| `RADIO_GROUP` | `RADIO_GROUP` | `UNKNOWN_FORMAT` | Single-choice from a fixed list (radio buttons) — see § "Choice fields" |
+| `DROPDOWN` | `DROPDOWN` | `UNKNOWN_FORMAT` | Single-choice from a fixed list (dropdown) — same shape as RADIO_GROUP |
+| `DATE_INPUT` | `DATE_INPUT` | `DATE` | Date field, plain text-style input — see § "Date fields" |
+| `DATE_PICKER` | `DATE_PICKER` | `DATE` | Date field, calendar-style picker — see § "Date fields" |
 
 > **Note:** `LONG_TEXT_INPUT` is not supported as a `componentType` via REST — it throws `INVALID_ARGUMENT`. Use `TEXT_INPUT` for all text fields.
 
 ### Choice fields (RADIO_GROUP / DROPDOWN)
 
-A single-choice field (radio buttons or a dropdown — e.g. an RSVP "Will you attend?") is a **`STRING` input field**, not a separate field type. It uses `identifier: "TEXT_INPUT"`, `inputType: "STRING"`, and sets `componentType` to `RADIO_GROUP` (or `DROPDOWN`) **inside `stringOptions`**. Two things must agree or the field breaks:
+A single-choice field (radio buttons or a dropdown — e.g. an RSVP "Will you attend?") is a **`STRING` input field**, not a separate field type. It uses `identifier: "RADIO_GROUP"` (or `"DROPDOWN"` — must match `componentType`), `inputType: "STRING"`, and sets `componentType` to `RADIO_GROUP` (or `DROPDOWN`) **inside `stringOptions`**. Three things must agree or the field breaks:
 
-1. **`stringOptions.validation.enum`** must list every option `value` (an empty `enum` is for free-text only).
-2. **`stringOptions.radioGroupOptions.options[]`** carries the rendered choices — each option needs its own **UUID `id`**, a `value`, and a `label`. (For `DROPDOWN`, use `dropdownOptions` with the same `{id, value, label}` shape.)
+1. **`identifier` must equal the `componentType` value** (`"RADIO_GROUP"` or `"DROPDOWN"`). Using `identifier: "TEXT_INPUT"` here does not just risk a fallback — it unconditionally makes the field come back as a plain `TEXT_INPUT`, discarding its options, even though the create call returns 200 and the options are briefly visible in the response's legacy `fields` array.
+2. **`stringOptions.validation.enum`** must list every option `value` (an empty `enum` is for free-text only).
+3. **`stringOptions.radioGroupOptions.options[]`** carries the rendered choices — each option needs its own **UUID `id`**, a `value`, and a `label`. (For `DROPDOWN`, use `dropdownOptions` with the same `{id, value, label}` shape.)
 
-> **CRITICAL — silent fallback to TEXT_INPUT.** If `radioGroupOptions` is missing/malformed (wrong key like `choices` instead of `options`, an option missing its `id`, or an empty `validation.enum`), the API does **not** error — it silently creates the field as a plain `TEXT_INPUT`. If a choice field renders as a text box, this is why. Build it correctly on the first call; do not probe.
+> **CRITICAL — silent fallback to TEXT_INPUT.** If `identifier` doesn't match `componentType`, or `radioGroupOptions` is missing/malformed (wrong key like `choices` instead of `options`, an option missing its `id`, or an empty `validation.enum`), the API does **not** error — it silently creates the field as a plain `TEXT_INPUT`. If a choice field renders as a text box (or vanishes on the next `GET`), this is why. Build it correctly on the first call; do not probe.
 
 ```json
 {
   "id": "a1b2c3d4-1002-4e00-8001-000000000002",
   "hidden": false,
-  "identifier": "TEXT_INPUT",
+  "identifier": "RADIO_GROUP",
   "fieldType": "INPUT",
   "inputOptions": {
     "target": "attending_0002",
@@ -277,6 +280,39 @@ A single-choice field (radio buttons or a dropdown — e.g. an RSVP "Will you at
 
 `numberOfColumns` is a string enum (`"ONE"`, `"TWO"`, `"THREE"`) controlling the radio layout — omit it and the field still works (defaults to one column).
 
+### Date fields (DATE_INPUT / DATE_PICKER)
+
+A date field (e.g. a date of birth) is also a **`STRING` input field** with `inputType: "STRING"`. As with choice fields, `identifier` must equal the `componentType` value — `"DATE_INPUT"` or `"DATE_PICKER"` — or the field is silently created as a plain `TEXT_INPUT` (or dropped, if `identifier` is a custom value) on the next read. Set `stringOptions.validation.format` to `"DATE"`.
+
+```json
+{
+  "id": "a1b2c3d4-1003-4e00-8001-000000000003",
+  "hidden": false,
+  "identifier": "DATE_INPUT",
+  "fieldType": "INPUT",
+  "inputOptions": {
+    "target": "date_of_birth_0003",
+    "pii": false,
+    "required": false,
+    "inputType": "STRING",
+    "readOnly": false,
+    "stringOptions": {
+      "validation": {
+        "format": "DATE",
+        "enum": []
+      },
+      "componentType": "DATE_INPUT",
+      "dateInputOptions": {
+        "label": "Date of Birth",
+        "showLabel": true
+      }
+    }
+  }
+}
+```
+
+For a calendar-style picker instead of a text-style date input, use `componentType: "DATE_PICKER"` / `identifier: "DATE_PICKER"` / `datePickerOptions` instead.
+
 ### Layout
 
 The `steps[].layout.large.items` array controls how fields are positioned:
@@ -297,8 +333,8 @@ The Wix Forms app (appDefId: `14ce1214-b278-a7e4-1373-00cebd1bef7c`) must be ins
 | Error | Cause | Fix |
 |---|---|---|
 | `Unrecognized value passed for enum` | Invalid `componentType` value (e.g., `LONG_TEXT_INPUT`) | Use only `componentType` values from the schema: `TEXT_INPUT`, `RADIO_GROUP`, `DROPDOWN`, `DATE_TIME`, `PHONE_INPUT`, `DATE_INPUT`, `TIME_INPUT`, `DATE_PICKER`, `PASSWORD` |
-| Field silently missing from created form | Custom `identifier` value (e.g., `"product_name"`) | Use a recognized identifier like `TEXT_INPUT` and set display name via `label` |
-| Choice field rendered as a plain text box | `radioGroupOptions`/`dropdownOptions` malformed (wrong key, option missing `id`, empty `validation.enum`) — API silently falls back to `TEXT_INPUT` | Match the § "Choice fields" shape exactly: `componentType` in `stringOptions`, `options[]` each with a UUID `id`, and `validation.enum` listing all option values |
+| Field silently missing from created form | Custom `identifier` value (e.g., `"product_name"`) not recognized by the API | For a generic text field use `identifier: "TEXT_INPUT"` and set display name via `label`; for any other `componentType`, set `identifier` to that same value (see § "Field Types Reference") |
+| Choice/date field silently comes back as `componentType: "TEXT_INPUT"` (options or date config gone) | `identifier` doesn't match `componentType` (most commonly `identifier: "TEXT_INPUT"` used for a `RADIO_GROUP`/`DROPDOWN`/`DATE_INPUT`/`DATE_PICKER` field), or `radioGroupOptions`/`dropdownOptions` malformed (wrong key, option missing `id`, empty `validation.enum`) | Set `identifier` to the exact same string as `componentType`; match the § "Choice fields" / § "Date fields" shape exactly |
 | `maximum number of forms reached` / form-cap error | Sites cap at ~4 forms; reached by creating throwaway test forms | `GET form-schema-service/v4/forms` then `DELETE` the unwanted forms; build the real form in one call (don't probe) |
 | `Permissions for given namespace not found` | `wix.form_app.form` namespace not active | Ensure the Wix Forms app is installed; try creating a form through the UI first to activate the namespace |
 | `missing installed app` | Wix Forms app not installed | Install app `14ce1214-b278-a7e4-1373-00cebd1bef7c` via the [Install Wix Apps](../app-installation/install-wix-apps.md) recipe |


### PR DESCRIPTION
#### Problem
The Create Form recipe's own recommended pattern for choice/date fields causes the exact bug it warns about. It instructs setting `identifier: "TEXT_INPUT"` for `RADIO_GROUP`/`DROPDOWN` fields (Field Types Reference table + "Choice fields" example), and doesn't cover `DATE_INPUT`/`DATE_PICKER` at all.

Live-verified on `wix.form_app.form` via Create Form: the Form Schemas API (form-schema-service) derives a field's rendered `componentType` on every subsequent read from its `identifier` string, matched against an internal fixed allow-list — completely independent of the `componentType` actually set in the request. Following the recipe's own guidance (`identifier: "TEXT_INPUT"` + `componentType: "RADIO_GROUP"`) makes the field's own create response immediately show `componentType: "TEXT_INPUT"`, discarding `radioGroupOptions` — no error, HTTP 200. Setting `identifier` to match the componentType instead (`"RADIO_GROUP"`, `"DROPDOWN"`, `"DATE_INPUT"`) reproducibly fixes it.

This is the root cause of an MCP feedback report where an agent built a lead-capture form with a dropdown "Preferred Campus" field and a "Date of Birth" field; both silently reverted to `TEXT_INPUT` after creation, and the DOB field's `validation.format` became immutably stuck at `DATE` even though its rendered type was lost.

#### Solution
- Corrected the "Field Types Reference" table and "Choice fields" example to use `identifier` matching `componentType` (`RADIO_GROUP`/`DROPDOWN`) instead of `"TEXT_INPUT"`.
- Added a new "Date fields (DATE_INPUT / DATE_PICKER)" section (previously undocumented), with the same `identifier`-must-match-`componentType` rule.
- Updated the "CRITICAL" bullet and troubleshooting table to describe the actual failure mode: a mismatched `identifier` doesn't just risk a fallback, it unconditionally coerces the field to `TEXT_INPUT` (or drops it if `identifier` is fully custom).

#### Considerations - important facts the reviewer should know
- The underlying service behavior (silently overriding `componentType` based on an undocumented `identifier` allow-list instead of erroring) is a real API bug being raised separately with the Forms team — this PR only fixes the recipe so agents following it stop reproducing that bug.
- Filed automatically by an AI agent acting on behalf of Ayal (ayalg@wix.com), researching Wix MCP user feedback. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1785825864996019
- Did not touch the file's existing wrong `appDefId` (`14ce1214-...`) — that's already tracked by open PR #658.