### PR TITLE
perf(wix-app): defer API reference reads until the call is written

### DIFF
--- a/skills/wix-app/SKILL.md
+++ b/skills/wix-app/SKILL.md
@@ -23,7 +23,7 @@ Helps build extensions for Wix CLI applications. Covers all extension types: das
   - [ ] Determined full scoped collection IDs if Data Collection extension is being created (see [Collection ID Coordination](#collection-id-coordination))
   - [ ] Explained recommendation with reasoning
 - [ ] **Step 2:** Read extension reference file(s) for the chosen type(s) and the project-wide [CODE_QUALITY.md](references/CODE_QUALITY.md)
-- [ ] **Step 3:** Checked API references; used MCP discovery only for gaps
+- [ ] **Step 3:** Identified which APIs each extension needs and which reference file covers each one — did NOT pre-read those API reference files (they are read just-in-time in Step 4b)
 - [ ] **Step 4a:** Scaffolded each CLI-supported extension via `wix generate --params`
 - [ ] **Step 4b:** Filled in business logic in the generated files
   - [ ] Invoked `wix-design-system` skill ONLY before editing the first `.tsx`/`.jsx` file that imports `@wix/design-system`. Skip for backend-only or data-only extensions.
@@ -204,19 +204,20 @@ If unclear on approach (placement, visibility, configuration, integration), ask 
 
 Use the Extension Types Reference Table and decision content above. State extension type and brief reasoning (placement, functionality, integration).
 
-### Step 3: Read Extension Reference, Check API References, Then Discover (if needed)
+### Step 3: Read Extension Reference, Map Required APIs, Then Discover (if needed)
 
-**Workflow: Read extension reference → Check API references → Use MCP only for gaps.**
+**Workflow: Read extension reference → map each required API to its reference file → read that file in Step 4b, when you write the call → use MCP only for gaps.**
 
 1. **Read the extension reference file** for the chosen extension type from the table above
 2. **Identify required APIs** from user requirements
-3. **Check relevant API reference files:**
+3. **Map each required API to the reference file that covers it — do NOT read those files yet:**
    - Backend events → `references/backend-event/COMMON-EVENTS.md`
    - Wix Data → `references/data-collection/WIX_DATA.md`
    - Dashboard SDK → `references/dashboard-page/DASHBOARD_API.md`
-   - Service Plugin SPIs → read `references/SERVICE_PLUGIN.md` together with the matching `references/service-plugin/<NAME>.md` leaf
-4. **Verify the specific method/event exists** in references
-5. **ONLY use MCP discovery if NOT found** in reference files
+   - Service Plugin SPIs → `references/SERVICE_PLUGIN.md` together with the matching `references/service-plugin/<NAME>.md` leaf
+4. **Read each mapped file in Step 4b**, immediately before writing the first call into that API — not now. These files are among the largest in this skill; loading them up front costs context on every later turn, including turns that never touch the API. If an extension turns out to need no such API (UI-only page, local state, form inputs), the file is never read at all.
+5. **Verify the specific method/event exists** in that reference when you read it
+6. **ONLY use MCP discovery if NOT found** in reference files
 
 **Platform APIs (never discover - in references):**
 - Wix Data, Dashboard SDK, Event SDK (common events), Service Plugin SPIs
@@ -267,6 +268,7 @@ Open every path returned in `newFiles` and replace stubbed handler bodies / UI /
 
 - ⚠️ MANDATORY when using WDS: Invoke the `wix-design-system` skill **before editing your first `.tsx`/`.jsx` file that imports `@wix/design-system`**. Do NOT invoke it preemptively for backend-only or data-only jobs — it adds large content to context that you won't use.
 - ⚠️ MANDATORY when using WDS: Add `import "@wix/design-system/styles.global.css";` in the **main component** entry file (`page.tsx`, modal `.tsx`, etc.) — not in child/tab/helper files.
+- ⚠️ MANDATORY for platform APIs: Read the API reference file you mapped in Step 3 (`WIX_DATA.md`, `DASHBOARD_API.md`, `COMMON-EVENTS.md`, `service-plugin/<NAME>.md`) **immediately before writing the first call into that API** — same just-in-time rule as WDS, and for the same reason. Still read the reference before reaching for MCP discovery; the point is *when* you read it, not *whether*.
 - ⚠️ MANDATORY when using Data Collections: Use the EXACT collection ID from `idSuffix` (case-sensitive). If `idSuffix` is `"product-recommendations"`, use `<app-namespace>/product-recommendations` NOT `productRecommendations`.
 
 ### Step 5: Run Validation
@@ -350,7 +352,9 @@ Stop and report errors if any step fails. Check `.wix/debug.log` on failures.
 - **Let the CLI scaffold** — don't burn tokens describing folder layouts or builder boilerplate
 - **Only run `wix schema generate --type <extensionType>`** when `wix generate --params` fails — don't pre-fetch it
 - **Read extension reference first** — always read the relevant extension reference file before implementing
-- **Check API references first** — read relevant API reference files before using MCP discovery
+- **Read API references just-in-time** — read `WIX_DATA.md` / `DASHBOARD_API.md` / `COMMON-EVENTS.md` / `service-plugin/<NAME>.md` immediately before writing the first call into that API, not during planning. They are among the largest files in this skill, and anything loaded early is re-read from cache on every later turn.
+- **Never load an API reference you won't call** — a UI-only page, a settings form, or a page with local state needs none of them
+- **Still reference-before-MCP** — deferring the read does not mean skipping it; check the reference file before MCP discovery
 - **Skip discovery** when all required APIs are in reference files
 - **maxResults: 5** for all MCP SDK searches
 - **ReadFullDocsMethodSchema** for SDK method schemas; **ReadFullDocsArticle** for prose guides only

--- a/yaml/wix-app-evals/dashboard-page-ui-only-defers-api-references.yml
+++ b/yaml/wix-app-evals/dashboard-page-ui-only-defers-api-references.yml
@@ -1,0 +1,34 @@
+name: dashboard-page-ui-only-defers-api-references
+description: A dashboard page that is pure local-state UI must not load the Dashboard SDK or Wix Data API references, which it never calls.
+triggerPrompt: |-
+  Build a dashboard page called "Margin Calculator" that helps a store owner work out pricing. The page shows three number inputs — cost price, desired margin percentage, and tax rate — and displays the resulting sale price, profit per unit, and tax amount, recalculating as the owner types. Everything is calculated in the browser from the current input values. Do not persist anything, do not read or write any collection, and do not navigate anywhere else in the dashboard.
+templateId: 33f2cb85-054e-4281-b617-3bc21ac0803f
+tags: [dashboard-page, data-collection]
+assertions:
+  - type: skill_was_called
+    skillNames: [wix-app]
+    referenceFiles:
+      wix-app: [references/DASHBOARD_PAGE.md]
+  - type: skill_was_called
+    negate: true
+    skillNames: [wix-app]
+    referenceFiles:
+      wix-app: [references/dashboard-page/DASHBOARD_API.md]
+  - type: skill_was_called
+    negate: true
+    skillNames: [wix-app]
+    referenceFiles:
+      wix-app: [references/data-collection/WIX_DATA.md]
+  - type: build_passed
+    command: npm run build
+  - type: llm_judge
+    model: claude-sonnet-4-6
+    minScore: 7
+    prompt: |-
+      Evaluate whether the agent built a working margin calculator dashboard page. Check: (1) There are inputs for cost price, margin percentage, and tax rate. (2) Sale price, profit per unit, and tax amount are derived from those inputs and update as they change. (3) The calculation happens in component state — no collection is created, queried, or written, and no Wix Data API is imported. (4) The page is a registered dashboard page and the UI is usable. Score 0-10.
+  - type: llm_judge
+    model: claude-sonnet-4-6
+    minScore: 7
+    prompt: |-
+      Rate how directly the agent reached a working UI-only dashboard page. Examine the tool-call trace. Score 0-10 (10 = direct: no wasted calls, no errors). This task needs no platform API — no Wix Data, no Dashboard SDK, no backend. Penalize and LIST any of: reading an API reference whose API is never called in the final code (for example `dashboard-page/DASHBOARD_API.md` or `data-collection/WIX_DATA.md`); reading any reference file before the code that needs it was being written; MCP doc searches for APIs the skill's own references already cover; a shape guessed wrong then corrected; a non-2xx error even if recovered. For each, name the likely skill/docs gap that invited the detour.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected gap, or 'clean path' if none>"}.


### PR DESCRIPTION
## What

Step 3 of the `wix-app` workflow instructs the agent to read the platform API reference files during planning — before scaffolding, before any code:

| File | Size |
|---|---:|
| `references/dashboard-page/DASHBOARD_API.md` | 22.5 KB |
| `references/data-collection/WIX_DATA.md` | 10.7 KB |
| `references/backend-event/COMMON-EVENTS.md` | 5.0 KB |
| `references/service-plugin/<NAME>.md` | varies |

These are among the largest files in the skill. Anything they add to context is re-read from cache on **every** subsequent turn, including turns that never touch that API.

This PR applies the just-in-time rule the skill **already uses successfully for `wix-design-system`**: map each required API to its reference file during planning, then read that file immediately before writing the first call into it.

## Why

Investigating an expensive App Builder run — job `213e0f14-1995-4a0f-8675-bd8bc3e52ca7`, a `dataCollection` + `dashboardPage` INIT — surfaced this as the largest controllable cost driver.

The run was **clean**: 15 steps, zero tool errors, zero doc-MCP searches, no `node_modules` hunting, no reference gap. The agent read exactly the right files and used them correctly. It still cost $0.80 in 5m47s.

Where the money went (from the run's usage summary):

| | tokens | ~share of cost |
|---|---:|---:|
| cache read | 931,199 | ~35% |
| cache write | 68,231 | ~32% |
| **output** | **14,154** | ~27% |

**Roughly two thirds of the bill was re-reading and re-caching context, not generating code.**

Tracing token deltas per turn, six reference files were pulled in two `batch-read`s on turns 2–3 of 15:

| batch-read | files | context added |
|---|---|---:|
| #1 | `DASHBOARD_PAGE.md`, `DATA_COLLECTION.md`, `BACKEND_API.md`, `CODE_QUALITY.md` | ~11.2k tok |
| #2 | `dashboard-page/DASHBOARD_API.md`, `data-collection/WIX_DATA.md` | ~11.1k tok |

The first write happened on turn 10. The batch-read #2 payload sat unused in context for ~7 turns, and was carried for all 5 turns after.

This is **not an outlier**. Across 147 `INIT_CODEGEN` App Builder jobs in 7 days:

| | p50 | avg | p90 | target |
|---|---:|---:|---:|---:|
| Duration | 4.48 min | 5.45 min | 10.93 min | < 3 min |
| Cost | $0.70 | $0.77 | — | < $0.50 |

67% of INIT runs exceed the duration target and the median run is 1.4× the cost target. The investigated job sits at roughly the median on both — which is the point: this isn't one bad run, it's the baseline.

## Scope

Deliberately narrow — this defers only the **API reference leaves**, not the extension reference files.

The extension references (`DASHBOARD_PAGE.md`, `DATA_COLLECTION.md`, …) carry the decision logic and builder shapes and are genuinely needed up front. Deferring those would risk the hallucinated-builder-API failures this skill exists to prevent. They are untouched.

**Reference-before-MCP is unchanged.** This changes *when* a reference is read, not *whether*. The rule is restated explicitly in both Step 4b and Cost Optimization so the deferral cannot be misread as "skip it and go to MCP".

Secondary benefit: extensions that need no platform API — UI-only pages, settings forms, pages with local state, all cases the Step 3 decision table already recognises — now never load these files at all.

## Eval coverage

Adds `yaml/wix-app-evals/dashboard-page-ui-only-defers-api-references.yml`: a pure local-state margin-calculator dashboard page that calls no platform API.

- `tags: [dashboard-page, data-collection]` — both are **negative dependencies**, so the scenario re-runs when `DASHBOARD_PAGE.md` / `dashboard-page/**` / `data-collection/**` change and proves the "don't load it" path still holds.
- Asserts `skill_was_called` with `negate: true` on `dashboard-page/DASHBOARD_API.md` and `data-collection/WIX_DATA.md`.
- An `llm_judge` on correctness (the calculator works, nothing is persisted) and a second `llm_judge` on the tool-call path that penalises loading an API reference whose API is never called.
- 6 assertions including two `llm_judge`s, so it clears the gate's quality bar.

Note that this PR edits `SKILL.md`, which per the gate rules runs the **whole** `wix-app` suite rather than a tag subset.

## Verification

- All existing pointers to the deferred files in the extension references are passive (`See [X] for complete documentation`, a table row) — none instruct an up-front read, so nothing contradicts the new rule.
- Scenario YAML parses and matches the structure of the existing `employee-shift-dashboard.yml`.
- No content removed from the skill; only the timing of the read and the surrounding rationale changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)