### PR TITLE
fix(wix-manage): quote bundle-and-save flow description to fix YAML parse error

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md
@@ -1,6 +1,6 @@
 ---
 name: "Flow: Bundle and Save"
-description: BUNDLE_AND_SAVE sub-flow — load [Goal: Drive Cross-Sells] FIRST (it owns classification and routing); this is a sub-step, NOT a direct entry from README.
+description: "BUNDLE_AND_SAVE sub-flow — load [Goal: Drive Cross-Sells] FIRST (it owns classification and routing); this is a sub-step, NOT a direct entry from README."
 ---
 # Flow: Bundle & Save Campaign
 


### PR DESCRIPTION
## Summary
- `description` in `ecommerce/pricing-promotions/ecom-pricing-flow-bundle-and-save.md` contained an unquoted `[Goal: Drive Cross-Sells]` — a colon+space inside a plain YAML scalar is parsed as a nested mapping key.
- This breaks frontmatter parsing with `Error in user YAML: (<unknown>): mapping values are not allowed in this context`.
- Fixed by wrapping the description in double quotes, matching the convention already used elsewhere (e.g. `ecom-load-context.md`).

## Test plan
- [x] Verified frontmatter now parses cleanly with `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)