### PR TITLE
🦞 igor-claw: fix bad Site Properties guidance for BUSINESS_SCHEDULE_NOT_FOUND

### DIFF
--- a/skills/wix-manage/references/bookings/bookings-staff-setup.md
+++ b/skills/wix-manage/references/bookings/bookings-staff-setup.md
@@ -111,9 +111,9 @@ Before creating staff members, ensure the foundation is properly configured:
 
 **Check Wix Bookings Installation**: Query staff members (`POST https://www.wixapis.com/bookings/v1/staff-members/query`) to test if Bookings is installed. If you receive "Business schedule not found" errors, the foundation needs setup.
 
-**Install Wix Bookings App** (if needed): Use the App Installer API with Wix Bookings app ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`.
+**Install Wix Bookings App** (if needed): Use the App Installer API with Wix Bookings app ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`. Installing Bookings automatically provisions the business schedule that Staff Members needs — no separate schedule-creation call is required.
 
-**Configure Business Schedule**: Set up site properties with business operating hours using the Site Properties API.
+**Configure Business Schedule** (optional — only if you want non-default hours): Use the Calendar Events V3 API, **not** the Site Properties API, to set business operating hours. See the [Configure Default Business Hours recipe](../calendar/configure-default-business-hours.md). The Site Properties Business Schedule API (`site-properties/v4/properties/business-schedule`) is an unrelated resource and won't fix a "Business schedule not found" error.
 
 **Create Calendar Schedule and Working Hours**: Create a calendar schedule for Wix Bookings integration and populate it with business `WORKING_HOURS` events.
 
@@ -204,7 +204,9 @@ Query the staff member to confirm:
 ### Troubleshooting Common Issues
 
 **"Business schedule not found" Error**:
-Execute systematic diagnosis: check app installation, site properties, calendar schedule, and working hours events in sequence. Fix the first failed component before proceeding.
+1. Check Wix Bookings app installation first ([List Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/list-installed-apps)). This is the cause in almost all cases — install the app and retry.
+2. **Do NOT** call the Site Properties Business Schedule API (`site-properties/v4/properties/business-schedule`) as a fix — it's a different, unrelated resource. It will return `200` without creating or affecting the Calendar business schedule that Staff Members/Calendar APIs check for.
+3. If Bookings is confirmed installed (via step 1) and the error still persists after retrying, this is a backend provisioning gap in the site's business schedule, not something fixable via a public API call (there is no create-business-schedule endpoint). Report this to the user and suggest contacting Wix Support with the site ID, rather than continuing to retry business-schedule/location workarounds.
 
 **Staff Member Still Shows Default Hours**:
 Completed assignment but missing event creation. Create `WORKING_HOURS` events using the Bulk Create Events API.


### PR DESCRIPTION
## What's broken

`skills/wix-manage/references/bookings/bookings-staff-setup.md` told agents to:
1. "Configure Business Schedule: Set up site properties with business operating hours using the Site Properties API" as a foundation-setup step, and
2. Check "site properties" as part of the diagnosis sequence for a `"Business schedule not found"` error.

The Site Properties Business Schedule API (`site-properties/v4/properties/business-schedule`) is an unrelated resource — it doesn't create or affect the Calendar business schedule (`externalId: 4e0579a5-491e-4e70-a872-d097eed6e520`) that Bookings Staff Members/Calendar APIs actually check for. Following this recipe as written sends an agent down a dead end: the Site Properties call succeeds (200), but `Create Staff Member` keeps 404ing with `BUSINESS_SCHEDULE_NOT_FOUND`.

This is exactly the sequence in a real feedback report: an agent hit `BUSINESS_SCHEDULE_NOT_FOUND` on Create Staff Member, called Site Properties' Update Business Schedule per docs, saw it succeed, retried, got the same 404, then also tried creating a Location — none of which touch the actual missing resource.

## Root cause (verified)

- Reproduced live via the Wix MCP on an owned test site: `POST site-properties/v4/properties/business-schedule` returns `200` on a site with no Bookings business schedule; `Create Staff Member` still returns `404 BUSINESS_SCHEDULE_NOT_FOUND` immediately after.
- Read `wix-private/scheduler`'s `SchedulesAdapter.getBusinessSchedule()`: it looks up a Calendar `Schedule` by `scheduleOwnerId == VirtualBusinessResourceId`, which is provisioned when Wix Bookings is installed — Site Properties never touches this.
- Found `FixResourceProvisioningTask` / `MigrateSiteBusinessResourceToFixedIdTask` in `wix-private/velocity-infra`: internal-only immigrator tasks that exist specifically to repair sites where this schedule failed to provision, confirming there's no public-API self-heal path for that case.

## The fix

- Point "Configure Business Schedule" at the Calendar Events V3 API (linking the existing `configure-default-business-hours` recipe) instead of Site Properties, and note it's optional since Bookings auto-provisions default hours on install.
- Rewrite the `"Business schedule not found"` troubleshooting entry into an ordered sequence: check/install Bookings first (fixes almost all cases) → explicitly do NOT use Site Properties as a fix → if Bookings is confirmed installed and it still fails, treat it as a backend provisioning gap and tell the user to contact Wix Support instead of continuing to retry workarounds.

Companion docs-source PRs (same root cause, upstream reference docs):
- https://github.com/wix-private/scheduler/pull/31538
- https://github.com/wix-private/scheduler/pull/31539

---
This PR was opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), while researching Wix MCP user feedback.
Feedback thread: https://wix.slack.com/archives/C08P5DKLJR5/p1785937398752899