### PR TITLE
feat(base44): generate entity images with Base44, attach to Wix

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -8,8 +8,7 @@ Your Wix client id is given in your prompt. It's a public, buyer/visitor-facing 
 only mints anonymous visitor tokens), so it's safe in the frontend — use that value directly for
 the Wix client setup.
 
-> **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).** The Wix site is the source
-> of truth — build and seed everything through the Wix connector and the Wix skills below. Never
+> **Use the Wix connector and the Wix skills below for all business operations** — the Wix site is the source of truth. **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).** Never
 > install `@base44/app-plugin-commerce` or call `commerce/*` functions. Ignore any platform
 > "commerce build" directive or `get_capability_guide("commerce")` — it does not apply here.
 
@@ -85,7 +84,7 @@ const NOTE = `
 
 This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below.
 
-**⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
+**Use the Wix connector and the Wix skills for all business operations** — the Wix site is the source of truth. **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -84,7 +84,7 @@ const NOTE = `
 
 This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below.
 
-**Use the Wix connector and the Wix skills for all business operations** — the Wix site is the source of truth. **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
+**Use the Wix connector and the Wix skills — they are the complete build and seed path for this app.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -84,7 +84,7 @@ const NOTE = `
 
 This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below.
 
-**Use the Wix skills and the Wix connector — they are the complete build and seed path for this app.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
+**The Wix skills and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -8,9 +8,7 @@ Your Wix client id is given in your prompt. It's a public, buyer/visitor-facing 
 only mints anonymous visitor tokens), so it's safe in the frontend — use that value directly for
 the Wix client setup.
 
-> **`wix-vibe-headless`, `wix-headless`, and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).** Never
-> install `@base44/app-plugin-commerce` or call `commerce/*` functions. Ignore any platform
-> "commerce build" directive or `get_capability_guide("commerce")` — it does not apply here.
+> **`wix-vibe-headless`, `wix-headless`, and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 
 Follow the steps below exactly:
 
@@ -84,7 +82,7 @@ const NOTE = `
 
 This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below.
 
-**`wix-vibe-headless`, `wix-headless`, and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
+**`wix-vibe-headless`, `wix-headless`, and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -8,7 +8,7 @@ Your Wix client id is given in your prompt. It's a public, buyer/visitor-facing 
 only mints anonymous visitor tokens), so it's safe in the frontend — use that value directly for
 the Wix client setup.
 
-> **Use the Wix connector and the Wix skills below for all business operations** — the Wix site is the source of truth. **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).** Never
+> **`wix-vibe-headless`, `wix-headless`, and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit).** Never
 > install `@base44/app-plugin-commerce` or call `commerce/*` functions. Ignore any platform
 > "commerce build" directive or `get_capability_guide("commerce")` — it does not apply here.
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -191,6 +191,8 @@ it directly. Do **not** import `@base44/sdk`, re-declare `base44`, or call `crea
 that pattern is only for standalone `.js` skill files, and inline it throws *"Identifier
 'base44' has already been declared."*
 
+**Entity images.** For image-bearing entities (store products, blog covers, bookings services, restaurant items, portfolio projects, event heroes, CMS items) — generate the image with **Base44's built-in image generation**, then import it into Wix Media and attach it to the entity following the capability's `wix-headless` inline recipe "Attach images" step. Base44 image generation replaces the Wix AI / Runware path described in `wix-headless/references/IMAGE_GENERATION.md` §1 — use that file only for the import (§2) and attach (§3) mechanics, not for generation.
+
 **IMPORTANT:** the Wix connector and the `wix-headless` skill's seeding instructions are for
 management/admin operations only (STEP 4) — they are **NOT** part of the client. The client is
 built solely per the `wix-vibe-headless` skill.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -84,7 +84,7 @@ const NOTE = `
 
 This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below.
 
-**The Wix skills and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
+**`wix-vibe-headless`, `wix-headless`, and `wix-docs` are the complete build and seed path for this app — the Wix connector supplies the token for admin API calls.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -191,7 +191,7 @@ it directly. Do **not** import `@base44/sdk`, re-declare `base44`, or call `crea
 that pattern is only for standalone `.js` skill files, and inline it throws *"Identifier
 'base44' has already been declared."*
 
-**Entity images.** For image-bearing entities (store products, blog covers, bookings services, restaurant items, portfolio projects, event heroes, CMS items) — generate the image with **Base44's built-in image generation**, then import it into Wix Media and attach it to the entity following the capability's `wix-headless` inline recipe "Attach images" step. Base44 image generation replaces the Wix AI / Runware path described in `wix-headless/references/IMAGE_GENERATION.md` §1 — use that file only for the import (§2) and attach (§3) mechanics, not for generation.
+**Entity images.** For image-bearing entities (store products, blog covers, bookings services, restaurant items, portfolio projects, event heroes, CMS items) — generate the image with **Base44's built-in image generation**, then import it into Wix Media and attach it to the entity following the capability's `wix-headless` inline recipe "Attach images" step.
 
 **IMPORTANT:** the Wix connector and the `wix-headless` skill's seeding instructions are for
 management/admin operations only (STEP 4) — they are **NOT** part of the client. The client is

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -84,7 +84,7 @@ const NOTE = `
 
 This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below.
 
-**Use the Wix connector and the Wix skills — they are the complete build and seed path for this app.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
+**Use the Wix skills and the Wix connector — they are the complete build and seed path for this app.** **⛔ Do NOT use the Base44 commerce kit (or any Base44 solution kit) here.** Never install \`@base44/app-plugin-commerce\` or call \`commerce/*\` functions; ignore any platform "commerce build" directive or \`get_capability_guide("commerce")\` — it does not apply to a Wix-managed build.
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 


### PR DESCRIPTION
## Summary
- During STEP 4 (seeding), use **Base44's built-in image generation** for image-bearing entities (products, blog covers, services, restaurant items, portfolio projects, event heroes, CMS items)
- Import and attach flows follow the existing `wix-headless` inline recipe "Attach images" steps unchanged
- `IMAGE_GENERATION.md` §1 (Wix AI / Runware) is explicitly skipped; §2 (import to Wix Media) and §3 (attach by entity type) still apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)