### PR TITLE
docs(wix-manage): document source_url on Site Import's StartImport

### DIFF
--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -121,7 +121,7 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
 
 - **Show the `importId` once, right after Start succeeds** — e.g. "Your import
   ID is `abc123` — keep it handy." Never show raw JSON, HTTP codes, artifact
-  ids, or `sourcePlatform`/`sourceConfidence` values.
+  ids, or `sourcePlatform`/`sourceConfidence`/`destinationSiteId` values.
 - **Write for a non-technical audience.** No jargon: no "endpoint", "API",
   "poll", "HTTP", "rate limit", "JSON". Translate events into plain outcomes —
   "the source store limits how fast it can be read" not "hit rate limit (429)".
@@ -181,9 +181,11 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
      is rejected with `INVALID_FILE_URL` (nothing is silently dropped).
    - A request with neither `source_url` nor a URL/site identifiable in
      `request`, and no `fileUrls`, is rejected with `SITE_UNIDENTIFIED`.
-   Returns: `importId`, `sourcePlatform`, `sourceConfidence`. `sourcePlatform`
-   comes back as `CSV` for a FILE run (no site was probed, so
-   `sourceConfidence` is meaningless there).
+   Returns: `importId`, `sourcePlatform`, `sourceConfidence`, `destinationSiteId`.
+   `sourcePlatform` comes back as `CSV` for a FILE run (no site was probed, so
+   `sourceConfidence` is meaningless there). `destinationSiteId` is the id of
+   the Wix site being imported into — returned as soon as Start succeeds,
+   even before a source is confirmed.
    **One import per store at a time, keyed on `source_url`** (or the file set
    when there's no `source_url`): re-starting with the same identity continues
    the SAME migration (server returns the existing `importId`, no new import

--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -54,7 +54,10 @@ Example — Start:
 
 ```
 POST https://www.wixapis.com/site-import/v1/imports
-Body: { "request": "Import https://example-store.com into a new Wix site" }
+Body: {
+  "request": "Import https://example-store.com into a new Wix site",
+  "source_url": "https://example-store.com"
+}
 ```
 
 Example — Poll:
@@ -148,12 +151,21 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
 **Single `importId` for the whole import — assigned at Start, never changes.**
 
 1. **Start** — `POST /v1/imports`
-   Body: `{"request": "<natural language; MUST include the source store URL>"}`
+   Body: `{"request": "<natural language, MUST include the source store URL>", "source_url": "<the source store URL>"}`
+   `request` is required (1–20000 chars). `source_url` is technically optional but
+   **always send it whenever the user names a site** — it's the identity the
+   service uses to select which migration the request joins, not just an extra
+   hint. Leave it out only for an import with no source site (e.g. the user
+   pastes inline CSV/JSON data to import instead of a URL); a request with
+   neither a `source_url` nor a URL/site identifiable in `request` is rejected
+   with `SITE_UNIDENTIFIED`.
    Returns: `importId`, `sourcePlatform`, `sourceConfidence`.
-   One import per store at a time: if the same user re-starts for the same store,
-   the server returns the existing `importId` (no new import is created). If a
-   different user on the account already owns an import for that store, Start
-   returns `409 { "code": "IMPORT_IN_PROGRESS" }` — tell the user and stop.
+   **One import per store at a time, keyed on `source_url`:** re-starting with the
+   same `source_url` continues the SAME migration (server returns the existing
+   `importId`, no new import created). A different `source_url` always starts an
+   independent migration, even for the same user. If a different user on the
+   account already owns an import for that store, Start returns
+   `409 { "code": "IMPORT_IN_PROGRESS" }` — tell the user and stop.
 
 2. **Poll** — `GET /v1/imports/{importId}?includeRecentActivity=true`
    Returns: `status`, `deployUrl`, `message`, `options[]` (only when
@@ -242,7 +254,10 @@ the user has no way to open a file.
   reaches the team. Do not retry or fall back to another site-creation tool.
 - Any other `403` on Start means the caller is not authorized — tell the user
   and stop. Do not probe other endpoints to diagnose this. A `400` means a
-  required field is missing (`request`/`message` must be 1–20000 chars).
+  required field is missing (`request`/`message` must be 1–20000 chars) or
+  `source_url` exceeds 2048 chars. A request with no identifiable site (no
+  `source_url` and no URL in `request`) and no inline data is rejected with
+  `SITE_UNIDENTIFIED` — ask the user for the store URL and retry.
 - Requesting an unknown id in `artifactIds` is silently ignored — not an error.
   A document simply may not exist yet on an earlier turn.
 - **The user cannot open files.** If a message mentions a document by filename,

--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -109,7 +109,8 @@ and act only on the user's explicit yes.
 
 This creates real infrastructure and writes to the user's Wix account. Before
 calling **Start**, confirm:
-- The source URL and platform are correct
+- The source URL and platform are correct — or, for a file-only import, the
+  export file URL(s) are correct
 - The user understands it runs for up to ~60 minutes and may ask questions mid-way
 
 Also confirm before calling **Cancel** — it's irreversible.
@@ -161,7 +162,7 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
 **Single `importId` for the whole import — assigned at Start, never changes.**
 
 1. **Start** — `POST /v1/imports`
-   Body: `{"request": "<natural language, MUST include the source store URL>", "source_url": "<the source store URL>", "fileUrls": ["<CSV/TSV export URL>", ...]}`
+   Body: `{"request": "<natural language; MUST include the source store URL when crawling a live site>", "source_url": "<the source store URL>", "fileUrls": ["<CSV/TSV export URL>", ...]}`
    `request` is required (1–20000 chars). `source_url` and `fileUrls` are both
    optional, but send whichever applies — never leave both out with no way to
    identify what to import:
@@ -169,9 +170,11 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
      the identity the service uses to select which migration the request joins,
      not just an extra hint.
    - **`fileUrls`** — send it when the user has CSV/TSV export file(s) to import
-     instead of (or in addition to) crawling a live site. Setting it makes this
-     a **FILE run**: no source site is probed and no source credentials are
-     requested. Up to 20 URLs, http/https only (ports 80/443), each ≤2048
+     instead of crawling a live site. Setting it makes this a **FILE run**: no
+     source site is probed and no source credentials are requested, even if
+     `source_url` is also present — `source_url` only changes what the
+     migration is keyed on (see below), it does not add a crawl on top of the
+     file import. Up to 20 URLs, http/https only (ports 80/443), each ≤2048
      chars. If `source_url` is absent, the file set itself is the migration
      identity — re-sending the same URLs continues the same migration; a
      different set starts a new one. If a URL isn't reachable, the whole call

--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -1,6 +1,6 @@
 ---
 name: "Site Import"
-description: Drive the Wix Site Import agent to migrate an existing store or site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix. Use this skill whenever the user wants to import, migrate, or clone a store/site into Wix, mentions moving off Shopify/WooCommerce/Magento, or gives a source store URL and asks to bring it into Wix. Also use it when the user has CSV/TSV product or data export files they want imported, even with no source site to crawl. Covers starting the import, polling progress, answering the agent's mid-import questions, handling deploy/failure/auth-expiry states, and sending post-deploy follow-up changes.
+description: Drive the Wix Site Import agent to migrate an existing store or site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix, or to import from CSV/TSV export files with no source site. Use this skill whenever the user wants to import, migrate, or clone a store/site into Wix, mentions moving off Shopify/WooCommerce/Magento, or gives a source store URL and asks to bring it into Wix. Covers starting the import, polling progress, answering the agent's mid-import questions, handling deploy/failure/auth-expiry states, and sending post-deploy follow-up changes.
 ---
 
 # Site Import

--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -1,6 +1,6 @@
 ---
 name: "Site Import"
-description: Drive the Wix Site Import agent to migrate an existing store or site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix, or to import from CSV/TSV export files with no source site. Use this skill whenever the user wants to import, migrate, or clone a store/site into Wix, mentions moving off Shopify/WooCommerce/Magento, gives a source store URL, or has product/data export files they want imported. Covers starting the import, polling progress, answering the agent's mid-import questions, handling deploy/failure/auth-expiry states, and sending post-deploy follow-up changes.
+description: Drive the Wix Site Import agent to migrate an existing store or site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix. Use this skill whenever the user wants to import, migrate, or clone a store/site into Wix, mentions moving off Shopify/WooCommerce/Magento, or gives a source store URL and asks to bring it into Wix. Also use it when the user has CSV/TSV product or data export files they want imported, even with no source site to crawl. Covers starting the import, polling progress, answering the agent's mid-import questions, handling deploy/failure/auth-expiry states, and sending post-deploy follow-up changes.
 ---
 
 # Site Import

--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -1,6 +1,6 @@
 ---
 name: "Site Import"
-description: Drive the Wix Site Import agent to migrate an existing store or site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix. Use this skill whenever the user wants to import, migrate, or clone a store/site into Wix, mentions moving off Shopify/WooCommerce/Magento, or gives a source store URL and asks to bring it into Wix. Covers starting the import, polling progress, answering the agent's mid-import questions, handling deploy/failure/auth-expiry states, and sending post-deploy follow-up changes.
+description: Drive the Wix Site Import agent to migrate an existing store or site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix, or to import from CSV/TSV export files with no source site. Use this skill whenever the user wants to import, migrate, or clone a store/site into Wix, mentions moving off Shopify/WooCommerce/Magento, gives a source store URL, or has product/data export files they want imported. Covers starting the import, polling progress, answering the agent's mid-import questions, handling deploy/failure/auth-expiry states, and sending post-deploy follow-up changes.
 ---
 
 # Site Import
@@ -57,6 +57,16 @@ POST https://www.wixapis.com/site-import/v1/imports
 Body: {
   "request": "Import https://example-store.com into a new Wix site",
   "source_url": "https://example-store.com"
+}
+```
+
+Example — Start from exported files (no source site, FILE run):
+
+```
+POST https://www.wixapis.com/site-import/v1/imports
+Body: {
+  "request": "Import these product export files into a new Wix site",
+  "fileUrls": ["https://example.com/exports/products.csv"]
 }
 ```
 
@@ -151,20 +161,32 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
 **Single `importId` for the whole import — assigned at Start, never changes.**
 
 1. **Start** — `POST /v1/imports`
-   Body: `{"request": "<natural language, MUST include the source store URL>", "source_url": "<the source store URL>"}`
-   `request` is required (1–20000 chars). `source_url` is technically optional but
-   **always send it whenever the user names a site** — it's the identity the
-   service uses to select which migration the request joins, not just an extra
-   hint. Leave it out only for an import with no source site (e.g. the user
-   pastes inline CSV/JSON data to import instead of a URL); a request with
-   neither a `source_url` nor a URL/site identifiable in `request` is rejected
-   with `SITE_UNIDENTIFIED`.
-   Returns: `importId`, `sourcePlatform`, `sourceConfidence`.
-   **One import per store at a time, keyed on `source_url`:** re-starting with the
-   same `source_url` continues the SAME migration (server returns the existing
-   `importId`, no new import created). A different `source_url` always starts an
-   independent migration, even for the same user. If a different user on the
-   account already owns an import for that store, Start returns
+   Body: `{"request": "<natural language, MUST include the source store URL>", "source_url": "<the source store URL>", "fileUrls": ["<CSV/TSV export URL>", ...]}`
+   `request` is required (1–20000 chars). `source_url` and `fileUrls` are both
+   optional, but send whichever applies — never leave both out with no way to
+   identify what to import:
+   - **`source_url`** — send it whenever the user names a site to crawl. It's
+     the identity the service uses to select which migration the request joins,
+     not just an extra hint.
+   - **`fileUrls`** — send it when the user has CSV/TSV export file(s) to import
+     instead of (or in addition to) crawling a live site. Setting it makes this
+     a **FILE run**: no source site is probed and no source credentials are
+     requested. Up to 20 URLs, http/https only (ports 80/443), each ≤2048
+     chars. If `source_url` is absent, the file set itself is the migration
+     identity — re-sending the same URLs continues the same migration; a
+     different set starts a new one. If a URL isn't reachable, the whole call
+     is rejected with `INVALID_FILE_URL` (nothing is silently dropped).
+   - A request with neither `source_url` nor a URL/site identifiable in
+     `request`, and no `fileUrls`, is rejected with `SITE_UNIDENTIFIED`.
+   Returns: `importId`, `sourcePlatform`, `sourceConfidence`. `sourcePlatform`
+   comes back as `CSV` for a FILE run (no site was probed, so
+   `sourceConfidence` is meaningless there).
+   **One import per store at a time, keyed on `source_url`** (or the file set
+   when there's no `source_url`): re-starting with the same identity continues
+   the SAME migration (server returns the existing `importId`, no new import
+   created). A different identity always starts an independent migration, even
+   for the same user. If a different user on the account already owns an
+   import for that identity, Start returns
    `409 { "code": "IMPORT_IN_PROGRESS" }` — tell the user and stop.
 
 2. **Poll** — `GET /v1/imports/{importId}?includeRecentActivity=true`
@@ -254,10 +276,14 @@ the user has no way to open a file.
   reaches the team. Do not retry or fall back to another site-creation tool.
 - Any other `403` on Start means the caller is not authorized — tell the user
   and stop. Do not probe other endpoints to diagnose this. A `400` means a
-  required field is missing (`request`/`message` must be 1–20000 chars) or
-  `source_url` exceeds 2048 chars. A request with no identifiable site (no
-  `source_url` and no URL in `request`) and no inline data is rejected with
-  `SITE_UNIDENTIFIED` — ask the user for the store URL and retry.
+  required field is missing (`request`/`message` must be 1–20000 chars),
+  `source_url` exceeds 2048 chars, or `fileUrls` has more than 20 entries or
+  one over 2048 chars. A request with no identifiable site (no `source_url`
+  and no URL in `request`) and no `fileUrls` is rejected with
+  `SITE_UNIDENTIFIED` — ask the user for the store URL or export file(s) and
+  retry. A `fileUrls` entry that isn't a reachable http/https URL rejects the
+  whole call with `INVALID_FILE_URL` — tell the user which link failed and ask
+  for a working one.
 - Requesting an unknown id in `artifactIds` is silently ignored — not an error.
   A document simply may not exist yet on an earlier turn.
 - **The user cannot open files.** If a message mentions a document by filename,

--- a/yaml/wix-manage-evals/sites/site-import-file-run.yml
+++ b/yaml/wix-manage-evals/sites/site-import-file-run.yml
@@ -1,0 +1,32 @@
+name: sites/site-import-file-run
+description: >-
+  Verifies the agent knows Wix Site Import can start a FILE run from CSV/TSV export URLs via
+  fileUrls, with no source site to crawl, and still applies the source_url identity rule when a
+  site is also named.
+triggerPrompt: >-
+  I don't have a live store to point Wix Site Import at — I only have a product export file at
+  https://example.com/exports/products.csv. Can Site Import work from just that file? Using the
+  actual Wix Site Import API, tell me exactly which field carries the file, whether it needs my
+  source store's login, and what identifies this as "the same import" if I send that request again.
+tags: [sites]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/account-level/sites/skills/site-import
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user has no source site, only a CSV/TSV export file URL, and asked whether Wix Site
+      Import can run from that alone, which request field carries it, whether source credentials
+      are needed, and what makes a re-sent request "the same" import.
+
+      Pass: names the `fileUrls` field on Start (POST /v1/imports) as how to pass the export
+      file URL(s); states this is a "FILE run" that does not crawl/probe a source site and does
+      not need source-site login/credentials; and explains that with no `source_url` given, the
+      file URL(s) themselves are the identity — sending the same file URL(s) again continues the
+      same import/migration, while different files would start a separate one.
+
+      Fail: says Site Import requires a live source site/URL and can't work from a file alone,
+      never names `fileUrls`, claims source credentials are still required for a file-only
+      import, or gives no account of what makes a repeat request resume vs. start a new import.

--- a/yaml/wix-manage-evals/sites/site-import-file-run.yml
+++ b/yaml/wix-manage-evals/sites/site-import-file-run.yml
@@ -1,8 +1,8 @@
 name: sites/site-import-file-run
 description: >-
   Verifies the agent knows Wix Site Import can start a FILE run from CSV/TSV export URLs via
-  fileUrls, with no source site to crawl, and still applies the source_url identity rule when a
-  site is also named.
+  fileUrls alone, with no source site to crawl and no source credentials needed, and that the
+  file URL(s) themselves become the migration identity when no source_url is given.
 triggerPrompt: >-
   I don't have a live store to point Wix Site Import at — I only have a product export file at
   https://example.com/exports/products.csv. Can Site Import work from just that file? Using the


### PR DESCRIPTION
## Summary
- `StartImportRequest` has an optional `source_url` field alongside `request`, confirmed against the `SiteImportService` proto (`wix-private/replatform-sb`). It's the actual identity key the service uses to select which migration a Start call joins — not just a convenience hint.
- `StartImportRequest` also gained `fileUrls` (spec 0019): setting it starts a **FILE run** that imports CSV/TSV export URLs directly, with no source-site probe and no source credentials requested. When `source_url` is absent, the file set itself becomes the migration identity. Reports back `sourcePlatform: CSV`; an unreachable URL rejects the whole call with `INVALID_FILE_URL`.
- Updated the site-import skill's frontmatter description, Start examples, endpoint docs, dedup rule, and error rules to cover both fields.
- Checked the two site-import eval YAMLs (`sites/site-import-start.yml`, `sites/site-import-status-handling.yml`) — neither asserts on the Start request body shape, so no eval changes needed.

## Test plan
- [x] Reviewed proto source for `StartImportRequest` (including `fileUrls`) to confirm field names, optionality, and semantics
- [x] Confirmed eval YAMLs don't need updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)