### PR TITLE
fix(wix-manage): correct the store-wide coupon scope

### DIFF
--- a/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
+++ b/skills/wix-manage/references/ecommerce/pricing-promotions/ecom-pricing-create-coupon.md
@@ -47,10 +47,7 @@ Before creating a coupon, check for code conflicts and existing promotions on th
         "code": "SUMMER20",
         "percentOffRate": 20,
         "scope": {
-          "namespace": "stores",
-          "group": {
-            "name": "product"
-          }
+          "namespace": "stores"
         },
         "startTime": 1717200000000,
         "expirationTime": 1719792000000,
@@ -91,10 +88,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
     "code": "SPRING15",
     "percentOffRate": 15,
     "scope": {
-      "namespace": "stores",
-      "group": {
-        "name": "product"
-      }
+      "namespace": "stores"
     },
     "startTime": 1714521600000,
     "usageLimit": 200,
@@ -167,10 +161,7 @@ Check for: duplicate codes, overlapping scopes with active coupons, and cross-me
     "code": "SAVE10",
     "moneyOffAmount": 10,
     "scope": {
-      "namespace": "stores",
-      "group": {
-        "name": "product"
-      }
+      "namespace": "stores"
     },
     "startTime": 1714521600000,
     "active": true
@@ -232,7 +223,7 @@ Instead of targeting a scope, you can require a minimum cart subtotal. This is a
 
 | Scope target | `namespace` | `group.name` | `group.entityId` |
 |---|---|---|---|
-| All store products | `"stores"` | `"product"` | Omit (applies to all) |
+| All store products | `"stores"` | Omit — sending `group` without `entityId` is rejected | Omit |
 | Specific product | `"stores"` | `"product"` | Product UUID |
 | Specific collection | `"stores"` | `"collection"` | Collection UUID |
 
@@ -246,7 +237,7 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 
 | Recommendation `scope` | Coupon `scope` |
 |---|---|
-| `SITE` | `{ "namespace": "stores", "group": { "name": "product" } }` (all products, no entityId) |
+| `SITE` | `{ "namespace": "stores" }` (all products — omit `group` entirely) |
 | `CATEGORY` | `{ "namespace": "stores", "group": { "name": "collection", "entityId": "<first categoryId>" } }` |
 | `ITEMS` | `{ "namespace": "stores", "group": { "name": "product", "entityId": "<first productId>" } }` |
 
@@ -340,7 +331,8 @@ When the recommendation output has `mechanism: "COUPON"`, use this mapping to co
 
 | Error | Cause | Fix |
 |---|---|---|
-| `"When scope or minimumSubtotal is not used - only FreeShipping coupon is allowed"` | Coupon sent without `scope` or `minimumSubtotal` | Add `scope: { "namespace": "stores", "group": { "name": "product" } }` for site-wide, or set `minimumSubtotal` |
+| `"When scope or minimumSubtotal is not used - only FreeShipping coupon is allowed"` | Coupon sent without `scope` or `minimumSubtotal` | Add `scope: { "namespace": "stores" }` for site-wide, or set `minimumSubtotal` |
+| `"The provided combination of scope and coupon type is invalid."` (reports `group=product, entityId=empty`) | `group` was sent without an `entityId` — valid only for `buyXGetY` | For all products send `scope: { "namespace": "stores" }`; supply `group` only together with its `entityId` |
 | Duplicate code | Another coupon uses the same code | Generate a different code |
 | Invalid startTime | Value too low (must be epoch ms, not seconds) | Multiply by 1000 if in seconds |
 | Both scope and minimumSubtotal set | These are oneOf — cannot use both | Choose scope OR minimumSubtotal |

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-store-wide-scope.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-store-wide-scope.yml
@@ -4,7 +4,7 @@ description: >
   rejects a scope that carries `group` without an `entityId` for percentage coupons, so a recipe
   that documents that shape for "all products" costs the agent a 400 and a retry.
 triggerPrompt: Create a coupon with the code SAVE20 that gives customers 20% off.
-tags: [ecommerce, aria]
+tags: [ecommerce]
 siteSetup:
   mode: template
   templateId: stores-v3-editor

