### PR TITLE
fix(wix-manage): variant price updates need Get Product, not a search result

### DIFF
--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -11,7 +11,7 @@ Use this recipe to update an existing Catalog V3 product: storefront visibility,
 Every Catalog V3 product update is revision-based:
 
 - If the user gives a product name instead of a product ID, use [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) and choose the exact product name match.
-- Use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) to retrieve the current product and `product.revision`.
+- Use [Get Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/get-product) to retrieve the current product, its `product.revision`, and its existing variants. Search Products and Query Products responses do not include `variantsInfo.variants`, so a variant or price update assembled from a search result sends an empty variants array and is rejected. Re-read the product before every variant-level update.
 - Include `product.id` and the current `product.revision` in every [Update Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/update-product) PATCH body.
 - Update Product is a partial update: only `product`, `product.id`, and `product.revision` are required, and top-level fields you omit (for example `name`, `ribbon`, `brand`) are left unchanged. The full-array overwrite rule applies only to the repeated fields `options`, `modifiers`, and `variantsInfo.variants`.
 - For simple text/HTML description updates, prefer `plainDescription`. Use `description` only when sending a Rich Content object.
@@ -29,7 +29,7 @@ curl -X POST "https://www.wixapis.com/stores/v3/products/search" \
   }'
 ```
 
-For product-name lookup, prefer Search Products before retrieving the product by ID.
+For product-name lookup, prefer Search Products before retrieving the product by ID. Search only resolves the product ID; it does not replace the Get Product call.
 
 ### Get the current revision
 
@@ -299,6 +299,8 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 
 ### Update Variant Price Only
 
+Read `{existingVariantId}` off the Get Product response; a Search or Query Products result does not carry it.
+
 ```bash
 curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
   -H "Content-Type: application/json" \
@@ -343,5 +345,6 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 | `choicesSettings must not be empty` | Missing choices array | Include full `choicesSettings.choices` array |
 | `Missing product option choices` | Variant references non-existent option | Use `optionChoiceNames` with exact option and choice names |
 | `price must not be empty` | A variant was created or replaced without a price | Include `price.actualPrice.amount` on every new variant |
+| `variantsInfo is invalid: variants has size 0, expected 1 or more` | Variants were read from a Search or Query Products response, which does not return them | Re-read the product with Get Product and send its `variantsInfo.variants` |
 | `Missing option choices` or `INVALID_DEFAULT_VARIANT` | Product has options but at least one variant has no matching choices | Rebuild `variantsInfo.variants` so every variant includes choices for all product options |
 | `DIGITAL_PRODUCT_CANNOT_BE_VISIBLE_IN_POS` | Sent `visibleInPos: true` on a digital product | Digital products can't be visible in POS; leave `visibleInPos` out of the body |

--- a/yaml/wix-manage-evals/stores/update-product-price-variant-ids.yml
+++ b/yaml/wix-manage-evals/stores/update-product-price-variant-ids.yml
@@ -1,0 +1,87 @@
+name: stores/update-product-price-variant-ids
+description: >
+  A store owner asks to change an existing Catalog V3 product's price. Verifies the agent
+  loads the Update Product with Options (Catalog V3) recipe and re-reads the product with
+  Get Product before the Update Product PATCH, because Search Products and Query Products
+  responses do not carry `variantsInfo.variants` — assembling the variants array from a
+  search result sends an empty array and the update is rejected.
+triggerPrompt: >
+  Change the price of my "Eval Gate Tee" product to $25.
+tags: [stores, aria]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3
+  - type: llm_judge          # correctness — the user's outcome
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Change the price of my \"Eval Gate Tee\" product to $25."
+
+      The site is a Catalog V3 store seeded with a product named "Eval Gate Tee" priced at
+      $19.50, with a single variant and no product options. The template also ships other
+      demo products; those are irrelevant and must not affect the score.
+
+      Score 9-10: the agent located the existing "Eval Gate Tee" product and set its price to
+      25 with a successful (2xx) Catalog V3 Update Product PATCH that carried the product's
+      existing variant, then confirmed the new price back to the user.
+
+      Score 7-8: the price is 25 on the existing product after a successful update, but the
+      confirmation to the user is vague or omits the new price.
+
+      Score 4-6: the price ends up correct but the existing variant was replaced rather than
+      updated (a new variant id, or lost variant data), or the agent cannot confirm the
+      resulting state.
+
+      Score 1-3: the agent created a NEW product instead of updating the existing one; OR
+      updated a different product, or to a price other than 25; OR the final update call
+      errored (non-2xx); OR it only described how to do it without doing it.
+
+      Ignore anything the agent did to unrelated demo products only if it did not change them;
+      do not deduct for merely reading or listing them.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the tool-call path (gates, per docs/eval-scenarios.md)
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
+      trace, including the request bodies and any error bodies.
+
+      Score 9-10: a direct path — the product was located, re-read with Get Product, and
+      updated in one successful PATCH. No non-2xx responses, no retried request bodies.
+
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for
+      example a probing or repeated API-spec/schema lookup to discover the Update Product
+      endpoint or its request shape, or a redundant read.
+
+      Score 1-3: any Update Product call was REJECTED and then retried. In particular, score
+      here when a variants array was assembled from a Search Products or Query Products
+      response and the PATCH came back with `variants has size 0, expected 1 or more` (or any
+      other rejection caused by variant data missing from a search or query result), even
+      though a later call succeeded. Also score here for a wrong endpoint or wrong catalog
+      version tried first.
+
+      Do not deduct for reading the seeded store's other demo products.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed tee product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Tee
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "19.50" } }
+                  physicalProperties: {}
+                  visible: true


### PR DESCRIPTION
## The defect

