### PR TITLE
fix(wix-manage): quote recommend-ecommerce-strategy description to fix YAML parse error

### DIFF
--- a/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
+++ b/skills/wix-manage/references/ecommerce/recommend-ecommerce-strategy.md
@@ -1,6 +1,6 @@
 ---
 name: "Recommend: eCommerce Strategy"
-description: Unified eCommerce recommendation skill — analyzes site data across ALL domains (discounts, shipping, and future domains) and generates up to 5 actionable recommendations. Entry point for requests about earning more from the visitors a store already has: sales, promotions, discounts, coupons, clearance, holiday deals, AOV, shipping. Out of scope — traffic acquisition (SEO, ads, social, content); route "grow my traffic" requests to marketing instead. Tracking is built-in.
+description: "Unified eCommerce recommendation skill — analyzes site data across ALL domains (discounts, shipping, and future domains) and generates up to 5 actionable recommendations. Entry point for requests about earning more from the visitors a store already has: sales, promotions, discounts, coupons, clearance, holiday deals, AOV, shipping. Out of scope — traffic acquisition (SEO, ads, social, content); route \"grow my traffic\" requests to marketing instead. Tracking is built-in."
 layer: R
 references:
   - name: "API: Recommendation Tracking"


### PR DESCRIPTION
## Summary
- `description` in `ecommerce/recommend-ecommerce-strategy.md` contained an unquoted `...already has: sales, promotions...` — a colon+space inside a plain YAML scalar is parsed as a nested mapping key.
- This breaks frontmatter parsing with `Error in user YAML: (<unknown>): mapping values are not allowed in this context`.
- Fixed by wrapping the description in double quotes (escaping the pre-existing internal double quotes around "grow my traffic"), matching the convention already used elsewhere (e.g. `ecom-load-context.md`).

## Test plan
- [x] Verified frontmatter now parses cleanly with `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)