### PR TITLE
feat(seed): one-call setup<Vertical> orchestrators + strictly-additive seeding

### DIFF
--- a/skills/wix-base44-headless/templates/bookings/TEMPLATE.md
+++ b/skills/wix-base44-headless/templates/bookings/TEMPLATE.md
@@ -78,7 +78,6 @@ import Home from "@/pages/Home";   // <- the home page YOU build
 ```
 
 ## 5. Seed (build-time, via exec_tool — see `seed/seed-bookings.js` header + SEED for exact calls)
-Order matters: **staff + category BEFORE services; class sessions AFTER.**
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
 const { WIX_METASITE_ID } = require("/app/src/wix.config.json");   // the file you filled in step 2
@@ -91,23 +90,19 @@ const s = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-await s.installBookingsApp(ctx);                          // if Wix Bookings isn't installed yet
-const staff = await s.queryStaff(ctx);                    // fresh install has a default owner
-const resourceId = staff[0].resourceId;                   // NB: resourceId, NOT id
-const cats = await s.createCategories(ctx, ["Our Services"]);   // every service needs a category id
-const services = await s.createServices(ctx, [
-  { type: "APPOINTMENT", name: "…", description: "…", price: 75, duration: 60, categoryId: cats[0].id, staffMemberIds: [resourceId] },
-  { type: "CLASS", name: "…", description: "…", price: 20, capacity: 20, categoryId: cats[0].id },
-]);
-await s.scheduleClassSessions(ctx, services.filter(x => x.type === "CLASS").map(x => ({
-  scheduleId: x.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
-})));
-// imagery ON only: generate images, then per-service revision-checked patch:
-// await s.attachServiceImage(ctx, { serviceId: x.id, revision: x.revision, image: { id, url, width, height } });
+// ONE call: install → resolve staff → categories → services → CLASS sessions → images, in the
+// right order, ids kept in memory. `category` is a NAME. Free service: free:true, omit price.
+await s.setupBookings(ctx, {
+  services: [
+    { type: "APPOINTMENT", name: "…", description: "…", price: 75, duration: 60, category: "Our Services" },
+    { type: "CLASS", name: "…", description: "…", price: 20, capacity: 20, category: "Our Services",
+      sessions: [{ start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00" }] },
+  ],
+});
 ```
-Seeding is **additive** — never delete/overwrite existing content; if a cleanup seems needed, ask
-first. Both bulk calls report per-item `success`/`error` — retry only failed items once. Unexpected
-shape or an uncovered operation → the **`wix-docs`** skill; never guess.
+Seeding is **additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, just add. Both bulk calls report per-item `success`/`error` — retry only failed items
+once. Unexpected shape or an uncovered operation → the **`wix-docs`** skill; never guess.
 
 ## 6. Done
 - Point the user to `https://manage.wix.com/dashboard/{metaSiteId}`; slots only appear once **staff

--- a/skills/wix-base44-headless/templates/bookings/seed/seed-bookings.js
+++ b/skills/wix-base44-headless/templates/bookings/seed/seed-bookings.js
@@ -235,7 +235,66 @@ async function attachServiceImage(ctx, it) {
   });
 }
 
