### PR TITLE
docs(wix-docs): prefer structured browse endpoint for REST API reference

### DIFF
--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-docs
-description: "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, or error before writing Wix code — never guess a Wix API from memory. A lookup is a short flow: find the right page, then read it. Two ways: (1) plain `curl` (zero dependencies) — find a page by **semantic search** (`POST /mcp-docs-search/v1/docs/search`, natural-language `{ search_term, document_type }`) **or by browsing** the docs tree as a menu from the `llms.txt` root (append `.md` to any docs path), then read the page by appending `.md` to its URL; and (2) the Wix MCP doc tools when your agent has them. Triggers: look up a Wix API, find the Wix endpoint/method, confirm a Wix request body or field, verify a Wix API shape, explore Wix docs, which Wix API do I call, read a Wix method schema."
+description: "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, or error before writing Wix code — never guess a Wix API from memory. A lookup is a short flow: find the right page, then read it. Two ways: (1) plain `curl` (zero dependencies) — find a page by **semantic search** (`POST /mcp-docs-search/v1/docs/search`, natural-language `{ search_term, document_type }`) **or by browsing** the docs tree as a menu — a structured, typed, counted browse of the REST API reference (`POST /mcp-docs-search/v1/docs/menu/browse`), or the `.md` menu tree from the `llms.txt` root for any portal — then read the page by appending `.md` to its URL; and (2) the Wix MCP doc tools when your agent has them. Triggers: look up a Wix API, find the Wix endpoint/method, confirm a Wix request body or field, verify a Wix API shape, explore Wix docs, which Wix API do I call, read a Wix method schema."
 ---
 
 # Wix Docs — look up the Wix API/SDK documentation
@@ -54,8 +54,40 @@ curl -sS -X POST 'https://www.wixapis.com/mcp-docs-search/v1/docs/search' \
 # no jq? → python3 -c 'import sys,json;[print(r["title"],r["url"]) for r in json.load(sys.stdin)["results"] if r.get("url")]'
 ```
 
-**B. Browse the tree from the root, like a menu.** Every docs path has a `.md` twin, so you can
-navigate the docs as a menu tree — no search needed. `curl https://dev.wix.com/docs/llms.txt` is the
+**B. Browse the docs tree as a menu.** Two ways: the **structured browse endpoint** for the REST
+API reference (preferred there — typed, counted, filterable), and the **`.md` menu tree** for every
+portal and for reading pages.
+
+**B1. Structured browse — REST API reference (`api-reference`).** `POST
+/mcp-docs-search/v1/docs/menu/browse` walks the tree and returns each child with its **kind**, its
+**HTTP verb** (for methods), and **subtree counts** ("Catalog V3 — 121 methods, 32 articles"), so
+you pick the right area by shape — in ~2 KB, not a ~40 KB menu page you have to `grep`. `include`,
+`name_filter`, and `depth` jump straight to what you want. Body: `menu_url?` (absolute docs URL;
+omit for the portal root — the top-level verticals), `document_type?` (`REST`, default), `depth?`
+(1, max 6), `include?` (`CATEGORY`·`RESOURCE`·`METHOD`·`ARTICLE`·`WEBHOOK`·`OBJECT`·`SKILL`),
+`deprecated?` (`HIDE` default·`SHOW`·`ONLY`), `name_filter?`, `format?` (`MARKDOWN` default →
+`content` string; `STRUCTURED` → JSON tree with `url`/`http_method`/`resource_id`/`child_counts`).
+
+```bash
+# a vertical's structure, with per-child subtree counts
+curl -sS -X POST 'https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"menu_url":"https://dev.wix.com/docs/api-reference/business-solutions/stores"}' \
+  | jq -r '.content'
+
+# jump straight to a method by name — no multi-level grep
+curl -sS -X POST 'https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"menu_url":"https://dev.wix.com/docs/api-reference/business-solutions/bookings","include":["METHOD"],"name_filter":"cancel","depth":4}' \
+  | jq -r '.content'
+```
+
+REST (`api-reference`) only, and browse-only: it hands you the page **URL** — read it by appending
+`.md` (§2), and get the exact schema from §C.
+
+**B2. `.md` menu tree — every portal, and how you read pages.** Every docs path has a `.md` twin, so
+you can navigate any portal with zero dependencies; use it for the **non-REST portals** (SDK, Velo,
+Headless, CLI) and to read leaves. `curl https://dev.wix.com/docs/llms.txt` is the
 top-level map; the portals under it:
 
 | Portal | Start here for |


### PR DESCRIPTION
## Summary
Updates the `wix-docs` skill's browse section (§1B) to lead with the new **structured browse endpoint** for the REST API reference, while **keeping** the `.md` menu-tree drill for everything else.

**B1 (new, preferred for `api-reference`):** `POST /mcp-docs-search/v1/docs/menu/browse` returns typed children + HTTP verbs + subtree counts ("Catalog V3 — 121 methods, 32 articles"), with `include` / `name_filter` / `depth` — ~2 KB and no grep, vs. grepping a ~40 KB `.md` menu page level by level.

**B2 (demoted, not removed):** the `.md` menu tree from the `llms.txt` root — still the way to browse the **non-REST portals** (SDK, Velo, Headless, CLI) and to **read** leaf pages. Table, drill example, and `EXTRACTING.md` reference all retained.

Frontmatter description updated to mention both browse paths.

## Why
The `.md` menu pages are `get-menu-content`-rendered markdown — no node types, no counts, no verbs, no filtering. The browse endpoint reads the structured menu tree, so it gives all of that and lets an agent jump straight to a method by name instead of drilling+grepping each level.

## Scope / caveats (stated in the skill)
- Browse endpoint is **REST (`api-reference`) only** for now; non-REST portals stay on the `.md` tree.
- It's **browse-only** — hands back the page URL; reading a page is still `.md` (§2), exact schema still §C.

## Test plan
- Endpoint is live in prod (`www.wixapis.com/mcp-docs-search/v1/docs/menu/browse`, GA'd) — both curl examples in the diff were run against prod and return the shown output.
- Docs-only change to one SKILL.md; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)