### PR TITLE
fix(wix-vibe-headless): wait for Stores V3 after install + robust seed-module loader

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -132,9 +132,9 @@ delete or overwrite existing content, even apparent sample data. If a cleanup tr
 ask the user first.
 
 Seed by calling your vertical's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and `require` its `seed-*.js`
-(build-time, via exec_tool); call its functions with your data. Gaps or an unexpected shape →
-the **`wix-docs`** skill.
+`.agents/skills/wix-vibe-headless/references/<vertical>/seed/SEED.md` and load its `seed-*.js` via
+its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
+shape → the **`wix-docs`** skill.
 
 **Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
 access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -10,7 +10,11 @@ seed operation. `require` it and call the functions with plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/blog/seed/seed-blog.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 const memberId = await seed.getAuthorMemberId(ctx);   // STEP 1 — required for every post create

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -9,7 +9,11 @@ Bookings seed operation. `require` it and call the functions with plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 await seed.installBookingsApp(ctx);                      // if the site doesn't have Wix Bookings yet

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -9,7 +9,11 @@ Wix Data seed operation. `require` it and call the functions with plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/cms/seed/seed-cms.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/cms/seed/seed-cms.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 await seed.installCmsApp(ctx);                          // if a data call returns WDE0110 (app not installed)

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -15,7 +15,11 @@ clean-up step (a fresh install ships no sample events).
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // STEP 1 — create each event as a DRAFT. TICKETING = paid tiers; RSVP = free built-in form (no fields to seed).

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -11,7 +11,11 @@ first, then thread their real ids into each project.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -10,7 +10,11 @@ plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // There is NO clean-up step — a fresh Pricing Plans install ships no sample plans.

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -12,7 +12,11 @@ with plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // ── MENU (always; the seedable core) ────────────────────────────────────────────────────────────

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -7,10 +7,14 @@ seed operation. `require` it and call the functions with plain data.
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
-const seed = require("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js");
+const fs = require("fs");
+// exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
+const seed = (() => { const m = { exports: {} };
+  new Function("module", "exports", "require", fs.readFileSync("/app/.agents/skills/wix-vibe-headless/references/storefront/seed/seed-store.js", "utf8"))(m, m.exports, require);
+  return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-await seed.installStoresApp(ctx);                       // if the site doesn't have Wix Stores yet
+await seed.installStoresApp(ctx);                       // installs if needed AND waits for the V3 catalog to be ready
 
 // Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
 // install; if what's there could be the owner's real catalog, ask first (seeding is additive).

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -35,6 +35,26 @@ async function req(ctx, path, { method = "POST", body } = {}) {
   return json;
 }
 
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A freshly installed Stores catalog transiently reports CATALOG_V1: V3 calls 428 with
+// applicationError.code === "CATALOG_V1_SITE_CALLING_CATALOG_V3_API" until provisioning settles to
+// V3. Poll a cheap V3 read until that code clears (bounded ~30s), so seeding doesn't race the
+// install. Returns once V3 is live (or after the budget — the caller's real call then surfaces it).
+async function waitForCatalogV3(ctx, { attempts = 20, delayMs = 1500 } = {}) {
+  for (let i = 0; i < attempts; i++) {
+    const res = await fetch(`${API}/stores/v3/products/query`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ctx.token}`, "wix-site-id": ctx.siteId, "Content-Type": "application/json" },
+      body: JSON.stringify({ query: { paging: { limit: 1 } } }),
+    });
+    if (res.ok) return;
+    const json = await res.json().catch(() => ({}));
+    if (json?.details?.applicationError?.code !== "CATALOG_V1_SITE_CALLING_CATALOG_V3_API") return;
+    await sleep(delayMs);
+  }
+}
+
 // plain string -> Wix rich-text description node tree (plainDescription is HTML/nodes, not text)
 function mkDesc(text, i) {
   return {
@@ -89,10 +109,16 @@ function expandVariants(options = [], { price, compareAtPrice, quantity }) {
 // ---- exported operations ----
 
 async function installStoresApp(ctx) {
-  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
-    tenant: { tenantType: "SITE", id: ctx.siteId },
-    appInstance: { appDefId: STORES_APP_ID, enabled: true },
-  } });
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: STORES_APP_ID, enabled: true },
+    } });
+  } catch {
+    // already installed is fine — the readiness wait below still confirms the V3 catalog is live
+  }
+  // Do NOT return to the caller until V3 is ready, else the first V3 seed call 428s on CATALOG_V1.
+  await waitForCatalogV3(ctx);
 }
 
 // Clean is JUDGMENT — never auto-delete. Agent lists, decides which are obvious install samples,


### PR DESCRIPTION
Two fixes for issues observed in a live prod build (a fresh Wix Stores site, seeded immediately after install).

## 1. Stores install → V3 seed race (`CATALOG_V1_SITE_CALLING_CATALOG_V3_API`)
On a fresh install, the first Catalog V3 call 428s because the site transiently reports **CATALOG_V1** until provisioning settles to V3:
```
POST /apps-installer-service/v1/app-instance/install   -> 200
POST /stores/v3/products/query                          -> 428  CATALOG_V1_SITE_CALLING_CATALOG_V3_API
```
The identical seed works on an already-installed (settled) site. Root cause: install and seed ran back-to-back with no wait.

**Fix:** `installStoresApp` now installs (idempotent) and then **polls a cheap V3 read until the `CATALOG_V1_SITE_CALLING_CATALOG_V3_API` code clears** (bounded ~30s) before returning. Seeding can no longer race the install. (Interim client-side mitigation while we ask the store platform for a synchronous provisioning / readiness signal.)

## 2. `require()` returns empty exports for the build-time seed modules
A live build spent ~5 turns because `require("…/seed-store.js")` returned `[]` in `exec_tool` (even after clearing `require.cache`), until it fell back to loading the file through a module wrapper.

**Fix:** every vertical's `SEED.md` loader now reads the file and runs it through `new Function("module","exports","require", …)` — the pattern that actually works — instead of a bare `require`. `base44.md` points at that snippet.

## Scope
- `references/storefront/seed/seed-store.js` — readiness wait.
- All 8 `references/*/seed/SEED.md` — loader snippet.
- `platforms/base44.md` — wording (kept under the 10k fetch cap: 9992 chars).