### PR TITLE
fix(wix-manage): give the pricing-plans recipe an archive step

### DIFF
--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -149,6 +149,24 @@ Each item in the request for this endpoint must adhere to these rules:
 - `itemSetId` must set to the created pool definition benefit item set id.
 - `externalId` must be set to the integrating app entity id, example: booking service id or blog post id.
 
+### 3. Stop offering a plan — archive it, don't delete it
+
+When the user asks to archive, retire, or stop offering a plan, **archive** it so existing
+subscribers and order history are preserved. Archiving is an Update Plan call — there is no
+separate archive endpoint, and Delete Plan is not the same thing:
+
+```bash
+curl -X PATCH \
+  'https://www.wixapis.com/pricing-plans/v3/plans/<PLAN_ID>' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{ "plan": { "id": "<PLAN_ID>", "revision": "<CURRENT_REVISION>", "archived": true } }'
+```
+
+Carry the plan's current `revision` or the update is rejected. `archived` is not listed in the
+generated Plan object reference, so it cannot be found by reading the schema — reach for it
+directly rather than searching for an archive method or falling back to Delete Plan.
+
 ## Pricing plans REST API Documentation Reference
 - [Create plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan)
 - [Get plan](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/get-plan)

--- a/yaml/wix-manage-evals/pricing-plans/archive-plan.yml
+++ b/yaml/wix-manage-evals/pricing-plans/archive-plan.yml
@@ -1,0 +1,62 @@
+name: pricing-plans/archive-plan
+description: >
+  A site owner asks for a plan to be created and then archived so it is no longer offered.
+  Verifies the agent loads the Create or Update Pricing Plans recipe and archives the plan with
+  an Update Plan call carrying `archived: true` — rather than deleting it, or discovering the
+  field by probing the generated schema, which does not list it.
+triggerPrompt: >
+  Create a plan called Legacy Plan at $15 a month, then archive it so it's no longer offered.
+tags: [pricing-plans, aria]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/create-and-update-pricing-plans
+  - type: llm_judge          # correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Create a plan called Legacy Plan at $15 a month, then
+      archive it so it's no longer offered."
+
+      Score 9-10: a plan named "Legacy Plan" was created with a recurring monthly price of 15,
+      and it was then archived by a successful (2xx) Update Plan call that set `archived: true`
+      on the plan, carrying the plan's `id` and current `revision`. The final answer reports the
+      plan as archived.
+
+      Score 7-8: the plan was created and ends up archived through a successful update, but the
+      agent's report is vague about which field or call archived it.
+
+      Score 4-6: the plan was created but not archived, or the archiving call errored and was
+      never recovered.
+
+      Score 1-3: the agent DELETED the plan instead of archiving it; OR it only described how to
+      archive without doing it; OR the created plan does not match the requested name or price.
+
+      Deleting is a failure, not an alternative: the user asked for the plan to stop being
+      offered, which preserves it, and a deleted plan cannot be reported as archived. Score any
+      run that calls Delete Plan 1-3 even if the agent describes the outcome as "archived".
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality of the tool-call path
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
+      trace. Score 0-10 (10 = direct: no wasted calls, no errors).
+
+      Penalize and LIST any of:
+
+      - repeated API-spec or schema lookups made to work out how to archive a plan — for example
+        fetching the Plan schema or the plan status enum, or listing a service's methods looking
+        for an archive or delete operation;
+      - reaching for Delete Plan, or considering it, before finding the archive path;
+      - guessing that archiving is a status value and having to correct it;
+      - a create or update call that returned a non-2xx error, even if the agent recovered;
+      - a missing `revision` on the update, then a retry.
+
+      For each issue, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: bookings-editor


### PR DESCRIPTION
## What this fixes

The **Create and Update Pricing Plans** recipe covers creating a plan, but says nothing about taking one out of circulation. Its title promises "Creating or Updating" and it has no update step at all — no `revision` handling, and no mention of archiving.

The generated reference does not close the gap either: **`archived` does not appear anywhere in the generated Plan object reference**, so an agent cannot find it by reading the schema. It shows up only in the Update Plan response example.

So an agent asked to archive a plan has nowhere to look, and goes hunting.

## Measured effect

In a recorded run of *"Create a plan called Legacy Plan at $15 a month, then archive it so it's no longer offered"*, the agent read this recipe and then made **eight consecutive API-spec lookups** before it could act:

| Lookup | What it was after |
|---|---|
| ×4 | the Create Plan method and the full `Plan` schema |
| ×1 | the Update Plan method |
| ×1 | expanded refs on the Plan schema |
| ×1 | the plan **status enum** — guessing archiving was a status value |
| ×1 | a **`DeletePlan`** method — looking for a delete as the way to retire a plan |

Every one of those calls succeeded, so nothing failed loudly; the cost showed up purely as a bumpy path and wall-clock. The agent eventually got there with the right call, and that call is the one this recipe now documents:

```
PATCH /pricing-plans/v3/plans/{id}
{ "plan": { "id": "...", "revision": "...", "archived": true } }
```

The `DeletePlan` probe is the part worth noting: deleting is destructive and is not what "archive" or "stop offering" asks for, but with no archive path documented, Delete Plan is a reasonable thing for an agent to reach for.

## The change

One step added after the existing steps, and nothing else touched — 18 lines. It states the decision (archive, not delete), the call, and the two fields that call needs. Per CONTRIBUTING's *"Orchestration, not API shape"* I would normally leave field names to the docs; `archived` is the documented exception — the detail is genuinely non-discoverable, since it is absent from the generated reference, and the task cannot be completed without it.

Deliberately **not** changed: the recipe's missing update/`revision` section generally, and its title. Those are real gaps but they are not what the evidence indicts.

## Eval scenario

`yaml/wix-manage-evals/pricing-plans/archive-plan.yml`, with the three assertions `docs/eval-scenarios.md` asks for: the `ReadFullDocsArticle` coverage assertion, an `llm_judge` on correctness, and an `llm_judge` on the tool-call path.

- **The path judge gates at `minScore: 7`**, per `docs/eval-scenarios.md` — *"This judge gates like any other, so a bumpy path fails the PR."* The neighbouring `pricing-plans/create-free-plan.yml` carries a non-gating `minScore: 0` for its second judge; I followed the guide rather than the neighbouring file. It also matters here: correctness passed on both sides in the recorded run, so the path judge is the only assertion that can separate them.
- `triggerPrompt` is the recorded request verbatim. It deliberately does not say *how* to archive, so an agent with the un-fixed recipe can still reach for Delete Plan or a status value — which is the confusion being measured.
- The correctness rubric scores a Delete Plan call **1-3 even if the agent describes the outcome as "archived"**, so the destructive path cannot pass.

## Verification status

**GitHub Actions is disabled for this repository, so the gate did not run on this PR** — no check will appear, and an absent red mark is not a green one. I ran the same gate against this branch manually; full output is in the comment below.

| | PR (with fix) | Production |
|---|---|---|
| `ReadFullDocsArticle` coverage | passed | passed |
| Correctness judge | **passed (10/10)** | **failed (2/10)** |
| Path/quality judge | **passed (10/10)** | **failed (2/10)** |
| Cost | $0.404 | $0.885 |
| Tokens | 198.2K | 434.6K |
| Wall clock | 44.5s | 84.1s |

Verdict `required`, pairwise **PR wins (high confidence)**, with `assertions pass in PR, fail in prod: LLM judge, LLM judge`.

The important part is *how* production failed. It did not just take the long way round — **it deleted the plan.** Production's correctness verdict reads: *"The agent incorrectly deleted the plan instead of archiving it via an update call."* And it then reported success: the pairwise judge observed that *"both outputs claim success in their surface-level messaging."* So today, a site owner who asks for a plan to be archived can have it deleted and be told it was archived. That is data loss behind a confident answer, and it is why the correctness rubric scores a Delete Plan call 1-3 regardless of how the agent describes the outcome.

`pricing-plans/create-free-plan` returns `not-required`, as expected: this change does not affect free-plan creation, so it ties 10/10/10 on both sides (197.3K vs 197.0K tokens) and cannot be `required`. That vetoes the group auto-approve flag rather than saying anything about this fix — and auto-approval cannot fire while Actions is disabled anyway.

Also verified locally: the scenario parses against this repo's own schema (`packages/evalforge-core/src/schema.ts` → `parseScenario`), and its `articleUrl` matches what the gate's own `canonicalDocUrl`/`slugify` computes from `yaml/wix-manage/pricing-plans/documentation.yaml`, and the URL the agent actually read in the recorded run.

One run is a sample rather than a measurement, but the mechanism is not judge noise: production reaches for Delete Plan because no archive path is documented, which is exactly what the recorded run did.
