### PR TITLE
fix(wix-manage): read Catalog V3 availability from `inventory`, not a V1 field name

### DIFF
--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -54,7 +54,9 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
 }'
 ```
 
-This returns all products with their default fields (id, name, slug, visible, productType, priceData, stock, media, etc.).
+This returns all products with their default fields, including `inventory` for product-level availability.
+
+Take availability from `inventory`, and look up any other field you need in the Catalog V3 docs rather than carrying a name over from Catalog V1 — the two catalogs do not share a product shape. A name that isn't on the V3 product reads as `undefined` rather than raising, so the request still succeeds and a check against it quietly matches nothing: an availability question answered that way returns an empty list, which reads as "everything is in stock" instead of as a failure.
 
 ### STEP 3: Understanding the `fields` parameter
 
@@ -186,7 +188,8 @@ Check the response `pagingMetadata` to determine if more pages exist.
 
 - **Variant data is NOT returned** by Query Products. To get variant details, use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) for individual products.
 - **Non-visible products** require the `SCOPE.STORES.PRODUCT_READ_ADMIN` permission.
-- Default fields include: `id`, `name`, `slug`, `visible`, `productType`, `priceData`, `stock`, `media`, `createdDate`, `updatedDate`.
+- Default fields include: `id`, `name`, `slug`, `visible`, `productType`, `inventory`, `media`, `createdDate`, `updatedDate`.
+- **Availability is not in STEP 4's filterable set.** To list out-of-stock products, query the catalog — paging until `pagingMetadata` reports no more results — and select on each returned product's `inventory` availability status in your own code, rather than putting it in `query.filter`.
 - The `fields` parameter adds fields **on top of** the defaults — you never need to request `id` or `name` explicitly.
 
 ## Conclusion

--- a/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
@@ -1,0 +1,107 @@
+name: stores/list-out-of-stock-products-catalog-v3
+description: >
+  A store owner asks which of their products are out of stock. Verifies the agent loads the
+  Find Products (Query and Search, Catalog V3) recipe and reads availability from the product's
+  `inventory` field, rather than a Catalog V1 field name that reads as `undefined` on a V3
+  product and silently yields an empty result. The seeded products are the ground truth, and
+  the agent can only know them by querying.
+triggerPrompt: >
+  Which of my products are out of stock?
+tags: [stores, aria]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3
+  - type: llm_judge          # correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Which of my products are out of stock?"
+
+      The site is a Catalog V3 store. On top of the template's own demo catalog, two products
+      were seeded explicitly out of stock: "Eval Gate Tee" and "Eval Gate Leggings". Some demo
+      products may also legitimately be out of stock.
+
+      Score 9-10: the agent queried the catalog and its final answer names BOTH "Eval Gate Tee"
+      and "Eval Gate Leggings" as out of stock.
+
+      Score 7-8: both seeded products are named as out of stock, but the answer is muddled —
+      for example it hedges about whether they are really out of stock, or buries them in a
+      list it describes as in stock.
+
+      Score 1-3: the answer omits either seeded product; OR it states or implies that nothing
+      is out of stock, that all products are in stock, or that the store has no out-of-stock
+      products; OR it lists products without having queried any Wix API.
+
+      Two rules for judging, both important:
+
+      - An answer of "none of your products are out of stock" is a FAILURE, not a pass. Two
+        products are out of stock. Reporting an empty result is the specific defect this
+        scenario exists to catch, so score it 1-3 even if the agent sounds confident and made
+        a successful (2xx) API call to get there.
+      - Additional out-of-stock products beyond the two seeded ones are NOT an error. The demo
+        catalog may contain its own out-of-stock items. Do not deduct for naming extra
+        products; judge only whether both seeded products are reported as out of stock.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality of the tool-call path
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
+      trace. Score 0-10 (10 = direct: no wasted calls, no errors).
+
+      Penalize and LIST any of:
+
+      - guessing where product availability lives and having to correct it — for example
+        reading a `stock` field, `inventoryStatus`, or a quantity off the product and getting
+        `undefined` or an empty result before finding the `inventory` field;
+      - extra probing calls made only to discover the response shape, such as re-querying the
+        catalog to dump a product object, or repeated API-spec/schema lookups for the Product
+        object's availability fields;
+      - sending availability inside `query.filter` on the products query and having it
+        rejected;
+      - a detour into per-variant or per-location inventory endpoints when a single catalog
+        query would have answered the question;
+      - any call that returned a non-2xx error, even if the agent recovered from it;
+      - a wrong endpoint or catalog version tried first.
+
+      For each issue, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      # A plain POST /stores/v3/products creates no inventory item, which leaves the product
+      # untracked and available — it would never surface as out of stock. products-with-inventory
+      # is what makes inventoryItem.inStock=false take effect.
+      - label: seed out-of-stock tee product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Gate Tee
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "19.50" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: false }
+      - label: seed out-of-stock leggings product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products-with-inventory
+        body:
+          product:
+            name: Eval Gate Leggings
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "29.90" } }
+                  physicalProperties: {}
+                  visible: true
+                  inventoryItem: { inStock: false }


### PR DESCRIPTION
## What this fixes

The **Find Products (Query and Search, Catalog V3)** recipe named two fields that do not exist on a Catalog V3 product. It said, in two places, that the default fields returned by `POST /stores/v3/products/query` include `priceData` and `stock`:

> This returns all products with their default fields (id, name, slug, visible, productType, **priceData**, **stock**, media, etc.)

> Default fields include: `id`, `name`, `slug`, `visible`, `productType`, **`priceData`**, **`stock`**, `media`, `createdDate`, `updatedDate`.

Both are Catalog **V1** names. A Catalog V3 product carries availability on `inventory` and product-level prices on `actualPriceRange`.

This is the worst shape a wrong field name can take, because nothing fails. `product.stock` is `undefined`, a check against it matches nothing, and the query still returns `200` — so the mistake surfaces as an empty result rather than as an error.

## Measured effect

In a recorded run of a *"which of my products are out of stock?"* task, against a store seeded with two out-of-stock products, the agent read this recipe and then ran, verbatim:

```js
const outOfStockProducts = allProducts.filter(p =>
  p.stock && (p.stock.inventoryStatus === "OUT_OF_STOCK" || p.stock.quantity === 0)
);
```

and answered, verbatim:

> I've checked your store's inventory, and currently, **none of your products are out of stock**. All 15 of your products are currently in stock!

Across six recorded runs of that task, **four** reported that nothing was out of stock. Of the runs that answered correctly, one got there only by abandoning the recipe's field list and probing the live response — its first attempt filtered on `stock.inventoryStatus`, returned nothing, and it took four further calls to discover `inventory.availabilityStatus`.

## Verified against the generated reference

Checked against the Catalog V3 reference rather than from memory:

- The Product object carries `inventory.availabilityStatus` (read-only, *"Current availability status"*). The Query Products reference documents the same field, and its response examples show `"availabilityStatus": "OUT_OF_STOCK"`.
- Neither `stock` nor `priceData` appears anywhere in the V3 Product object.
- Product-level prices are `actualPriceRange`.

So the generated reference was already correct — only this recipe contradicted it. That is what makes the recipe the right place to fix this, rather than anything upstream.

## The change

Deliberately minimal: the false claim is **removed** rather than restated as a corrected field list, since request/response shapes belong in the docs per CONTRIBUTING's *"Orchestration, not API shape"*.

- STEP 2 names `inventory` as the availability field, and explains the silent-`undefined` failure mode without re-teaching the V1 field names.
- The default-fields note drops `priceData` and `stock`, with `inventory` in their place.
- One orchestration line: availability is outside STEP 4's filterable set, so the selection happens client-side after paging.

That is +5 −2 on the recipe.

**Deliberately left alone:** the pre-existing `"fields": ["id", "name", "slug", "visible", "priceData"]` block in STEP 3 — it illustrates invalid `fields` enum values, not a response shape — and `PARTIALLY_OUT_OF_STOCK` handling, which no recorded run got wrong.

The recipe's front-matter `description` and its `SKILL.md` entry are **unchanged**. Retrieval already works for this task: the failing run did load this recipe. Editing the description is an untested routing change for every task that currently matches it, and this PR has no scenario that would notice a drop.

## Eval scenario

`yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml`, with the three assertions `docs/eval-scenarios.md` asks for: the `ReadFullDocsArticle` coverage assertion, an `llm_judge` on correctness, and an `llm_judge` on the tool-call path.

Two things worth flagging for review:

- **The quality judge gates at `minScore: 7`**, per `docs/eval-scenarios.md` — *"This judge gates like any other, so a bumpy path fails the PR."* The neighbouring `stores/hide-product-visibility-catalog-v3.yml` carries a non-gating `minScore: 0` for its path judge; I followed the guide rather than the neighbouring file.
- The correctness rubric scores *"none of your products are out of stock"* as an explicit **failure**, and explicitly does **not** penalise out-of-stock products beyond the two seeded ones, because the demo catalog has its own. Both directions were needed: recorded runs of this task have been scored as passing while reporting an empty list, and scored as failing for naming a product outside the seed.

`triggerPrompt` is the bare *"Which of my products are out of stock?"* so it does not pre-solve the ambiguity the defect exploits.

## Verification status

**GitHub Actions is currently disabled for this repository, so the gate did not run on this PR.** `actions/permissions` reports `enabled: false`, there are zero workflow runs for this branch's head commit across *every* workflow, and each workflow still reports `state: active` — so this is a repository-level shutoff, not a `paths:` mismatch and not this branch. No check will appear here; please do not read the absence of a red mark as a green one.

Because of that, I ran the same gate against this branch **manually**. The result is in a comment below, and it discriminates:

| | PR (with fix) | Production |
|---|---|---|
| `ReadFullDocsArticle` coverage | passed | passed |
| Correctness judge | passed (10/10) | passed (10/10) |
| Path/quality judge | **passed (8/10)** | **failed (5/10)** |
| Cost | $0.513 | $0.738 |
| Tokens | 251.4K | 362.3K |
| Wall clock | 104.8s | 90.6s |

Verdict `required`, with `assertions pass in PR, fail in prod: LLM judge`. The path judge is the discriminator — both sides reached the right answer in this run, so correctness alone would not have separated them. Production also named 3 of the 4 out-of-stock products where the PR side named 4. Note that this is one run, not a measurement: these judges are not perfectly reproducible, and wall clock went the other way while cost and tokens fell ~30%.

Also verified locally:

- the scenario parses against this repo's own schema (`packages/evalforge-core/src/schema.ts` → `parseScenario`): 3 assertions, 2 bootstrap steps, tags accepted;
- its `articleUrl` is identical to what the gate's own `canonicalDocUrl`/`slugify` computes for this recipe from `yaml/wix-manage/stores/documentation.yaml`, and identical to the URL the agent actually called in the recorded run.

One housekeeping note: the manual run registered the scenario under the usual per-PR draft tag. The promote and cleanup workflows that would normally retag or remove it on merge/close cannot run while Actions is disabled, so that may need doing by hand.
