### PR TITLE
fix(wix-vibe-headless): storefront cart image is item.image.url, not item.image

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -240,7 +240,7 @@ export default function CartDrawer() {
         <>
           {lineItems.map((item) => (
             <div key={item.id}>
-              <img src={item.image} alt={item.productName?.original} />
+              <img src={item.image?.url} alt={item.productName?.original} />   {/* cart image is an object: item.image.url (NOT a bare string — don't apply the ProductCard //-fix to it) */}
               <span>{item.productName?.original}</span>
               {item.descriptionLines?.map((dl, i) => (               // variant/modifier summary Wix supplies
                 <small key={i}>{dl.name?.original}: {dl.plainText?.original || dl.colorInfo?.original}</small>


### PR DESCRIPTION
## What
The storefront reference `CartDrawer` in `references/storefront/INSTRUCTIONS.md` bound the cart thumbnail as `src={item.image}`. A Wix cart line item exposes its image as an **object** — `lineItems[].image.url` — exactly as `wix-store-cart.js`'s own JSDoc documents. `item.image` is the object, not a URL string.

## Impact (observed in a live prod build)
- Best case: `<img src={object}>` coerces to `"[object Object]"` → broken cart thumbnail.
- What actually happened in a real "Moomin Pillow Store" build: the agent grounded on this snippet and "improved" it by copying the **ProductCard `//`-protocol fix** onto the cart image — `item.image.startsWith("//")` — which threw **`url.startsWith is not a function`** and white-screened the whole app via the error boundary. The agent then patched it with a `typeof` guard that returns `null` for every line (since `item.image` is always an object), leaving cart thumbnails silently blank, and never got a verified clean render.

## Fix
`src={item.image?.url}`, plus an inline note that the cart image is already a URL object so the `//`-fix must not be applied to it — heading off the exact re-derivation that caused the crash.

The scaffold's JSDoc (`lineItems[].image.url {string}`) was already correct; only the reference component disagreed with it.