### PR TITLE
fix(wix-manage): quote stock-mover flow description to fix YAML parse error

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md
@@ -1,6 +1,6 @@
 ---
 name: "Flow: Stock Mover"
-description: Stock-mover clearance sub-flow — load [Goal: Clear Inventory] FIRST (it owns the routing); this is a sub-step.
+description: "Stock-mover clearance sub-flow — load [Goal: Clear Inventory] FIRST (it owns the routing); this is a sub-step."
 ---
 # Flow: Stock Mover Clearance
 


### PR DESCRIPTION
## Summary
- `description` in `ecommerce/pricing-promotions/ecom-pricing-flow-stock-mover.md` contained an unquoted `[Goal: Clear Inventory]` — a colon+space inside a plain YAML scalar is parsed as a nested mapping key.
- This breaks frontmatter parsing with `Error in user YAML: (<unknown>): mapping values are not allowed in this context`.
- Fixed by wrapping the description in double quotes, matching the convention already used elsewhere (e.g. `ecom-load-context.md`).

## Test plan
- [x] Verified frontmatter now parses cleanly with `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)