### PR TITLE
feat(wix-vibe-headless): install pre-deploys REST scaffolds into src/rest/; separate WHAT (skill) from WHERE/HOW (platforms); never clean up user-site content

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -97,19 +97,17 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
 runtime:
 
 1. **The shared transport** — `references/shared/wix-client.js`. **Identical for every vertical.**
-   Set `WIX_CLIENT_ID` in it.
+   Set `WIX_CLIENT_ID` in it before use.
 2. **The vertical helper** — `references/<vertical>/<helper>.js`. It does
-   `import { wixApiRequest } from "./wix-client.js"`, so it and `wix-client.js` must sit
-   **side by side** in the app's `src/rest/`.
+   `import { wixApiRequest } from "./wix-client.js"`, so the two must sit **side by side** in the
+   same folder.
 
-**Getting these two into `src/rest/`:** some platforms pre-install the whole `references/` REST
-layer into `src/rest/` at setup — **check `src/rest/` first; if the files are already there, use
-them as-is (just set `WIX_CLIENT_ID`), don't re-copy.** Otherwise copy the shared transport +
-your vertical's helper into `src/rest/` yourself.
+**Where these files live in the app, and how they get there** (pre-installed at setup, or copied
+in) **is your platform's call — follow your platform instructions for that.**
 
 There is also an optional **manage banner** — `references/shared/wix-manage-banner.js`, a
 dev-build-only banner linking the running app to the Wix Business Manager (the back office)