+/**
+ * ONE-CALL seed: install → resolve staff → categories → services → CLASS sessions → images, in the
+ * correct order, keeping ids in memory (no hand-threading of scheduleId/resourceId across exec
+ * calls). DEFAULT path — call it once instead of the individual functions.
+ *
+ * @param plan {{
+ *   services: [{ type:"APPOINTMENT"|"CLASS", name, description, tagLine?, price?, free?, duration?,
+ *                capacity?, category?(name), staffMemberIds?,
+ *                sessions?: [{ start, end, capacity? }],  // CLASS only; local "YYYY-MM-DDThh:mm:ss"
+ *                image? }],                                // {id,url,width,height} to attach, optional
+ *   staffResourceId?: string,   // defaults to the fresh install's owner (queryStaff()[0].resourceId)
+ * }}
+ * Cleanup is intentionally NOT here — deleting existing services is a judgment call.
+ * @returns { services:[...createServices], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
+ */
+async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
+  await installBookingsApp(ctx);
+
+  let resourceId = staffResourceId;
+  if (!resourceId) {
+    const staff = await queryStaff(ctx);
+    resourceId = staff[0]?.resourceId; // fresh install ships a default owner
+  }
+
+  const catNames = [...new Set(services.map((s) => s.category).filter(Boolean))];
+  const cats = catNames.length ? await createCategories(ctx, catNames) : [];
+  const catIdByName = new Map(cats.map((c) => [c.name, c.id]));
+
+  const created = await createServices(ctx, services.map((s) => ({
+    type: s.type, name: s.name, description: s.description, tagLine: s.tagLine,
+    price: s.price, free: s.free, duration: s.duration, capacity: s.capacity,
+    categoryId: s.category ? catIdByName.get(s.category) : undefined,
+    staffMemberIds: s.staffMemberIds ?? (s.type === "APPOINTMENT" && resourceId ? [resourceId] : undefined),
+  })));
+
+  const sessions = [];
+  created.forEach((c, i) => {
+    const plan = services[i];
+    if (c.type === "CLASS" && Array.isArray(plan?.sessions)) {
+      for (const ses of plan.sessions) {
+        sessions.push({ scheduleId: c.scheduleId, resourceId, start: ses.start, end: ses.end, capacity: ses.capacity ?? plan.capacity });
+      }
+    }
+  });
+  const scheduled = sessions.length ? await scheduleClassSessions(ctx, sessions) : [];
+
+  let imagesAttached = 0;
+  for (let i = 0; i < created.length; i++) {
+    const img = services[i]?.image;
+    if (img && created[i]?.id) {
+      await attachServiceImage(ctx, { serviceId: created[i].id, revision: created[i].revision, image: img });
+      imagesAttached++;
+    }
+  }
+
+  return { services: created, categories: cats, resourceId, sessionsScheduled: scheduled.length, imagesAttached };
+}
+
 module.exports = {
+  setupBookings,
   installBookingsApp, listServices, deleteServices,
   queryStaff, createStaff, queryCategories, createCategories,
   createServices, scheduleClassSessions, getService, attachServiceImage,

--- a/skills/wix-base44-headless/templates/storefront/TEMPLATE.md
+++ b/skills/wix-base44-headless/templates/storefront/TEMPLATE.md
@@ -97,18 +97,18 @@ const s = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-await s.installStoresApp(ctx);                    // if Wix Stores isn't installed yet
-const products = await s.bulkCreateProducts(ctx, [
-  { name: "…", description: "…", price: 49.99, quantity: 12 /*, options? only for real buyer choices */ },
-]);
-const cats = await s.createCategories(ctx, ["…"]);            // only if the brief names categories
-await s.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
-// imagery: generate per-product images, then ONE bulk attach:
-await s.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, revision: p.revision, url: imageUrls[i], altText: p.slug })));
+// ONE call: install (+wait for V3) → products → categories → images, ids kept in memory.
+// categories map name -> product NAMES; imageUrl per product only when imagery is on.
+await s.setupStore(ctx, {
+  products: [
+    { name: "…", description: "…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] /*, options? only for real buyer choices */ },
+  ],
+  categories: { "…": ["…"] },   // omit if the brief names none
+});
 ```
-Seeding is **additive** — never delete/overwrite existing content; if a cleanup seems needed, ask
-first. Unexpected shape or an operation the module doesn't cover → the **`wix-docs`** skill; never
-guess.
+Seeding is **additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, just add. Unexpected shape or an operation the module doesn't cover → the
+**`wix-docs`** skill; never guess.
 
 ## 6. Done
 - Mount the dev-only manage banner if the app carries `wix-manage-banner.js` (links to the Wix back

--- a/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
+++ b/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
@@ -201,7 +201,47 @@ async function attachProductImages(ctx, items) {
   });
 }
 
+/**
+ * ONE-CALL seed: install → create products → categories → attach images, in the correct order,
+ * keeping the created ids in memory (no hand-threading of product ids across exec calls). This is
+ * the DEFAULT path — call it once instead of the individual functions.
+ *
+ * @param plan {{
+ *   products: [{ name, description, price, compareAtPrice?, quantity, options?, imageUrl?, altText? }],
+ *   categories?: { [categoryName]: string[] },   // map of category name -> product NAMES in it
+ * }}
+ * Cleanup is intentionally NOT here — deleting existing content is a judgment call; do it explicitly
+ * with listProducts/deleteProducts first if (and only if) the site holds obvious install samples.
+ * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number }
+ */
+async function setupStore(ctx, { products = [], categories = {} } = {}) {
+  await installStoresApp(ctx); // installs if needed AND waits for the V3 catalog to be ready
+
+  const created = await bulkCreateProducts(ctx, products);
+  const withNames = created.map((p, i) => ({ ...p, name: products[i]?.name }));
+  const idByName = new Map(withNames.map((p) => [p.name, p.id]));
+
+  const names = Object.keys(categories);
+  const cats = names.length ? await createCategories(ctx, names) : [];
+  if (cats.length) {
+    const mapping = {};
+    for (const c of cats) {
+      const ids = (categories[c.name] || []).map((n) => idByName.get(n)).filter(Boolean);
+      if (ids.length) mapping[c.id] = ids;
+    }
+    if (Object.keys(mapping).length) await addProductsToCategories(ctx, mapping);
+  }
+
+  const imageItems = withNames
+    .map((p, i) => ({ id: p.id, revision: p.revision, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
+    .filter((it) => it.url);
+  if (imageItems.length) await attachProductImages(ctx, imageItems);
+
+  return { products: withNames, categories: cats, imagesAttached: imageItems.length };
+}
+
 module.exports = {
+  setupStore,
   installStoresApp, listProducts, deleteProducts,
   bulkCreateProducts, createCategories, addProductsToCategories, attachProductImages,
 };

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -7,6 +7,10 @@ seed operation. `require` it and call the functions with plain data.
 > **NOT yet live-verified — transcribed from `setup-blog.md`.** Endpoints/fields mirror the recipe
 > exactly; if a call returns an unexpected shape, use the **`wix-docs`** skill (never guess).
 
+**DEFAULT — one call.** `setupBlog(ctx, plan)` runs the whole flow (memberId → categories/tags →
+posts → covers), keeping every id in memory. Pass category/tag **names** and it resolves them to
+ids internally; covers attach only for posts that carry a WixMedia file id.
+
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
@@ -17,6 +21,29 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
+const result = await seed.setupBlog(ctx, {
+  categories: ["Recipes", "Brewing"],   // optional — names, resolved to ids internally
+  posts: [
+    { title: "How We Roast Our Beans", category: "Recipes", tags: ["coffee"],
+      content: [
+        { type: "heading", text: "From farm to cup", level: 2 },
+        { type: "paragraph", text: "Every batch starts with beans from a single estate." },
+        { type: "quote", text: "Great coffee is grown, not made." },
+      ],
+      // imagery ON only: import per IMAGE_GENERATION.md, then pass the WixMedia file id here
+      coverImageUrl: fileIds[0],
+    },
+  ],
+});
+// → { posts:[{id,index,success}], categories:[{id,name}], tags:[{id,name}], coversAttached }
+// check each posts[].success (bulk returns 200 even on partial failure).
+```
+
+## Escape hatch — individual functions
+
+Call the steps yourself when you need finer control (custom ordering, reusing existing ids):
+
+```js
 const memberId = await seed.getAuthorMemberId(ctx);   // STEP 1 — required for every post create
 
 // STEP 3 (optional): only if the request groups posts (e.g. "Recipes and Brewing sections")
@@ -38,6 +65,7 @@ await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fi
 ## Functions
 | fn | does |
 |---|---|
+| `setupBlog(ctx, plan)` | **DEFAULT** — one call: memberId → categories/tags → posts → covers; names resolved to ids internally → `{posts,categories,tags,coversAttached}` |
 | `getAuthorMemberId(ctx)` | STEP 1 — fetch a real member id for author attribution (throws if none) |
 | `createPosts(ctx, posts, { memberId })` | STEP 2 — auto single-vs-bulk create, published → `[{id,index,success}]` |
 | `createCategories(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.categoryIds`) |

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -178,6 +178,44 @@ async function attachPostCovers(ctx, covers) {
   }
 }
 
+/**
+ * DEFAULT one-call path — seed a whole blog in ONE exec call. Resolves the author memberId and
+ * category/tag names → ids internally and keeps every id in memory, so nothing is hand-threaded
+ * across exec calls. Order: memberId → categories/tags → posts (with resolved ids) → covers.
+ * @param plan {
+ *   posts: [{ title, content?|richContent?, category?|categories?(name|names), tags?(names), coverImageUrl?|cover?(WixMedia fileId) }],
+ *   categories?: [name],  // pre-create categories even if no post references them
+ *   tags?: [name],
+ * }
+ *   category/categories/tags are display NAMES (resolved to ids here); cover/coverImageUrl is the
+ *   WixMedia file id — a cover is attached only for posts that provide one.
+ * @returns { posts:[{id,index,success}], categories:[{id,name}], tags:[{id,name}], coversAttached }
+ */
+async function setupBlog(ctx, { posts = [], categories = [], tags = [] } = {}) {
+  const memberId = await getAuthorMemberId(ctx);
+  const catNames = [...new Set([...categories, ...posts.flatMap((p) => [].concat(p.category ?? [], p.categories ?? []))])];
+  const tagNames = [...new Set([...tags, ...posts.flatMap((p) => [].concat(p.tags ?? []))])];
+  const cats = catNames.length ? await createCategories(ctx, catNames) : [];
+  const tgs = tagNames.length ? await createTags(ctx, tagNames) : [];
+  const catId = new Map(cats.map((c) => [c.name, c.id]));
+  const tagId = new Map(tgs.map((t) => [t.name, t.id]));
+  const created = await createPosts(ctx, posts.map((p) => {
+    const cn = [].concat(p.category ?? [], p.categories ?? []);
+    const tn = [].concat(p.tags ?? []);
+    return {
+      ...p,
+      ...(cn.length ? { categoryIds: cn.map((n) => catId.get(n)).filter(Boolean) } : {}),
+      ...(tn.length ? { tagIds: tn.map((n) => tagId.get(n)).filter(Boolean) } : {}),
+    };
+  }), { memberId });
+  const covers = created
+    .map((post, i) => ({ postId: post.id, fileId: posts[i]?.coverImageUrl ?? posts[i]?.cover }))
+    .filter((c) => c.postId && c.fileId);
+  if (covers.length) await attachPostCovers(ctx, covers);
+  return { posts: created, categories: cats, tags: tgs, coversAttached: covers.length };
+}
+
 module.exports = {
+  setupBlog,
   getAuthorMemberId, createPosts, createCategories, createTags, attachPostCovers,
 };

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -2,7 +2,7 @@
 
 Seed a Wix Bookings catalog by **calling `seed-bookings.js`** — don't hand-write the REST calls.
 It's a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix
-Bookings seed operation. `require` it and call the functions with plain data.
+Bookings seed operation. Load it and call **`setupBookings` — the one-call path** — with plain data.
 
 > **Transcribed from `wix-headless/references/inline-recipes/setup-bookings.md` — NOT yet live-verified.**
 
@@ -16,40 +16,33 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-await seed.installBookingsApp(ctx);                      // if the site doesn't have Wix Bookings yet
-
-// Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
-// install; if what's there could be the owner's real services, ask first (seeding is additive).
-const existing = await seed.listServices(ctx);
-// await seed.deleteServices(ctx, existing.filter(isObviousSample).map(s => s.id));
-
-// ⚠️ ORDER: staff (STEP 1) + category (STEP 2) BEFORE services (STEP 3); sessions (STEP 4) AFTER.
-const staff = await seed.queryStaff(ctx);                // fresh install has a default "Business Owner"
-const resourceId = staff[0].resourceId;                  // NB: resourceId, NOT staff.id
-const cats = await seed.createCategories(ctx, ["Our Services"]);   // fresh install ships ZERO categories
-
-const services = await seed.createServices(ctx, [
-  { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…",
-    price: 75, duration: 60, categoryId: cats[0].id, staffMemberIds: [resourceId] },
-  { type: "CLASS", name: "Morning Yoga", description: "…", capacity: 20,
-    price: 20, categoryId: cats[0].id },   // free service: set free:true, omit price
-]);
-
-// CLASS only — needs each class's returned scheduleId, else its calendar is empty:
-await seed.scheduleClassSessions(ctx, services.filter(s => s.type === "CLASS").map(s => ({
-  scheduleId: s.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
-})));
+// ONE call: install → resolve staff → categories → services → CLASS sessions → images, all in the
+// correct order with ids kept in memory (no hand-threading of scheduleId/resourceId). `category` is
+// a NAME (resolved to an id internally). Free service: set free:true, omit price. CLASS `sessions`
+// are local "YYYY-MM-DDThh:mm:ss".
+const result = await seed.setupBookings(ctx, {
+  services: [
+    { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…", price: 75, duration: 60, category: "Our Services" },
+    { type: "CLASS", name: "Morning Yoga", description: "…", price: 20, capacity: 20, category: "Our Services",
+      sessions: [{ start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00" }] },
+  ],
+  // staffResourceId defaults to the fresh install's owner (queryStaff()[0].resourceId).
+});
+// result: { services:[...], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
 
 // imagery ON only: generate per IMAGE_GENERATION.md, then patch each service (revision-checked):
 // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
 ```
 
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add. Need finer control than `setupBookings`? The individual
+functions below still exist (setupBookings is built from them, in the order shown).
+
 ## Functions
 | fn | does |
 |---|---|
+| `setupBookings(ctx, {services, staffResourceId?})` | **one-call**: install → staff → categories → services → CLASS sessions → images |
 | `installBookingsApp(ctx)` | install the Wix Bookings app on the site |
-| `listServices(ctx)` | `[{id,name}]` — for the sample-cleanup judgment |
-| `deleteServices(ctx, ids)` | delete each service (only obvious samples) |
 | `queryStaff(ctx)` | `[{resourceId,id,name}]` — STEP 1; use `resourceId`, not `id` |
 | `createStaff(ctx, [{name,description}])` | create named staff → `[{resourceId,id,name}]` (omit email/phone) |
 | `queryCategories(ctx)` | `[{id,name}]` — reuse a category created earlier this run |

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -235,7 +235,66 @@ async function attachServiceImage(ctx, it) {
   });
 }
 
