### PR TITLE
fix(stores): correct image-attach success check — PATCH vs GET media.main shapes differ

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -178,18 +178,13 @@ The request body is `items` (each with the product's `catalogItemId` and the Sto
    ```
    The image may be referenced by a `static.wixstatic.com` **`url`** or by its Wix Media **`id`** (`<hash>~mv2.png`) — either works.
 
-- **Write via `media.itemsInfo.items`** (inside the `product` wrapper), never `media.main` — the server derives `media.main` from it. `media.itemsInfo` itself is **write-only** — it comes back `null` on read, so never assert on it.
-- **Success = the PATCH returns `200` with no `error` in the body. Use that as your signal — do NOT gate success on reading the image URL back.** The image URL lives at a **different path in the PATCH response vs. a GET read-back**, and checking the wrong one reads `undefined` and reports a false failure on a *successful* attach (a multi-round debug loop). The two shapes:
+- **Write the image via `media.itemsInfo.items`** (inside the `product` wrapper); the server derives `media.main` from it.
+- **A `200` from the PATCH is success.** To confirm the image persisted, **re-GET the product and read `media.main.image.url`**:
 
   ```jsonc
-  // PATCH /stores/v3/products/{id} response — image URL is FLAT on media.main (no media.main.image):
-  "media": { "main": { "url": "https://static.wixstatic.com/media/…~mv2.png", "altText": "…", "mediaType": "IMAGE" } }
-
-  // GET /stores/v3/products/{id} read-back — image URL is NESTED under media.main.image (no flat media.main.url):
+  // GET /stores/v3/products/{id} → the attached image:
   "media": { "main": { "image": { "url": "https://static.wixstatic.com/media/…~mv2.png", "width": 1024, "height": 1024 }, "altText": "…" } }
   ```
-
-  So: trust the PATCH `200`. If you additionally want to confirm persistence, **re-GET the product and read `media.main.image.url`** — never look for `media.main.image` on the PATCH response (it isn't there).
 - Send **one image per product** (primary); a larger gallery is out of scope for the seed.
 - **Never block on image failure** — skip and leave the product text-only.
 

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -178,7 +178,11 @@ The request body is `items` (each with the product's `catalogItemId` and the Sto
    ```
    The image may be referenced by a `static.wixstatic.com` **`url`** or by its Wix Media **`id`** (`<hash>~mv2.png`) — either works.
 
-- The field that persists is **`media.itemsInfo.items`**, NOT `media.main`. **⚠️ `media.main` set ALONE silently no-ops** — a `200` comes back but re-query shows no image; that is the trap. The server promotes the first `itemsInfo.items` entry to `media.main` for you, so **verify success by reading `media.main.image.url`** — it must resolve to a `static.wixstatic.com` URL. Check that nested string, **not** the presence of `media.main` (which can be a non-null object with no image and makes a failed attach look successful). Conversely `media.itemsInfo` is **write-only** — it comes back `null` on read, so never assert on it.
+- **Write via `media.itemsInfo.items`** (inside the `product` wrapper), never `media.main` — the server derives `media.main` from it. **Success is the PATCH returning `200` with no `error` in the body — use that as your signal.** Do **not** gate success on reading the media back: **the media shape differs between the two responses**, and applying the wrong one is a false-negative that starts a multi-round debug loop.
+  - **PATCH response** → image URL at **`media.main.url`** (flat; there is **no** `media.main.image` here).
+  - **GET read-back** → image URL at **`media.main.image.url`** (nested; there is **no** flat `media.main.url` here).
+  - `media.itemsInfo` is **write-only** — it comes back `null` on read, so never assert on it.
+  - So: trust the PATCH `200`. If you additionally want to confirm persistence, **re-GET the product and read `media.main.image.url`** — do **not** look for `media.main.image` on the PATCH response (it isn't there).
 - Send **one image per product** (primary); a larger gallery is out of scope for the seed.
 - **Never block on image failure** — skip and leave the product text-only.
 

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -178,11 +178,18 @@ The request body is `items` (each with the product's `catalogItemId` and the Sto
    ```
    The image may be referenced by a `static.wixstatic.com` **`url`** or by its Wix Media **`id`** (`<hash>~mv2.png`) — either works.
 
-- **Write via `media.itemsInfo.items`** (inside the `product` wrapper), never `media.main` — the server derives `media.main` from it. **Success is the PATCH returning `200` with no `error` in the body — use that as your signal.** Do **not** gate success on reading the media back: **the media shape differs between the two responses**, and applying the wrong one is a false-negative that starts a multi-round debug loop.
-  - **PATCH response** → image URL at **`media.main.url`** (flat; there is **no** `media.main.image` here).
-  - **GET read-back** → image URL at **`media.main.image.url`** (nested; there is **no** flat `media.main.url` here).
-  - `media.itemsInfo` is **write-only** — it comes back `null` on read, so never assert on it.
-  - So: trust the PATCH `200`. If you additionally want to confirm persistence, **re-GET the product and read `media.main.image.url`** — do **not** look for `media.main.image` on the PATCH response (it isn't there).
+- **Write via `media.itemsInfo.items`** (inside the `product` wrapper), never `media.main` — the server derives `media.main` from it. `media.itemsInfo` itself is **write-only** — it comes back `null` on read, so never assert on it.
+- **Success = the PATCH returns `200` with no `error` in the body. Use that as your signal — do NOT gate success on reading the image URL back.** The image URL lives at a **different path in the PATCH response vs. a GET read-back**, and checking the wrong one reads `undefined` and reports a false failure on a *successful* attach (a multi-round debug loop). The two shapes:
+
+  ```jsonc
+  // PATCH /stores/v3/products/{id} response — image URL is FLAT on media.main (no media.main.image):
+  "media": { "main": { "url": "https://static.wixstatic.com/media/…~mv2.png", "altText": "…", "mediaType": "IMAGE" } }
+
+  // GET /stores/v3/products/{id} read-back — image URL is NESTED under media.main.image (no flat media.main.url):
+  "media": { "main": { "image": { "url": "https://static.wixstatic.com/media/…~mv2.png", "width": 1024, "height": 1024 }, "altText": "…" } }
+  ```
+
+  So: trust the PATCH `200`. If you additionally want to confirm persistence, **re-GET the product and read `media.main.image.url`** — never look for `media.main.image` on the PATCH response (it isn't there).
 - Send **one image per product** (primary); a larger gallery is out of scope for the seed.
 - **Never block on image failure** — skip and leave the product text-only.
 

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -179,10 +179,13 @@ The request body is `items` (each with the product's `catalogItemId` and the Sto
    The image may be referenced by a `static.wixstatic.com` **`url`** or by its Wix Media **`id`** (`<hash>~mv2.png`) — either works.
 
 - **Write the image via `media.itemsInfo.items`** (inside the `product` wrapper); the server derives `media.main` from it.
-- **A `200` from the PATCH is success.** To confirm the image persisted, **re-GET the product and read `media.main.image.url`**:
+- **A `200` from the PATCH is success.** The image URL is at `media.main.url` in the PATCH response, and at `media.main.image.url` on a GET read-back:
 
   ```jsonc
-  // GET /stores/v3/products/{id} → the attached image:
+  // PATCH /stores/v3/products/{id} response:
+  "media": { "main": { "url": "https://static.wixstatic.com/media/…~mv2.png", "altText": "…", "mediaType": "IMAGE" } }
+
+  // GET /stores/v3/products/{id} read-back:
   "media": { "main": { "image": { "url": "https://static.wixstatic.com/media/…~mv2.png", "width": 1024, "height": 1024 }, "altText": "…" } }
   ```
 - Send **one image per product** (primary); a larger gallery is out of scope for the seed.


### PR DESCRIPTION
# Feedback

Builder run ("Stitched Shadows", a Wix Stores storefront) hit a ~100s image-attach debug loop: the attach PATCHes returned `success:false` for **all 6 products** even though every image attached correctly. Root-caused it, then **verified live** with 6 real API calls against a test Wix Stores V3 site (token minted via `npx @wix/cli token`).

## What's actually happening (measured, not inferred)

The product-media response shape **differs between the write and the read**:

| response | image URL location | `media.main.image`? |
|---|---|---|
| `PATCH /stores/v3/products/{id}` | **`media.main.url`** (flat) | absent |
| `GET  /stores/v3/products/{id}` (read-back) | **`media.main.image.url`** (nested) | present |

The recipe told the agent to *"verify success by reading `media.main.image.url`"* — which is the **read-back** path only. The agent verified off the **PATCH response** (the natural thing to do right after the write), where the field is `media.main.url` and `media.main.image` doesn't exist → `undefined` → `success:false` on a successful attach → debug loop.

Also confirmed while there (so we don't "fix" the wrong thing):
- Import `/site-media/v1/files/import` → `{ file: { url, id } }`. The recipe's `file.url` / `file.id` is **correct** — no change.
- `media.itemsInfo` returns `null` on read (write-only) — recipe already correct.
- `GET` with an empty body works (HTTP 200); the "GET/HEAD cannot have body" error seen in the run was a caller bug, not the API.

## Change

Rewrote the verify bullet in `setup-online-store.md` → "Attach images":
- **Lead with the robust signal:** a PATCH `200` with no `error` is success; don't gate success on parsing media back.
- **State both response shapes, labeled** (PATCH → `media.main.url`; GET → `media.main.image.url`) so the trap is explicit.
- If confirming persistence, **re-GET and read `media.main.image.url`** — never look for it on the PATCH response.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)