### PR TITLE
fix(base44): skip-source note seen before the reads + exact seed-recipe paths

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -113,16 +113,16 @@ truth for how the client is built.
 
 **All REST scaffolds are already in `src/rest/`** — STEP 1 deployed the shared transport
 (`wix-client.js`, `wix-manage-banner.js`) and every vertical helper (`wix-store-catalog.js`, …)
-there, so SKILL.md's "get them into `src/rest/`" step is done. Use your vertical's files (a store
-uses `wix-store-catalog.js` + `wix-store-cart.js`), set `WIX_CLIENT_ID` in `wix-client.js` and
+there. Use your vertical's files, set `WIX_CLIENT_ID` in `wix-client.js` and
 `WIX_METASITE_ID` in `wix-manage-banner.js`, and adapt with targeted edits — **do not regenerate
-them**. Unused verticals are harmless (bundler drops them). Generate from scratch only the
-app-specific UI (components/pages).
+them**. Unused verticals are harmless. Generate only the app-specific UI (components/pages).
+
+**No need to read the scaffolds' source** (`wix-client.js`/`wix-store-*.js`) — the vertical's
+`INSTRUCTIONS.md` has every field shape + correct usage. Just import them.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
-(the `AuthProvider` / `useAuth` imports and wrappers from `@/lib/AuthContext`) — a full-file
-rewrite drops them and the platform validator rejects the write, costing a redo. Wire your
-routes/imports in with targeted `find_replace` edits and leave the rest as-is.
+(`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
+rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
 
 ## STEP 4 — Manage and seed the business
 
@@ -131,9 +131,9 @@ cleanup/reset step in the `wix-headless` seed recipes: it's a live user-owned bu
 delete or overwrite existing content, even apparent sample data. If a cleanup truly seems needed,
 ask the user first.
 
-Seed real content by following the **`wix-headless`** skill's `references/SEED.md`; where its
-recipes don't cover something, fall back to the **`wix-docs`** skill to search + read the relevant
-Wix API docs.
+Seed by following these **exact** paths (recipes live under `references/` — don't drop it):
+`.agents/skills/wix-headless/references/SEED.md` + `…/references/inline-recipes/setup-<vertical>.md`
+(e.g. `setup-online-store.md`). Gaps → the **`wix-docs`** skill.
 
 **Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
 access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -44,11 +44,9 @@ however the project wants; wire it to these two snippets. Copy them into the app
 - `src/rest/wix-store-cart.js` — **Cart & checkout:**
   `addToCart`, `getCurrentCart`, `updateCartItemQuantity`, `removeFromCart`, `checkout`
 
-**You don't need to open the source of `wix-client.js` / `wix-store-catalog.js` /
-`wix-store-cart.js`** — just `import` from them. Every field shape and gotcha you need is in
-this file (the prose below + the **Reference components** section), and those components show
-correct usage of every helper. Skip reading the util source; adapt the components' logic and
-restyle to the brand.
+Every field shape and gotcha you need is in this file (the prose below + the **Reference
+components** section), and those components show correct usage of every helper — `import` from
+`wix-client.js` / `wix-store-*.js`, adapt the components' logic, and restyle to the brand.
 
 ## How to wire it (UI is the project's choice)
 - **Product grid** — `queryProducts()` for the listing (visible products only); pass


### PR DESCRIPTION
From a real build trace (Moomin Plush Shop) — both fixes target wasted read round-trips.

## 1. Hoist the "don't read the util source" note into base44.md STEP 3
#865 added that note, but the trace shows the agent reads the util source **before** it reads INSTRUCTIONS.md (read order: `SKILL.md → SEED.md → wix-client.js → wix-store-*.js → INSTRUCTIONS.md`). The note lived *inside* INSTRUCTIONS.md, so it arrived too late — the agent read all 4 util files anyway. Moved it to **base44.md STEP 3** (seen before any reads); dropped it from INSTRUCTIONS.md. Placement lesson: an instruction only changes behavior if it's seen before the decision it targets.

## 2. Exact seed-recipe paths in STEP 4
The trace shows `read_file` **File not found** on `.agents/skills/wix-headless/inline-recipes/setup-online-store.md` — the agent dropped the `references/` segment, then retried correctly. STEP 4 only said "`references/SEED.md`" loosely and never gave setup-online-store.md's path. Now gives the **exact** full paths and warns not to drop `references/`.

## Verified
- base44.md stays under the 10k `fetch_website` cap (9,955, trimmed adjacent prose to fit).
- Note removed from INSTRUCTIONS.md; components stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)