+/**
+ * ONE-CALL seed: install → resolve staff → categories → services → CLASS sessions → images, in the
+ * correct order, keeping ids in memory (no hand-threading of scheduleId/resourceId across exec
+ * calls). DEFAULT path — call it once instead of the individual functions.
+ *
+ * @param plan {{
+ *   services: [{ type:"APPOINTMENT"|"CLASS", name, description, tagLine?, price?, free?, duration?,
+ *                capacity?, category?(name), staffMemberIds?,
+ *                sessions?: [{ start, end, capacity? }],  // CLASS only; local "YYYY-MM-DDThh:mm:ss"
+ *                image? }],                                // {id,url,width,height} to attach, optional
+ *   staffResourceId?: string,   // defaults to the fresh install's owner (queryStaff()[0].resourceId)
+ * }}
+ * Cleanup is intentionally NOT here — deleting existing services is a judgment call.
+ * @returns { services:[...createServices], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
+ */
+async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
+  await installBookingsApp(ctx);
+
+  let resourceId = staffResourceId;
+  if (!resourceId) {
+    const staff = await queryStaff(ctx);
+    resourceId = staff[0]?.resourceId; // fresh install ships a default owner
+  }
+
+  const catNames = [...new Set(services.map((s) => s.category).filter(Boolean))];
+  const cats = catNames.length ? await createCategories(ctx, catNames) : [];
+  const catIdByName = new Map(cats.map((c) => [c.name, c.id]));
+
+  const created = await createServices(ctx, services.map((s) => ({
+    type: s.type, name: s.name, description: s.description, tagLine: s.tagLine,
+    price: s.price, free: s.free, duration: s.duration, capacity: s.capacity,
+    categoryId: s.category ? catIdByName.get(s.category) : undefined,
+    staffMemberIds: s.staffMemberIds ?? (s.type === "APPOINTMENT" && resourceId ? [resourceId] : undefined),
+  })));
+
+  const sessions = [];
+  created.forEach((c, i) => {
+    const plan = services[i];
+    if (c.type === "CLASS" && Array.isArray(plan?.sessions)) {
+      for (const ses of plan.sessions) {
+        sessions.push({ scheduleId: c.scheduleId, resourceId, start: ses.start, end: ses.end, capacity: ses.capacity ?? plan.capacity });
+      }
+    }
+  });
+  const scheduled = sessions.length ? await scheduleClassSessions(ctx, sessions) : [];
+
+  let imagesAttached = 0;
+  for (let i = 0; i < created.length; i++) {
+    const img = services[i]?.image;
+    if (img && created[i]?.id) {
+      await attachServiceImage(ctx, { serviceId: created[i].id, revision: created[i].revision, image: img });
+      imagesAttached++;
+    }
+  }
+
+  return { services: created, categories: cats, resourceId, sessionsScheduled: scheduled.length, imagesAttached };
+}
+
 module.exports = {
+  setupBookings,
   installBookingsApp, listServices, deleteServices,
   queryStaff, createStaff, queryCategories, createCategories,
   createServices, scheduleClassSessions, getService, attachServiceImage,

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -16,10 +16,51 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
+// DEFAULT — one call runs install → create each collection → insert items → attach images → wire
+// references, keeping created item ids in memory. Reference an item by its caller-chosen `_key`
+// (unique across the whole plan) — no ids to paste. Which collections/fields/counts/images come
+// from the request, not this module. Public-read is the default (override per collection via
+// `permissions`: PERMISSIONS.collaborative | memberPrivate | memberSharedReadOnly).
+const summary = await seed.setupCms(ctx, {
+  collections: [
+    { id: "categories", displayName: "Categories",
+      fields: [{ key: "name", displayName: "Name", type: "TEXT" }],
+      items: [
+        { _key: "cat-dessert", name: "Dessert" },
+        { _key: "cat-main",    name: "Mains" },
+      ] },
+    { id: "recipes", displayName: "Recipes",
+      fields: [
+        { key: "title", displayName: "Title", type: "TEXT" },
+        { key: "photo", displayName: "Photo", type: "IMAGE" },
+        // MULTI_REFERENCE → categories; typeMetadata.multiReference.referencedCollectionId is MANDATORY (STEP 1 note)
+        { key: "categories", displayName: "Categories", type: "MULTI_REFERENCE",
+          typeMetadata: { multiReference: { referencedCollectionId: "categories" } } },
+      ],
+      items: [
+        // image ON only: fileUrl generated per IMAGE_GENERATION.md; drop `image` to leave the item text-only
+        { _key: "recipe-cake", title: "Chocolate Cake", image: { fieldKey: "photo", url: fileUrl } },
+      ] },
+  ],
+  // optional — omit when nothing relates. Keys resolve to the created ids from `_key`.
+  references: [
+    { collectionId: "recipes", referringItemFieldName: "categories",
+      referringItemKey: "recipe-cake", referencedItemKey: "cat-dessert" },
+  ],
+});
+// summary = { collections, itemIdsByCollection, referencesInserted, imagesAttached }
+```
+
+## Escape hatch — individual steps
+
+Call the low-level fns directly when `setupCms` doesn't fit (e.g. verifying persistence mid-flow, or a
+shape the plan can't express). Order: install → createCollection → bulkInsertItems → queryItems (verify)
+→ insertReferences (cross-collection) → attachItemImage.
+
+```js
 await seed.installCmsApp(ctx);                          // if a data call returns WDE0110 (app not installed)
 
-// STEP 1 — create each collection BEFORE inserting its items. Public-read is the default (a headless
-// visitor reads but can't elevate). Which collections/fields/counts come from the request, not this module.
+// STEP 1 — create each collection BEFORE inserting its items (public-read default).
 const col = await seed.createCollection(ctx, {
   id: "team-members", displayName: "Team Members",
   fields: [
@@ -54,6 +95,7 @@ await seed.attachItemImage(ctx, "team-members", { itemId: items[0].id, imageFiel
 ## Functions
 | fn | does |
 |---|---|
+| `setupCms(ctx, {collections, references?})` | **DEFAULT** — one call: install → create+insert each collection → attach images → wire references, keeping ids in memory (reference items by `_key`) → `{collections, itemIdsByCollection, referencesInserted, imagesAttached}` |
 | `installCmsApp(ctx)` | install the Wix Data (CMS) app on the site |
 | `createCollection(ctx, {id, displayName, fields, permissions?})` | STEP 1 — create one collection → the created collection (default `PERMISSIONS.publicRead`) |
 | `bulkInsertItems(ctx, collectionId, items)` | STEP 2 — one bulk insert of plain-field items → `[{id,data}]` |

--- a/skills/wix-vibe-headless/references/cms/seed/seed-cms.js
+++ b/skills/wix-vibe-headless/references/cms/seed/seed-cms.js
@@ -167,7 +167,63 @@ async function attachItemImage(ctx, dataCollectionId, { itemId, imageFieldKey, u
   return req(ctx, `/wix-data/v2/items/${itemId}`, { method: "PUT", body: { dataCollectionId, dataItem: { data } } });
 }
 
+// strip seed-only metadata (_key handle, image spec) so only real fields reach the insert
+const stripSeedMeta = ({ _key, image, ...fields }) => fields;
+
+/**
+ * DEFAULT one-call path — run the whole CMS seed (install → per-collection create+insert → images →
+ * cross-collection references) in ONE exec_tool call, keeping created item ids in memory so references
+ * and image attaches resolve WITHOUT the caller hand-threading ids across calls.
+ *
+ * @param plan {
+ *   collections: [{ id, displayName, fields, permissions?,       // fields/permissions per createCollection
+ *     items: [{ ...plainFields, _key?, image?: { fieldKey, url } }] }],  // _key = stable handle; image = attach spec
+ *   references?: [{ collectionId, referringItemFieldName, referringItemKey, referencedItemKey }],  // keys → ids via _key
+ * }
+ *   _key is a caller-chosen stable handle (unique across the whole plan) used to point references and
+ *   images at an item without pasting Wix ids. Optional pieces run only when present: an item's image
+ *   only when it carries `image.url`; references only when the array is non-empty.
+ * @returns { collections:[id], itemIdsByCollection:{[id]:[itemId]}, referencesInserted, imagesAttached }
+ */
+async function setupCms(ctx, { collections = [], references = [] } = {}) {
+  await installCmsApp(ctx);
+  const idByKey = new Map(); // _key -> created item id (resolves references + images, cross-collection)
+  const itemIdsByCollection = {};
+  let imagesAttached = 0;
+
+  for (const { id, displayName, fields, permissions, items = [] } of collections) {
+    await createCollection(ctx, { id, displayName, fields, permissions });
+    const created = await bulkInsertItems(ctx, id, items.map(stripSeedMeta));
+    itemIdsByCollection[id] = created.map((c) => c.id);
+    items.forEach((item, i) => { if (item._key != null) idByKey.set(item._key, created[i].id); });
+    for (let i = 0; i < items.length; i++) {
+      const img = items[i].image;
+      if (!img?.url) continue; // images ON only — leave the item text-only otherwise
+      await attachItemImage(ctx, id, { itemId: created[i].id, imageFieldKey: img.fieldKey, url: img.url });
+      imagesAttached++;
+    }
+  }
+
+  // group by referring collection so each collection's links go in ONE insert-references call
+  const byCollection = {};
+  for (const r of references) {
+    (byCollection[r.collectionId] ??= []).push({
+      referringItemFieldName: r.referringItemFieldName,
+      referringItemId: idByKey.get(r.referringItemKey) ?? r.referringItemKey,
+      referencedItemId: idByKey.get(r.referencedItemKey) ?? r.referencedItemKey,
+    });
+  }
+  let referencesInserted = 0;
+  for (const [collectionId, refs] of Object.entries(byCollection)) {
+    await insertReferences(ctx, collectionId, refs);
+    referencesInserted += refs.length;
+  }
+
+  return { collections: collections.map((c) => c.id), itemIdsByCollection, referencesInserted, imagesAttached };
+}
+
 module.exports = {
+  setupCms,
   PERMISSIONS,
   installCmsApp, createCollection,
   bulkInsertItems, insertItem, queryItems,

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -22,8 +22,32 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
+// DEFAULT — one call runs the whole flow per event (create DRAFT → tiers → publish), then resolves
+// category NAMES → ids + assigns and attaches main images. Ids are kept in memory; nothing is
+// hand-threaded across exec calls. Dates MUST be in the future (ISO-8601 UTC); default ~60–90 days
+// out and note it if the request gives none. price is a decimal STRING; ticket name <= 30 chars;
+// omit ticketTiers for RSVP/free, omit image when imagery is off. height/width REQUIRED or it won't render.
+const summary = await seed.setupEvents(ctx, {
+  events: [{
+    title: "Summer Synth Festival", shortDescription: "One night of analog sound.",
+    type: "TICKETING", startDate: "2026-10-01T03:30:00.000Z", endDate: "2026-10-01T07:00:00.000Z",
+    timeZoneId: "America/Los_Angeles",
+    location: { name: "The Echo Lot", type: "VENUE", address: { addressLine: "120 Harbor St", city: "Seattle", subdivision: "US-WA", postalCode: "98101", country: "US" } },
+    ticketTiers: [{ name: "General Admission", price: "65.00", initialLimit: 200 }],
+    category: "Talks",
+    image: { id: file.id, url: file.url, height: 1024, width: 1024 }, // altText defaults to the event slug
+  }],
+});
+// summary -> { events: [{ id, slug, ticketCount, category }], categories: [{ id, name }], imagesAttached }
+```
+
+### Escape hatch — individual steps
+
+Call the step functions directly only when `setupEvents` doesn't fit (e.g. re-running a single step,
+or a shape it doesn't model). Same order applies: create DRAFT → (ticketed) tiers → publish → categories → image.
+
+```js
 // STEP 1 — create each event as a DRAFT. TICKETING = paid tiers; RSVP = free built-in form (no fields to seed).
-// Dates MUST be in the future (ISO-8601 UTC); default ~60–90 days out and note it if the request gives none.
 const ev = await seed.createEvent(ctx, {
   title: "Summer Synth Festival", shortDescription: "One night of analog sound.",
   type: "TICKETING", startDate: "2026-10-01T03:30:00.000Z", endDate: "2026-10-01T07:00:00.000Z",
@@ -53,6 +77,7 @@ Free/RSVP events need neither.
 ## Functions
 | fn | does |
 |---|---|
+| `setupEvents(ctx, {events})` | **DEFAULT** — one call: per event create DRAFT → tiers → publish, then resolve category names → assign + attach images → `{events, categories, imagesAttached}` |
 | `createEvent(ctx, event)` | STEP 1 — create ONE draft event (no bulk; loop for many) → `{id, slug}` |
 | `createTicketTiers(ctx, eventId, tiers)` | STEP 2 — TICKETING only, parallel batch → `[{id}]` |
 | `publishEvent(ctx, eventId)` | STEP 3 — publish (one-way) |

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -167,7 +167,47 @@ async function setEventMainImage(ctx, item) {
   });
 }
 
+/**
+ * ONE-CALL seed: per event create DRAFT → (ticketed) add tiers → publish, then create + assign
+ * named categories and attach main images — in the correct order, keeping created ids in memory
+ * (no hand-threading of event ids across exec calls). DEFAULT path.
+ * @param plan {{ events: [{
+ *   ...createEvent fields (title, shortDescription?, type, startDate, endDate, timeZoneId, location, …),
+ *   ticketTiers?: [{ name, price, initialLimit?, … }],   // TICKETING only; omit to skip
+ *   category?: string,                                     // category NAME; resolved to id + assigned
+ *   image?: { id, url, height, width, altText? }           // imagery ON only; omit to skip
+ * }] }}
+ * Cleanup is intentionally NOT here — deleting existing content is a judgment call.
+ */
+async function setupEvents(ctx, { events = [] } = {}) {
+  const created = [];
+  for (const ev of events) {
+    const e = await createEvent(ctx, ev);
+    const tiers = ev.ticketTiers?.length ? await createTicketTiers(ctx, e.id, ev.ticketTiers) : [];
+    await publishEvent(ctx, e.id);
+    created.push({ ...e, category: ev.category, image: ev.image, ticketCount: tiers.length });
+  }
+  const names = [...new Set(created.map((e) => e.category).filter(Boolean))];
+  const cats = names.length ? await createEventCategories(ctx, names) : [];
+  for (const c of cats) {
+    const eventIds = created.filter((e) => e.category === c.name).map((e) => e.id);
+    await assignEventsToCategory(ctx, c.id, eventIds);
+  }
+  let imagesAttached = 0;
+  for (const e of created) {
+    if (!e.image?.url) continue;
+    await setEventMainImage(ctx, { eventId: e.id, altText: e.slug, ...e.image });
+    imagesAttached++;
+  }
+  return {
+    events: created.map((e) => ({ id: e.id, slug: e.slug, ticketCount: e.ticketCount, category: e.category ?? null })),
+    categories: cats,
+    imagesAttached,
+  };
+}
+
 module.exports = {
+  setupEvents,
   createEvent, createTicketTiers, publishEvent,
   createEventCategories, assignEventsToCategory, setEventMainImage,
 };

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -8,6 +8,13 @@ Portfolio seed operation. `require` it and call the functions with plain data.
 that Wix does **not** validate — a wrong id silently orphans the project. Create the collections
 first, then thread their real ids into each project.
 
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add.
+
+**DEFAULT — one call.** `setupPortfolio(ctx, plan)` runs the whole flow in the right order
+(collections → projects → items → covers), threading ids in memory. Pass covers/items only when
+imagery is on. Drop to the individual functions below only for step-by-step control.
+
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
@@ -18,14 +25,26 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-// Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
-// install (the "My Portfolio" collection + its sample projects); projects BEFORE collections.
-// If what's there could be the owner's real content, ask first (seeding is additive).
-const projs = await seed.listProjects(ctx);
-// await seed.deleteProjects(ctx, projs.filter(isObviousSample).map(p => p.id));
-const cols = await seed.listCollections(ctx);
-// await seed.deleteCollections(ctx, cols.filter(isObviousSample).map(c => c.id));
+const summary = await seed.setupPortfolio(ctx, {
+  collections: [
+    { title: "Brand Identity", description: "Logo systems and visual identities." },
+  ],
+  projects: [
+    { title: "Northwind Rebrand", description: "Full identity refresh for a logistics firm.",
+      collection: "Brand Identity",                    // resolved to that collection's id
+      details: [{ label: "Year", text: "2025" }],
+      // imagery ON only — generate + import per IMAGE_GENERATION.md, then pass ids/dims:
+      cover: { imageId: ids[0], height: 2880, width: 1920 },
+      items: [{ sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }] },
+  ],
+});
+// summary => { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
+```
 
+### Escape hatch — individual functions
+Use these directly when you need step-by-step control. Same order applies.
+
+```js
 const collections = await seed.createCollections(ctx, [                                 // STEP 1
   { title: "Brand Identity", description: "Logo systems and visual identities." },
 ]);
@@ -43,10 +62,7 @@ await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, t
 ## Functions
 | fn | does |
 |---|---|
-| `listProjects(ctx)` | `[{id,title}]` — for the sample-cleanup judgment |
-| `deleteProjects(ctx, ids)` | one DELETE per id (no bulk); run before collections |
-| `listCollections(ctx)` | `[{id,title}]` |
-| `deleteCollections(ctx, ids)` | one DELETE per id (no bulk); run after projects |
+| `setupPortfolio(ctx, plan)` | **DEFAULT** — one call: collections → projects → items → covers; returns `{collections,projects,itemsCreated,coversAttached}` |
 | `createCollections(ctx, collections)` | STEP 1 — `[{title,description?,hidden?}]` → `[{id,slug,revision}]` |
 | `createProjects(ctx, projects)` | STEP 2 — `[{title,description?,collectionIds,details?,hidden?}]` → `[{id,slug,revision}]` |
 | `attachProjectCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each project's cover (imagery on) |

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -149,7 +149,57 @@ async function createProjectItems(ctx, items) {
   return out;
 }
 
+/**
+ * DEFAULT one-call path — seed a whole portfolio from one plan; ids stay in memory so
+ * collections→projects→items→covers are wired without hand-threading ids. Order matches SEED.md:
+ * createCollections → createProjects (into collections) → createProjectItems → attach*Covers.
+ * @param plan {
+ *   collections: [{ title, description?, hidden?, cover?: { imageId, height, width } }],
+ *   projects:    [{ title, description?, details?, hidden?,
+ *                   collection?: "<collection title>",   // resolved to that collection's id
+ *                   items?: [{ sortOrder, title, imageId, height, width }],
+ *                   cover?: { imageId, height, width } }],
+ * }
+ *   Covers/items are opt-in (imagery on) — a project/collection without a `cover`/`items` skips it.
+ * @returns { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
+ */
+async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
+  const cols = await createCollections(ctx, collections);               // STEP 1
+  const idByName = new Map(collections.map((c, i) => [c.title, cols[i].id]));
+
+  const projs = await createProjects(                                   // STEP 2
+    ctx,
+    projects.map((p) => ({
+      title: p.title, description: p.description, details: p.details, hidden: p.hidden,
+      collectionIds: p.collection ? [idByName.get(p.collection)].filter(Boolean) : [],
+    })),
+  );
+
+  const itemsFlat = projects.flatMap((p, i) =>
+    (p.items ?? []).map((it) => ({ ...it, projectId: projs[i].id })),
+  );
+  const items = itemsFlat.length ? await createProjectItems(ctx, itemsFlat) : [];
+
+  const projCovers = projects
+    .map((p, i) => (p.cover ? { id: projs[i].id, revision: projs[i].revision, ...p.cover } : null))
+    .filter(Boolean);
+  if (projCovers.length) await attachProjectCovers(ctx, projCovers);
+
+  const colCovers = collections
+    .map((c, i) => (c.cover ? { id: cols[i].id, revision: cols[i].revision, ...c.cover } : null))
+    .filter(Boolean);
+  if (colCovers.length) await attachCollectionCovers(ctx, colCovers);
+
+  return {
+    collections: cols,
+    projects: projs,
+    itemsCreated: items.length,
+    coversAttached: projCovers.length + colCovers.length,
+  };
+}
+
 module.exports = {
+  setupPortfolio,
   listProjects, deleteProjects, listCollections, deleteCollections,
   createCollections, createProjects,
   attachProjectCovers, attachCollectionCovers, createProjectItems,

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -19,14 +19,29 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // There is NO clean-up step — a fresh Pricing Plans install ships no sample plans.
 
-const plans = await seed.createPlans(ctx, [
-  { name: "Studio Membership", description: "Unlimited group classes.", price: "20.00",
-    type: "recurring", billingCycle: { period: "MONTH", count: 1 },
-    perks: ["Unlimited group classes", "10% off workshops"],
-    coveredServiceIds: bookingsServiceIds },  // optional — only when this plan covers bookings services
-  // …just the plan data. price = decimal STRING; currency is site-derived (don't send it).
-]);
+// DEFAULT: one call. Creates the plan(s), keeps their ids in memory, and (per plan) wires bookings
+// coverage when provided — createPlans then attachBookingsCoverage (2a→2b→2c), in order.
+const { plans, coverageAttached, benefitsCreated } = await seed.setupPricingPlans(ctx, {
+  plans: [
+    { name: "Studio Membership", description: "Unlimited group classes.", price: "20.00",
+      type: "recurring", billingCycle: { period: "MONTH", count: 1 },
+      perks: ["Unlimited group classes", "10% off workshops"],
+      coveredServiceIds: bookingsServiceIds },  // optional — only when this plan covers bookings services
+    // …just the plan data. price = decimal STRING; currency is site-derived (don't send it).
+    // limited pack instead of unlimited: bookingsCoverage: { serviceIds, creditAmount: 8 }
+  ],
+});
+// A plans-only run (no bookings) just omits coveredServiceIds — STEP 2 is skipped automatically.
+```
 
+## Escape hatch — individual functions
+Call the steps yourself when you need finer control than the one-call path:
+
+```js
+const plans = await seed.createPlans(ctx, [
+  { name: "Studio Membership", price: "20.00", perks: ["Unlimited group classes"],
+    coveredServiceIds: bookingsServiceIds },
+]);
 // STEP 2 — only when bookings is in the run AND the plan covers services (skip otherwise):
 await seed.attachBookingsCoverage(ctx, plans[0].id, plans[0].coveredServiceIds);
 // limited pack instead of unlimited: attachBookingsCoverage(ctx, id, ids, { creditAmount: 8 })
@@ -35,6 +50,7 @@ await seed.attachBookingsCoverage(ctx, plans[0].id, plans[0].coveredServiceIds);
 ## Functions
 | fn | does |
 |---|---|
+| `setupPricingPlans(ctx, {plans})` | **DEFAULT** one call: createPlans → per-plan attachBookingsCoverage → `{plans,coverageAttached,benefitsCreated}` |
 | `createPlans(ctx, plans)` | one create call per plan (V3 has no bulk) → `[{id,name,coveredServiceIds}]` |
 | `attachBookingsCoverage(ctx, planId, serviceIds, {creditAmount?})` | STEP 2: 2a→2b→2c in order → `{itemSetId,serviceIds}` |
 | `getProgramDefinition(ctx, planId)` | 2a: READ the auto-created program definition (retry-once on 404) → `programDefinitionId` |

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
@@ -206,7 +206,34 @@ async function attachBookingsCoverage(ctx, planId, serviceIds, { creditAmount } 
   return { itemSetId, serviceIds };
 }
 
+/**
+ * DEFAULT one-call path — create plan(s) and, per plan, wire bookings coverage when provided.
+ * One call; created plan ids stay in memory so coverage never needs hand-threading of plan.id.
+ * Order: createPlans (all plans) -> per covering plan attachBookingsCoverage (2a->2b->2c, in order).
+ * The program definition is provisioned asynchronously ~1s after the plan; the retry-once-after-
+ * backoff on its 404 lives in getProgramDefinition and is preserved via attachBookingsCoverage.
+ * @param plan { plans: [{ ...createPlans fields (name, description?, price, type?, billingCycle?,
+ *   perks?, visibility?, buyable?),
+ *   coveredServiceIds?,                                    // bookings service ids this plan covers
+ *   bookingsCoverage?: { serviceIds?, creditAmount? } }] } // richer coverage; creditAmount = limited pack
+ * @returns { plans: [{id,name,coveredServiceIds}], coverageAttached: [{planId,itemSetId,serviceIds}], benefitsCreated }
+ */
+async function setupPricingPlans(ctx, { plans = [] } = {}) {
+  const created = await createPlans(ctx, plans); // ids kept in memory
+  const coverageAttached = [];
+  for (let i = 0; i < created.length; i++) {
+    const cov = plans[i].bookingsCoverage || {};
+    const serviceIds = cov.serviceIds || created[i].coveredServiceIds;
+    if (!serviceIds?.length) continue; // plans-only plan — skip STEP 2
+    const r = await attachBookingsCoverage(ctx, created[i].id, serviceIds, { creditAmount: cov.creditAmount });
+    coverageAttached.push({ planId: created[i].id, ...r });
+  }
+  const benefitsCreated = coverageAttached.reduce((n, c) => n + c.serviceIds.length, 0);
+  return { plans: created, coverageAttached, benefitsCreated };
+}
+
 module.exports = {
+  setupPricingPlans,
   createPlans,
   attachBookingsCoverage,
   getProgramDefinition, createPoolDefinition, createBenefitItems,

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -9,6 +9,12 @@ with plain data.
 > **NOT yet live-verified — transcribed from `setup-restaurants.md`, `setup-restaurant-orders.md`,
 > `setup-restaurant-reservations.md`, `setup-restaurant-experiences.md`.**
 
+## Default: one call
+
+`setupRestaurants(ctx, plan)` does the whole seed in one call — installs the Menus app and builds the
+menu **bottom-up (items → sections → menu)** with ids kept in memory, so you never hand-thread ids
+across exec calls. Online ordering and table reservations run only when the plan asks for them.
+
 ```js
 // build-time exec_tool
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
@@ -19,15 +25,34 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
+const result = await seed.setupRestaurants(ctx, {
+  menu: {
+    name: "Dinner", description: "Evening menu",
+    sections: [
+      { name: "Antipasti", description: "To start", items: [
+        { name: "Bruschetta al Pomodoro", description: "Grilled sourdough, San Marzano tomatoes, basil.", price: 9.50, imageUrl: "https://…" },
+      ] },
+    ],
+  },
+  ordering: { address },                            // omit for menu-only; `true` skips the STEP 0 address (flag it)
+  reservations: { configuration: { onlineReservations: { partySize: { min: 2, max: 10 } } } },
+});
+// → { menuId, sectionIds, itemIds, orderingEnabled, reservationsEnabled, imagesAttached }
+```
+
+## Escape hatch: the individual fns
+
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add.
+
+Reach for these only when the one-call path doesn't fit (partial re-seed, custom
+fulfillment methods, experiences). The **items → sections → menu** ordering below is the rule
+`setupRestaurants`/`createMenu` bake in — a section is created with its `itemIds`, a menu with its
+`sectionIds`, so each child must exist before its parent.
+
+```js
 // ── MENU (always; the seedable core) ────────────────────────────────────────────────────────────
 await seed.installMenusApp(ctx);                    // if the site doesn't have Wix Restaurants Menus yet
-
-// Clean is a JUDGMENT call — never auto-delete. Only remove the install's obvious default "Dinner
-// Menu" on a fresh install; if it could be the owner's real menu, ask first (seeding is additive).
-// Children before parents: items → sections → menus.
-// const items = await seed.listMenuItems(ctx);   await seed.deleteMenuItems(ctx, items.map(i => i.id));
-// const secs  = await seed.listMenuSections(ctx); await seed.deleteMenuSections(ctx, secs.map(s => s.id));
-// const menus = await seed.listMenus(ctx);        for (const m of menus) await seed.deleteMenu(ctx, m.id);
 
 const menu = await seed.createMenu(ctx, {           // builds items → sections → menu bottom-up
   name: "Dinner", description: "Evening menu",
@@ -67,9 +92,6 @@ await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Expe
 | fn | does |
 |---|---|
 | `installMenusApp(ctx)` | install the Wix Restaurants Menus app |
-| `listMenuItems(ctx)` / `deleteMenuItems(ctx, ids)` | list / bulk-delete items (sample-cleanup judgment) |
-| `listMenuSections(ctx)` / `deleteMenuSections(ctx, ids)` | list / bulk-delete sections |
-| `listMenus(ctx)` / `deleteMenu(ctx, menuId)` | list / delete a menu (no bulk delete — one per menu) |
 | `createMenu(ctx, {name,description?,sections})` | items → sections → menu bottom-up → `{menuId,sectionIds,itemIds}` |
 | `attachItemImages(ctx, [{id,revision,price,image}])` | imagery pass — full-replace PATCH (echo revision + priceInfo) |
 

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -353,7 +353,89 @@ async function createExperiences(ctx, reservationLocationId, experiences) {
   return out;
 }
 
+// ══ ONE-CALL ORCHESTRATOR ══════════════════════════════════════════════════════════════════════════
+/**
+ * DEFAULT one-call path — seed a whole Wix Restaurants site from a plain plan; the caller threads NO
+ * ids across exec calls. Installs the Menus app and builds the menu BOTTOM-UP (items → sections → menu):
+ * `createMenu` bulk-creates every item first, then the sections carrying their item ids, then the menu
+ * carrying its section ids — every child exists before its parent. In-memory name→id maps (item, section)
+ * wire the tree and map each plan item to its created id for the image pass (full-replace, echo revision
+ * + price; freshly created items are at revision "1"). Online ordering and table reservations are
+ * on-demand add-ons — touched ONLY when the plan asks, each installing its own app and following the
+ * module's own fns. Ordering needs a business-location address (`setBusinessLocation` STEP 0); if the
+ * plan names none the recipe's precondition applies (record + flag). `enableOnlineReservations` is
+ * premium-gated (428 on a free site) — expected and non-fatal, recorded not thrown.
+ *
+ * @param plan {
+ *   menu: { name, description?, sections: [{ name, description?,
+ *           items: [{ name, description?, price, imageUrl?|image? }] }] },
+ *   ordering?:     boolean | { address? },
+ *   reservations?: boolean | { address?, configuration? },
+ * }
+ * @returns { menuId, sectionIds, itemIds, orderingEnabled, reservationsEnabled, imagesAttached }
+ */
+async function setupRestaurants(ctx, plan) {
+  await installMenusApp(ctx);
+
+  const { menuId, sectionIds, itemIds } = await createMenu(ctx, plan.menu);
+
+  // name→id maps: createMenu flattens sections→items in order, so itemIds/sectionIds line up 1:1.
+  const flatItems = plan.menu.sections.flatMap((s) => s.items || []);
+  const itemNameToId = new Map(flatItems.map((it, i) => [it.name, itemIds[i]]));
+
+  // imagery pass — map each plan item that carries an image to its created id (revision "1", fresh).
+  const imageItems = flatItems
+    .filter((it) => it.image || it.imageUrl)
+    .map((it) => ({
+      id: itemNameToId.get(it.name),
+      revision: "1",
+      price: it.price,
+      image: it.image || { url: it.imageUrl },
+    }));
+  let imagesAttached = 0;
+  if (imageItems.length) {
+    try { await attachItemImages(ctx, imageItems); imagesAttached = imageItems.length; }
+    catch { /* never block on image failure */ }
+  }
+
+  // shared STEP 0 address — set once across both add-ons (SEED.md: do it once if both run).
+  let locationSet = false;
+  const ensureLocation = async (address) => {
+    if (address && !locationSet) { await setBusinessLocation(ctx, address); locationSet = true; }
+  };
+
+  let orderingEnabled = false;
+  if (plan.ordering) {
+    const cfg = typeof plan.ordering === "object" ? plan.ordering : {};
+    await installOrdersApp(ctx);                 // auto-provisions operation + methods + per-menu settings
+    await ensureLocation(cfg.address);
+    await listOperations(ctx);                   // verify the auto-created operation
+    await queryMenuOrderingSettings(ctx);        // confirm each menu is orderable
+    orderingEnabled = true;
+  }
+
+  let reservationsEnabled = false;
+  if (plan.reservations) {
+    const cfg = typeof plan.reservations === "object" ? plan.reservations : {};
+    await installTableReservationsApp(ctx);      // auto-provisions the default reservation location
+    await ensureLocation(cfg.address);           // independent of menu; address optional for reservations
+    let [loc] = await listReservationLocations(ctx);
+    if (loc && cfg.configuration) {
+      await updateReservationLocation(ctx, loc.id, loc.revision, cfg.configuration);
+      [loc] = await listReservationLocations(ctx);  // re-read for the bumped revision
+    }
+    if (loc) {
+      try { await enableOnlineReservations(ctx, loc.id, loc.revision); reservationsEnabled = true; }
+      catch { /* 428 PREMIUM_ONLY on a free site is expected — record, don't fail */ }
+    }
+  }
+
+  return { menuId, sectionIds, itemIds, orderingEnabled, reservationsEnabled, imagesAttached };
+}
+
 module.exports = {
+  // DEFAULT one-call orchestrator
+  setupRestaurants,
   // app install
   installMenusApp, installOrdersApp, installTableReservationsApp,
   // menu

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -2,7 +2,7 @@
 
 Seed a Wix Stores catalog by **calling `seed-store.js`** — don't hand-write the REST calls. It's
 a build-time module (run via `exec_tool`, not shipped in the app) that abstracts every Wix Stores
-seed operation. `require` it and call the functions with plain data.
+seed operation. Load it and call **`setupStore` — the one-call path** — with plain data.
 
 ```js
 // build-time exec_tool
@@ -14,31 +14,28 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-await seed.installStoresApp(ctx);                       // installs if needed AND waits for the V3 catalog to be ready
-
-// Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a fresh
-// install; if what's there could be the owner's real catalog, ask first (seeding is additive).
-const existing = await seed.listProducts(ctx);
-// await seed.deleteProducts(ctx, existing.filter(isObviousSample).map(p => p.id));
-
-const products = await seed.bulkCreateProducts(ctx, [
-  { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12 },
-  // …just the catalog data. options ONLY for real buyer choices (Size/Color); default none.
-]);
-
-const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);   // only if the brief names categories
-await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
-
-// imagery ON only: generate images per IMAGE_GENERATION.md, then one bulk attach
-await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, revision: p.revision, url: imageUrls[i], altText: p.slug })));
+// ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
+// in memory (no hand-threading). Categories map name -> product NAMES. imageUrl per product only
+// when imagery is on. options ONLY for real buyer choices (Size/Color); default none.
+const result = await seed.setupStore(ctx, {
+  products: [
+    { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },
+    // …just the catalog data
+  ],
+  categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none
+});
+// result: { products:[{id,slug,revision,name}], categories:[{id,name}], imagesAttached }
 ```
+
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add. Need finer control than `setupStore`? The individual functions
+below still exist (setupStore is built from them).
 
 ## Functions
 | fn | does |
 |---|---|
-| `installStoresApp(ctx)` | install the Wix Stores app on the site |
-| `listProducts(ctx)` | `[{id,name}]` — for the sample-cleanup judgment |
-| `deleteProducts(ctx, ids)` | bulk-delete (only obvious samples) |
+| `setupStore(ctx, {products, categories?})` | **one-call**: install+wait → products → categories → images |
+| `installStoresApp(ctx)` | install the Wix Stores app on the site (waits for the V3 catalog) |
 | `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]` |
 | `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -201,7 +201,47 @@ async function attachProductImages(ctx, items) {
   });
 }
 
+/**
+ * ONE-CALL seed: install → create products → categories → attach images, in the correct order,
+ * keeping the created ids in memory (no hand-threading of product ids across exec calls). This is
+ * the DEFAULT path — call it once instead of the individual functions.
+ *
+ * @param plan {{
+ *   products: [{ name, description, price, compareAtPrice?, quantity, options?, imageUrl?, altText? }],
+ *   categories?: { [categoryName]: string[] },   // map of category name -> product NAMES in it
+ * }}
+ * Cleanup is intentionally NOT here — deleting existing content is a judgment call; do it explicitly
+ * with listProducts/deleteProducts first if (and only if) the site holds obvious install samples.
+ * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number }
+ */
+async function setupStore(ctx, { products = [], categories = {} } = {}) {
+  await installStoresApp(ctx); // installs if needed AND waits for the V3 catalog to be ready
+
+  const created = await bulkCreateProducts(ctx, products);
+  const withNames = created.map((p, i) => ({ ...p, name: products[i]?.name }));
+  const idByName = new Map(withNames.map((p) => [p.name, p.id]));
+
+  const names = Object.keys(categories);
+  const cats = names.length ? await createCategories(ctx, names) : [];
+  if (cats.length) {
+    const mapping = {};
+    for (const c of cats) {
+      const ids = (categories[c.name] || []).map((n) => idByName.get(n)).filter(Boolean);
+      if (ids.length) mapping[c.id] = ids;
+    }
+    if (Object.keys(mapping).length) await addProductsToCategories(ctx, mapping);
+  }
+
+  const imageItems = withNames
+    .map((p, i) => ({ id: p.id, revision: p.revision, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
+    .filter((it) => it.url);
+  if (imageItems.length) await attachProductImages(ctx, imageItems);
+
+  return { products: withNames, categories: cats, imagesAttached: imageItems.length };
+}
+
 module.exports = {
+  setupStore,
   installStoresApp, listProducts, deleteProducts,
   bulkCreateProducts, createCategories, addProductsToCategories, attachProductImages,
 };


### PR DESCRIPTION
## What
Adds a **one-call orchestrator** to every vertical's build-time seed module, and makes seeding **strictly additive** (no cleanup) across all seed docs.

### One-call `setup<Vertical>`
Instead of the agent running 4+ stateless `exec_tool` calls — re-pasting the module-loader preamble each time and **hand-threading created ids** (copying product/section GUIDs out of one exec result into the next as string literals) — each module now exposes a single function that does the whole flow in **one call**, keeping ids in memory:

| vertical | fn | flow |
|---|---|---|
| storefront | `setupStore` | install(+wait V3) → products → categories → images |
| bookings | `setupBookings` | install → staff → categories → services → CLASS sessions → images |
| events | `setupEvents` | create → tiers → publish → categories/assign → image |
| blog | `setupBlog` | author → categories/tags → posts → covers |
| cms | `setupCms` | install → collections → items → references → images (keyed in-memory) |
| portfolio | `setupPortfolio` | collections → projects → items → covers |
| pricing-plans | `setupPricingPlans` | plans → bookings coverage/benefits |
| restaurants | `setupRestaurants` | install → items→sections→menu → (ordering/reservations on demand) |

Each is the **first export** and the **DEFAULT path** shown in its `SEED.md`; the individual functions stay as an escape hatch. The two covered verticals are also synced into the `wix-base44-headless` template copies + their `TEMPLATE.md` seed steps.

### Strictly additive — no cleanup
Removed **all** cleanup/delete guidance and the "only if it's an obvious install sample" judgment language from every `SEED.md`/`TEMPLATE.md`. New wording everywhere: *"Seeding is additive — never delete or overwrite existing content. Don't clean up, don't remove sample data, don't reset. Just add."* Orchestrators contain no delete logic.

## Why
A live prod build showed the exec ergonomics were the remaining friction even after seeding worked: the loader preamble was re-pasted into all 4 seed calls and product GUIDs were hand-copied between them. One call removes both.

## Verified
- `node --check` passes on all 8 modules + the 2 template copies.
- Each module has its `setup*` orchestrator exported first.
- No residual cleanup/delete language in any SEED.md/TEMPLATE.md.

Note: individual `delete*`/`list*` functions remain in module code (undocumented) — not referenced by any orchestrator or doc. Can remove them entirely if preferred.