### PR TITLE
fix(wix-manage): tag eval scenarios by area only

### DIFF
--- a/yaml/wix-manage-evals/pricing-plans/archive-plan.yml
+++ b/yaml/wix-manage-evals/pricing-plans/archive-plan.yml
@@ -6,7 +6,7 @@ description: >
   field by probing the generated schema, which does not list it.
 triggerPrompt: >
   Create a plan called Legacy Plan at $15 a month, then archive it so it's no longer offered.
-tags: [pricing-plans, aria]
+tags: [pricing-plans]
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/hide-product-visibility-catalog-v3.yml
@@ -9,7 +9,7 @@ triggerPrompt: >
   Hide my "Eval Gate Tee" product so it no longer shows in my store. Then tell me which
   field you set and on which endpoint, and whether the product's variant ended up hidden
   too.
-tags: [stores, aria]
+tags: [stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/list-out-of-stock-products-catalog-v3.yml
@@ -7,7 +7,7 @@ description: >
   the agent can only know them by querying.
 triggerPrompt: >
   Which of my products are out of stock?
-tags: [stores, aria]
+tags: [stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/stores/update-product-price-variant-ids.yml
+++ b/yaml/wix-manage-evals/stores/update-product-price-variant-ids.yml
@@ -7,7 +7,7 @@ description: >
   search result sends an empty array and the update is rejected.
 triggerPrompt: >
   Change the price of my "Eval Gate Tee" product to $25.
-tags: [stores, aria]
+tags: [stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:


### PR DESCRIPTION
Scenarios under `yaml/wix-manage-evals/` carry a single area tag — `[stores]`, `[ecommerce]`, `[pricing-plans]` and so on. Four scenarios also carried `aria`:

| Scenario | Was | Now |
| --- | --- | --- |
| `stores/hide-product-visibility-catalog-v3` | `[stores, aria]` | `[stores]` |
| `stores/list-out-of-stock-products-catalog-v3` | `[stores, aria]` | `[stores]` |
| `stores/update-product-price-variant-ids` | `[stores, aria]` | `[stores]` |
| `pricing-plans/archive-plan` | `[pricing-plans, aria]` | `[pricing-plans]` |

`aria` is the selector for a separate scheduled run over a different scenario set. Because these four carried it, they were being pulled into that run alongside scenarios they have nothing to do with — inflating it, and mixing two unrelated populations in results that get read as a single set. The tag was copied over from that other set's convention when these scenarios were written; it was never meant to appear here.

## Scope

Tag lines only. No assertion, trigger prompt, rubric, or site setup is touched, and the area tag each scenario is grouped and gated under is unchanged. Every scenario keeps running under this repo's gate exactly as before.

## On the gate result

Behaviour is identical on both sides of the comparison, so all four scenarios will come back `not-required` and the group cannot be auto-approved. That is the correct outcome for a metadata correction rather than a signal that something is wrong — there is no behaviour difference for a comparison to detect, and creating one would mean changing a scenario's content, which is the opposite of what this PR is for.
