### PR TITLE
feat(vibe-headless): per-vertical seed modules (drop wix-headless SEED.md dependency)

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -131,9 +131,10 @@ cleanup/reset step in the `wix-headless` seed recipes: it's a live user-owned bu
 delete or overwrite existing content, even apparent sample data. If a cleanup truly seems needed,
 ask the user first.
 
-Seed by following these **exact** paths (recipes live under `references/` — don't drop it):
-`.agents/skills/wix-headless/references/SEED.md` + `…/references/inline-recipes/setup-<vertical>.md`
-(e.g. `setup-online-store.md`). Gaps → the **`wix-docs`** skill.
+Seed by calling your vertical's ready-made seed module — read
+`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and `require` its `seed-*.js`
+(build-time, via exec_tool); call its functions with your data. Gaps or an unexpected shape →
+the **`wix-docs`** skill.
 
 **Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
 access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -1,0 +1,51 @@
+# Blog — seeding
+
+Seed a Wix Blog (Blog V3) by **calling `seed-blog.js`** — don't hand-write the REST calls. It's
+a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Blog
+seed operation. `require` it and call the functions with plain data.
+
+> **NOT yet live-verified — transcribed from `setup-blog.md`.** Endpoints/fields mirror the recipe
+> exactly; if a call returns an unexpected shape, use the **`wix-docs`** skill (never guess).
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+const memberId = await seed.getAuthorMemberId(ctx);   // STEP 1 — required for every post create
+
+// STEP 3 (optional): only if the request groups posts (e.g. "Recipes and Brewing sections")
+const cats = await seed.createCategories(ctx, ["Recipes", "Brewing"]);
+
+// STEP 2: bulk for postCount >= 2, single endpoint for 1 — handled inside. content = plain blocks.
+const posts = await seed.createPosts(ctx, [
+  { title: "How We Roast Our Beans", categoryIds: [cats[0].id], content: [
+    { type: "heading", text: "From farm to cup", level: 2 },
+    { type: "paragraph", text: "Every batch starts with beans from a single estate." },
+    { type: "quote", text: "Great coffee is grown, not made." },
+  ] },
+]);   // → [{ id, index, success }] — check each .success (bulk returns 200 even on partial failure)
+
+// imagery ON only: import images per IMAGE_GENERATION.md, then attach covers (PATCH + re-publish)
+await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fileIds[i] })));
+```
+
+## Functions
+| fn | does |
+|---|---|
+| `getAuthorMemberId(ctx)` | STEP 1 — fetch a real member id for author attribution (throws if none) |
+| `createPosts(ctx, posts, { memberId })` | STEP 2 — auto single-vs-bulk create, published → `[{id,index,success}]` |
+| `createCategories(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.categoryIds`) |
+| `createTags(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.tagIds`) |
+| `attachPostCovers(ctx, [{postId,fileId}])` | imagery-on: PATCH cover (`displayed+custom+wixMedia.image.id`) + re-publish |
+
+`content` blocks: `{type:"heading",text,level?}` · `{type:"paragraph",text}` · `{type:"quote",text}` ·
+`{type:"bulleted"|"ordered",items:[…]}`. For node types the recipe doesn't cover (code, images),
+pass a pre-built Ricos `richContent` on the post instead. No Blog-app install helper — the recipe
+assumes Blog is already installed on the site.
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix Blog API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-blog.md`.

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -1,0 +1,183 @@
+// Blog seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Blog V3
+// request/response mechanics (the required author memberId, single-vs-bulk endpoint switch,
+// the flat-per-item bulk shape, Ricos richContent nesting, sequential category/tag creates,
+// the cover-image PATCH + re-publish) live here, once.
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//   const memberId = await seed.getAuthorMemberId(ctx);                    // STEP 1 — required for every post
+//   const cats = await seed.createCategories(ctx, ["Recipes", "Brewing"]); // STEP 3 — only if the brief groups posts
+//   const posts = await seed.createPosts(ctx, [
+//     { title: "How We Roast Our Beans", categoryIds: [cats[0].id], content: [
+//       { type: "heading", text: "From farm to cup", level: 2 },
+//       { type: "paragraph", text: "Every batch starts with beans from a single estate." },
+//       { type: "quote", text: "Great coffee is grown, not made." },
+//     ] },
+//   ], { memberId });
+//   // imagery ON only: import images per IMAGE_GENERATION.md, then attach covers + re-publish
+//   await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fileIds[i] })));
+//
+// **NOT yet live-verified — transcribed from setup-blog.md.** If any call fails with a shape the
+// caller didn't expect, fall back to the wix-docs skill (search + read the live Wix Blog API
+// reference) — never guess. Source recipe (authoritative):
+// wix-headless/references/inline-recipes/setup-blog.md.
+
+const API = "https://www.wixapis.com";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// ---- Ricos richContent builder (per recipe § "CRITICAL RICOS NESTING") ----
+// A post's `content` is a list of plain block descriptors; this builds the Ricos node tree.
+// Rules baked in: TEXT is always a leaf inside a container; BLOCKQUOTE / LIST_ITEM wrap a
+// PARAGRAPH; BULLETED_LIST / ORDERED_LIST wrap LIST_ITEM -> PARAGRAPH -> TEXT; every container
+// node gets a unique id, TEXT leaves use id "". Supported block types: heading, paragraph,
+// quote, bulleted, ordered. For node types the recipe doesn't spell out (CODE_BLOCK, IMAGE, …)
+// pass a pre-built `richContent` on the post instead and it's used verbatim (see fall-back below).
+const mkText = (text) => ({ type: "TEXT", id: "", nodes: [], textData: { text: text || "", decorations: [] } });
+const mkParagraph = (id, text) => ({ type: "PARAGRAPH", id, nodes: [mkText(text)], paragraphData: {} });
+
+function mkRichContent(blocks = [], postIdx = 0) {
+  let n = 0;
+  const id = () => `p${postIdx}-n${n++}`;
+  const nodes = [];
+  for (const b of blocks) {
+    switch (b.type) {
+      case "heading":
+        nodes.push({ type: "HEADING", id: id(), nodes: [mkText(b.text)], headingData: { level: b.level ?? 2 } });
+        break;
+      case "quote":
+        // BLOCKQUOTE wraps a PARAGRAPH, per recipe
+        nodes.push({ type: "BLOCKQUOTE", id: id(), nodes: [mkParagraph(id(), b.text)], blockquoteData: { indentation: 1 } });
+        break;
+      case "bulleted":
+      case "ordered": {
+        // LIST -> LIST_ITEM -> PARAGRAPH -> TEXT, per recipe
+        const listType = b.type === "bulleted" ? "BULLETED_LIST" : "ORDERED_LIST";
+        nodes.push({
+          type: listType, id: id(),
+          nodes: (b.items ?? []).map((item) => ({ type: "LIST_ITEM", id: id(), nodes: [mkParagraph(id(), item)] })),
+        });
+        break;
+      }
+      case "paragraph":
+      default:
+        nodes.push(mkParagraph(id(), b.text));
+    }
+  }
+  return { nodes };
+}
+
+// One post's plain data -> a flat Blog V3 draft-post object.
+// `content` (block list) is turned into Ricos richContent unless a pre-built `richContent` is given.
+// media is omitted here — covers are a separate pass (attachPostCovers), imagery-gated. Per recipe.
+function buildPost(p, i, memberId) {
+  return {
+    title: p.title,
+    memberId,
+    richContent: p.richContent ?? mkRichContent(p.content, i),
+    ...(p.categoryIds ? { categoryIds: p.categoryIds } : {}),
+    ...(p.tagIds ? { tagIds: p.tagIds } : {}),
+  };
+}
+
+// ---- exported operations ----
+
+// STEP 1: fetch a real author memberId (required — every post create needs it; a fabricated id
+// fails with "memberIds ... do not exist"). Returns members[0].id; throws loudly if none exist.
+async function getAuthorMemberId(ctx) {
+  const r = await req(ctx, "/members/v1/members?fieldsets=PUBLIC&paging.limit=1", { method: "GET" });
+  const id = r.members?.[0]?.id;
+  if (!id) throw new Error(`No site member found for author attribution: ${JSON.stringify(r).slice(0, 400)}`);
+  return id;
+}
+
+/**
+ * STEP 2: create posts, published (publish:true so they go live immediately).
+ * Auto-selects the endpoint per recipe: single-post endpoint for exactly one post (nested
+ * `{ draftPost }` envelope), the bulk endpoint for >= 2 (flat per-item objects, NOT wrapped).
+ * @param posts [{ title, content: [blocks] | richContent?, categoryIds?, tagIds? }]
+ *   content blocks: { type:"heading", text, level? } | { type:"paragraph", text }
+ *     | { type:"quote", text } | { type:"bulleted"|"ordered", items:[text,...] }.
+ *   Pass a pre-built Ricos `richContent` instead of `content` for node types not covered here.
+ * @param opts { memberId }  memberId from getAuthorMemberId — required; publish defaults to true.
+ * @returns [{ id, index, success }]  (id is the draftPostId; feeds attachPostCovers)
+ */
+async function createPosts(ctx, posts, { memberId, publish = true } = {}) {
+  if (!memberId) throw new Error("createPosts requires opts.memberId (see getAuthorMemberId)");
+  if (posts.length === 1) {
+    // single-post endpoint uses the nested { draftPost } envelope
+    const r = await req(ctx, "/blog/v3/draft-posts", { body: { draftPost: buildPost(posts[0], 0, memberId), publish } });
+    return [{ id: r.draftPost?.id, index: 0, success: !!r.draftPost?.id }];
+  }
+  // bulk endpoint: `bulk` is a path segment BETWEEN v3 and draft-posts; each item is FLAT (no draftPost wrapper)
+  const r = await req(ctx, "/blog/v3/bulk/draft-posts/create", {
+    body: { draftPosts: posts.map((p, i) => buildPost(p, i, memberId)), publish },
+  });
+  // Bulk returns 200 even on partial failure — read per-item results[].itemMetadata.success.
+  return (r.results ?? []).map((x) => ({
+    id: x.itemMetadata?.id, index: x.itemMetadata?.originalIndex, success: !!x.itemMetadata?.success,
+  }));
+}
+
+// STEP 3 (optional — only if the request groups posts): create categories, one POST each.
+// No bulk endpoint. `label` is the Category display-name field (Category object model; the recipe
+// gives the endpoint but not the body). Returns [{ id, name }] — feed ids into post.categoryIds.
+async function createCategories(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/blog/v3/categories", { body: { category: { label: name } } });
+    out.push({ id: r.category?.id, name });
+  }
+  return out;
+}
+
+// STEP 3 (optional): create tags, one POST each. `label` is the Tag display-name field.
+// Returns [{ id, name }] — feed ids into post.tagIds.
+async function createTags(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/blog/v3/tags", { body: { tag: { label: name } } });
+    out.push({ id: r.tag?.id, name });
+  }
+  return out;
+}
+
+// Attach images step (imagery ON only). covers: [{ postId, fileId }] where fileId is the WixMedia
+// file.id from IMAGE_GENERATION.md import (Blog binds the cover by id, not url). Per post:
+//   PATCH /blog/v3/draft-posts/{id}  (NOT POST …/{id}/update — that 404s for a single post),
+// setting media.displayed:true + media.custom:true + wixMedia.image.id (id ALONE is a silent no-op),
+// then re-publish (the PATCH sets hasUnpublishedChanges, so the live post stays cover-less until republish).
+// Image failures never block the run — skip a failed cover, leave the post text-only.
+async function attachPostCovers(ctx, covers) {
+  for (const { postId, fileId } of covers) {
+    try {
+      await req(ctx, `/blog/v3/draft-posts/${postId}`, {
+        method: "PATCH",
+        body: { draftPost: { media: { displayed: true, custom: true, wixMedia: { image: { id: fileId } } } } },
+      });
+      await req(ctx, `/blog/v3/draft-posts/${postId}/publish`, { method: "POST" });
+    } catch (e) {
+      console.warn(`cover attach skipped for post ${postId}: ${e.message}`);
+    }
+  }
+}
+
+module.exports = {
+  getAuthorMemberId, createPosts, createCategories, createTags, attachPostCovers,
+};

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -1,0 +1,64 @@
+# Bookings — seeding
+
+Seed a Wix Bookings catalog by **calling `seed-bookings.js`** — don't hand-write the REST calls.
+It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix
+Bookings seed operation. `require` it and call the functions with plain data.
+
+> **Transcribed from `wix-headless/references/inline-recipes/setup-bookings.md` — NOT yet live-verified.**
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+await seed.installBookingsApp(ctx);                      // if the site doesn't have Wix Bookings yet
+
+// Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
+// install; if what's there could be the owner's real services, ask first (seeding is additive).
+const existing = await seed.listServices(ctx);
+// await seed.deleteServices(ctx, existing.filter(isObviousSample).map(s => s.id));
+
+// ⚠️ ORDER: staff (STEP 1) + category (STEP 2) BEFORE services (STEP 3); sessions (STEP 4) AFTER.
+const staff = await seed.queryStaff(ctx);                // fresh install has a default "Business Owner"
+const resourceId = staff[0].resourceId;                  // NB: resourceId, NOT staff.id
+const cats = await seed.createCategories(ctx, ["Our Services"]);   // fresh install ships ZERO categories
+
+const services = await seed.createServices(ctx, [
+  { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…",
+    price: 75, duration: 60, categoryId: cats[0].id, staffMemberIds: [resourceId] },
+  { type: "CLASS", name: "Morning Yoga", description: "…", capacity: 20,
+    price: 20, categoryId: cats[0].id },   // free service: set free:true, omit price
+]);
+
+// CLASS only — needs each class's returned scheduleId, else its calendar is empty:
+await seed.scheduleClassSessions(ctx, services.filter(s => s.type === "CLASS").map(s => ({
+  scheduleId: s.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
+})));
+
+// imagery ON only: generate per IMAGE_GENERATION.md, then patch each service (revision-checked):
+// await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
+```
+
+## Functions
+| fn | does |
+|---|---|
+| `installBookingsApp(ctx)` | install the Wix Bookings app on the site |
+| `listServices(ctx)` | `[{id,name}]` — for the sample-cleanup judgment |
+| `deleteServices(ctx, ids)` | delete each service (only obvious samples) |
+| `queryStaff(ctx)` | `[{resourceId,id,name}]` — STEP 1; use `resourceId`, not `id` |
+| `createStaff(ctx, [{name,description}])` | create named staff → `[{resourceId,id,name}]` (omit email/phone) |
+| `queryCategories(ctx)` | `[{id,name}]` — reuse a category created earlier this run |
+| `createCategories(ctx, names)` | STEP 2 — every service needs a `category.id` or it's invisible → `[{id,name}]` |
+| `createServices(ctx, services)` | STEP 3 — one bulk create (APPOINTMENT/CLASS mixed) → `[{id,slug,revision,type,scheduleId,success,error}]` |
+| `scheduleClassSessions(ctx, sessions)` | STEP 4 (CLASS only) — one bulk Calendar-Events-V3 create → `[{id,success,error}]` |
+| `getService(ctx, serviceId)` | fetch a service (current `revision`; confirm an image landed) |
+| `attachServiceImage(ctx, {serviceId,revision,image})` | imagery ON — patch `media.mainMedia`/`coverMedia` (revision-checked) |
+
+Both bulk calls report per-item `success`/`error` — retry only the failed items **once** with the
+same body; don't loop and don't re-create the ones that already succeeded.
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-bookings.md`.

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -1,0 +1,242 @@
+// Bookings seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Bookings
+// request/response mechanics (the flat Services-V2 payload, the resourceId-vs-staff-id trap,
+// the category-visibility invariant, the { event: {…} } session wrapper, the silent media.image
+// drop) live here, once.
+//
+// **NOT yet live-verified — transcribed from setup-bookings.md.**
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44 (generic: use $TOKEN)
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//
+//   await seed.installBookingsApp(ctx);                          // if the site doesn't have Wix Bookings yet
+//
+//   // Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a
+//   // fresh install; if what's there could be the owner's real services, ask first (additive).
+//   const existing = await seed.listServices(ctx);
+//   // await seed.deleteServices(ctx, existing.filter(isObviousSample).map(s => s.id));
+//
+//   // ORDER MATTERS: resolve a staff resource (STEP 1) and a category (STEP 2) BEFORE services (STEP 3).
+//   const staff = await seed.queryStaff(ctx);                    // fresh install has a default "Business Owner"
+//   const resourceId = staff[0].resourceId;                      // NB: resourceId, NOT staff id
+//   const cats = await seed.createCategories(ctx, ["Our Services"]);
+//   const services = await seed.createServices(ctx, [
+//     { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…",
+//       price: 75, duration: 60, categoryId: cats[0].id, staffMemberIds: [resourceId] },
+//     { type: "CLASS", name: "Morning Yoga", description: "…", capacity: 20,
+//       price: 20, categoryId: cats[0].id },
+//   ]);
+//   // STEP 4 (CLASS only): needs each class's returned scheduleId.
+//   await seed.scheduleClassSessions(ctx, services.filter(s => s.type === "CLASS").map(s => ({
+//     scheduleId: s.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
+//   })));
+//   // imagery ON only: generate per IMAGE_GENERATION.md, then patch each service (revision-checked).
+//   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
+//
+// If any call fails with a shape the caller didn't expect, or you need an operation this module
+// doesn't cover, fall back to the wix-docs skill (search + read the live Wix API reference) —
+// never guess. Source recipe (authoritative): wix-headless/references/inline-recipes/setup-bookings.md.
+
+const API = "https://www.wixapis.com";
+// Wix Bookings app id (from the recipe's "API surfaces" note).
+const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// name -> url slug fallback when item.mainSlug.name is absent (lowercase, non-alphanumerics -> hyphens, dedupe)
+function slugify(name) {
+  return String(name || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// plain service -> flat Services V2 create object. price omitted / free:true -> NO_FEE.
+// sessionDurations is APPOINTMENT-only; staffMemberIds is required-non-empty for APPOINTMENT, omitted for CLASS.
+function buildService(s) {
+  const isAppointment = s.type === "APPOINTMENT";
+  const free = s.free === true || s.price == null;
+  const out = {
+    type: s.type,
+    name: s.name,
+    description: s.description,
+    tagLine: s.tagLine,
+    defaultCapacity: s.capacity ?? (isAppointment ? 1 : undefined), // required for ALL types
+    onlineBooking: { enabled: true, requireManualApproval: false, allowMultipleRequests: false },
+    payment: free
+      ? { rateType: "NO_FEE", options: { online: false, inPerson: true } }
+      : {
+          rateType: "FIXED",
+          fixed: { price: { value: String(s.price), currency: s.currency ?? "USD" } }, // value is a STRING; site currency wins
+          options: { online: true, inPerson: false },
+        },
+    category: { id: s.categoryId }, // mandatory for live-site visibility
+    locations: [{ type: "BUSINESS" }], // never OWNER_BUSINESS on the services endpoint
+  };
+  if (isAppointment) {
+    out.schedule = { availabilityConstraints: { sessionDurations: [s.duration] } }; // APPOINTMENT only, minutes
+    out.staffMemberIds = s.staffMemberIds; // resourceId(s) from STEP 1 — non-empty or MISSING_APPOINTMENT_RESOURCES
+  }
+  return out;
+}
+
+// ---- exported operations ----
+
+async function installBookingsApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: BOOKINGS_APP_ID, enabled: true },
+  } });
+}
+
+// Clean is JUDGMENT — never auto-delete. Agent lists, decides which are obvious install samples,
+// deletes only those. The default "Business Owner" is a RESOURCE, not a service — it won't appear here.
+async function listServices(ctx) {
+  const r = await req(ctx, "/bookings/v2/services/query", { body: { query: { paging: { limit: 100 } } } });
+  return (r.services ?? []).map((s) => ({ id: s.id, name: s.name }));
+}
+async function deleteServices(ctx, ids) {
+  if (!ids || !ids.length) return;
+  for (const id of ids) {
+    await req(ctx, `/bookings/v2/services/${id}`, { method: "DELETE" });
+  }
+}
+
+// STEP 1: resolve staff resources. Returns [{ resourceId, id, name }].
+// ⚠️ staffMemberIds takes resourceId, NOT the staff id — read staffMember.resourceId.
+async function queryStaff(ctx) {
+  const r = await req(ctx, "/bookings/v1/staff-members/query", {
+    body: { query: {}, fields: ["RESOURCE_DETAILS"] },
+  });
+  return (r.staffMembers ?? []).map((m) => ({ resourceId: m.resourceId, id: m.id, name: m.name }));
+}
+
+// STEP 1 (optional): create named staff when the request names stylists/providers. staff: [{ name, description }].
+// ⚠️ Omit email/phone unless you have a real value — V1 rejects empty strings. Returns [{ resourceId, id, name }].
+async function createStaff(ctx, staff) {
+  const out = [];
+  for (const m of staff) {
+    const body = { staffMember: { name: m.name, description: m.description } };
+    const r = await req(ctx, "/bookings/v1/staff-members", { body });
+    out.push({ resourceId: r.staffMember?.resourceId, id: r.staffMember?.id, name: r.staffMember?.name });
+  }
+  return out;
+}
+
+// STEP 2: query existing categories (to reuse one created earlier this run). Returns [{ id, name }].
+async function queryCategories(ctx) {
+  const r = await req(ctx, "/bookings/v2/categories/query", { body: { query: {} } });
+  return (r.categories ?? []).map((c) => ({ id: c.id, name: c.name }));
+}
+
+// STEP 2: create categories — every service needs a category.id or it's invisible on the live site.
+// Independent (no shared revision, unlike Stores categories); looped here one call per category.
+async function createCategories(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/bookings/v2/categories", { body: { category: { name } } });
+    out.push({ id: r.category?.id, name });
+  }
+  return out;
+}
+
+/**
+ * STEP 3: bulk-create services (up to 100), one call. APPOINTMENT and CLASS may be mixed.
+ * MUST run AFTER staff (STEP 1) and category (STEP 2) are resolved.
+ * @param services [{ type:"APPOINTMENT"|"CLASS", name, description, tagLine?, categoryId,
+ *   price?, currency?, free?, duration?(APPOINTMENT minutes), capacity?, staffMemberIds?(resourceIds, APPOINTMENT) }]
+ * @returns [{ id, slug, revision, type, scheduleId, index, success, error }]
+ *   scheduleId feeds scheduleClassSessions (CLASS); revision feeds attachServiceImage.
+ *   Retry only the items where success===false, ONCE, with the same body — don't loop, don't re-create successes.
+ */
+async function createServices(ctx, services) {
+  const body = { services: services.map(buildService), returnEntity: true };
+  const r = await req(ctx, "/bookings/v2/bulk/services/create", { body });
+  return (r.results ?? []).map((res, i) => {
+    const item = res.item ?? {};
+    return {
+      id: item.id ?? res.itemMetadata?.id,
+      slug: item.mainSlug?.name ?? slugify(item.name ?? services[i]?.name),
+      revision: item.revision,
+      type: item.type ?? services[i]?.type,
+      scheduleId: item.schedule?.id,
+      index: res.itemMetadata?.originalIndex ?? i,
+      success: res.itemMetadata?.success ?? false,
+      error: res.itemMetadata?.error,
+    };
+  });
+}
+
+/**
+ * STEP 4 (CLASS only): schedule sessions in one bulk Calendar-Events-V3 call. Skip for APPOINTMENT.
+ * @param sessions [{ scheduleId(CLASS item.schedule.id), resourceId(from STEP 1), start, end, capacity? }]
+ *   start/end are LOCAL wall-clock "YYYY-MM-DDThh:mm:ss" (no Z), today-or-future.
+ * @returns [{ id, index, success, error }]  — events send no returnEntity, so ids come from itemMetadata only.
+ *   Retry only failed events once.
+ */
+async function scheduleClassSessions(ctx, sessions) {
+  const body = {
+    events: sessions.map((s) => ({
+      event: {
+        scheduleId: s.scheduleId,
+        type: "CLASS",
+        start: { localDate: s.start },
+        end: { localDate: s.end },
+        resources: [{ id: s.resourceId, permissionRole: "WRITER" }], // non-empty + WRITER, else UNKNOWN_ROLE 400
+        ...(s.capacity != null ? { totalCapacity: s.capacity } : {}),
+      },
+    })),
+  };
+  const r = await req(ctx, "/calendar/v3/bulk/events/create", { body });
+  return (r.results ?? []).map((res, i) => ({
+    id: res.itemMetadata?.id,
+    index: res.itemMetadata?.originalIndex ?? i,
+    success: res.itemMetadata?.success ?? false,
+    error: res.itemMetadata?.error,
+  }));
+}
+
+// Fetch a service (for its current revision before an image patch, or to confirm an image landed).
+async function getService(ctx, serviceId) {
+  return req(ctx, `/bookings/v2/services/${serviceId}`, { method: "GET" });
+}
+
+/**
+ * Attach images (imagery ON only). Writes under media.mainMedia + media.coverMedia; revision-checked.
+ * @param it { serviceId, revision, image: { id, url, width, height } }  (image.id is the binding field)
+ * ⚠️ Writing under media.image (not mainMedia/coverMedia) returns 200 but SILENTLY drops the image — a 200
+ * is not proof; confirm with getService and check media.mainMedia is populated. Never block on failure.
+ */
+async function attachServiceImage(ctx, it) {
+  return req(ctx, `/bookings/v2/services/${it.serviceId}`, {
+    method: "PATCH",
+    body: {
+      service: {
+        id: it.serviceId,
+        revision: it.revision,
+        media: { mainMedia: { image: it.image }, coverMedia: { image: it.image } },
+      },
+    },
+  });
+}
+
+module.exports = {
+  installBookingsApp, listServices, deleteServices,
+  queryStaff, createStaff, queryCategories, createCategories,
+  createServices, scheduleClassSessions, getService, attachServiceImage,
+};

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -1,0 +1,65 @@
+# CMS — seeding
+
+Seed Wix CMS (Wix Data v2) collections by **calling `seed-cms.js`** — don't hand-write the REST
+calls. It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every
+Wix Data seed operation. `require` it and call the functions with plain data.
+
+> **NOT yet live-verified — transcribed from `setup-cms.md`.**
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/cms/seed/seed-cms.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+await seed.installCmsApp(ctx);                          // if a data call returns WDE0110 (app not installed)
+
+// STEP 1 — create each collection BEFORE inserting its items. Public-read is the default (a headless
+// visitor reads but can't elevate). Which collections/fields/counts come from the request, not this module.
+const col = await seed.createCollection(ctx, {
+  id: "team-members", displayName: "Team Members",
+  fields: [
+    { key: "name", displayName: "Name", type: "TEXT" },
+    { key: "bio",  displayName: "Bio",  type: "RICH_TEXT" },
+    { key: "order", displayName: "Order", type: "NUMBER" },
+  ],
+  // permissions defaults to PERMISSIONS.publicRead; override for the other shapes:
+  //   PERMISSIONS.collaborative        (visitor-writable shared board — anonymous, unscoped)
+  //   PERMISSIONS.memberPrivate        (per-user-private "my …" rows; seed EMPTY, members populate)
+  //   PERMISSIONS.memberSharedReadOnly (gated: any member reads, only seed/admin writes)
+});
+
+// STEP 2 — bulk-insert with plain fields only (MULTI_REFERENCE is silently dropped at insert)
+const items = await seed.bulkInsertItems(ctx, "team-members", [
+  { name: "Ada Lovelace", role: "Founder",  bio: "<p>Builds the things.</p>", order: 1 },
+  { name: "Alan Turing",  role: "Engineer", bio: "<p>Breaks the things.</p>", order: 2 },
+]);
+
+// STEP 3 — verify persisted (a POST without an error does NOT prove content persisted)
+const rows = await seed.queryItems(ctx, "team-members");
+
+// STEP 4 — wire multi-references only if collections relate (target field needs referencedCollectionId from STEP 1)
+await seed.insertReferences(ctx, "recipes", [
+  { referringItemFieldName: "categories", referringItemId: recipeId, referencedItemId: categoryId },
+]);
+
+// imagery ON only: generate per IMAGE_GENERATION.md, then read-merge-PUT the url onto the item's IMAGE field
+await seed.attachItemImage(ctx, "team-members", { itemId: items[0].id, imageFieldKey: "photo", url: fileUrl });
+```
+
+## Functions
+| fn | does |
+|---|---|
+| `installCmsApp(ctx)` | install the Wix Data (CMS) app on the site |
+| `createCollection(ctx, {id, displayName, fields, permissions?})` | STEP 1 — create one collection → the created collection (default `PERMISSIONS.publicRead`) |
+| `bulkInsertItems(ctx, collectionId, items)` | STEP 2 — one bulk insert of plain-field items → `[{id,data}]` |
+| `insertItem(ctx, collectionId, data)` | STEP 2 (single) — insert one item → `{id,data}` |
+| `queryItems(ctx, collectionId)` | STEP 3 — query for verification → `[{id,data}]` |
+| `insertReferences(ctx, collectionId, [{referringItemFieldName, referringItemId, referencedItemId}])` | STEP 4 — wire multi-references |
+| `attachItemImage(ctx, collectionId, {itemId, imageFieldKey, url})` | imagery ON only — read-merge-PUT the image url onto an item |
+| `PERMISSIONS` | preset blocks: `publicRead`, `collaborative`, `memberPrivate`, `memberSharedReadOnly` |
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-cms.md`.

--- a/skills/wix-vibe-headless/references/cms/seed/seed-cms.js
+++ b/skills/wix-vibe-headless/references/cms/seed/seed-cms.js
@@ -1,0 +1,175 @@
+// CMS (Wix Data v2) seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Data
+// request/response mechanics (the mandatory permissions block, the public-read default,
+// the member-scoped variants, the reference typeMetadata key, the dataItem/dataItemReferences
+// body shapes, the provisioning-race retry, the read-merge-PUT image attach) live here, once.
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/cms/seed/seed-cms.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//   await seed.installCmsApp(ctx);                                        // if WDE0110 (app not installed)
+//   const col = await seed.createCollection(ctx, {                       // STEP 1 (public-read default)
+//     id: "team-members", displayName: "Team Members",
+//     fields: [{ key: "name", displayName: "Name", type: "TEXT" }, { key: "order", displayName: "Order", type: "NUMBER" }],
+//   });
+//   const items = await seed.bulkInsertItems(ctx, "team-members", [       // STEP 2 (plain fields only)
+//     { name: "Ada Lovelace", role: "Founder", order: 1 },
+//   ]);
+//   const rows = await seed.queryItems(ctx, "team-members");             // STEP 3 (verify persisted)
+//   await seed.insertReferences(ctx, "recipes", [                        // STEP 4 (only if collections relate)
+//     { referringItemFieldName: "categories", referringItemId: recipeId, referencedItemId: categoryId },
+//   ]);
+//   await seed.attachItemImage(ctx, "team-members", { itemId, imageFieldKey: "photo", url: fileUrl }); // imagery ON only
+//
+// **NOT yet live-verified — transcribed from setup-cms.md.**
+//
+// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
+// wix-headless/references/inline-recipes/setup-cms.md.
+
+const API = "https://www.wixapis.com";
+const CMS_APP_ID = "e593b0bd-b783-45b8-97c2-873d42aacaf4"; // per recipe (Wix Data app; WDE0110 = not installed)
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// A fresh site's Wix Data backend can fail the FIRST few create/insert calls transiently
+// (403 on create, 400 WDE0117 "MetaSite not found" on insert, or 5xx) — a provisioning race that
+// self-heals in seconds. Retry the SAME body ONCE, then fail loud; never loop (per recipe).
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function isTransient(err) {
+  const m = String(err && err.message);
+  return /-> 403:/.test(m) || /-> 5\d\d:/.test(m) || m.includes("WDE0117");
+}
+async function retryOnce(fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isTransient(err)) throw err;
+    await sleep(3000);
+    return await fn();
+  }
+}
+
+// Permission presets — the `permissions` block is MANDATORY on create (per recipe).
+// Default is publicRead: a headless visitor token reads but cannot elevate, so a PUBLIC
+// collection's `read` MUST be "ANYONE" or the visitor query returns zero items with no error.
+// Write verbs stay "ADMIN" (only the seed token writes) unless the site lets visitors write.
+const PERMISSIONS = {
+  // admin-owned content, anyone reads (the default)
+  publicRead: { insert: "ADMIN", update: "ADMIN", remove: "ADMIN", read: "ANYONE" },
+  // visitor-written shared/global data (guestbook, community board) — the only open-write level
+  // the anonymous visitor token supports; NO per-user scoping (any visitor edits any row)
+  collaborative: { read: "ANYONE", insert: "ANYONE", update: "ANYONE", remove: "ANYONE" },
+  // per-user-private "my …" data — member sees/edits only their OWN rows (_owner-matched);
+  // runs on the member token; seed such a collection EMPTY (members populate it themselves)
+  memberPrivate: { read: "SITE_MEMBER_AUTHOR", insert: "SITE_MEMBER", update: "SITE_MEMBER_AUTHOR", remove: "SITE_MEMBER_AUTHOR" },
+  // gated content: any logged-in member reads, only the seed/admin writes
+  memberSharedReadOnly: { read: "SITE_MEMBER", insert: "ADMIN", update: "ADMIN", remove: "ADMIN" },
+};
+
+// ---- exported operations ----
+
+// Install the Wix Data (CMS) app if the site doesn't have it (WDE0110 on a data call = not installed).
+async function installCmsApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: CMS_APP_ID, enabled: true },
+  } });
+}
+
+/**
+ * STEP 1 — create ONE collection (public-read by default).
+ * @param col { id, displayName, fields, permissions? }
+ *   fields = the Wix Data field schema verbatim ([{ key, displayName, type, typeMetadata? }]).
+ *     A REFERENCE/MULTI_REFERENCE field MUST carry `typeMetadata.(multiReference|reference).referencedCollectionId`
+ *     (NOT `referencedCollection` — the docs' stale key stores an empty target and every later link is dead);
+ *     the target collection must be created FIRST.
+ *   permissions = one of PERMISSIONS.* or a custom { insert, update, remove, read } block. Default: publicRead.
+ * @returns the created collection (its `id` is the value you sent — Wix does not rename it; keep it + the field keys).
+ */
+async function createCollection(ctx, { id, displayName, fields, permissions = PERMISSIONS.publicRead }) {
+  const r = await retryOnce(() =>
+    req(ctx, "/wix-data/v2/collections", {
+      body: { collection: { id, displayName, fields, permissions } },
+    }));
+  return r.collection ?? r;
+}
+
+/**
+ * STEP 2 — bulk-insert a collection's items in ONE call.
+ * @param items plain field-value objects ([{ name, role, order }]). Each is wrapped as { data } internally.
+ *   Set plain fields + single REFERENCE fields (pass the referenced item's `_id` string) only.
+ *   Do NOT put a MULTI_REFERENCE value here — it is SILENTLY DROPPED (no error); wire it in STEP 4.
+ * @returns [{ id, data }] — item id read from results[].dataItem.id (NOT results[].item).
+ */
+async function bulkInsertItems(ctx, dataCollectionId, items) {
+  const r = await retryOnce(() =>
+    req(ctx, "/wix-data/v2/bulk/items/insert", {
+      body: { dataCollectionId, dataItems: items.map((data) => ({ data })), returnEntity: true },
+    }));
+  return (r.results ?? []).map((x) => ({ id: x.dataItem?.id, data: x.dataItem?.data }));
+}
+
+/**
+ * STEP 2 (single) — insert one item; equivalent to bulkInsertItems for a one-item collection.
+ * @returns { id, data } — from the single-insert `dataItem` wrapper.
+ */
+async function insertItem(ctx, dataCollectionId, data) {
+  const r = await retryOnce(() =>
+    req(ctx, "/wix-data/v2/items", { body: { dataCollectionId, dataItem: { data } } }));
+  return { id: r.dataItem?.id, data: r.dataItem?.data };
+}
+
+// STEP 3 — query a collection to verify inserts persisted (a POST without an error does NOT prove it).
+// The recipe documents only the query body `{ dataCollectionId }`, not the response shape — this maps the
+// standard `dataItems` wrapper; if the shape differs, fall back to wix-docs. // per recipe
+async function queryItems(ctx, dataCollectionId) {
+  const r = await req(ctx, "/wix-data/v2/items/query", { body: { dataCollectionId } });
+  return (r.dataItems ?? []).map((d) => ({ id: d.id, data: d.data }));
+}
+
+/**
+ * STEP 4 — wire MULTI_REFERENCE links (skip unless collections relate).
+ * @param references [{ referringItemFieldName, referringItemId, referencedItemId }]
+ *   referringItemFieldName = the multi-reference field key on the referring collection;
+ *   referringItemId = that item's id; referencedItemId = the target item's id. Both ids from STEP 2.
+ *   Resolves ONLY if the field was created with a non-empty referencedCollectionId (STEP 1).
+ */
+async function insertReferences(ctx, dataCollectionId, references) {
+  return req(ctx, "/wix-data/v2/bulk/items/insert-references", {
+    body: { dataCollectionId, dataItemReferences: references },
+  });
+}
+
+// Attach a generated image to an item (imagery ON only). Read-merge-PUT — a partial PUT wipes omitted
+// fields, so query the item, merge the url into its IMAGE field key, and PUT the WHOLE record back.
+// Never block on image failure — on failure skip and leave the item text-only. url = the permanent
+// wixstatic.com file.url (an IMAGE field stores the URL string).
+async function attachItemImage(ctx, dataCollectionId, { itemId, imageFieldKey, url }) {
+  const rows = await queryItems(ctx, dataCollectionId);
+  const row = rows.find((x) => x.id === itemId);
+  if (!row) throw new Error(`attachItemImage: item ${itemId} not found in ${dataCollectionId}`);
+  const data = { ...row.data, _id: itemId, [imageFieldKey]: url };
+  return req(ctx, `/wix-data/v2/items/${itemId}`, { method: "PUT", body: { dataCollectionId, dataItem: { data } } });
+}
+
+module.exports = {
+  PERMISSIONS,
+  installCmsApp, createCollection,
+  bulkInsertItems, insertItem, queryItems,
+  insertReferences, attachItemImage,
+};

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -1,0 +1,62 @@
+# Events — seeding
+
+Seed Wix Events (Events V3) by **calling `seed-events.js`** — don't hand-write the REST calls. It's
+a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Events
+seed operation. `require` it and call the functions with plain data.
+
+> **NOT yet live-verified — transcribed from `setup-events.md`.** Endpoints/fields are as written in
+> the recipe; if a live call disagrees, trust the docs (see Fallback).
+
+Two one-way constraints fix the order: `registration.initialType` (`TICKETING`/`RSVP`) is **immutable**
+after create, and **publishing is one-way**. So per event: create DRAFT → (ticketed) add tiers → publish.
+Wix Events is **pre-installed** by setup — never reinstall (a 403 means fail loudly). There is no
+clean-up step (a fresh install ships no sample events).
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+// STEP 1 — create each event as a DRAFT. TICKETING = paid tiers; RSVP = free built-in form (no fields to seed).
+// Dates MUST be in the future (ISO-8601 UTC); default ~60–90 days out and note it if the request gives none.
+const ev = await seed.createEvent(ctx, {
+  title: "Summer Synth Festival", shortDescription: "One night of analog sound.",
+  type: "TICKETING", startDate: "2026-10-01T03:30:00.000Z", endDate: "2026-10-01T07:00:00.000Z",
+  timeZoneId: "America/Los_Angeles",
+  location: { name: "The Echo Lot", type: "VENUE", address: { addressLine: "120 Harbor St", city: "Seattle", subdivision: "US-WA", postalCode: "98101", country: "US" } },
+});
+
+// STEP 2 — TICKETING only: add tiers BEFORE publish. price is a decimal STRING; name <= 30 chars; omit initialLimit for unlimited.
+const tiers = await seed.createTicketTiers(ctx, ev.id, [{ name: "General Admission", price: "65.00", initialLimit: 200 }]);
+
+// STEP 3 — publish (one-way; ticketed events only after tiers exist)
+await seed.publishEvent(ctx, ev.id);
+
+// STEP 4 (optional) — group by a format/track (v1 Categories)
+const cats = await seed.createEventCategories(ctx, ["Talks"]);
+await seed.assignEventsToCategory(ctx, cats[0].id, [ev.id]);
+
+// Attach images (imagery ON only): generate per IMAGE_GENERATION.md, then set mainImage. height/width REQUIRED or it won't render.
+await seed.setEventMainImage(ctx, { eventId: ev.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: ev.slug });
+```
+
+**Paid-ticket precondition — record, do NOT block:** seeding succeeds and the event goes live
+regardless of payment setup, but *completing a paid purchase* later needs a premium plan **and** a
+configured payment method in the dashboard. Note it in the kept output; never fail the seed over it.
+Free/RSVP events need neither.
+
+## Functions
+| fn | does |
+|---|---|
+| `createEvent(ctx, event)` | STEP 1 — create ONE draft event (no bulk; loop for many) → `{id, slug}` |
+| `createTicketTiers(ctx, eventId, tiers)` | STEP 2 — TICKETING only, parallel batch → `[{id}]` |
+| `publishEvent(ctx, eventId)` | STEP 3 — publish (one-way) |
+| `createEventCategories(ctx, names)` | STEP 4 (opt) — v1 Categories, one call each → `[{id,name}]` |
+| `assignEventsToCategory(ctx, categoryId, eventIds)` | STEP 4 (opt) — path `/{categoryId}/events`, body `{eventId:[…]}` |
+| `setEventMainImage(ctx, {eventId,id,url,height,width,altText})` | imagery ON — PATCH `mainImage` (no revision) |
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-events.md`.

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -1,0 +1,173 @@
+// Wix Events (Events V3) seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Events request/response
+// mechanics (the draft→tickets→publish order, the TICKETING-vs-RSVP registration block, the decimal
+// STRING price, the v1 Categories API, the mainImage object) live here, once.
+//
+// NOT yet live-verified — transcribed from setup-events.md. Endpoints/fields are as written in the
+// recipe; if a live call disagrees, trust the docs.
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44 (generic: use $TOKEN)
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//
+//   // Wix Events is PRE-INSTALLED by setup — do NOT reinstall. A 403/app-not-installed means fail loudly.
+//   // No clean-up: a fresh Events install ships no sample events, so nothing to delete first.
+//
+//   // STEP 1: create each event as a DRAFT (TICKETING = paid tiers | RSVP = free built-in form)
+//   const ev = await seed.createEvent(ctx, {
+//     title: "Summer Synth Festival", shortDescription: "One night of analog sound.",
+//     type: "TICKETING", startDate: "2026-10-01T03:30:00.000Z", endDate: "2026-10-01T07:00:00.000Z",
+//     timeZoneId: "America/Los_Angeles",
+//     location: { name: "The Echo Lot", type: "VENUE", address: { addressLine: "120 Harbor St", city: "Seattle", subdivision: "US-WA", postalCode: "98101", country: "US" } },
+//   });
+//   // STEP 2 (TICKETING only): add ticket tiers BEFORE publish
+//   const tiers = await seed.createTicketTiers(ctx, ev.id, [{ name: "General Admission", price: "65.00", initialLimit: 200 }]);
+//   // STEP 3: publish (one-way)
+//   await seed.publishEvent(ctx, ev.id);
+//   // STEP 4 (optional): group by format/track
+//   const cats = await seed.createEventCategories(ctx, ["Talks"]);
+//   await seed.assignEventsToCategory(ctx, cats[0].id, [ev.id]);
+//   // Attach images (imagery ON only): height/width REQUIRED or it won't render
+//   await seed.setEventMainImage(ctx, { eventId: ev.id, id: fileId, url: fileUrl, height: 1024, width: 1024, altText: ev.slug });
+//
+// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
+// wix-headless/references/inline-recipes/setup-events.md.
+
+const API = "https://www.wixapis.com";
+// Wix Events app id — for reference only. The app is pre-installed by setup; never reinstall here.
+const EVENTS_APP_ID = "140603ad-af8d-84a5-2c80-a0f60cb47351";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// {type:"TICKETING"|"RSVP", ...} -> Wix registration block. TICKETING carries a tickets{} config;
+// RSVP carries an rsvp{responseType} and seeds NO form fields (name+email form is built-in).
+// initialType is IMMUTABLE after create — set from the request, never plan to convert.
+function buildRegistration(ev) {
+  if (ev.type === "TICKETING") {
+    return {
+      initialType: "TICKETING",
+      tickets: {
+        ticketLimitPerOrder: ev.ticketLimitPerOrder ?? 8, // per recipe (example value)
+        currency: ev.currency ?? "USD", // per recipe (example value)
+        reservationDurationInMinutes: ev.reservationDurationInMinutes ?? 20, // per recipe (example value)
+      },
+    };
+  }
+  return {
+    initialType: "RSVP",
+    rsvp: { responseType: ev.rsvpResponseType ?? "YES_ONLY" }, // "YES_ONLY" | "YES_AND_NO"
+  };
+}
+
+// ---- exported operations ----
+
+/**
+ * STEP 1 — create ONE event as a draft (no bulk endpoint; loop for multiple events).
+ * @param ev { title, shortDescription?, type:"TICKETING"|"RSVP",
+ *   startDate, endDate, timeZoneId, showTimeZone?,   // dates are ISO-8601 UTC and MUST be in the future
+ *   location,                                         // {name,type:"VENUE",address:{…}} | {name,type:"ONLINE"} | {locationTbd:true,name}
+ *   ticketLimitPerOrder?, currency?, reservationDurationInMinutes?,  // TICKETING only
+ *   rsvpResponseType? }                                              // RSVP only
+ * @returns { id, slug }  (id feeds STEP 2/3; slug is the URL identifier — do NOT confuse with id)
+ */
+async function createEvent(ctx, ev) {
+  const body = {
+    draft: true,
+    event: {
+      title: ev.title,
+      shortDescription: ev.shortDescription,
+      location: ev.location,
+      dateAndTimeSettings: {
+        startDate: ev.startDate,
+        endDate: ev.endDate,
+        timeZoneId: ev.timeZoneId,
+        showTimeZone: ev.showTimeZone ?? true, // per recipe (example value)
+      },
+      registration: buildRegistration(ev),
+    },
+    fields: ["DETAILS", "TEXTS", "REGISTRATION", "URLS"],
+  };
+  const r = await req(ctx, "/events/v3/events", { body });
+  return { id: r.event?.id, slug: r.event?.slug };
+}
+
+/**
+ * STEP 2 — create ticket definitions for a TICKETING event (skip for RSVP). Must run BEFORE publish.
+ * Tiers for one event are independent — fired as one parallel batch.
+ * @param tiers [{ name (<=30 chars), description?, price (decimal STRING, e.g. "65.00"),
+ *   currency?, initialLimit? (omit for unlimited), feeType? ("FEE_INCLUDED"|"FEE_ADDED_AT_CHECKOUT"|"NO_FEE") }]
+ * @returns [{ id }]  (frontend lists tiers and reserves by ticketDefinition id)
+ */
+async function createTicketTiers(ctx, eventId, tiers) {
+  return Promise.all(tiers.map(async (t) => {
+    const body = {
+      ticketDefinition: {
+        eventId,
+        name: t.name,
+        description: t.description,
+        ...(t.initialLimit != null ? { initialLimit: t.initialLimit } : {}), // omit => unlimited
+        pricingMethod: { fixedPrice: { value: String(t.price), currency: t.currency ?? "USD" } }, // value MUST be a decimal string
+        feeType: t.feeType ?? "FEE_INCLUDED", // per recipe (default)
+      },
+      fields: ["SALES_DETAILS"],
+    };
+    const r = await req(ctx, "/events/v3/ticket-definitions", { body });
+    return { id: r.ticketDefinition?.id };
+  }));
+}
+
+// STEP 3 — publish the event (one-way). For a TICKETING event, publish only AFTER its tiers exist.
+async function publishEvent(ctx, eventId) {
+  return req(ctx, `/events/v3/events/${eventId}/publish`, { body: {} });
+}
+
+// STEP 4 (optional) — group events by a format/track. Categories are the v1 API (NOT v3). One call each.
+async function createEventCategories(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/events/v1/categories", { body: { category: { name } } });
+    out.push({ id: r.category?.id, name });
+  }
+  return out;
+}
+
+// Assign events to a category. Path is /{categoryId}/events (NOT /assign); body key is `eventId` (array).
+async function assignEventsToCategory(ctx, categoryId, eventIds) {
+  return req(ctx, `/events/v1/categories/${categoryId}/events`, { body: { eventId: eventIds } });
+}
+
+// Attach images (imagery ON only). mainImage is an Image OBJECT; height/width are REQUIRED or it won't
+// render. Events V3 uses NO revision — partial PATCH keyed by event.id. Works before OR after publish.
+// item: { eventId, id, url, height, width, altText }  (id = the WixMedia image id)
+async function setEventMainImage(ctx, item) {
+  return req(ctx, `/events/v3/events/${item.eventId}`, {
+    method: "PATCH",
+    body: {
+      event: {
+        id: item.eventId,
+        mainImage: { id: item.id, url: item.url, height: item.height, width: item.width, altText: item.altText },
+      },
+      fields: ["DETAILS"], // mainImage reads back only under DETAILS
+    },
+  });
+}
+
+module.exports = {
+  createEvent, createTicketTiers, publishEvent,
+  createEventCategories, assignEventsToCategory, setEventMainImage,
+};

--- a/skills/wix-vibe-headless/references/members/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/members/seed/SEED.md
@@ -1,0 +1,13 @@
+# Members — seeding
+
+**Nothing to seed.** Members login is the identity layer: members **self-register** through the
+Wix login page, so there is no member to create at build time and nothing lands in a `seeded`
+map. There is intentionally no `seed-*.js` here.
+
+The members work is entirely **frontend wiring** (custom login, account area, gated content) —
+see this vertical's `INSTRUCTIONS.md` and the reference components.
+
+_Optional, off by default:_ only if a run's prompt explicitly asks to exercise the pricing-plans
+purchase path end-to-end, one test member may be created — keep this off so headless runs stay
+deterministic and don't stall on an interactive login. If you need that, use the **`wix-docs`**
+skill for the current member-create shape (source: `wix-headless/references/SEED.md` § members).

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -1,0 +1,61 @@
+# Portfolio — seeding
+
+Seed a Wix Portfolio by **calling `seed-portfolio.js`** — don't hand-write the REST calls. It's
+a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix
+Portfolio seed operation. `require` it and call the functions with plain data.
+
+**Collections before projects.** A project is assigned to collections by a `collectionIds` array
+that Wix does **not** validate — a wrong id silently orphans the project. Create the collections
+first, then thread their real ids into each project.
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+// Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
+// install (the "My Portfolio" collection + its sample projects); projects BEFORE collections.
+// If what's there could be the owner's real content, ask first (seeding is additive).
+const projs = await seed.listProjects(ctx);
+// await seed.deleteProjects(ctx, projs.filter(isObviousSample).map(p => p.id));
+const cols = await seed.listCollections(ctx);
+// await seed.deleteCollections(ctx, cols.filter(isObviousSample).map(c => c.id));
+
+const collections = await seed.createCollections(ctx, [                                 // STEP 1
+  { title: "Brand Identity", description: "Logo systems and visual identities." },
+]);
+const projects = await seed.createProjects(ctx, [                                       // STEP 2
+  { title: "Northwind Rebrand", description: "Full identity refresh for a logistics firm.",
+    collectionIds: [collections[0].id], details: [{ label: "Year", text: "2025" }] },
+]);
+
+// imagery ON only: generate + import images per IMAGE_GENERATION.md, then attach
+await seed.attachProjectCovers(ctx, projects.map((p, i) => ({ id: p.id, revision: p.revision, imageId: ids[i], height: 2880, width: 1920 })));
+await seed.attachCollectionCovers(ctx, collections.map((c, i) => ({ id: c.id, revision: c.revision, imageId: cids[i], height: 2880, width: 1920 })));
+await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }]);
+```
+
+## Functions
+| fn | does |
+|---|---|
+| `listProjects(ctx)` | `[{id,title}]` — for the sample-cleanup judgment |
+| `deleteProjects(ctx, ids)` | one DELETE per id (no bulk); run before collections |
+| `listCollections(ctx)` | `[{id,title}]` |
+| `deleteCollections(ctx, ids)` | one DELETE per id (no bulk); run after projects |
+| `createCollections(ctx, collections)` | STEP 1 — `[{title,description?,hidden?}]` → `[{id,slug,revision}]` |
+| `createProjects(ctx, projects)` | STEP 2 — `[{title,description?,collectionIds,details?,hidden?}]` → `[{id,slug,revision}]` |
+| `attachProjectCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each project's cover (imagery on) |
+| `attachCollectionCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each collection's cover (imagery on) |
+| `createProjectItems(ctx, [{projectId,sortOrder,title,imageId,height,width}])` | one POST per gallery image (imagery on) |
+
+`hidden` defaults to `false` (shown) — omit it for visible entities; send `hidden: true` only to
+hide. On `428` / `APP_NOT_INSTALLED`, the Setup step was skipped — fail loudly, don't self-install.
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-portfolio.md`.
+
+**Transcribed from the recipe — NOT yet live-verified.** The endpoints/fields mirror
+`setup-portfolio.md`; confirm against a real run or the Wix docs before trusting edge shapes.

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -1,0 +1,156 @@
+// Portfolio seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Portfolio
+// request/response mechanics (the collection/project wrappers, title-not-name, the
+// hidden-defaults-to-false polarity, collections-before-projects, cover PATCH + gallery
+// items) live here, once.
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//
+//   // Clean is JUDGMENT — never auto-delete. Only obvious install samples on a fresh install;
+//   // projects BEFORE collections. If it could be the owner's real content, ask first.
+//   const projs = await seed.listProjects(ctx);
+//   // await seed.deleteProjects(ctx, projs.filter(isObviousSample).map(p => p.id));
+//   const cols = await seed.listCollections(ctx);
+//   // await seed.deleteCollections(ctx, cols.filter(isObviousSample).map(c => c.id));
+//
+//   const collections = await seed.createCollections(ctx, [{ title, description }]);        // STEP 1
+//   const projects = await seed.createProjects(ctx, [                                        // STEP 2
+//     { title, description, collectionIds: [collections[0].id], details: [{ label, text }] },
+//   ]);
+//   // imagery ON only:
+//   await seed.attachProjectCovers(ctx, projects.map((p,i) => ({ id:p.id, revision:p.revision, imageId:ids[i], height:2880, width:1920 })));
+//   await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title, imageId, height:896, width:1200 }]);
+//
+// **NOT yet live-verified — transcribed from setup-portfolio.md.** If any call fails with a
+// shape the caller didn't expect, fall back to the wix-docs skill (search + read the live Wix
+// API reference) — never guess. Source recipe (authoritative):
+// wix-headless/references/inline-recipes/setup-portfolio.md.
+
+const API = "https://www.wixapis.com";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// ---- exported operations ----
+
+// STEP 0 clean helpers. Clean is JUDGMENT — never auto-delete. Delete children before parents:
+// projects first, then collections (deleting a collection does not clean up its projects).
+async function listProjects(ctx) {
+  const r = await req(ctx, "/portfolio/v1/projects", { method: "GET" });
+  return (r.projects ?? []).map((p) => ({ id: p.id, title: p.title }));
+}
+// No bulk-delete for projects — one DELETE call per id (each returns 200).
+async function deleteProjects(ctx, ids) {
+  if (!ids || !ids.length) return;
+  for (const id of ids) await req(ctx, `/portfolio/v1/projects/${id}`, { method: "DELETE" });
+}
+async function listCollections(ctx) {
+  const r = await req(ctx, "/portfolio/v1/collections", { method: "GET" });
+  return (r.collections ?? []).map((c) => ({ id: c.id, title: c.title }));
+}
+// No bulk-delete for collections — one DELETE call per id (each returns 200).
+async function deleteCollections(ctx, ids) {
+  if (!ids || !ids.length) return;
+  for (const id of ids) await req(ctx, `/portfolio/v1/collections/${id}`, { method: "DELETE" });
+}
+
+/**
+ * STEP 1 — Create the collections. MUST run before createProjects: a project's collectionIds
+ * are NOT validated, so projects need the real collection ids read back from here.
+ * @param collections [{ title, description?, hidden? }]  (display name is `title`, not `name`;
+ *   `slug` auto-generates from title when omitted; `hidden` defaults to false = shown, so omit
+ *   it for a visible collection and send `hidden: true` only to hide.)
+ *   No bulk-create — one call per collection; concurrent is safe (no 409 race) but sequential
+ *   is just as correct and simplest.
+ * @returns [{ id, slug, revision }]  (id feeds each project's collectionIds; revision feeds covers)
+ */
+async function createCollections(ctx, collections) {
+  const out = [];
+  for (const c of collections) {
+    const body = { collection: { title: c.title, description: c.description } };
+    if (c.hidden) body.collection.hidden = true; // omit otherwise — defaults to shown
+    const r = await req(ctx, "/portfolio/v1/collections", { body });
+    out.push({ id: r.collection?.id, slug: r.collection?.slug, revision: r.collection?.revision });
+  }
+  return out;
+}
+
+/**
+ * STEP 2 — Create the projects, each assigned to its collection(s) via collectionIds.
+ * @param projects [{ title, description?, collectionIds: [id], details?, hidden? }]
+ *   collectionIds MUST hold real ids from createCollections — they are NOT validated, so a
+ *   wrong/missing id is accepted silently and orphans the project (reachable only from the
+ *   all-projects list). `details` is an optional [{ label, text }] array (Role, Year, Client…).
+ *   `hidden` defaults to false = shown. No bulk-create — one call per project; concurrent safe.
+ * @returns [{ id, slug, revision }]  (revision feeds attachProjectCovers)
+ */
+async function createProjects(ctx, projects) {
+  const out = [];
+  for (const p of projects) {
+    const project = {
+      title: p.title,
+      description: p.description,
+      collectionIds: p.collectionIds ?? [],
+    };
+    if (p.details) project.details = p.details;
+    if (p.hidden) project.hidden = true; // omit otherwise — defaults to shown
+    const r = await req(ctx, "/portfolio/v1/projects", { body: { project } });
+    out.push({ id: r.project?.id, slug: r.project?.slug, revision: r.project?.revision });
+  }
+  return out;
+}
+
+// Imagery opt-in — skip when imagery is off. Cover = the listing-card thumbnail. PATCH per entity,
+// echoing the current revision (a missing/stale revision fails). height + width are required
+// alongside the imported WixMedia image id. items: [{ id, revision, imageId, height, width }].
+async function attachProjectCovers(ctx, items) {
+  for (const it of items) {
+    await req(ctx, `/portfolio/v1/projects/${it.id}`, {
+      method: "PATCH",
+      body: { project: { id: it.id, revision: it.revision, coverImage: { imageInfo: { id: it.imageId, height: it.height, width: it.width } } } },
+    });
+  }
+}
+async function attachCollectionCovers(ctx, items) {
+  for (const it of items) {
+    await req(ctx, `/portfolio/v1/collections/${it.id}`, {
+      method: "PATCH",
+      body: { collection: { id: it.id, revision: it.revision, coverImage: { imageInfo: { id: it.imageId, height: it.height, width: it.width } } } },
+    });
+  }
+}
+
+// Imagery opt-in — the project's media gallery (detail-page images) is a SEPARATE `item` entity,
+// one POST per image. sortOrder (1,2,3…) sets render order. lowercase `items` — `/Items` 404s.
+// There is NO public list endpoint. items: [{ projectId, sortOrder, title, imageId, height, width }].
+async function createProjectItems(ctx, items) {
+  const out = [];
+  for (const it of items) {
+    const r = await req(ctx, "/portfolio/v1/items", {
+      body: { item: { projectId: it.projectId, sortOrder: it.sortOrder, title: it.title, image: { imageInfo: { id: it.imageId, height: it.height, width: it.width } } } },
+    });
+    out.push({ id: r.item?.id });
+  }
+  return out;
+}
+
+module.exports = {
+  listProjects, deleteProjects, listCollections, deleteCollections,
+  createCollections, createProjects,
+  attachProjectCovers, attachCollectionCovers, createProjectItems,
+};

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -1,0 +1,54 @@
+# Pricing Plans — seeding
+
+Seed Wix Pricing Plans (Plans V3) by **calling `seed-pricing-plans.js`** — don't hand-write the
+REST calls. It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts
+every Pricing Plans + Benefit Programs seed operation. `require` it and call the functions with
+plain data.
+
+> **NOT yet live-verified — transcribed from `setup-pricing-plans.md`.**
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+// There is NO clean-up step — a fresh Pricing Plans install ships no sample plans.
+
+const plans = await seed.createPlans(ctx, [
+  { name: "Studio Membership", description: "Unlimited group classes.", price: "20.00",
+    type: "recurring", billingCycle: { period: "MONTH", count: 1 },
+    perks: ["Unlimited group classes", "10% off workshops"],
+    coveredServiceIds: bookingsServiceIds },  // optional — only when this plan covers bookings services
+  // …just the plan data. price = decimal STRING; currency is site-derived (don't send it).
+]);
+
+// STEP 2 — only when bookings is in the run AND the plan covers services (skip otherwise):
+await seed.attachBookingsCoverage(ctx, plans[0].id, plans[0].coveredServiceIds);
+// limited pack instead of unlimited: attachBookingsCoverage(ctx, id, ids, { creditAmount: 8 })
+```
+
+## Functions
+| fn | does |
+|---|---|
+| `createPlans(ctx, plans)` | one create call per plan (V3 has no bulk) → `[{id,name,coveredServiceIds}]` |
+| `attachBookingsCoverage(ctx, planId, serviceIds, {creditAmount?})` | STEP 2: 2a→2b→2c in order → `{itemSetId,serviceIds}` |
+| `getProgramDefinition(ctx, planId)` | 2a: READ the auto-created program definition (retry-once on 404) → `programDefinitionId` |
+| `createPoolDefinition(ctx, programDefinitionId, {creditAmount?})` | 2b: one pool + one Bookings benefit → `itemSetId` |
+| `createBenefitItems(ctx, itemSetId, serviceIds)` | 2c: bulk-create one benefit item per covered service |
+
+Plan `type`: `"recurring"` (default; `billingCycle` defaults to `{MONTH,1}`), `"one-time"`
+(bills once then ends; pass `billingCycle: null` for the unlimited one-time), or `"free"`
+(amount forced to `"0"` + a per-member-lifetime purchase limit). Amounts are decimal **strings**;
+`perks` are display-only bullets; plans default to `visibility: "PUBLIC"` + `buyable: true`.
+
+## Bookings-first dependency
+STEP 2 attaches **bookings service ids** to a plan through the Benefit Programs API (the coverage
+is NOT a plan field or a perk). Those ids come from the **bookings seed**
+(`seeded.bookings.serviceIds[]`), so **seed bookings before pricing-plans** and pass the ids in as
+`coveredServiceIds`. A plans-only run (no bookings) stops after `createPlans` — skip STEP 2 entirely.
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-pricing-plans.md`.

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
@@ -1,0 +1,213 @@
+// Pricing-Plans seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Pricing Plans (V3)
+// + Benefit Programs request/response mechanics (the client-supplied GUID rule, the string-amount
+// rule, the three ordered coverage sub-steps, the @wix/pricing-plans namespace) live here, once.
+//
+// **NOT yet live-verified — transcribed from setup-pricing-plans.md.**
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//
+//   // Bookings is seeded FIRST — its service ids feed a plan's coverage (see SEED.md).
+//   const plans = await seed.createPlans(ctx, [
+//     { name: "Studio Membership", description: "Unlimited group classes.", price: "20.00",
+//       type: "recurring", billingCycle: { period: "MONTH", count: 1 },
+//       perks: ["Unlimited group classes", "10% off workshops"],
+//       coveredServiceIds: bookingsServiceIds },   // optional — only when this plan covers bookings
+//   ]);
+//   // Then, per plan that covers bookings services (STEP 2; skip entirely with no bookings):
+//   await seed.attachBookingsCoverage(ctx, plans[0].id, plans[0].coveredServiceIds);
+//
+// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
+// wix-headless/references/inline-recipes/setup-pricing-plans.md.
+
+const { randomUUID } = require("crypto");
+
+const API = "https://www.wixapis.com";
+const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97"; // per recipe: providerAppId for coverage
+const PP_NAMESPACE = "@wix/pricing-plans"; // per recipe: literal, with @ and slash, in every 2a–2c call
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// [ "text" | { description } ] -> Wix perks[]; each gets a fresh client-supplied GUID (required).
+function buildPerks(perks = []) {
+  return perks.map((p) => ({
+    id: randomUUID(),
+    description: typeof p === "string" ? p : p.description,
+  }));
+}
+
+// billingTerms selects the plan type (recurring | one-time | free). Amounts are decimal STRINGS.
+// recurring: billingCycle {period,count} (default MONTH/1) + startType ON_PURCHASE + endType UNTIL_CANCELLED.
+// one-time:  endType CYCLES_COMPLETED + cyclesCompletedDetails {billingCycleCount:1} (bill once, then ends);
+//            an unlimited one-time instead sets billingCycle:null + endType UNTIL_CANCELLED.
+function buildBillingTerms(plan) {
+  const type = plan.type || "recurring";
+  if (type === "one-time") {
+    if (plan.billingCycle === null) {
+      return { billingCycle: null, startType: "ON_PURCHASE", endType: "UNTIL_CANCELLED" };
+    }
+    const cycle = plan.billingCycle || { period: "MONTH", count: 1 };
+    return {
+      billingCycle: cycle,
+      startType: "ON_PURCHASE",
+      endType: "CYCLES_COMPLETED",
+      cyclesCompletedDetails: { billingCycleCount: 1 },
+    };
+  }
+  // recurring (also the shape a free plan rides on)
+  const cycle = plan.billingCycle || { period: "MONTH", count: 1 };
+  return { billingCycle: cycle, startType: "ON_PURCHASE", endType: "UNTIL_CANCELLED" };
+}
+
+// one pricingVariant with one pricingStrategy (schema allows ≤20 but is "currently limited to 1").
+function buildPricingVariant(plan) {
+  const free = (plan.type || "recurring") === "free";
+  const amount = free ? "0" : String(plan.price);
+  return {
+    id: randomUUID(), // required, client-supplied GUID — never model-typed
+    name: plan.variantName || "Standard",
+    billingTerms: buildBillingTerms(plan),
+    pricingStrategies: [{ flatRate: { amount } }],
+  };
+}
+
+// ---- exported operations ----
+
+/**
+ * Create the plan(s). Plans V3 has NO bulk-create — one create call per plan.
+ * @param plans [{ name, description?, price,           // price = decimal string ("20.00"); ignored for free
+ *   type?: "recurring"|"one-time"|"free",              // default "recurring"
+ *   billingCycle?: { period: "DAY"|"WEEK"|"MONTH"|"YEAR", count } | null,  // default { MONTH, 1 }
+ *   perks?: ["..."] | [{ description }],               // display-only bullets (no functional effect)
+ *   visibility?, buyable?,                             // default "PUBLIC" / true (public + orderable)
+ *   coveredServiceIds? }]                              // metadata for attachBookingsCoverage; not sent here
+ * @returns [{ id, name, coveredServiceIds }]  (id = plan.id — orders by it AND is the coverage externalId)
+ */
+async function createPlans(ctx, plans) {
+  const out = [];
+  for (const plan of plans) {
+    const free = (plan.type || "recurring") === "free";
+    const body = {
+      plan: {
+        name: plan.name,
+        description: plan.description,
+        status: "ACTIVE", // REQUIRED — omitting returns 400 "status value is required"
+        visibility: plan.visibility || "PUBLIC",
+        buyable: plan.buyable ?? true,
+        buyerCanCancel: plan.buyerCanCancel ?? true,
+        pricingVariants: [buildPricingVariant(plan)],
+        perks: buildPerks(plan.perks),
+        // free: cap lifetime reuse (older maxPurchasesPerBuyer is deprecated — prefer purchaseLimits)
+        ...(free ? { purchaseLimits: { type: "PER_MEMBER_LIFETIME", count: 1 } } : {}),
+      },
+    };
+    const r = await req(ctx, "/pricing-plans/v3/plans", { body });
+    out.push({ id: r.plan?.id, name: plan.name, coveredServiceIds: plan.coveredServiceIds });
+  }
+  return out;
+}
+
+// ---- STEP 2: bookings coverage via Benefit Programs API (SKIP when no bookings in the run) ----
+// Strictly ordered: plan.id -> programDefinition.id -> itemSetId -> items. Do NOT parallelize.
+
+// 2a: READ the auto-created program definition (the Plans app creates it; you never create it).
+// Provisioning is ~immediate but async — retry ONCE after a short backoff on 404/empty, don't loop.
+async function getProgramDefinition(ctx, planId) {
+  const path = `/benefit-programs/v1/program-definitions/by-namespace-and-external-id?externalId=${planId}&namespace=${encodeURIComponent(PP_NAMESPACE)}`;
+  try {
+    const r = await req(ctx, path, { method: "GET" });
+    if (r.programDefinition?.id) return r.programDefinition.id;
+  } catch {
+    // fall through to the single insurance retry
+  }
+  await sleep(1000);
+  const r = await req(ctx, path, { method: "GET" });
+  return r.programDefinition?.id;
+}
+
+// 2b: create ONE pool definition with EXACTLY ONE benefit naming Bookings as the provider.
+// price "0" = unlimited (default; no creditConfiguration). Limited pack: pass creditAmount ->
+// price "1" + details.creditConfiguration (SIBLING of benefits[], NOT inside a benefit).
+async function createPoolDefinition(ctx, programDefinitionId, { creditAmount } = {}) {
+  const limited = creditAmount != null;
+  const details = {
+    ...(limited ? { creditConfiguration: { amount: String(creditAmount) } } : {}),
+    benefits: [
+      {
+        benefitKey: randomUUID(), // freshly generated random UUID you supply
+        displayName: "Bookings sessions",
+        providerAppId: BOOKINGS_APP_ID,
+        price: limited ? "1" : "0",
+      },
+    ],
+  };
+  const r = await req(ctx, "/benefit-programs/v1/pool-definitions", {
+    body: {
+      poolDefinition: {
+        namespace: PP_NAMESPACE,
+        displayName: "Bookings benefit",
+        programDefinitionIds: [programDefinitionId],
+        details,
+      },
+      cascade: "IMMEDIATELY",
+    },
+  });
+  // itemSetId lives at poolDefinition.details.benefits[i].itemSetId — one benefit here, so [0].
+  return r.poolDefinition?.details?.benefits?.[0]?.itemSetId;
+}
+
+// 2c: bulk-create the benefit items — ONE item per covered service (externalId = bookings service id).
+// Up to 100 items per call; category is an empty string; namespace/providerAppId repeat 2b's values.
+async function createBenefitItems(ctx, itemSetId, serviceIds) {
+  return req(ctx, "/benefit-programs/v1/bulk/items/create", {
+    body: {
+      items: serviceIds.map((externalId) => ({
+        namespace: PP_NAMESPACE,
+        category: "",
+        providerAppId: BOOKINGS_APP_ID,
+        itemSetId,
+        externalId,
+      })),
+      returnEntity: true,
+    },
+  });
+}
+
+/**
+ * Wire a plan to COVER bookings services (STEP 2, per plan). Runs 2a -> 2b -> 2c in order.
+ * @param planId          plan.id from createPlans
+ * @param serviceIds      bookings service ids (seeded.bookings.serviceIds[]) the plan should cover
+ * @param creditAmount?   session-count for a limited pack; omit for the default unlimited ("0") case
+ * @returns { itemSetId, serviceIds }  — keep as seed-time linkage (bookingsCoverage[planId])
+ */
+async function attachBookingsCoverage(ctx, planId, serviceIds, { creditAmount } = {}) {
+  const programDefinitionId = await getProgramDefinition(ctx, planId);
+  const itemSetId = await createPoolDefinition(ctx, programDefinitionId, { creditAmount });
+  await createBenefitItems(ctx, itemSetId, serviceIds);
+  return { itemSetId, serviceIds };
+}
+
+module.exports = {
+  createPlans,
+  attachBookingsCoverage,
+  getProgramDefinition, createPoolDefinition, createBenefitItems,
+};

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -1,0 +1,132 @@
+# Restaurants — seeding
+
+Seed a Wix Restaurants site by **calling `seed-restaurants.js`** — don't hand-write the REST calls.
+It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every seed
+operation across the vertical's four recipes: the **menu** (always) plus three on-demand add-ons —
+**online ordering**, **table reservations**, and **experiences**. `require` it and call the functions
+with plain data.
+
+> **NOT yet live-verified — transcribed from `setup-restaurants.md`, `setup-restaurant-orders.md`,
+> `setup-restaurant-reservations.md`, `setup-restaurant-experiences.md`.**
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+// ── MENU (always; the seedable core) ────────────────────────────────────────────────────────────
+await seed.installMenusApp(ctx);                    // if the site doesn't have Wix Restaurants Menus yet
+
+// Clean is a JUDGMENT call — never auto-delete. Only remove the install's obvious default "Dinner
+// Menu" on a fresh install; if it could be the owner's real menu, ask first (seeding is additive).
+// Children before parents: items → sections → menus.
+// const items = await seed.listMenuItems(ctx);   await seed.deleteMenuItems(ctx, items.map(i => i.id));
+// const secs  = await seed.listMenuSections(ctx); await seed.deleteMenuSections(ctx, secs.map(s => s.id));
+// const menus = await seed.listMenus(ctx);        for (const m of menus) await seed.deleteMenu(ctx, m.id);
+
+const menu = await seed.createMenu(ctx, {           // builds items → sections → menu bottom-up
+  name: "Dinner", description: "Evening menu",
+  sections: [
+    { name: "Antipasti", description: "To start", items: [
+      { name: "Bruschetta al Pomodoro", description: "Grilled sourdough, San Marzano tomatoes, basil.", price: 9.50 },
+    ] },
+  ],
+});                                                 // → { menuId, sectionIds, itemIds }
+
+// imagery ON only: generate per IMAGE_GENERATION.md, then attach (full-replace — echo revision + price)
+// await seed.attachItemImages(ctx, [{ id, revision, price, image: { id, url, height, width } }]);
+
+// ── ONLINE ORDERING (add-on, on demand; MENU-FIRST) ──────────────────────────────────────────────
+await seed.installOrdersApp(ctx);                   // auto-provisions a working ordering setup
+await seed.setBusinessLocation(ctx, address);       // STEP 0 — REQUIRED (see preconditions)
+const [op] = await seed.listOperations(ctx);        // verify the auto-created operation (never create one)
+// if (op.onlineOrderingStatus !== "ENABLED") await seed.enableOperation(ctx, op.id, op.revision);
+const methods = await seed.listFulfillmentMethods(ctx);      // reshape ONLY what the request names
+// await seed.updateFulfillmentMethod(ctx, methods[0].id, { revision: methods[0].revision, name: "Delivery", fee: "5" });
+const settings = await seed.queryMenuOrderingSettings(ctx);  // confirm each menu is onlineOrderingEnabled
+
+// ── TABLE RESERVATIONS (add-on, on demand; INDEPENDENT of menu/ordering) ─────────────────────────
+await seed.installTableReservationsApp(ctx);        // auto-provisions a default reservation location
+await seed.setBusinessLocation(ctx, address);       // STEP 0 — shared with ordering (do it once if both)
+const [loc] = await seed.listReservationLocations(ctx);      // discover the default (never create one)
+// await seed.updateReservationLocation(ctx, loc.id, loc.revision, { onlineReservations: { partySize: { min: 2, max: 10 } } });
+await seed.enableOnlineReservations(ctx, loc.id, loc.revision);  // PREMIUM-GATED — 428 on a free site (record, don't fail)
+
+// ── EXPERIENCES (add-on WITHIN Table Reservations, on demand) ────────────────────────────────────
+await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Experience doc */ } }]);
+```
+
+## Functions
+
+**Menu** (`setup-restaurants.md`)
+| fn | does |
+|---|---|
+| `installMenusApp(ctx)` | install the Wix Restaurants Menus app |
+| `listMenuItems(ctx)` / `deleteMenuItems(ctx, ids)` | list / bulk-delete items (sample-cleanup judgment) |
+| `listMenuSections(ctx)` / `deleteMenuSections(ctx, ids)` | list / bulk-delete sections |
+| `listMenus(ctx)` / `deleteMenu(ctx, menuId)` | list / delete a menu (no bulk delete — one per menu) |
+| `createMenu(ctx, {name,description?,sections})` | items → sections → menu bottom-up → `{menuId,sectionIds,itemIds}` |
+| `attachItemImages(ctx, [{id,revision,price,image}])` | imagery pass — full-replace PATCH (echo revision + priceInfo) |
+
+**Shared** (ordering + reservations STEP 0)
+| fn | does |
+|---|---|
+| `setBusinessLocation(ctx, location)` | full-override Update Location (or create if none) — REQUIRED for ordering |
+
+**Online ordering** (`setup-restaurant-orders.md`) — verify/reshape the auto-provisioned setup
+| fn | does |
+|---|---|
+| `installOrdersApp(ctx)` | install the Orders app (auto-provisions operation + methods + per-menu settings) |
+| `listOperations(ctx)` | the auto-created operation(s) — never create one |
+| `enableOperation(ctx, id, revision)` | PATCH `onlineOrderingStatus:"ENABLED"` (only if not already) |
+| `listFulfillmentMethods(ctx)` | the three auto-created methods |
+| `updateFulfillmentMethod(ctx, id, patch)` | rename / re-fee / disable (partial; `fee`/`minOrderPrice` decimal strings) |
+| `createFulfillmentMethod(ctx, method)` | add one beyond the defaults (NOT auto-attached) |
+| `setOperationFulfillmentIds(ctx, id, revision, ids)` | attach a created method (full array) |
+| `queryMenuOrderingSettings(ctx)` | confirm each menu `onlineOrderingEnabled` + bound to the operation |
+| `updateMenuOrderingSettings(ctx, id, patch)` | flip a menu orderable / display-only |
+
+**Table reservations** (`setup-restaurant-reservations.md`) — configure the auto-provisioned location
+| fn | does |
+|---|---|
+| `installTableReservationsApp(ctx)` | install the app (auto-provisions the default reservation location) |
+| `listReservationLocations(ctx)` | discover the default (never create one — API can't) |
+| `updateReservationLocation(ctx, id, revision, configuration)` | party-size / hours / turnover (config only; `location` immutable) |
+| `enableOnlineReservations(ctx, id, revision)` | turn online reservations on — PREMIUM-GATED (428 on free) |
+
+**Experiences** (`setup-restaurant-experiences.md`) — feature of Table Reservations (no extra install)
+| fn | does |
+|---|---|
+| `createExperiences(ctx, reservationLocationId, experiences)` | one experience per named dining occasion → `[{id,name}]` |
+
+## Ordering rules (do not violate)
+- **Menu is bottom-up: items → sections → menu.** A section is created with its `itemIds`, a menu with
+  its `sectionIds`, so each child must exist before its parent. `createMenu` does this in three phases.
+- **`visible: true` at every level** (item, section, menu) — storefront queries return only visible
+  entities. Baked in by `createMenu`.
+- **Menu before ordering.** Seed the menu first, then the ordering add-on (as one unit) — each menu
+  binds to the operation via a menu-ordering-settings object. Ordering auto-provisions per menu either
+  way, but the verify step needs a menu to confirm against.
+- **`setBusinessLocation` STEP 0 is required for ordering** — without a real address Wix limits ordering
+  to "testing only" and checkout breaks. Shared with reservations (do it once if both add-ons run).
+- **Reservations are independent** — they bind to a location, not a menu; no menu-first rule, nothing to
+  bulk-seed (visitors create reservations at runtime).
+- Operations and reservation locations are **auto-provisioned — never create them**; discover and PATCH.
+
+## Preconditions (record in the handoff, do NOT fail the seed)
+- **Ordering address (STEP 0)** — required; if the brief names none, set a clearly-marked placeholder and
+  flag the owner to set their real business address before ordering works.
+- **Paid checkout** needs a **premium plan + a configured payment method** (dashboard/premium — can't be
+  done headlessly).
+- **`enableOnlineReservations` is premium-only** — throws `428 PREMIUM_ONLY` on a non-premium site;
+  expected and non-fatal, record it and continue (don't retry-spiral).
+- **Booking an experience** is premium-gated the same way (create works on a free site; booking needs
+  premium + online reservations enabled).
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover, use the
+**`wix-docs`** skill to search + read the live Wix API reference — never guess. The **Experiences** create
+payload especially lives in the docs (fields evolve). The authoritative source recipes are
+`wix-headless/references/inline-recipes/setup-restaurants.md`, `setup-restaurant-orders.md`,
+`setup-restaurant-reservations.md`, and `setup-restaurant-experiences.md`.

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -1,0 +1,372 @@
+// Restaurants seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Restaurants
+// request/response mechanics (bottom-up items→sections→menu, the priceInfo decimal-string rule,
+// the visible:true-at-every-level rule, the full-replace image PATCH, the per-micro-service host
+// prefixes for ordering, the premium/address preconditions) live here, once.
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44 (generic: use $TOKEN)
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//
+//   // --- MENU (always; the seedable core) ---
+//   await seed.installMenusApp(ctx);                               // if the site doesn't have Wix Restaurants Menus yet
+//   const menu = await seed.createMenu(ctx, {                      // builds items → sections → menu bottom-up
+//     name: "Dinner", description: "Evening menu",
+//     sections: [
+//       { name: "Antipasti", description: "To start", items: [
+//         { name: "Bruschetta al Pomodoro", description: "Grilled sourdough, San Marzano tomatoes, basil.", price: 9.50 },
+//       ] },
+//     ],
+//   });                                                            // → { menuId, sectionIds, itemIds }
+//
+//   // --- ONLINE ORDERING (add-on, on demand; MENU-FIRST — seed the menu above first) ---
+//   await seed.installOrdersApp(ctx);                              // auto-provisions a working ordering setup
+//   await seed.setBusinessLocation(ctx, address);                 // STEP 0 — REQUIRED (see preconditions below)
+//   const ops = await seed.listOperations(ctx);                    // verify the auto-created operation (never create one)
+//   const methods = await seed.listFulfillmentMethods(ctx);        // reshape only what the request names
+//   const mos = await seed.queryMenuOrderingSettings(ctx);         // confirm each menu is onlineOrderingEnabled
+//
+//   // --- TABLE RESERVATIONS (add-on, on demand; INDEPENDENT of menu/ordering) ---
+//   await seed.installTableReservationsApp(ctx);                   // auto-provisions a default reservation location
+//   await seed.setBusinessLocation(ctx, address);                 // STEP 0 — shared with ordering (do it once if both)
+//   const [loc] = await seed.listReservationLocations(ctx);        // discover the default (never create one)
+//   await seed.enableOnlineReservations(ctx, loc.id, loc.revision);// PREMIUM-GATED — 428 on a free site (record, don't fail)
+//
+//   // --- EXPERIENCES (add-on WITHIN Table Reservations, on demand) ---
+//   await seed.createExperiences(ctx, loc.id, experiences);        // one per named dining occasion
+//
+// **NOT yet live-verified — transcribed from setup-restaurants.md / setup-restaurant-orders.md /
+// setup-restaurant-reservations.md / setup-restaurant-experiences.md.** If any call fails with a
+// shape the caller didn't expect, fall back to the wix-docs skill (search + read the live Wix API
+// reference) — never guess.
+//
+// ── PRECONDITIONS the recipes flag (record in the handoff, do NOT fail the seed) ─────────────────
+//   • Ordering STEP 0 address is REQUIRED: without a real business-location address Wix limits
+//     ordering to "testing only" and checkout breaks. If the brief names no address, set a clearly
+//     marked placeholder and flag the owner to fix it.
+//   • Completing a PAID order needs a premium plan + a configured payment method (dashboard/premium
+//     provisioning the skill can't do headlessly).
+//   • enableOnlineReservations is PREMIUM-ONLY: on a non-premium site it throws `428 PREMIUM_ONLY`.
+//     That is EXPECTED and non-fatal — record it as a precondition and continue; do not retry-spiral.
+//   • Booking an Experience is premium-gated the same way (create works on a free site; booking needs
+//     premium + online reservations enabled).
+
+const API = "https://www.wixapis.com";
+
+// App definition ids (SETUP.md §2). Menus is the seedable core; Orders + Table Reservations are
+// separate optional apps. Experiences are a FEATURE of Table Reservations — no separate install.
+const MENUS_APP_ID = "b278a256-2757-4f19-9313-c05c783bec92";
+const ORDERS_APP_ID = "9a5d83fd-8570-482e-81ab-cfa88942ee60";
+const TABLE_RESERVATIONS_APP_ID = "f9c07de2-5341-40c6-b096-8eb39de391fb";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// ── app install ─────────────────────────────────────────────────────────────────────────────────
+// Body shape per SETUP.md §2 (tenant + appInstance). One install call per app.
+async function installApp(ctx, appDefId) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", {
+    body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId, enabled: true },
+    },
+  });
+}
+async function installMenusApp(ctx) { return installApp(ctx, MENUS_APP_ID); }
+async function installOrdersApp(ctx) { return installApp(ctx, ORDERS_APP_ID); }
+async function installTableReservationsApp(ctx) { return installApp(ctx, TABLE_RESERVATIONS_APP_ID); }
+
+// ══ MENU (setup-restaurants.md) ═══════════════════════════════════════════════════════════════════
+// Everything is the Restaurants Menus V1 API on /restaurants/menus/v1/... — one service.
+// REST flattens the protobuf wrappers: send plain values (`"visible": true`), never `{"value": …}`.
+
+// STEP 0 — clean the install's default sample "Dinner Menu". JUDGMENT call: only delete when it's
+// obviously the install's own sample; if it could be the owner's real menu, ask first (seeding is
+// additive). Children before parents: items → sections → menus.
+async function listMenuItems(ctx) {
+  const r = await req(ctx, "/restaurants/menus/v1/items", { method: "GET" });
+  return (r.items ?? []).map((it) => ({ id: it.id, name: it.name }));
+}
+async function deleteMenuItems(ctx, ids) {
+  if (!ids || !ids.length) return;
+  return req(ctx, "/restaurants/menus/v1/bulk/items/delete", { method: "DELETE", body: { ids } });
+}
+async function listMenuSections(ctx) {
+  const r = await req(ctx, "/restaurants/menus/v1/sections", { method: "GET" });
+  return (r.sections ?? []).map((s) => ({ id: s.id, name: s.name }));
+}
+async function deleteMenuSections(ctx, ids) {
+  if (!ids || !ids.length) return;
+  return req(ctx, "/restaurants/menus/v1/bulk/sections/delete", { method: "DELETE", body: { ids } });
+}
+async function listMenus(ctx) {
+  const r = await req(ctx, "/restaurants/menus/v1/menus", { method: "GET" });
+  return (r.menus ?? []).map((m) => ({ id: m.id, name: m.name }));
+}
+// No bulk-delete endpoint for menus — one DELETE per menu; single delete takes only the path id (no revision).
+async function deleteMenu(ctx, menuId) {
+  return req(ctx, `/restaurants/menus/v1/menus/${menuId}`, { method: "DELETE" });
+}
+
+/**
+ * Build one menu BOTTOM-UP (items → sections → menu) in three bulk phases.
+ * @param menu {
+ *   name, description?,
+ *   sections: [{ name, description?, items: [{ name, description?, price }] }]
+ * }
+ *   price -> priceInfo.price as a decimal STRING; currency is the site's (send none).
+ *   description is a plain string (NOT rich-text nodes); omit for a name-only item/section.
+ *   visible:true is baked in at every level (item, section, menu) — required to render on the live site.
+ * @returns { menuId, sectionIds:[…], itemIds:[…] }  (revisions available via listMenuItems for imagery pass)
+ */
+async function createMenu(ctx, menu) {
+  // STEP 1 — bulk-create every item across all sections in ONE request; track which section each belongs to.
+  const flat = [];
+  menu.sections.forEach((sec, si) => (sec.items || []).forEach((it) => flat.push({ ...it, _section: si })));
+  const itemRes = await req(ctx, "/restaurants/menus/v1/bulk/items/create", {
+    body: {
+      items: flat.map((it) => ({
+        name: it.name,
+        ...(it.description ? { description: it.description } : {}),
+        priceInfo: { price: String(it.price) },
+        visible: true,
+      })),
+      returnEntity: true,
+    },
+  });
+  // created items are under results[].item (results[].itemMetadata.success is the per-item flag)
+  const createdItems = (itemRes.results ?? []).map((r) => r.item);
+  const itemIdsBySection = menu.sections.map(() => []);
+  flat.forEach((it, i) => {
+    const id = createdItems[i]?.id;
+    if (id) itemIdsBySection[it._section].push(id);
+  });
+
+  // STEP 2 — bulk-create sections, each carrying the itemIds of its items (real ids from STEP 1).
+  const secRes = await req(ctx, "/restaurants/menus/v1/bulk/sections/create", {
+    body: {
+      sections: menu.sections.map((sec, si) => ({
+        name: sec.name,
+        ...(sec.description ? { description: sec.description } : {}),
+        visible: true,
+        itemIds: itemIdsBySection[si],
+      })),
+      returnEntity: true,
+    },
+  });
+  const sectionIds = (secRes.results ?? []).map((r) => r.item?.id);
+
+  // STEP 3 — create the menu (single create wraps in `menu`), carrying its sectionIds.
+  // businessLocationId omitted -> binds to the site's default (main) location.
+  const menuRes = await req(ctx, "/restaurants/menus/v1/menus", {
+    body: {
+      menu: {
+        name: menu.name,
+        ...(menu.description ? { description: menu.description } : {}),
+        visible: true,
+        sectionIds,
+      },
+    },
+  });
+  return { menuId: menuRes.menu?.id, sectionIds, itemIds: createdItems.map((it) => it?.id) };
+}
+
+// Imagery ON only (pass-2). The ITEM is the image-bearing entity. Update Item is a FULL-ENTITY REPLACE
+// with NO field mask — you MUST echo each item's current `revision` AND `priceInfo`, or it fails
+// `428 MISSING_ITEM_PRICING` and the image does NOT apply. `image` is an OBJECT { id, url, height, width }
+// (never a bare string); the binding field is the Wix Media file `id`. Never block on image failure.
+// items: [{ id, revision, price, image: { id, url, height, width } }]
+async function attachItemImages(ctx, items) {
+  return req(ctx, "/restaurants/menus/v1/bulk/items/update", {
+    body: {
+      items: items.map((it) => ({
+        item: {
+          id: it.id,
+          revision: it.revision,
+          priceInfo: { price: String(it.price) },
+          image: it.image,
+        },
+      })),
+    },
+  });
+}
+
+// ══ BUSINESS LOCATION (shared STEP 0 for ordering + reservations) ══════════════════════════════════
+// Update Location is a FULL OVERRIDE — send the WHOLE `location` object (omitted fields are wiped),
+// echo `default:true` (omitting it 400s CHANGE_DEFAULT_FORBIDDEN) and the current `revision`.
+// address.country is a 2-letter ISO-3166 code. The address propagates to Site Properties.
+// `location`: { name, timeZone, email?, phone?, address:{ country, subdivision, city, postalCode,
+//               streetAddress:{ number, name }, formattedAddress } }
+async function setBusinessLocation(ctx, location) {
+  const list = await req(ctx, "/locations/v1/locations", { method: "GET" });
+  const def = (list.locations ?? []).find((l) => l.default);
+  // No default location at all (a bare Orders-only site can have none) -> CREATE one; operations
+  // auto-bind on first-location-add. Otherwise overwrite the existing default (full override).
+  if (!def) {
+    const r = await req(ctx, "/locations/v1/locations", { body: { location: { ...location, default: true } } });
+    return r.location;
+  }
+  const r = await req(ctx, `/locations/v1/locations/${def.id}`, {
+    method: "PUT",
+    body: { location: { ...location, id: def.id, revision: def.revision, default: true } },
+  });
+  return r.location;
+}
+
+// ══ ONLINE ORDERING (setup-restaurant-orders.md) ═══════════════════════════════════════════════════
+// MENU-FIRST: a menu must exist (createMenu above) before ordering; each menu binds to the operation
+// via a menu-ordering-settings object. The Orders-app install AUTO-provisions a working setup (an
+// ENABLED operation with Pickup + Delivery attached, every menu ordering-enabled) — these helpers
+// VERIFY and RESHAPE it; they do NOT build ordering from scratch. Each micro-service is on its OWN
+// host prefix (restaurants-operations / fulfillment-methods / menu-ordering-settings) — do not normalize.
+
+// STEP 1 — verify the auto-created operation (never POST to create one). If empty, the install hasn't
+// finished provisioning: wait briefly and retry the GET once (caller's concern), then fail loud.
+async function listOperations(ctx) {
+  const r = await req(ctx, "/restaurants-operations/v1/operations", { method: "GET" });
+  return r.operations ?? [];
+}
+// Normally already "ENABLED" — only PATCH if you see DISABLED/PAUSED_UNTIL. revision mandatory + current.
+async function enableOperation(ctx, operationId, revision) {
+  return req(ctx, `/restaurants-operations/v1/operations/${operationId}`, {
+    method: "PATCH",
+    body: { operation: { revision, onlineOrderingStatus: "ENABLED" } },
+  });
+}
+// A newly created fulfillment method is NOT auto-attached — PATCH the operation's fulfillmentIds with
+// the FULL array (existing ids + the new one) or it won't be offered at checkout.
+async function setOperationFulfillmentIds(ctx, operationId, revision, fulfillmentIds) {
+  return req(ctx, `/restaurants-operations/v1/operations/${operationId}`, {
+    method: "PATCH",
+    body: { operation: { revision, fulfillmentIds } },
+  });
+}
+
+// STEP 2 — reconcile fulfillment methods to the request. Install ships three (Pickup enabled,
+// "Delivery Area #1" enabled fee "0", "DoorDash Drive" disabled), all with a San Francisco placeholder
+// address. Wrap bodies in camelCase `fulfillmentMethod`; fee/minOrderPrice are decimal STRINGS.
+async function listFulfillmentMethods(ctx) {
+  const r = await req(ctx, "/fulfillment-methods/v1/fulfillment-methods", { method: "GET" });
+  return r.fulfillmentMethods ?? [];
+}
+// patch: partial { revision, name?, fee?, minOrderPrice?, enabled?, availability?, pickupOptions?/deliveryOptions? }
+async function updateFulfillmentMethod(ctx, methodId, patch) {
+  return req(ctx, `/fulfillment-methods/v1/fulfillment-methods/${methodId}`, {
+    method: "PATCH",
+    body: { fulfillmentMethod: patch },
+  });
+}
+// Create a method beyond the defaults, THEN setOperationFulfillmentIds to attach it (create does NOT attach).
+// pickupOptions for type PICKUP, deliveryOptions (with a deliveryArea) for DELIVERY — send the one matching type.
+async function createFulfillmentMethod(ctx, fulfillmentMethod) {
+  const r = await req(ctx, "/fulfillment-methods/v1/fulfillment-methods", { body: { fulfillmentMethod } });
+  return r.fulfillmentMethod;
+}
+
+// STEP 3 — verify each menu is orderable. Auto-created + auto-enabled per menu, so normally a confirmation.
+async function queryMenuOrderingSettings(ctx) {
+  const r = await req(ctx, "/menu-ordering-settings/v1/menu-ordering-settings/query", { body: { query: {} } });
+  return r.menuOrderingSettings ?? [];
+}
+// Only if an entry shows onlineOrderingEnabled:false / operationId:"none" (or a menu should be display-only).
+// patch: { revision, operationId, onlineOrderingEnabled, availability:{ type:"ALWAYS_AVAILABLE", timeZone } }
+async function updateMenuOrderingSettings(ctx, settingsId, patch) {
+  return req(ctx, `/menu-ordering-settings/v1/menu-ordering-settings/${settingsId}`, {
+    method: "PATCH",
+    body: { menuOrderingSettings: patch },
+  });
+}
+
+// ══ TABLE RESERVATIONS (setup-restaurant-reservations.md) ══════════════════════════════════════════
+// INDEPENDENT of the menu (reservations bind to a LOCATION, not a menu — no menu-first rule) and there
+// is NOTHING to bulk-seed (visitors create reservations at runtime). The install AUTO-provisions one
+// default reservation location with a complete config; the one thing OFF is onlineReservationsEnabled.
+// A reservation location CANNOT be created via this API — discover, configure, and enable it.
+// Use the post-Jan-2026 field names: partySize (not partiesSize), approval (not manualApproval),
+// tables.ids (not tableIds), ignoreConflicts.
+
+// STEP 1 — discover the default location (never create one). If empty, wait + retry the GET once, else fail loud.
+async function listReservationLocations(ctx) {
+  const r = await req(ctx, "/table-reservations/reservation-locations/v1/reservation-locations", { method: "GET" });
+  return r.reservationLocations ?? [];
+}
+// STEP 2 — customize config (only what the request names). Partial PATCH; revision mandatory. Works on a
+// non-premium site. The `location` object (address/name) is IMMUTABLE here — only touch `configuration`.
+// configuration: { onlineReservations: { partySize?:{min,max}, minimumReservationNotice?:{number,unit},
+//                  defaultTurnoverTime?, businessSchedule?, approval?:{mode:"AUTOMATIC"}, ... } }
+async function updateReservationLocation(ctx, reservationLocationId, revision, configuration) {
+  return req(ctx, `/table-reservations/reservation-locations/v1/reservation-locations/${reservationLocationId}`, {
+    method: "PATCH",
+    body: { reservationLocation: { id: reservationLocationId, revision, configuration } },
+  });
+}
+// STEP 3 — turn on online reservations. PREMIUM-ONLY: on a non-premium site this THROWS `428 PREMIUM_ONLY`
+// ("Can't turn on online reservation for a non-premium website"). That is EXPECTED and non-fatal — the
+// caller records it as a premium precondition and continues; do NOT retry-spiral or fail the seed.
+async function enableOnlineReservations(ctx, reservationLocationId, revision) {
+  return req(ctx, `/table-reservations/reservation-locations/v1/reservation-locations/${reservationLocationId}`, {
+    method: "PATCH",
+    body: {
+      reservationLocation: {
+        id: reservationLocationId,
+        revision,
+        configuration: { onlineReservations: { onlineReservationsEnabled: true } },
+      },
+    },
+  });
+}
+
+// ══ EXPERIENCES (setup-restaurant-experiences.md) ══════════════════════════════════════════════════
+// An experience is a reservation that IS a curated dining occasion (wine tasting, chef's table). Feature
+// of the Table Reservations app — no separate install. Created against a reservationLocationId (from
+// listReservationLocations). The full create payload lives in the live docs (fields evolve) — build each
+// `experience` from the Create-Experience doc; this only wires the loop. Set configuration.visible:true.
+// GOTCHAS the docs won't state:
+//   • Notice fields are FLAT under onlineReservations (minimumReservationNotice / maximumReservationNotice),
+//     NOT wrapped in `noticePeriod` (the doc example's wrapper is stale).
+//   • paymentPolicyType: PER_GUEST (needs perGuestOptions.price, a decimal string) or FREE.
+//   • businessSchedule.entries[] carries the recurrence (WEEKLY + weeklyOptions.startDaysAndTimes[{day,time}],
+//     or ONE_TIME); durationInMinutes sits on businessSchedule, not per entry.
+//   • Creating works on a free site; BOOKING is premium-gated (record, don't fail).
+// experiences: [{ configuration: { displayInfo:{name,shortDescription}, paymentPolicy, onlineReservations, visible } }]
+async function createExperiences(ctx, reservationLocationId, experiences) {
+  const out = [];
+  for (const exp of experiences) {
+    const r = await req(ctx, "/table-reservations/experiences/v1/experiences", {
+      body: { experience: { reservationLocationId, ...exp } },
+    });
+    out.push({ id: r.experience?.id, name: r.experience?.configuration?.displayInfo?.name });
+  }
+  return out;
+}
+
+module.exports = {
+  // app install
+  installMenusApp, installOrdersApp, installTableReservationsApp,
+  // menu
+  listMenuItems, deleteMenuItems, listMenuSections, deleteMenuSections, listMenus, deleteMenu,
+  createMenu, attachItemImages,
+  // shared business location (ordering + reservations STEP 0)
+  setBusinessLocation,
+  // ordering add-on
+  listOperations, enableOperation, setOperationFulfillmentIds,
+  listFulfillmentMethods, updateFulfillmentMethod, createFulfillmentMethod,
+  queryMenuOrderingSettings, updateMenuOrderingSettings,
+  // reservations add-on
+  listReservationLocations, updateReservationLocation, enableOnlineReservations,
+  // experiences add-on
+  createExperiences,
+};

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -1,0 +1,46 @@
+# Storefront — seeding
+
+Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write the REST calls. It's
+a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
+seed operation. `require` it and call the functions with plain data.
+
+```js
+// build-time exec_tool
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js");
+const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+
+await seed.installStoresApp(ctx);                       // if the site doesn't have Wix Stores yet
+
+// Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
+// install; if what's there could be the owner's real catalog, ask first (seeding is additive).
+const existing = await seed.listProducts(ctx);
+// await seed.deleteProducts(ctx, existing.filter(isObviousSample).map(p => p.id));
+
+const products = await seed.bulkCreateProducts(ctx, [
+  { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12 },
+  // …just the catalog data. options ONLY for real buyer choices (Size/Color); default none.
+]);
+
+const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);   // only if the brief names categories
+await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
+
+// imagery ON only: generate images per IMAGE_GENERATION.md, then one bulk attach
+await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, revision: p.revision, url: imageUrls[i], altText: p.slug })));
+```
+
+## Functions
+| fn | does |
+|---|---|
+| `installStoresApp(ctx)` | install the Wix Stores app on the site |
+| `listProducts(ctx)` | `[{id,name}]` — for the sample-cleanup judgment |
+| `deleteProducts(ctx, ids)` | bulk-delete (only obvious samples) |
+| `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]` |
+| `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
+| `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
+| `attachProductImages(ctx, [{id,revision,url,altText}])` | one bulk media attach |
+
+## Fallback
+If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
+use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
+authoritative source recipe is `wix-headless/references/inline-recipes/setup-online-store.md`.

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -1,0 +1,181 @@
+// Storefront seed helpers — run at BUILD TIME via exec_tool (NOT shipped in the app).
+// The agent requires this and calls the functions with plain data; all Wix Stores
+// request/response mechanics (bulk shapes, variant expansion, rich-text descriptions,
+// the 409-serial category rule, the re-hosted-image quirk) live here, once.
+//
+// Usage (build-time exec_tool):
+//   const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // Base44
+//   const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js");
+//   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
+//   await seed.installStoresApp(ctx);
+//   const products = await seed.bulkCreateProducts(ctx, [{ name, description, price, quantity, options? }]);
+//   const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);
+//   await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
+//   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, revision:p.revision, url:imageUrls[i], altText:p.slug })));
+//
+// If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
+// (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
+// wix-headless/references/inline-recipes/setup-online-store.md.
+
+const API = "https://www.wixapis.com";
+const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  const res = await fetch(API + path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${ctx.token}`,
+      "wix-site-id": ctx.siteId,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  return json;
+}
+
+// plain string -> Wix rich-text description node tree (plainDescription is HTML/nodes, not text)
+function mkDesc(text, i) {
+  return {
+    nodes: [{
+      type: "PARAGRAPH", id: `desc-${i}`,
+      nodes: [{ type: "TEXT", textData: { text: text || "" } }],
+      paragraphData: { textStyle: { textAlignment: "AUTO" } },
+    }],
+    metadata: { version: 1, id: `desc-meta-${i}` },
+  };
+}
+
+// [{name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}]}] -> Wix options[]
+function buildOptions(options = []) {
+  return options.map((o) => {
+    const color = o.type === "color";
+    return {
+      name: o.name,
+      optionRenderType: color ? "SWATCH_CHOICES" : "TEXT_CHOICES",
+      choicesSettings: {
+        choices: o.choices.map((c) =>
+          color
+            ? { choiceType: "ONE_COLOR", name: c.name, colorCode: c.colorCode }
+            : { choiceType: "CHOICE_TEXT", name: typeof c === "string" ? c : c.name }),
+      },
+    };
+  });
+}
+
+// full Cartesian product of variants, each priced/stocked from the product; visible:true baked in
+function expandVariants(options = [], { price, compareAtPrice, quantity }) {
+  const base = {
+    price: {
+      actualPrice: { amount: String(price) },
+      ...(compareAtPrice ? { compareAtPrice: { amount: String(compareAtPrice) } } : {}),
+    },
+    visible: true,
+    physicalProperties: {},
+    inventoryItem: { quantity: quantity ?? 0, preorderInfo: { enabled: false } },
+  };
+  if (!options.length) return [base];
+  let combos = [[]];
+  for (const o of options) {
+    const rt = o.type === "color" ? "SWATCH_CHOICES" : "TEXT_CHOICES";
+    const names = o.choices.map((c) => (typeof c === "string" ? c : c.name));
+    combos = combos.flatMap((combo) =>
+      names.map((choiceName) => [...combo, { optionChoiceNames: { optionName: o.name, choiceName, renderType: rt } }]));
+  }
+  return combos.map((choices) => ({ ...base, choices }));
+}
+
+// ---- exported operations ----
+
+async function installStoresApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: STORES_APP_ID, enabled: true },
+  } });
+}
+
+// Clean is JUDGMENT — never auto-delete. Agent lists, decides which are obvious install samples,
+// deletes only those (SEED.md: seeding is additive; deleting real content needs the owner's OK).
+async function listProducts(ctx) {
+  const r = await req(ctx, "/stores/v3/products/query", { body: { query: { paging: { limit: 50 } } } });
+  return (r.products ?? []).map((p) => ({ id: p.id, name: p.name }));
+}
+async function deleteProducts(ctx, ids) {
+  if (!ids || !ids.length) return;
+  return req(ctx, "/stores/v3/bulk/products/delete", { body: { productIds: ids } });
+}
+
+/**
+ * Bulk-create products.
+ * @param products [{ name, description, price, compareAtPrice?, quantity,
+ *   options?: [{ name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}] }] }]
+ *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
+ *   Display-only attributes go in name/category/description, NOT options. Default: no options.
+ *   visible/physicalProperties/variant-expansion handled here.
+ * @returns [{ id, slug, revision }]  (revision feeds attachProductImages)
+ */
+async function bulkCreateProducts(ctx, products) {
+  const body = {
+    returnEntity: true,
+    products: products.map((p, i) => ({
+      name: p.name,
+      productType: "PHYSICAL",
+      physicalProperties: {},
+      visible: true,
+      visibleInPos: true,
+      description: mkDesc(p.description, i),
+      options: buildOptions(p.options),
+      variantsInfo: { variants: expandVariants(p.options, p) },
+    })),
+  };
+  const r = await req(ctx, "/stores/v3/bulk/products-with-inventory/create", { body });
+  // NB: results nest under productResults.results[].item — NOT a top-level `results`.
+  return (r.productResults?.results ?? []).map((x) => ({
+    id: x.item?.id, slug: x.item?.slug, revision: x.item?.revision,
+  }));
+}
+
+// Categories: no bulk create, and MUST be sequential — they share the @wix/stores tree revision,
+// so concurrent creates 409. Run after products (catalog can lag right after the Stores install).
+async function createCategories(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/categories/v1/categories", {
+      body: { category: { name, visible: true }, treeReference: { appNamespace: "@wix/stores", treeKey: null } },
+    });
+    out.push({ id: r.category?.id, name });
+  }
+  return out;
+}
+
+// mapping: { [categoryId]: [productId, ...] } — also sequential (same shared tree)
+async function addProductsToCategories(ctx, mapping) {
+  for (const [categoryId, productIds] of Object.entries(mapping)) {
+    await req(ctx, `/categories/v1/bulk/categories/${categoryId}/add-items`, {
+      body: {
+        items: productIds.map((catalogItemId) => ({ catalogItemId, appId: STORES_APP_ID })),
+        treeReference: { appNamespace: "@wix/stores", treeKey: null },
+      },
+    });
+  }
+}
+
+// Bulk image attach in ONE call. items: [{ id, revision, url, altText }]
+// revision comes from bulkCreateProducts' return. Wix re-hosts the image (new wixstatic id on
+// read-back) and bumps revision; media-only update preserves options/variants. Read success from
+// results[].itemMetadata.success + bulkActionMetadata.totalSuccesses.
+async function attachProductImages(ctx, items) {
+  return req(ctx, "/stores/v3/bulk/products/update", {
+    body: {
+      products: items.map((it) => ({
+        product: { id: it.id, revision: it.revision, media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
+      })),
+    },
+  });
+}
+
+module.exports = {
+  installStoresApp, listProducts, deleteProducts,
+  bulkCreateProducts, createCategories, addProductsToCategories, attachProductImages,
+};


### PR DESCRIPTION
## What
Each `wix-vibe-headless` vertical now owns its seeding: a build-time **seed module** + **SEED.md** under `references/<vertical>/seed/`, abstracting the Wix seed operations into callable functions the agent `require`s and calls with plain data (no more re-authoring the REST plumbing from prose). **base44.md STEP 4** now points at the vertical's own seed module instead of `wix-headless`'s `SEED.md` + inline-recipes — with the **`wix-docs`** skill as the fallback for anything a module doesn't cover.

| vertical | module | fns |
|---|---|---|
| storefront | `seed-store.js` | 7 |
| bookings | `seed-bookings.js` | 11 |
| events | `seed-events.js` | 6 |
| cms | `seed-cms.js` | 8 |
| blog | `seed-blog.js` | 5 |
| portfolio | `seed-portfolio.js` | 9 |
| pricing-plans | `seed-pricing-plans.js` | 5 (bookings-coverage wired) |
| restaurants | `seed-restaurants.js` | 24 (menu + ordering + reservations + experiences) |
| members | — (SEED.md: nothing to seed, self-register) | — |

## Verification status (honest)
- **storefront: live-verified** against a test store (install → bulk-create → categories → bulk-attach).
- **others: faithfully transcribed** from `wix-headless/references/inline-recipes/setup-*.md` — each module cites its source recipe and carries a **"NOT yet live-verified"** header. The `wix-docs` fallback (kept in every SEED.md + base44 STEP 4) covers transcription gaps. They should be live-verified per vertical over time; until then the fallback is the safety net.
- **install-body shape corrected** to the shape from a real verified build — `{ tenant: { tenantType: "SITE", id }, appInstance: { appDefId, enabled: true } }` — across storefront/bookings/cms (the transcribers had split on this; restaurants already had it right).
- All 8 modules pass `node --check` and load (75 functions total).

## Design notes
- Seed modules live in a `seed/` **subdir** so the STEP-1 `references/*/*.js` → `src/rest/` copy loop does **not** sweep them into the frontend bundle — they're build-time-only, `require`d from the skill path.
- One thing to confirm on a live build: that the builder's `exec_tool` can `require()` a module from the skill path (the install exec already has full Node `fs`/`require`, so it should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)