### PR TITLE
fix(wix-app): sharpen site-plugin cart write path + event-listener lifecycle

### DIFF
--- a/skills/wix-app/references/SITE_PLUGIN.md
+++ b/skills/wix-app/references/SITE_PLUGIN.md
@@ -89,6 +89,36 @@ export default MyElement;
 - Use `this.getAttribute('attribute-name')` to read attribute values
 - Wix handles `define()` for you — do NOT call `customElements.define()` in your code
 
+### Interactive Plugins: Attach Listeners in Exactly One Place
+
+When the plugin has controls, `render()` replaces `innerHTML`, which destroys the old nodes — so listeners must be re-attached after **every** render. Bind them in exactly one place, or a single click fires the handler twice:
+
+```typescript
+// ❌ WRONG — render() already attaches, so connectedCallback binds twice.
+// Both listeners sit on the same button, so one click runs the handler
+// twice — e.g. the item is added to the cart two times.
+connectedCallback() {
+  this.render();        // render() ends with this.attachEvents()
+  this.attachEvents();  // duplicate registration
+}
+
+// ✅ CORRECT — render() owns attachment; lifecycle hooks only render.
+connectedCallback() {
+  this.render();
+}
+
+attributeChangedCallback() {
+  this.render();
+}
+
+render() {
+  this.innerHTML = `...`;
+  this.attachEvents(); // single place, runs after every re-render
+}
+```
+
+Removing the element from the DOM mid-dispatch does not cancel the remaining listeners on it, so re-rendering inside the handler will not suppress the second call. Fix the duplicate registration rather than masking it with an in-flight flag.
+
 ## Settings Panel Pattern
 
 ```typescript
@@ -343,6 +373,48 @@ import { createClient } from "@wix/sdk";
 const wixClient = createClient({ modules: { items, products } });
 await wixClient.items.query(...); // Wrong — API surface differs through client
 ```
+
+### Adding to the Cart
+
+`currentCart.addToCurrentCart()` takes **two different arrays**, and picking the wrong one type-checks but breaks at runtime:
+
+- **`lineItems`** — catalog items only. Each entry **requires** `catalogReference: { catalogItemId, appId }`.
+- **`customLineItems`** — items that are not in a catalog (configurators, bundles, made-to-order). Each entry carries its own `productName`, `price`, and `itemType`.
+
+Never invent a `catalogReference` to force a custom item into `lineItems` — use `customLineItems`.
+
+```typescript
+import { currentCart } from "@wix/ecom";
+
+// ✅ Non-catalog item — customLineItems, price is a decimal STRING
+await currentCart.addToCurrentCart({
+  customLineItems: [
+    {
+      quantity: 1,
+      price: "45.00", // string, no currency symbol
+      productName: { original: "Hoodie (JH001)" },
+      itemType: { preset: "PHYSICAL" },
+      descriptionLines: [
+        { name: { original: "Size" }, plainText: { original: "L" } },
+      ],
+    },
+  ],
+});
+
+// ✅ Catalog item — lineItems, catalogReference required
+await currentCart.addToCurrentCart({
+  lineItems: [
+    {
+      quantity: 1,
+      catalogReference: { catalogItemId: productId, appId: storesAppId },
+    },
+  ],
+});
+```
+
+After any cart mutation, call `refreshCart()` so the site's cart UI and the Cart Updated event pick it up.
+
+> Do **not** grep `node_modules/@wix/ecom` to confirm these methods exist. `@wix/<pkg>` packages are re-export facades — `currentCart` comes from `@wix/auto_sdk_ecom_current-cart`, so `addToCurrentCart` matches zero files under `@wix/ecom`. An empty result is not evidence the API is missing.
 
 ### Performance Considerations
 


### PR DESCRIPTION
## Problem

Two gaps in `wix-app/references/SITE_PLUGIN.md`, both surfaced by job `fa519aec-cb27-4c81-80a0-b9c1e3fa5485` (INIT_CODEGEN, App Builder, **5.46 min / $0.88** — 1.8× both SLOs).

This is a *reference present but too thin* case, not a missing reference — panorama confirms the agent read `SITE_PLUGIN.md` at +3s. So this sharpens the existing file rather than adding a new one.

### 1. Cart writes

`SITE_PLUGIN.md:327` already showed `import { currentCart } from "@wix/ecom"` — but only a **read** (`getCurrentCart()`). A plugin that needs to *add* to the cart had to leave the skill to find the write path.

The agent spent **~165s of a 328s run** re-deriving `addToCurrentCart`, even though a discovery subagent had returned it correctly at +75s. What broke its confidence: `grep addToCurrentCart node_modules/@wix/ecom/dist` came back empty — because `@wix/ecom` is a re-export facade (`currentCart` comes from `@wix/auto_sdk_ecom_current-cart`), so the method matches zero files there. It then re-searched the docs and spawned a *second* subagent for the same answer.

Also documents the **`lineItems` vs `customLineItems`** split. Both type-check, so `tsc` will not catch forcing a non-catalog item into `lineItems` with an invented `catalogReference` — it fails at runtime.

### 2. Event listeners

The component pattern only covers static markup, so interactive plugins improvise. The generated plugin bound events in **both** `render()` and `connectedCallback()`:

```ts
connectedCallback(): void {
  this.render();        // render() already ends with this.attachEvents()
  this.attachEvents();  // duplicate
}
```

Both listeners sit on the same button, so a single click ran the handler twice and **added the bundle to the cart two times**. `tsc --noEmit` and `wix build` both passed on this — nothing in CI catches it.

## Change

Additive, docs-only (+72 lines to `SITE_PLUGIN.md`):

- **`### Adding to the Cart`** — `lineItems` vs `customLineItems` with a worked example of each, `price` as a decimal string, the `refreshCart()` follow-up, and a note that grepping `node_modules/@wix/ecom` proves nothing.
- **`### Interactive Plugins: Attach Listeners in Exactly One Place`** — wrong/right lifecycle pair, with the reason re-rendering inside the handler does not suppress the second call.

## Companion

ditto https://github.com/wix-private/ditto/pull/1030 — teaches the `node_modules` guardrail the same facade fact, for when an agent gets there anyway. That guard fired in **60+ distinct jobs over 7 days**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)