The Catalog V3 update-product recipe tells an agent to resolve a product name with **Search Products**, and separately that a variant update must "include each existing variant `id`". It never says where those ids come from. Search Products and Query Products responses do **not** carry `variantsInfo.variants`, so an agent that reuses the product object it already has from the search result sends an empty variants array, and `PATCH /stores/v3/products/{id}` rejects it.

From a recorded run transcript of a "change the price of my *Eval Gate Tee* product to $25" request, verbatim:

```
POST https://www.wixapis.com/stores/v3/products/search → 200
  ({products: Array(13), pagingMetadata: {count, cursors, hasNext}})

PATCH https://www.wixapis.com/stores/v3/products/{id}
Wix API error (400): {"message":"product is invalid:\n`-- variantsInfo is invalid:\n    `-- variants has size 0, expected 1 or more","details":{"validationError":{"fieldViolations":[{"field":"product.variantsInfo.variants","description":"has size 0, expected 1 or more","violatedRule":"MIN_SIZE","data":{"threshold":1}}]}}}
```

The agent's own code, from the same step:

```js
let variants = product.variantsInfo && product.variantsInfo.variants
  ? product.variantsInfo.variants : [];   // product came from the search response
```

It recovered by re-reading the product with Get Product and repeating the PATCH — with a comment quoting this recipe back at itself (*"the docs say: 'When updating existing variants, include each existing variant id.'"*). The user got the right price; the path cost a rejected mutation and an extra round trip.

The sibling find-products recipe already documents the equivalent fact for Query Products ("**Variant data is NOT returned** by Query Products"). Search Products behaves the same way, and its `fields` enum has no value that adds variants — so a re-read is the only way to get them.

## The fix

Three touches on the file the agent actually read, plus one error-table row:

- the Get Product bullet now says it is what supplies the existing variants, and why a search result cannot substitute;
- the product-name-lookup line says Search only resolves the ID;
- the "Update Variant Price Only" step names Get Product as the source of `{existingVariantId}` (that step sits near the tail of a long file, where a truncating client is least likely to have read the head);
- one row in the existing Error Message Reference table for the verbatim 400.

+5/−2 on the recipe. This is orchestration — call order and which call returns what — not a restatement of request/response shape: no new field lists or enums, and every field name used already appears in the file.

The front-matter `description` is unchanged. The recipe already claims "variant-specific pricing", so this adds no new capability to route to, and rewriting a retrieval key that other requests already match is not worth the untested routing change.

## Routing rationale

The page the failing agent loaded was this recipe's canonical URL, taken from its own tool call — not generated API reference, and not a guide. Recipe pages are sourced only from this repository, so this is where the fix goes. The upstream Products V3 reference is not wrong: it types `variantsInfo` identically on Get, Search and Query because the response message is the same `Product`, and which fields a given method populates is exactly the kind of sequencing fact a recipe exists to carry. Nothing here is a proto or reference-rendering defect.

Fixing the neighbouring find-products recipe instead was rejected: the failing agent never opened it, so guidance placed there would not have changed the run.

## Scenario

`yaml/wix-manage-evals/stores/update-product-price-variant-ids.yml` — three assertions per `docs/eval-scenarios.md`: the `ReadFullDocsArticle` coverage assertion on this recipe's doc URL, an `llm_judge` on the outcome, and a **gating** `llm_judge` on the path whose 1–3 band is the rejected-then-retried PATCH specifically. The trigger prompt is the plain user request, with no hint that a re-read is needed — an agent holding the old content is still free to take the shortcut. Both rubrics explicitly ignore the demo products the store template ships.

`minScore: 7` on the path judge follows this repository's guide rather than the non-gating `minScore: 0` on the neighbouring scenario in the same folder.

No `time_limit`: the pairwise comparison already reports the wall-clock delta against a control, which is the signal a fixed ceiling gropes at.

## Eval result

The gate was run manually against this branch — repository Actions are disabled, so no check will appear. Three paired comparisons; full per-assertion figures are in the gate comment below. Summary:

- The added scenario passes **all three assertions on the PR side in 3 of 3 runs** (coverage ✅, outcome 10/10, path 10/10).
- In run 3 production **failed the gating path judge, 2/10**, while the PR side passed at 10/10 — `required: true`, PR wins at high confidence, earned on a decision assertion rather than the efficiency threshold. Production spent 500,812 tokens and 92.2 s against the PR side's 199,838 and 52.9 s.
- Production's own trace in that run says it out loud: after two rejected calls it re-read the product because *"the variantsInfo … wasn't fully returned by the query endpoint."* That is the fact this PR puts in the recipe.
- Run 2 is the counterweight: production re-read the product unprompted, both sides scored 10/10 on both judges, and `required` came only from efficiency (54% of production's tokens and cost). **The shortcut is not deterministic** — 1 of 3 gate comparisons, and 1 of 2 nightly runs of the equivalent corpus scenario. Run 1's production side never executed at all (4.3 s, no API calls), so that comparison's verdict is a provisioning artefact.

**This PR will not be auto-approved, and that is expected.** Changing this recipe pulls in every scenario asserting its doc URL, which includes the pre-existing `stores/hide-product-visibility-catalog-v3`. That scenario is about product visibility, this change does not affect it, and it duly returned `not-required` in runs 1 and 3 — and approval requires *every* scenario in the group to be `required`. Read the per-scenario verdicts rather than the headline.

With Actions off, the gate's merge-time promote and close-time cleanup steps will also not fire on their own for this PR.

## Note for reviewers

Two other open PRs currently edit this same recipe. Neither holds this recipe's scenarios in the eval backend, so this PR's gate did not fast-fail on them — but whichever lands first will make the others need a rebase.
