### PR TITLE
fix(wix-manage): quote upsell-boost flow description to fix YAML parse error

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md
@@ -1,6 +1,6 @@
 ---
 name: "Flow: Upsell Boost"
-description: UPSELL_BOOST sub-flow — load [Goal: Increase AOV] FIRST (it owns classification and routing); this is a sub-step, NOT a direct entry from README.
+description: "UPSELL_BOOST sub-flow — load [Goal: Increase AOV] FIRST (it owns classification and routing); this is a sub-step, NOT a direct entry from README."
 ---
 # Flow: Upsell Boost Campaign
 


### PR DESCRIPTION
## Summary
- `description` in `ecommerce/pricing-promotions/ecom-pricing-flow-upsell-boost.md` contained an unquoted `[Goal: Increase AOV]` — a colon+space inside a plain YAML scalar is parsed as a nested mapping key.
- This breaks frontmatter parsing with `Error in user YAML: (<unknown>): mapping values are not allowed in this context`.
- Fixed by wrapping the description in double quotes, matching the convention already used elsewhere (e.g. `ecom-load-context.md`).

## Test plan
- [x] Verified frontmatter now parses cleanly with `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)