-behind it. It sits beside `wix-client.js` in `src/rest/` (pre-installed with it, or copy it in);
+behind it. It sits beside `wix-client.js` (placed the same way — per your platform instructions);
 set `WIX_METASITE_ID` and call `mountWixManageBanner()` once from the app entry. It renders only when a dev-build flag
 (`import.meta.env.DEV`) exists and is true — never in production, and not at all on stacks
 without such a flag. It sits in normal flow at the top (pushes the site down, doesn't float

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -153,9 +153,9 @@ installed, not what the business is about. Never default to store/bookings on si
 2. **Pick the vertical(s)** from the routing table — and when the request doesn't name any,
    **ask or check the site** (see above) instead of guessing. Open each picked vertical's
    `INSTRUCTIONS.md`.
-3. **Copy the two files per vertical** — `shared/wix-client.js` (once) + the vertical helper —
-   into the app's `src/rest/` (adjust only the import path if the app uses a different folder),
-   and set `WIX_CLIENT_ID`.
+3. **Ensure the two files per vertical are in place** — `shared/wix-client.js` (once) + the
+   vertical helper, side by side — and set `WIX_CLIENT_ID`. (Where they live and how they get
+   there is your platform's call — see its instructions.)
 4. **Wire the UI** to the exported helpers following the vertical's INSTRUCTIONS. Build the UI
    however the project wants — these scaffolds ship the REST layer only, no components.
 5. **Verify** against the vertical's checklist before declaring done: token persists across

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -105,14 +105,6 @@ runtime:
 **Where these files live in the app, and how they get there** (pre-installed at setup, or copied
 in) **is your platform's call — follow your platform instructions for that.**
 
-There is also an optional **manage banner** — `references/shared/wix-manage-banner.js`, a
-dev-build-only banner linking the running app to the Wix Business Manager (the back office)
-behind it. It sits beside `wix-client.js` (placed the same way — per your platform instructions);
-set `WIX_METASITE_ID` and call `mountWixManageBanner()` once from the app entry. It renders only when a dev-build flag
-(`import.meta.env.DEV`) exists and is true — never in production, and not at all on stacks
-without such a flag. It sits in normal flow at the top (pushes the site down, doesn't float
-over it) and is dismissible via its ✕ (persisted in `localStorage`).
-
 Each vertical's `INSTRUCTIONS.md` is the full playbook for that solution: when to use it,
 prerequisites, the exported API, how to wire it, the hard rules, and a verification checklist.
 **Open the relevant `INSTRUCTIONS.md` before wiring** — the shapes and gotchas live there.

--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -97,15 +97,20 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
 runtime:
 
 1. **The shared transport** — `references/shared/wix-client.js`. **Identical for every vertical.**
-   Copy it once into the app's `src/rest/` and set `WIX_CLIENT_ID` in it.
-2. **The vertical helper** — `references/<vertical>/<helper>.js`. Copy it into the **same**
-   `src/rest/` folder (it does `import { wixApiRequest } from "./wix-client.js"`, so the two
-   files must sit side by side).
+   Set `WIX_CLIENT_ID` in it.
+2. **The vertical helper** — `references/<vertical>/<helper>.js`. It does
+   `import { wixApiRequest } from "./wix-client.js"`, so it and `wix-client.js` must sit
+   **side by side** in the app's `src/rest/`.
+
+**Getting these two into `src/rest/`:** some platforms pre-install the whole `references/` REST
+layer into `src/rest/` at setup — **check `src/rest/` first; if the files are already there, use
+them as-is (just set `WIX_CLIENT_ID`), don't re-copy.** Otherwise copy the shared transport +
+your vertical's helper into `src/rest/` yourself.
 
 There is also an optional **manage banner** — `references/shared/wix-manage-banner.js`, a
 dev-build-only banner linking the running app to the Wix Business Manager (the back office)
-behind it. Copy it beside `wix-client.js`, set `WIX_METASITE_ID`, and call
-`mountWixManageBanner()` once from the app entry. It renders only when a dev-build flag
+behind it. It sits beside `wix-client.js` in `src/rest/` (pre-installed with it, or copy it in);
+set `WIX_METASITE_ID` and call `mountWixManageBanner()` once from the app entry. It renders only when a dev-build flag
 (`import.meta.env.DEV`) exists and is true — never in production, and not at all on stacks
 without such a flag. It sits in normal flow at the top (pushes the site down, doesn't float
 over it) and is dismissible via its ✕ (persisted in `localStorage`).

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -173,14 +173,10 @@ as-is.
 
 ## STEP 4 — Manage and seed the business
 
-**⛔ Never delete or clean up anything on the user's site.** Seeding here is strictly **additive**:
-never delete, remove, overwrite, or "reset" existing entities or content — products, collections,
-posts, media, CMS items, categories, anything — and never call a delete/bulk-delete endpoint. This
-holds **even for what looks like install sample/mock data**, and **even where the `wix-headless`
-seed skill's recipes describe a cleanup/reset step — ignore that; it does not apply here.** The
-site is a live, user-owned business that may already hold real content (a prior run, or
-owner-added). If a genuine cleanup truly seems needed, **ask the user first** and act only on their
-explicit approval.
+**⛔ Never delete or clean up anything on the user's site — seeding is additive only.** Ignore any
+cleanup/reset step in the `wix-headless` seed recipes: it's a live user-owned business, so never
+delete or overwrite existing content, even apparent sample data. If a cleanup truly seems needed,
+ask the user first.
 
 Seed the site with real content by following the **`wix-headless` skill**'s
 `references/SEED.md` (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -170,12 +170,12 @@ source of truth for how the client app is built.
 
 **All the REST scaffolds are already in `src/rest/`** — STEP 1 deployed the shared transport
 (`wix-client.js`, `wix-manage-banner.js`) and every vertical helper (`wix-store-catalog.js`,
-`wix-bookings-services.js`, …) there. **Do not regenerate or re-copy them** (ignore SKILL.md's
-"copy it into src/rest" step — already done). Just **use your vertical's files** from `src/rest/`
-(e.g. a store uses `wix-store-catalog.js` + `wix-store-cart.js`), set `WIX_CLIENT_ID` in
-`src/rest/wix-client.js` and `WIX_METASITE_ID` in `wix-manage-banner.js`, and adapt with targeted
-edits. Files for other verticals are harmless (unused → dropped by the bundler); leave or delete
-them. Generate from scratch only the app-specific UI (components/pages).
+`wix-bookings-services.js`, …) there, so SKILL.md's "get them into `src/rest/`" step is already
+done. **Use your vertical's files** from `src/rest/` (e.g. a store uses `wix-store-catalog.js` +
+`wix-store-cart.js`), set `WIX_CLIENT_ID` in `src/rest/wix-client.js` and `WIX_METASITE_ID` in
+`wix-manage-banner.js`, and adapt with targeted edits — **do not regenerate them**. Files for
+other verticals are harmless (unused → dropped by the bundler); leave or delete them. Generate
+from scratch only the app-specific UI (components/pages).
 
 **`src/App.jsx`: edit surgically, never rewrite.** On Base44 it carries required platform auth
 scaffolding (the `AuthProvider` / `useAuth` imports and wrappers from `@/lib/AuthContext`) — a

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -37,7 +37,7 @@ exec_tool, exactly as written:
 
 ```js
 const { execSync } = require('child_process');
-const { readdirSync } = require('fs');
+const { readdirSync, existsSync, mkdirSync, copyFileSync } = require('fs');
 
 const skills = ['wix-headless', 'wix-vibe-headless', 'wix-docs'];
 const results = {};
@@ -56,7 +56,19 @@ for (const skill of skills) {
   }
 }
 
-return { results, installed: readdirSync('/app/.agents/skills') };
+// Pre-place the shared REST scaffolds into src/rest/ so STEP 3 doesn't regenerate them
+// token-by-token. These two are vertical-agnostic and always needed; per-vertical helpers are
+// copied in STEP 3 once the vertical is known. copyFileSync is a no-cost copy (no LLM decode).
+const SHARED = '/app/.agents/skills/wix-vibe-headless/references/shared';
+const copiedToSrcRest = [];
+if (existsSync(SHARED)) {
+  mkdirSync('/app/src/rest', { recursive: true });
+  for (const f of ['wix-client.js', 'wix-manage-banner.js']) {
+    if (existsSync(`${SHARED}/${f}`)) { copyFileSync(`${SHARED}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
+  }
+}
+
+return { results, installed: readdirSync('/app/.agents/skills'), copiedToSrcRest };
 ```
 
 **Option B — tarball.** Use this **only if Option A actually errored** (check its `results`) —
@@ -148,9 +160,16 @@ guessed ones. If the call fails or reports nothing relevant, ask the user what t
 ## STEP 3 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — it is the single
-source of truth for how the client app is built. To save time, prefer copying ready-made files
-the `wix-vibe-headless` skill provides (e.g. the Wix client setup) and adapting them over
-re-generating them from scratch.
+source of truth for how the client app is built.
+
+**The shared REST scaffolds are already in `src/rest/`** — STEP 1 copied `wix-client.js` and
+`wix-manage-banner.js` there. **Do not regenerate them.** Just: set `WIX_CLIENT_ID` in
+`src/rest/wix-client.js` (and `WIX_METASITE_ID` in the banner), then **`cp` your vertical's
+helper** — `.agents/skills/wix-vibe-headless/references/<vertical>/*.js` (e.g. storefront's
+`wix-store-catalog.js` / `wix-store-cart.js`) — into that same `src/rest/` folder via exec_tool,
+and adapt with targeted edits. Copying (a shell `cp`) is instant; re-typing these files with
+`write_file` wastes a minute of generation for no gain. Generate from scratch only the
+app-specific UI (components/pages).
 
 **`src/App.jsx`: edit surgically, never rewrite.** On Base44 it carries required platform auth
 scaffolding (the `AuthProvider` / `useAuth` imports and wrappers from `@/lib/AuthContext`) — a

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -56,17 +56,21 @@ for (const skill of skills) {
   }
 }
 
-// Pre-place the shared REST scaffolds into src/rest/ so STEP 3 doesn't regenerate them
-// token-by-token. `references/shared/` holds the vertical-agnostic layer (the wix-client
-// transport every vertical imports, plus the manage banner) — copy ALL of it, so a newly
-// added shared file is picked up automatically. Per-vertical helpers are copied in STEP 3
-// once the vertical is known. copyFileSync is a no-cost copy (no LLM decode).
-const SHARED = '/app/.agents/skills/wix-vibe-headless/references/shared';
+// Deploy the ready-made REST scaffolds into src/rest/ so STEP 3 builds from them instead of
+// regenerating them token-by-token. Copy EVERY .js under references/*/ (the shared transport +
+// all vertical helpers) FLAT into src/rest/ — filenames are unique and each helper imports its
+// sibling `./wix-client.js`, so a flat folder keeps those imports valid with no rewrite.
+// copyFileSync is a no-cost copy (no LLM decode); unused verticals are dead files the bundler drops.
+const REF = '/app/.agents/skills/wix-vibe-headless/references';
 const copiedToSrcRest = [];
-if (existsSync(SHARED)) {
+if (existsSync(REF)) {
   mkdirSync('/app/src/rest', { recursive: true });
-  for (const f of readdirSync(SHARED)) {
-    if (f.endsWith('.js')) { copyFileSync(`${SHARED}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
+  for (const dir of readdirSync(REF)) {
+    let files;
+    try { files = readdirSync(`${REF}/${dir}`); } catch { continue; }   // skip non-dirs
+    for (const f of files) {
+      if (f.endsWith('.js')) { copyFileSync(`${REF}/${dir}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
+    }
   }
 }
 
@@ -164,14 +168,14 @@ guessed ones. If the call fails or reports nothing relevant, ask the user what t
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — it is the single
 source of truth for how the client app is built.
 
-**The shared REST scaffolds are already in `src/rest/`** — STEP 1 copied `wix-client.js` and
-`wix-manage-banner.js` there. **Do not regenerate them.** Just: set `WIX_CLIENT_ID` in
-`src/rest/wix-client.js` (and `WIX_METASITE_ID` in the banner), then **`cp` your vertical's
-helper** — `.agents/skills/wix-vibe-headless/references/<vertical>/*.js` (e.g. storefront's
-`wix-store-catalog.js` / `wix-store-cart.js`) — into that same `src/rest/` folder via exec_tool,
-and adapt with targeted edits. Copying (a shell `cp`) is instant; re-typing these files with
-`write_file` wastes a minute of generation for no gain. Generate from scratch only the
-app-specific UI (components/pages).
+**All the REST scaffolds are already in `src/rest/`** — STEP 1 deployed the shared transport
+(`wix-client.js`, `wix-manage-banner.js`) and every vertical helper (`wix-store-catalog.js`,
+`wix-bookings-services.js`, …) there. **Do not regenerate or re-copy them** (ignore SKILL.md's
+"copy it into src/rest" step — already done). Just **use your vertical's files** from `src/rest/`
+(e.g. a store uses `wix-store-catalog.js` + `wix-store-cart.js`), set `WIX_CLIENT_ID` in
+`src/rest/wix-client.js` and `WIX_METASITE_ID` in `wix-manage-banner.js`, and adapt with targeted
+edits. Files for other verticals are harmless (unused → dropped by the bundler); leave or delete
+them. Generate from scratch only the app-specific UI (components/pages).
 
 **`src/App.jsx`: edit surgically, never rewrite.** On Base44 it carries required platform auth
 scaffolding (the `AuthProvider` / `useAuth` imports and wrappers from `@/lib/AuthContext`) — a

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -173,15 +173,19 @@ as-is.
 
 ## STEP 4 — Manage and seed the business
 
+**⛔ Never delete or clean up anything on the user's site.** Seeding here is strictly **additive**:
+never delete, remove, overwrite, or "reset" existing entities or content — products, collections,
+posts, media, CMS items, categories, anything — and never call a delete/bulk-delete endpoint. This
+holds **even for what looks like install sample/mock data**, and **even where the `wix-headless`
+seed skill's recipes describe a cleanup/reset step — ignore that; it does not apply here.** The
+site is a live, user-owned business that may already hold real content (a prior run, or
+owner-added). If a genuine cleanup truly seems needed, **ask the user first** and act only on their
+explicit approval.
+
 Seed the site with real content by following the **`wix-headless` skill**'s
 `references/SEED.md` (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes
 don't cover what you need, **fall back to the `wix-docs` skill** (`.agents/skills/wix-docs`) to
 search and read the relevant Wix API docs.
-
-**Seeding is additive.** You may clean up the app install's **obvious default sample/mock data**
-right after a fresh install, but the site may already hold **real content** (a prior run, or
-owner-added) — if what's there isn't obviously install sample data, or you're unsure, **do not
-delete or overwrite it without the user's explicit ask or approval** (ask first).
 
 **Auth for these admin calls is the already-configured Wix connector — and nothing else.** Get the
 access token from it and send it as a bearer token — do **not** hand-roll a token getter (e.g. a

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -32,8 +32,7 @@ Install three skills — they land under `.agents/skills/` as:
 - **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
   the seeding recipes above don't cover.
 
-**Option A — skills CLI.** This is the Base44-verified install path — run it first via
-exec_tool, exactly as written:
+Install via the skills CLI — run this through exec_tool, exactly as written:
 
 ```js
 const { execSync } = require('child_process');
@@ -77,18 +76,7 @@ if (existsSync(REF)) {
 return { results, installed: readdirSync('/app/.agents/skills'), copiedToSrcRest };
 ```
 
-**Option B — tarball.** Use this **only if Option A actually errored** (check its `results`) —
-do not skip Option A on a guess. Run via exec_tool:
-
-```js
-const { execSync } = require('child_process');
-for (const s of ['headless', 'vibe-headless', 'docs']) {
-  execSync(`mkdir -p /app/.agents/skills/wix-${s} && curl -s "https://www.wix.com/skills/${s}.tgz" | tar xz -C /app/.agents/skills/wix-${s} --strip-components=1`);
-}
-return 'done';
-```
-
-**STEP 1b — pin the skill location in AGENTS.md.** After the install succeeds (either option),
+**STEP 1b — pin the skill location in AGENTS.md.** After the install succeeds,
 run this via exec_tool exactly as written. It appends (never rewrites) a note so any later
 turn knows where the skills live without guessing, and is idempotent (re-running is a no-op):
 
@@ -123,7 +111,7 @@ if (!cur.includes('Wix-managed headless frontend')) fs.appendFileSync(amd, NOTE)
 return 'noted';
 ```
 
-Either way you end up with `.agents/skills/{wix-headless,wix-vibe-headless,wix-docs}`. **Read them
+You end up with `.agents/skills/{wix-headless,wix-vibe-headless,wix-docs}`. **Read them
 with the `read_file` tool** — it caps by line (~5000, well above these docs, so each comes through
 whole; page with offset/limit only if ever needed), whereas `cat` through exec_tool caps output at
 ~5000 chars and silently truncates, and web-fetch tools truncate/summarise. The path form depends

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -57,14 +57,16 @@ for (const skill of skills) {
 }
 
 // Pre-place the shared REST scaffolds into src/rest/ so STEP 3 doesn't regenerate them
-// token-by-token. These two are vertical-agnostic and always needed; per-vertical helpers are
-// copied in STEP 3 once the vertical is known. copyFileSync is a no-cost copy (no LLM decode).
+// token-by-token. `references/shared/` holds the vertical-agnostic layer (the wix-client
+// transport every vertical imports, plus the manage banner) — copy ALL of it, so a newly
+// added shared file is picked up automatically. Per-vertical helpers are copied in STEP 3
+// once the vertical is known. copyFileSync is a no-cost copy (no LLM decode).
 const SHARED = '/app/.agents/skills/wix-vibe-headless/references/shared';
 const copiedToSrcRest = [];
 if (existsSync(SHARED)) {
   mkdirSync('/app/src/rest', { recursive: true });
-  for (const f of ['wix-client.js', 'wix-manage-banner.js']) {
-    if (existsSync(`${SHARED}/${f}`)) { copyFileSync(`${SHARED}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
+  for (const f of readdirSync(SHARED)) {
+    if (f.endsWith('.js')) { copyFileSync(`${SHARED}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
   }
 }
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -71,14 +71,18 @@ source of truth for how the client app is built against the Wix APIs (over the p
 
 ## STEP 4 — Seed and manage the business
 
+**⛔ Never delete or clean up anything on the user's site.** Seeding here is strictly **additive**:
+never delete, remove, overwrite, or "reset" existing entities or content — products, collections,
+posts, media, CMS items, categories, anything — and never call a delete/bulk-delete endpoint. This
+holds **even for what looks like install sample/mock data**, and **even where the `wix-headless`
+seed skill's recipes describe a cleanup/reset step — ignore that; it does not apply here.** The
+site is a live, user-owned business that may already hold real content (a prior run, or
+owner-added). If a genuine cleanup truly seems needed, **ask the user first** and act only on their
+explicit approval.
+
 Seed the site with real content by following the `wix-headless` skill's `references/SEED.md`
 (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes don't cover what you
 need, fall back to the `wix-docs` skill to search and read the relevant Wix API docs.
-
-**Seeding is additive.** You may clean up the app install's **obvious default sample/mock data**
-right after a fresh install, but the site may already hold **real content** (a prior run, or
-owner-added) — if what's there isn't obviously install sample data, or you're unsure, **do not
-delete or overwrite it without the user's explicit ask or approval** (ask first).
 
 These management/admin calls need **elevated Wix credentials** — the public client id is not
 enough. If you don't already have a way to authenticate them, either **connect your platform's

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -71,14 +71,10 @@ source of truth for how the client app is built against the Wix APIs (over the p
 
 ## STEP 4 — Seed and manage the business
 
-**⛔ Never delete or clean up anything on the user's site.** Seeding here is strictly **additive**:
-never delete, remove, overwrite, or "reset" existing entities or content — products, collections,
-posts, media, CMS items, categories, anything — and never call a delete/bulk-delete endpoint. This
-holds **even for what looks like install sample/mock data**, and **even where the `wix-headless`
-seed skill's recipes describe a cleanup/reset step — ignore that; it does not apply here.** The
-site is a live, user-owned business that may already hold real content (a prior run, or
-owner-added). If a genuine cleanup truly seems needed, **ask the user first** and act only on their
-explicit approval.
+**⛔ Never delete or clean up anything on the user's site — seeding is additive only.** Ignore any
+cleanup/reset step in the `wix-headless` seed recipes: it's a live user-owned business, so never
+delete or overwrite existing content, even apparent sample data. If a cleanup truly seems needed,
+ask the user first.
 
 Seed the site with real content by following the `wix-headless` skill's `references/SEED.md`
 (`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes don't cover what you

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -67,9 +67,13 @@ non-sample content); the same set drives STEP 4's seeding — never seed guessed
 
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **exactly** — it is the single
 source of truth for how the client app is built against the Wix APIs (over the public
-`WIX_CLIENT_ID`, which is a buyer/visitor-facing credential, safe in the frontend). To save time,
-prefer copying the ready-made files the `wix-vibe-headless` skill provides (e.g. the Wix client
-setup) and adapting them over re-generating them from scratch.
+`WIX_CLIENT_ID`, which is a buyer/visitor-facing credential, safe in the frontend).
+
+**Placement (this platform):** copy the ready-made REST files into the app's `src/rest/` — the
+shared transport `references/shared/wix-client.js` (set `WIX_CLIENT_ID` in it) plus your
+vertical's helper(s) `references/<vertical>/*.js`, **side by side** in that folder (the helper
+imports its sibling `./wix-client.js`). Adapt them with targeted edits; **don't re-generate them
+from scratch.** Generate only the app-specific UI.
 
 ## STEP 4 — Seed and manage the business
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -69,12 +69,6 @@ Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **exactly** — i
 source of truth for how the client app is built against the Wix APIs (over the public
 `WIX_CLIENT_ID`, which is a buyer/visitor-facing credential, safe in the frontend).
 
-**Placement (this platform):** copy the ready-made REST files into the app's `src/rest/` — the
-shared transport `references/shared/wix-client.js` (set `WIX_CLIENT_ID` in it) plus your
-vertical's helper(s) `references/<vertical>/*.js`, **side by side** in that folder (the helper
-imports its sibling `./wix-client.js`). Adapt them with targeted edits; **don't re-generate them
-from scratch.** Generate only the app-specific UI.
-
 ## STEP 4 — Seed and manage the business
 
 Seed the site with real content by following the `wix-headless` skill's `references/SEED.md`
@@ -116,10 +110,9 @@ back to the `wix-docs` skill where the operation isn't documented there.
 
 After the site is built and seeded:
 
-1. **Add the dev-only manage banner** (required) (links the app to its Wix back office): copy the
-   `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js` next to
-   `wix-client.js`, set `WIX_METASITE_ID` to your metasite id, and call
-   `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
+1. **Add the dev-only manage banner** (required) (links the app to its Wix back office): from the
+   `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js`, set `WIX_METASITE_ID` to
+   your metasite id and call `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
    builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
    guarantee: verify the gate actually holds in this stack, and that a production build never
    shows the banner (no dev flag → no banner at all). Also verify it really pushes the site


### PR DESCRIPTION
## Summary

Reduces build time and clarifies ownership for the `wix-vibe-headless` skill, and hardens the seeding rule. Three files touched: `SKILL.md`, `platforms/base44.md`, `platforms/generic.md`.

## Changes

### 1. Install pre-deploys the ready-made REST scaffolds (base44)
- STEP 1 install (`npx skills add`) now copies **every** `references/*/*.js` scaffold **flat into `/app/src/rest/`** at install time (kit/plugin-style delivery), so the agent adapts existing files instead of regenerating `wix-client.js` + vertical helpers token-by-token. Flat layout keeps the `./wix-client.js` sibling imports resolving; unused verticals are harmless (bundler drops them).
- STEP 3 now says: the scaffolds are already in `src/rest/` — use your vertical's files, set `WIX_CLIENT_ID`, **don't regenerate**; edit `App.jsx` surgically, never rewrite.

### 2. Single install path — dropped the tarball fallback (base44)
- Removed **Option B** (the `curl | tar` tarball fallback) entirely. `npx skills add` is now the sole, verified install path. Removed the "Option A / Option B / either way" framing.

### 3. Separate WHAT from WHERE/HOW (SKILL.md ↔ platforms)
- **SKILL.md** now only describes **what** the two files per vertical are and their sibling co-location constraint (set `WIX_CLIENT_ID`). All `src/rest`/placement/copy mechanics removed — *"where these files live and how they get there is your platform's call."*
- **generic.md** now owns placement for its platform (and only its platform): STEP 3 previously carried the copy instruction; file-delivery mechanics were then removed from generic.md too, leaving base44.md (which pre-installs) as the concrete delivery site.

### 4. Manage banner is platform-owned, not skill-owned
- Removed the optional **manage banner** paragraph from **SKILL.md** entirely. The banner (mount + dev-only gate + `WIX_METASITE_ID`) is described by the platform prompts, not the core skill.
- generic.md's "When done" banner step no longer prescribes copying `wix-manage-banner.js` next to `wix-client.js` — it just references the skill file and mounts it.

### 5. ⛔ Never clean up user-site content when seeding (base44 + generic)
- Added a hard rule at the **top of STEP 4**, *before* the agent is pointed at the `wix-headless` `SEED.md`: seeding is **additive only** — never delete/overwrite existing content, even apparent sample data, and **explicitly ignore any cleanup/reset step in the seed recipes**. Ask the user first for any genuine cleanup.
- Replaced the previous permissive *"you may clean up obvious default sample data"* paragraph that contradicted this.

## Files
- `skills/wix-vibe-headless/SKILL.md`
- `skills/wix-vibe-headless/platforms/base44.md`
- `skills/wix-vibe-headless/platforms/generic.md`