### PR TITLE
fix(booking-policy-skill): replace introduction URL with specific method links

### DIFF
--- a/skills/wix-manage/references/bookings/booking-service-policy-setup.md
+++ b/skills/wix-manage/references/bookings/booking-service-policy-setup.md
@@ -89,7 +89,9 @@ Query the service to confirm policies are applied correctly. The service should 
 
 ## API Documentation References
 
-- [Booking Policies API](https://dev.wix.com/docs/api-reference/business-solutions/bookings/policies/introduction)
+- [Query Booking Policies](https://dev.wix.com/docs/api-reference/business-solutions/bookings/policies/booking-policies/query-booking-policies) — `POST https://www.wixapis.com/bookings/v1/booking-policies/query`
+- [Update Booking Policy](https://dev.wix.com/docs/api-reference/business-solutions/bookings/policies/booking-policies/update-booking-policy) — `PATCH https://www.wixapis.com/bookings/v1/booking-policies/{bookingPolicy.id}`
+- [Create Booking Policy](https://dev.wix.com/docs/api-reference/business-solutions/bookings/policies/booking-policies/create-booking-policy) — `POST https://www.wixapis.com/bookings/v1/booking-policies`
 - [Bulk Create Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services) — `POST https://www.wixapis.com/bookings/v2/bulk/services/create`
 - [Update Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/update-service) — `PATCH https://www.wixapis.com/bookings/v2/services/<SERVICE_ID>`
 - [Query Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/query-services) — `POST https://www.wixapis.com/bookings/v2/services/query`


### PR DESCRIPTION
## Problem

The `booking-service-policy-setup` skill recipe listed the Booking Policies API reference as:

```
[Booking Policies API](https://dev.wix.com/.../bookings/policies/introduction)
```

That's an article URL. When the agent passed it to `SearchWixAPISpec`, it got an error:
> "this is a documentation article, not an API resource/method"

This caused a wasted tool call and forced the agent into two extra search rounds to find the actual method URLs.

## Fix

Replaced the introduction link with the three method URLs the agent actually needs:

- Query Booking Policies — `POST /bookings/v1/booking-policies/query`
- Update Booking Policy — `PATCH /bookings/v1/booking-policies/{bookingPolicy.id}`
- Create Booking Policy — `POST /bookings/v1/booking-policies`

Grounded in a production Aria conversation (`c60b2423`) where this exact friction was observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)