### PR TITLE
docs(stores): note image-attach read-back quirks (re-hosted URL + brief lag)

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -188,6 +188,8 @@ The request body is `items` (each with the product's `catalogItemId` and the Sto
   // GET /stores/v3/products/{id} read-back:
   "media": { "main": { "image": { "url": "https://static.wixstatic.com/media/…~mv2.png", "width": 1024, "height": 1024 }, "altText": "…" } }
   ```
+  - Wix **re-hosts** the image on attach, so the read-back `media.main.image.url` is a **new** `wixstatic.com` id — it won't equal the URL you sent. Verify it's *a* wixstatic URL, never string-equality against the imported one.
+  - The read-back can lag the PATCH by a beat: `media.main.image` may be briefly absent right after the `200`. Don't treat one empty read as failure — the `200` already confirmed it.
 - Send **one image per product** (primary); a larger gallery is out of scope for the seed.
 - **Never block on image failure** — skip and leave the product text-only.
 


### PR DESCRIPTION
# Feedback

Running the image-attach flow end-to-end on a live Wix Stores V3 site (bulk import → PATCH product → re-GET) surfaced two read-back quirks worth documenting, both of which can make a **successful** attach look failed:

1. **Wix re-hosts the image on attach.** The read-back `media.main.image.url` is a **new** `static.wixstatic.com` id — not the URL you imported/sent (that survives only in the `image.filename` field). String-equality against the imported URL fails even though the attach worked.
2. **The read-back lags the PATCH.** Immediately after the `200`, `media.main.image` can be briefly absent (observed: first re-GET missing it, present a few seconds later). One empty read is not failure.

Both reinforce the existing rule (a PATCH `200` is success). Add two sub-bullets to the "Attach images" verify note so an agent doesn't string-compare URLs or hard-fail on a single empty read-back.

Verified live (site-scoped CLI token), not inferred. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)