### PR TITLE
perf(base44): merge skill-install + AGENTS.md-pin into one exec (−1 round-trip/build)

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -20,11 +20,13 @@ Install three skills — they land under `.agents/skills/`:
 - **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything the recipes don't
   cover.
 
-Install via the skills CLI — run this through exec_tool, exactly as written:
+Install via the skills CLI — run this through exec_tool, exactly as written. One call: installs
+the three skills, deploys the REST scaffolds into `src/rest/`, and pins an AGENTS.md note
+(appended, idempotent):
 
 ```js
 const { execSync } = require('child_process');
-const { readdirSync, existsSync, mkdirSync, copyFileSync } = require('fs');
+const { readdirSync, existsSync, mkdirSync, copyFileSync, readFileSync, appendFileSync } = require('fs');
 
 const skills = ['wix-headless', 'wix-vibe-headless', 'wix-docs'];
 const results = {};
@@ -57,14 +59,7 @@ if (existsSync(REF)) {
   }
 }
 
-return { results, installed: readdirSync('/app/.agents/skills'), copiedToSrcRest };
-```
-
-**STEP 1b — pin the skill location in AGENTS.md.** After install, run this via exec_tool exactly as
-written — it appends (never rewrites) an AGENTS.md note for later turns, and is idempotent:
-
-```js
-const fs = require('fs');
+// Pin the skill location + project facts in AGENTS.md for later turns (idempotent).
 const NOTE = `
 
 ## This app — a Wix-managed headless frontend (built with the Wix skills)
@@ -78,9 +73,10 @@ The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from th
 - \`wix-docs\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
 `;
 const amd = '/app/AGENTS.md';
-const cur = fs.existsSync(amd) ? fs.readFileSync(amd, 'utf8') : '';
-if (!cur.includes('Wix-managed headless frontend')) fs.appendFileSync(amd, NOTE);
-return 'noted';
+const cur = existsSync(amd) ? readFileSync(amd, 'utf8') : '';
+if (!cur.includes('Wix-managed headless frontend')) appendFileSync(amd, NOTE);
+
+return { results, installed: readdirSync('/app/.agents/skills'), copiedToSrcRest, agentsMdPinned: true };
 ```
 
 Read the skills with **`read_file`** (rooted at `/app` → workspace-relative path, e.g.


### PR DESCRIPTION
## Why
In every Base44 Wix build, STEP 1 ran the skill install as one exec, then **STEP 1b ran the AGENTS.md pin as a *second* exec** — which costs a whole extra agent round: an `R3 thinking` + `R3 generating` (re-decoding the static NOTE) + a second ~15s sandbox exec. Measured on a real build (Rock Star Plushies): the pin round was ~2.6s think + ~18s generate + ~15.1s exec.

## What
Fold the AGENTS.md note-append into the **tail of the STEP 1 install block** (the same exec that installs the skills and copies the REST scaffolds), and delete the standalone STEP 1b block. One exec now does **install + scaffold-copy + AGENTS pin**.

- Added `readFileSync, appendFileSync` to the block's existing `fs` destructure.
- Moved the `NOTE` + idempotent `appendFileSync` before the block's `return` (now also returns `agentsMdPinned: true`).
- The NOTE text is **byte-identical** — no behavior change, just one fewer round-trip.

## Impact
Saves **~1 round-trip per build (~15–17s)**: eliminates R3's separate thinking + the second sandbox exec. (The NOTE's decode still happens once, inside the merged block — the win is the removed round + sandbox spin.)

## Verified
- Merged JS block passes `node --check`.
- `base44.md` stays under the **10k `fetch_website` truncation cap** (9,973 chars, margin 27).
- STEP 1b removed; net −4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)