--- a/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-store-wide-scope.yml
+++ b/yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-store-wide-scope.yml
@@ -1,0 +1,54 @@
+name: ecommerce/pricing-promotions/create-coupon-store-wide-scope
+description: >
+  Verifies a store-wide percentage coupon is created on the first create call. The Coupons API
+  rejects a scope that carries `group` without an `entityId` for percentage coupons, so a recipe
+  that documents that shape for "all products" costs the agent a 400 and a retry.
+triggerPrompt: Create a coupon with the code SAVE20 that gives customers 20% off.
+tags: [ecommerce, aria]
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Create a coupon with the code SAVE20 that gives customers 20% off."
+
+      Score 8-10 if the trace shows a coupon successfully created (2xx) with code "SAVE20", a 20%
+      percentage discount, and a scope covering ALL store products, and the agent confirmed it.
+
+      Score 1-3 if any of these hold: no coupon was created; the code or the 20% percentage rate is
+      wrong; a fixed-amount / fixed-price / free-shipping coupon was created instead of a percentage
+      one; or the coupon was narrowed to a single product or a single collection rather than the whole
+      store.
+
+      Do NOT penalise incidental extras: other coupons or products already present on the site
+      template, a read-only query of existing coupons before creating, a name chosen by the agent, or
+      optional fields such as usageLimit or limitPerCustomer being set or omitted.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how cleanly the agent reached the coupon. Examine the tool-call trace.
+
+      Score 1-3 if ANY create-coupon call was rejected, even when a later retry succeeded — in
+      particular a 400 whose body reads "The provided combination of scope and coupon type is
+      invalid." and reports `group=product, entityId=empty` (or `group=ALL`). Sending `group` without
+      an `entityId` is not a valid store-wide scope for a percentage coupon; the correct store-wide
+      scope carries the namespace alone. Also score 1-3 for any other non-2xx on the create call, or
+      for the coupon scope being guessed wrong and then corrected.
+
+      Score 8-10 only if the first create call was accepted.
+
+      A read-only query of existing coupons before creating is part of the documented flow and is not
+      a penalty. Neither is reading documentation.
+
+      For each stumble you find, name the likely docs gap behind it.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected docs gap, or 'clean path' if none>"}.


### PR DESCRIPTION
## The defect

`ecom-pricing-create-coupon.md` documented the "all store products" coupon scope as

```json
"scope": { "namespace": "stores", "group": { "name": "product" } }
```

with the `entityId` omitted — in both store-wide request examples, the *Scope values for Wix
Stores* table, the `SITE` row of the recommendation mapping, and the fix column of the error table.

The Coupons API rejects that combination for a percentage coupon. Verbatim, from a recorded run
transcript (`POST https://www.wixapis.com/stores/v2/coupons`):

```
Wix API error (400): {"message":"The provided combination of scope and coupon type is invalid.
Provided combination:
namespace=stores, group=product, entityId=empty, coupon type=PercentOff
Supported combinations:
- namespace=stores, group=empty, entityId=empty and coupon type is one of BuyXGetY
- namespace=stores, group=product, entityId=some-id and coupon type is one of BuyXGetY
- namespace=stores, group=collection, entityId=some-id and coupon type is one of BuyXGetY
- nam…
```

(the recorded error body is truncated at that point)

`group` is valid only together with its `entityId`; a store-wide coupon carries the namespace
alone. The [Valid scope values](https://dev.wix.com/docs/api-reference/business-solutions/coupons/coupons/valid-scope-values)
reference this recipe already links to says exactly that — Group is *"optional - if not listed, the
coupon will apply to all products/services/events in the namespace"*, and Entity ID is *"required
only when Group is listed"*. The recipe contradicted the page it cites.

## Blast radius

Reproduced on five consecutive nightly runs of the same scenario. In each one the agent read
`…/skills/pricing-create-coupon`, sent the documented store-wide scope on its first create call,
took the 400, then retried with `group` removed and succeeded. The outcome judge scored 10/10 every
time — the user does get the coupon — while the path judge scored 6–7 and named the scope
combination as the gap.

The recovery is what the recipe cost: one rejected mutating call plus a retry, on the most common
coupon request there is.

## The fix

Correct the shape everywhere the recipe already restates it (no new prose about API shape, per
*Orchestration, not API shape*), and add the 400 to the existing error table:

- both store-wide request examples and the query-response example → `"scope": { "namespace": "stores" }`
- *Scope values for Wix Stores* → "All store products" omits `group` and `group.entityId`
- `SITE` mapping row → `{ "namespace": "stores" }`
- error table: the *"scope or minimumSubtotal is not used"* fix no longer suggests the invalid shape
- error table: one new row for *"The provided combination of scope and coupon type is invalid."*

+7 / −15 on the recipe. The front-matter `description` is unchanged — this corrects a shape, it does
not extend what the recipe covers, so the retrieval key should not move.

## Routing

The failing agent read this recipe — `ReadFullDocsArticle` on
`https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon`
was the call immediately before the rejected create, and the recipe is the only source of the wrong
shape. The upstream reference is already correct, so there is nothing to fix in the API docs, and
the API's own 400 is already explicit about the supported combinations. The defect is the recipe
restating a shape its own cited reference contradicts, so it is fixed here and only here.

## Coverage

New scenario `yaml/wix-manage-evals/ecommerce/pricing-promotions/ecom-pricing-create-coupon-store-wide-scope.yml`,
three assertions per `docs/eval-scenarios.md`: `ReadFullDocsArticle` coverage on the recipe's doc
URL, an `llm_judge` on the outcome, and a gating `llm_judge` on the tool-call path that fails a
create call rejected with this 400 even when a retry recovers. The trigger prompt is the unmodified
request that produced the finding — it names no scope, so an agent with the old content still has
every reason to go wrong.

Validated against `packages/evalforge-core/src/schema.ts` (`parseScenario`), and the `articleUrl`
against the gate's `canonicalDocUrl`.

## Note on checks

GitHub Actions is disabled repository-wide (`actions/permissions` → `enabled: false`), so no check
will appear on this PR. The gate was run manually against this branch; results are in a comment
below.
