### PR TITLE
fix(wix-vibe-headless): worked shape snippets across all verticals (kill guess-the-shape crashes)

### DIFF
--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -44,31 +44,128 @@ The Post, Category, and Tag shapes are documented as JSDoc comments at the top o
 the full API reference for anything not shown.
 
 ## How to wire it (UI is the project's choice)
+Every list helper returns an **object, not a bare array** — `queryPosts` /
+`queryPostsByCategory` / `queryPostsByTag` → `{ posts, nextCursor }`; `queryCategories` →
+`{ categories, total }`; `queryTags` → `{ tags, total }`. **Destructure first** — calling
+`.map` / `.filter` on the returned object throws `… is not a function`. See the worked
+snippets below.
+
 - **Post feed** — `queryPosts()` for the listing (published posts only, newest first with
-  pinned posts leading); pass `nextCursor` back as `cursor` to load the next page. Render
-  `title`, `excerpt`, `firstPublishedDate`, `minutesToRead`, and the cover image from
+  pinned posts leading). Destructure `{ posts, nextCursor }` and iterate `posts`; pass
+  `nextCursor` back as `cursor` to load the next page. Render `title`, `excerpt`,
+  `firstPublishedDate`, `minutesToRead`, and the cover image from
   **`post.media.wixMedia.image.url`** (see the cover-image note below). Route to the detail page by `slug`.
+  **Author byline:** the reader helpers do **not** expose an author name (the post shape carries no
+  `author` object) — resolve it via the **members** vertical or omit the byline; never render
+  `post.author.name` (it is `undefined`).
 - **Post detail** — `getPostBySlug(slug)` keyed off the URL slug; returns `null` on miss —
   show a not-found state, never invent a post. It returns full content:
   - `contentText` — the body as plain text. Split on `"\n"` to render simple paragraphs.
   - `richContent` — the body as a Ricos rich-content document (images, embeds, formatting).
     Render it with a Ricos renderer for a faithful post. See "Beyond the snippets" if you
     need rich rendering; `contentText` is the zero-dependency default.
-  - Resolve `categoryIds` / `tagIds` to labels with `queryCategories()` / `queryTags()`
-    (build an id→label map) to show category/tag chips.
+  - Resolve `categoryIds` / `tagIds` to chips by matching each id against `category.id` /
+    `tag.id` from `queryCategories()` / `queryTags()` (build an id→object map). The display
+    field is **`.label`** (not `.name`). This lookup is hit on **every** post render, so fetch
+    the categories/tags once and reuse the map — do not re-query per card.
 - **Cover image** — use **`post.media.wixMedia.image.url`** (a ready-to-use https URL) for the card
   thumbnail and post header. `media` is returned by default (including on the list query), so no extra
   fieldset is needed. When `post.media?.wixMedia?.image` is absent, the cover is the first image inside
   `richContent` — fall back to the first IMAGE node there, or show a text-only card. Never substitute a
-  stock/placeholder image.
-- **Category page** — `queryCategories()` for a category menu (ordered by `displayPosition`;
-  hide categories with `postCount === 0` if you want); `getCategoryBySlug(slug)` for a
-  category landing page. Pass `category.id` to `queryPostsByCategory(categoryId, { limit?, cursor? })`
-  to list that category's posts; paginate exactly like `queryPosts`.
-- **Tag page** — `queryTags()` for a tag cloud/list (most-used first); `getTagBySlug(slug)`
-  for a tag landing page. Pass `tag.id` to `queryPostsByTag(tagId, { limit?, cursor? })`.
+  stock/placeholder image. (This is a **different** path from the category cover — see below.)
+- **Category page** — `queryCategories()` for a category menu; destructure `{ categories, total }`
+  (ordered by `displayPosition`; hide categories with **`postCount === 0`** if you want).
+  Display each category by **`.label`**; a category also carries a cover image at
+  **`category.coverImage.url`** (note: a different path from the post cover
+  `post.media.wixMedia.image.url`). `getCategoryBySlug(slug)` returns the category landing page;
+  pass `category.id` to `queryPostsByCategory(categoryId, { limit?, cursor? })` to list that
+  category's posts; paginate exactly like `queryPosts`.
+- **Tag page** — `queryTags()` for a tag cloud/list (most-used first); destructure
+  `{ tags, total }`. Display each tag by **`.label`**; the per-tag count is
+  **`publishedPostCount`** (note the divergence: categories use `postCount`, tags use
+  `publishedPostCount`). `getTagBySlug(slug)` for a tag landing page; pass `tag.id` to
+  `queryPostsByTag(tagId, { limit?, cursor? })`.
 - **Empty state** — if `getTotalPosts()` is 0, show an empty state telling the user to
   publish posts in their Wix dashboard. Never invent posts.
+
+## Worked snippets (adapt the logic, restyle freely)
+Headless React — the data wiring (destructuring, field paths, id→label resolution) is correct
+and complete; the markup is deliberately plain. **Copy the logic; restyle the JSX to the brand.**
+
+**`pages/Blog.jsx`** — the post feed (listing + empty state + paging). Destructure
+`{ posts, nextCursor }` first; the helper returns an object, not an array.
+
+```jsx
+import { useState, useEffect } from "react";
+import { queryPosts, getTotalPosts } from "@/rest/wix-blog";
+import PostCard from "@/components/PostCard";
+
+export default function Blog() {
+  const [posts, setPosts] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    getTotalPosts().then(setTotal);
+    // NB: destructure — queryPosts returns { posts, nextCursor }, not a bare array.
+    queryPosts({ limit: 20 }).then(({ posts, nextCursor }) => {
+      setPosts(posts);
+      setCursor(nextCursor);
+    });
+  }, []);
+
+  const loadMore = () =>
+    queryPosts({ limit: 20, cursor }).then(({ posts: more, nextCursor }) => {
+      setPosts((p) => [...p, ...more]);
+      setCursor(nextCursor);
+    });
+
+  if (total === 0) return <p>{/* empty state — tell the user to publish posts in Wix */}</p>;
+  return (
+    <div /* restyle */>
+      <div /* grid */>{posts.map((p) => <PostCard key={p.id} post={p} />)}</div>
+      {cursor && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+`queryPostsByCategory(categoryId, …)` and `queryPostsByTag(tagId, …)` return the same
+`{ posts, nextCursor }` shape — wire the category/tag landing pages identically.
+
+**`useTaxonomy` + `PostChips`** — resolve `categoryIds`/`tagIds` to chip labels. Fetch the
+categories/tags **once** (this lookup runs on every post render) and reuse the map.
+
+```jsx
+import { useState, useEffect } from "react";
+import { queryCategories, queryTags } from "@/rest/wix-blog";
+
+// Categories + tags turn a post's categoryIds/tagIds into chip labels.
+// Fetch them ONCE (a context/provider) and reuse — do NOT re-query per post card.
+export function useTaxonomy() {
+  const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+  useEffect(() => {
+    // NB: destructure — queryCategories → { categories, total }, queryTags → { tags, total }.
+    queryCategories().then(({ categories }) => setCategories(categories));
+    queryTags().then(({ tags }) => setTags(tags));
+  }, []);
+  const catById = new Map(categories.map((c) => [c.id, c])); // display c.label · count c.postCount
+  const tagById = new Map(tags.map((t) => [t.id, t]));       // display t.label · count t.publishedPostCount
+  return { catById, tagById };
+}
+
+// Resolve a post's ids against category.id / tag.id; display .label (NOT .name); route by .slug.
+export function PostChips({ post, catById, tagById }) {
+  const cats = (post.categoryIds || []).map((id) => catById.get(id)).filter(Boolean);
+  const tags = (post.tagIds || []).map((id) => tagById.get(id)).filter(Boolean);
+  return (
+    <>
+      {cats.map((c) => <a key={c.id} href={`/blog/category/${c.slug}`}>{c.label}</a>)}
+      {tags.map((t) => <a key={t.id} href={`/blog/tag/${t.slug}`}>{t.label}</a>)}
+    </>
+  );
+}
+```
 
 ## Hard rules (do not violate)
 - ✅ Fetch posts/categories/tags ONLY through the shipped helpers (the official Blog REST
@@ -81,8 +178,15 @@ the full API reference for anything not shown.
   and does not expose engagement actions; leave such UI empty or omit it.
 - ❌ Never use a placeholder/stock cover image. If `post.media?.wixMedia?.image` is missing, fall back
   to the first richContent image or a text-only card.
+- ❌ Never render an author name — the reader helpers don't expose one. `post.author.name` is
+  `undefined`; resolve authors via the members vertical or omit the byline.
+- ✅ Every list helper returns an object: destructure `{ posts, nextCursor }` /
+  `{ categories, total }` / `{ tags, total }` before `.map`/`.filter`.
+- ✅ Display categories and tags by **`.label`** (not `.name`); resolve `categoryIds`/`tagIds`
+  by matching `.id`. Category count is `postCount`; tag count is `publishedPostCount`.
 - ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Use `post.media.wixMedia.image.url` for the cover image.
+- ✅ Use `post.media.wixMedia.image.url` for the post cover; `category.coverImage.url` for the
+  category cover (they are different paths).
 - The helpers fail soft on single-item lookups: `getPostBySlug` / `getCategoryBySlug` /
   `getTagBySlug` return `null` on a miss so you can show a proper not-found state — don't
   swallow that into a fake item.
@@ -118,10 +222,12 @@ Substitute the site's `metaSiteId` to complete the links (you have it from the h
 ## Verification checklist (before declaring done)
 - [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
 - [ ] Visitor token persists across reload (no re-mint storm; same anonymous visitor)
-- [ ] Post feed lists live published posts, newest first, and paginates via `nextCursor`
+- [ ] Post feed lists live published posts, newest first, and paginates via `nextCursor` (destructured from `{ posts, nextCursor }`)
 - [ ] Post detail loads by `slug` and renders real `contentText` (or rendered `richContent`)
 - [ ] `getPostBySlug` on a bad slug shows a not-found state (no invented post)
 - [ ] Cover images come from `post.media.wixMedia.image.url` (or richContent fallback) — no stock placeholders
+- [ ] Category/tag menus destructure `{ categories }` / `{ tags }` and display `.label` (category cover from `category.coverImage.url`)
+- [ ] No author byline rendered from the post (no `post.author.name`) — omitted or sourced from members
 - [ ] Category and tag pages list the right posts via `queryPostsByCategory` / `queryPostsByTag`
 - [ ] Empty state shown when `getTotalPosts()` is 0
 - [ ] No mock posts, authors, comments, likes, or view counts anywhere

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -56,25 +56,30 @@ each helper file. Read them before building the UI — they describe the key fie
 the full API reference for anything not shown.
 
 ## How to wire it (UI is the project's choice)
-- **Service list** — `queryServices()` for the listing (visitor-visible services only). Render
-  `name`, `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price
-  from `payment.fixed.price`. `value` + `currency` are always present; `formattedValue` is
+- **Service list** — `const { services, total, nextOffset } = await queryServices({ limit, offset })`
+  for the listing (visitor-visible services only); it returns an **object, not a bare array** —
+  destructure it, then render `.services`. Each service's id is `service.id`. Render `name`,
+  `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price from
+  `payment.fixed.price`. `value` + `currency` are always present; `formattedValue` is
   **optional** (it may be missing), so don't depend on it — build the price from `value`+`currency`
   and use `formattedValue` only when present. e.g. `new Intl.NumberFormat(undefined, { style:
   'currency', currency }).format(Number(value))`. (Rendering `formattedValue` alone leaves the price
-  blank — or your "Varies" fallback — whenever it's absent.) Pass the returned
-  `nextOffset` back as `offset` to load the next page. Books **APPOINTMENT and CLASS** services
-  (see the slot picker below); COURSE is whole-course enrollment and out of scope.
+  blank — or your "Varies" fallback — whenever it's absent.) Pass the returned `nextOffset` back as
+  `offset` to load the next page (it is `null` on the last page). See the **`pages/Services.jsx`**
+  snippet below. Books **APPOINTMENT and CLASS** services (see the slot picker below); COURSE is
+  whole-course enrollment and out of scope.
 - **Service detail** — `getService(serviceId)` keyed off the URL/route; returns null on miss —
   show a not-found state, never invent a service. Render `description`, price, and `locations`.
-- **Slot picker** — use **`listSlotsForService(service, { fromLocalDate, toLocalDate, timeZone? })`**:
+- **Slot picker** — `const { slots, nextCursor } = await listSlotsForService(service, { fromLocalDate, toLocalDate, timeZone? })`:
   it routes by `service.type` — APPOINTMENT → `listAvailableSlots` (staff working hours), CLASS/COURSE
-  → `listEventTimeSlots` (scheduled sessions). Both return the same slot shape. (Call the specific
-  function directly if you already know the type.) Dates are **local** wall-clock strings
-  `"YYYY-MM-DDThh:mm:ss"` (no zone), interpreted in `timeZone` (defaults to the visitor's IANA zone).
-  Only `bookable: true` slots come back. Render each `slot.localStartDate`/`localEndDate`; group by
-  day for a calendar. Pass `nextCursor` back
-  as `cursor` to page.
+  → `listEventTimeSlots` (scheduled sessions). Both return the same `{ slots, nextCursor }` shape;
+  iterate `.slots`. (Call the specific function directly if you already know the type.) Dates are
+  **local** wall-clock strings `"YYYY-MM-DDThh:mm:ss"` (no zone), interpreted in `timeZone` (defaults
+  to the visitor's IANA zone). **Mind the date-arg naming difference:** the list calls take
+  `fromLocalDate`/`toLocalDate`, while the single-slot re-validate call (`getAvailableSlot`, below)
+  takes `localStartDate`/`localEndDate` — they are not interchangeable. Only `bookable: true` slots
+  come back. Render each `slot.localStartDate`/`localEndDate`; group by day for a calendar. Pass
+  `nextCursor` back as `cursor` to page. See the **`SlotPicker.jsx`** snippet below.
 - **Booking form** — collect the buyer's `firstName`, `lastName`, `email`, `phone`. Keep it
   minimal; richer per-service form fields live in the service's `form.id` (see "Beyond the snippets").
 - **Participant count** — cap it by the service policy, not just slot capacity. The most a single
@@ -86,10 +91,15 @@ the full API reference for anything not shown.
   on it alone lets the buyer pick a count that `createBooking` then rejects. Pass the chosen count
   as `createBooking`'s `totalParticipants`.
 - **Re-validate + book** — right before submitting, call
-  `getAvailableSlot(serviceId, { localStartDate, localEndDate, timeZone? })` to confirm the slot
-  is still open (and to pick up the staff resource). Then create + check out in one step:
-  `window.location.href = (await bookAndCheckout(slot, { email, firstName, lastName, phone })).checkoutUrl;`
-  Or split it: `const booking = await createBooking(slot, contact); const url = await checkoutBooking(booking.id);`
+  `const slot = await getAvailableSlot(serviceId, { localStartDate, localEndDate, timeZone? })` to
+  confirm the slot is still open (and to pick up the staff resource). It returns the slot object or
+  **`null`** if the time was just taken — **guard for `null`** and prompt for another slot; never
+  book a null slot. Then create + check out in one step:
+  `window.location.href = (await bookAndCheckout(slot, { email, firstName, lastName, phone }, { totalParticipants })).checkoutUrl;`
+  (`bookAndCheckout` returns `{ booking, checkoutUrl }`.) Or split it — note `createBooking` is the
+  **3-arg** form `(slot, contact, options)` and `checkoutBooking` returns a **bare URL string**:
+  `const booking = await createBooking(slot, contact, { totalParticipants, timeZone }); window.location.href = await checkoutBooking(booking.id);`
+  See the **`BookingForm.jsx`** snippet below.
 - **Confirmation / return** — after the buyer returns from hosted checkout, the order is placed
   and Wix Bookings confirms the booking automatically (status becomes `CONFIRMED`, or `PENDING`
   if the service needs manual approval). Show a confirmation screen on return.
@@ -98,7 +108,9 @@ the full API reference for anything not shown.
 
 ## Hard rules (do not violate)
 - ✅ Book ONLY via `createBooking()` → `checkoutBooking()` (or `bookAndCheckout()`), then redirect
-  to the returned `fullUrl`.
+  to the returned URL: `window.location.href = await checkoutBooking(bookingId)` — `checkoutBooking`
+  returns a **bare URL string** (not an object; no `.fullUrl`), and `bookAndCheckout` returns
+  `{ booking, checkoutUrl }` (redirect to `checkoutUrl`).
 - ❌ Never hand-build a `/checkout`, booking, or calendar URL.
 - ❌ Never mock services, time slots, or availability — render live Wix data or the empty state.
 - ❌ Never invent reviews, ratings, staff, or testimonials. Empty review UI only.
@@ -136,6 +148,173 @@ exact endpoint, method, and body in the **official Wix API reference** first (ne
 Keep the snippets as the default for everything they already do; reach for the API reference
 only for the gap.
 
+## Reference components (headless — adapt the logic, restyle freely)
+
+These are the recurring bookings pieces, written **headless**: the data wiring (Wix field paths,
+`{ services, ... }` / `{ slots, ... }` destructuring, the local-date arg names, the null-slot guard,
+the participant cap) is correct and complete — the markup is deliberately plain. **Copy the logic
+exactly; restyle the JSX to the brand.** They consume the `src/rest/` helpers; you don't need to
+read those helpers' source.
+
+**`pages/Services.jsx`** — the service listing (grid + empty state + paging). `queryServices`
+returns an **object, not a bare array** — `{ services, total, nextOffset }`; destructure first
+(calling `.map` on the returned object throws `… is not a function`). The id is `service.id`;
+`payment.fixed.price.formattedValue` is optional, so format from `value`+`currency`.
+
+```jsx
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { queryServices, mediaUrl } from "@/rest/wix-bookings-services";
+
+export default function Services() {
+  const [services, setServices] = useState([]);
+  const [nextOffset, setNextOffset] = useState(null);
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    // queryServices returns an OBJECT, not a bare array — destructure it.
+    queryServices({ limit: 24 }).then(({ services, total, nextOffset }) => {
+      setServices(services);
+      setTotal(total);
+      setNextOffset(nextOffset);
+    });
+  }, []);
+
+  const loadMore = () =>
+    queryServices({ limit: 24, offset: nextOffset }).then(({ services: more, nextOffset: next }) => {
+      setServices((s) => [...s, ...more]);
+      setNextOffset(next);
+    });
+
+  if (total === 0) return <p>{/* empty state — add a service in the Wix dashboard */}</p>;
+  return (
+    <div /* restyle */>
+      {services.map((service) => {
+        const image = mediaUrl(service.media?.items?.[0]?.image);
+        const p = service.payment?.fixed?.price;                     // may be absent (free / custom-priced)
+        const price = p && (p.formattedValue                         // formattedValue is OPTIONAL — build from value+currency when missing
+          || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value)));
+        return (
+          <Link key={service.id} to={`/service/${service.id}`} /* the service id is service.id */>
+            {image && <img src={image} alt={service.name} loading="lazy" />}
+            <h3>{service.name}</h3>
+            {service.tagLine && <p>{service.tagLine}</p>}
+            {price && <span>{price}</span>}
+          </Link>
+        );
+      })}
+      {nextOffset != null && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
+**`SlotPicker.jsx`** — lists bookable slots for a chosen service. `listSlotsForService` routes by
+`service.type` and returns `{ slots, nextCursor }`; iterate `.slots`, page with `nextCursor`. The
+**list** call takes `fromLocalDate`/`toLocalDate` (local wall-clock, no zone) — a different arg
+naming than the single-slot `getAvailableSlot`.
+
+```jsx
+import { useState, useEffect } from "react";
+import { listSlotsForService } from "@/rest/wix-bookings-services";
+
+// Local wall-clock "YYYY-MM-DDThh:mm:ss" (NO zone / Z) — the slot APIs interpret it in timeZone.
+function localMidnight(daysFromNow = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T00:00:00`;
+}
+
+export default function SlotPicker({ service, onPick }) {
+  const [slots, setSlots] = useState([]);
+  const [cursor, setCursor] = useState(null);
+
+  useEffect(() => {
+    // listSlotsForService routes by service.type and returns { slots, nextCursor }. Note the arg names:
+    // the LIST call uses fromLocalDate / toLocalDate (getAvailableSlot, the single-slot re-validate
+    // call, uses localStartDate / localEndDate instead).
+    listSlotsForService(service, { fromLocalDate: localMidnight(0), toLocalDate: localMidnight(14) })
+      .then(({ slots, nextCursor }) => { setSlots(slots); setCursor(nextCursor); });
+  }, [service]);
+
+  const loadMore = () =>
+    listSlotsForService(service, { cursor }).then(({ slots: more, nextCursor }) => {
+      setSlots((s) => [...s, ...more]);
+      setCursor(nextCursor);
+    });
+
+  return (
+    <div /* restyle: group slots by day for a calendar */>
+      {slots.map((slot) => (
+        <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
+          onClick={() => onPick(slot)}>
+          {new Date(slot.localStartDate).toLocaleString()}
+        </button>
+      ))}
+      {cursor && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
+**`BookingForm.jsx`** — re-validate the picked slot, then book + check out. `getAvailableSlot`
+returns the slot **or `null`** (guard it — the time may have just been taken). `createBooking` is
+the 3-arg form `(slot, contact, { totalParticipants, timeZone })`, and `checkoutBooking` returns a
+**bare URL string** you redirect straight to.
+
+```jsx
+import { useState } from "react";
+import { getAvailableSlot } from "@/rest/wix-bookings-services";
+import { createBooking, checkoutBooking } from "@/rest/wix-bookings-checkout";
+
+export default function BookingForm({ service, slot }) {
+  const [contact, setContact] = useState({ firstName: "", lastName: "", email: "", phone: "" });
+  const [submitting, setSubmitting] = useState(false);
+
+  // maxParticipantsPerBooking is the per-booking cap (commonly 1 → no selector at all). Never use
+  // slot.remainingCapacity as the per-buyer limit — a count above the policy makes createBooking fail.
+  const maxParticipants = service.bookingPolicy?.participantsPolicy?.maxParticipantsPerBooking ?? 1;
+  const [participants, setParticipants] = useState(1);
+  const set = (k) => (e) => setContact((c) => ({ ...c, [k]: e.target.value }));
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      // Re-validate right before booking — slots get taken. getAvailableSlot returns the slot or NULL;
+      // the single-slot call uses localStartDate / localEndDate (not from/toLocalDate).
+      const fresh = await getAvailableSlot(service.id, {
+        localStartDate: slot.localStartDate,
+        localEndDate: slot.localEndDate,
+      });
+      if (!fresh) { alert("That time was just taken — please pick another."); return; }
+
+      // createBooking is the 3-arg form: (slot, contact, options). Pass the chosen count as totalParticipants.
+      const booking = await createBooking(fresh, contact, { totalParticipants: participants });
+      // checkoutBooking returns a BARE URL string (not an object) — redirect straight to it.
+      window.location.href = await checkoutBooking(booking.id);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} /* restyle */>
+      <input required type="email" placeholder="Email" value={contact.email} onChange={set("email")} />
+      <input placeholder="First name" value={contact.firstName} onChange={set("firstName")} />
+      <input placeholder="Last name" value={contact.lastName} onChange={set("lastName")} />
+      <input placeholder="Phone" value={contact.phone} onChange={set("phone")} />
+      {maxParticipants > 1 && (
+        <input type="number" min={1} max={maxParticipants} value={participants}
+          onChange={(e) => setParticipants(Number(e.target.value))} />
+      )}
+      <button type="submit" disabled={submitting}>Book</button>
+    </form>
+  );
+}
+```
+
 ## Point the user to their dashboard
 In some cases, users need to access the Wix dashboard in order to edit the bookings content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For bookings data those pages are:
 - **Booking Services** — `https://manage.wix.com/dashboard/{metaSiteId}/bookings/services` (`Dashboard → Bookings → Booking Services`; add services and service categories)
@@ -151,7 +330,7 @@ Substitute the site's `metaSiteId` to complete the links (you have it from the h
 - [ ] Slot is re-validated with `getAvailableSlot()` immediately before booking
 - [ ] Participant selector capped by `maxParticipantsPerBooking` (hidden when 1) — a count above the policy is not offerable
 - [ ] `createBooking()` returns a booking with `status: "CREATED"` and a real id
-- [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL)
+- [ ] Checkout redirects to the URL `checkoutBooking()` returns (a bare string) — or `bookAndCheckout()`'s `checkoutUrl` — with no hand-built URL
 - [ ] On return from checkout the booking is confirmed (status `CONFIRMED`/`PENDING`)
 - [ ] No mock services, slots, or availability anywhere
 - [ ] Told the user at least once that they can continue setting up their bookings in the dashboard and provided deep links.

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -35,7 +35,10 @@ the official Wix Data endpoints.
    continue.
 4. You need each collection's **collection ID** (its name, e.g. `Tutorials`) and its
    **field keys** (e.g. `title`, `publishDate`). Read field keys off a fetched item, or
-   from the collection schema (see "Beyond the snippets").
+   from the collection schema (see "Beyond the snippets"). **Carry your own seed/design
+   plan's field keys forward as the canonical list for rendering** — the item shape here is
+   user-defined (these are the keys *you* planned for the collection), so drive the UI off
+   that known list rather than guessing keys or reverse-engineering them from a single row.
 
 ## The API (copy as-is; do not re-derive it)
 This skill ships only the REST layer — no UI components. Build the UI however the project
@@ -53,11 +56,31 @@ syntax** are documented as JSDoc comments at the top of `wix-cms.js`. Read them 
 building the UI — read helpers return the item's flat `data` payload (which always
 includes `_id`), and writes are bound by collection permissions.
 
+**Owner field — use `_owner`.** The system field that holds the item's owner (the member
+who inserted it) is **`_owner`** in Wix Data v2 — this is the key to filter on for a "my
+items" view (`filter: { _owner: <memberId> }`) and the one Wix stamps on member inserts.
+(The JSDoc comment in `wix-cms.js` currently labels it `_ownerId`; that is a typo in the
+comment — the live field is `_owner`.)
+
 ## How to wire it (UI is the project's choice)
 - **Content list** — `queryDataItems(collectionId, { filter?, sort?, limit?, cursor? })`
-  for the listing; render fields directly off each returned item (`item.title`, etc.).
-  Pass the returned `nextCursor` back as `cursor` to load the next page. Define
-  `filter`/`sort` on the first request only — cursor follow-ups reuse the original query.
+  **resolves to `{ items, nextCursor }`** (not a bare array) — destructure it, iterate
+  `.items`, and render fields directly off each item (`item.title`, etc.). Each item is
+  the flat `data` payload and always carries `_id`. Pass the returned `nextCursor` back as
+  `cursor` to load the next page. Define `filter`/`sort` on the first request only — cursor
+  follow-ups reuse the original query (pass only the cursor). See the reference snippet below.
+- **Sort & date filters** — `sort` is an **array** of `{ fieldName, order: "ASC"|"DESC" }`
+  (e.g. `sort: [{ fieldName: "publishDate", order: "DESC" }]`) — **not** a Mongo
+  `{ field: -1 }` object. In a `filter`, date comparands must be wrapped as
+  `{ "$date": "2026-05-05T00:00:00.000Z" }` (ISO string), not a bare string — e.g.
+  `{ publishDate: { $lte: { "$date": new Date().toISOString() } } }`.
+- **Reference fields** — a `MULTI_REFERENCE` field is **not** inline by default: without
+  asking for it, `item.<field>` is not populated, so don't `.map` over it. Pass
+  `includeReferences: [{ field: "<field>", limit: N }]` to `queryDataItems`; the referenced
+  items then come back under `item.<field>`, and you render them by mapping that (see the
+  snippet). The exact expanded shape (an array of referenced `data` payloads, each with its
+  own `_id`) and any beyond-the-inline-limit expansion — confirm against the Query Referenced
+  Data Items reference under "Beyond the snippets"; it is not spelled out in the helper's JSDoc.
 - **Detail page** — route by the item's `_id` and call `getDataItem(collectionId, itemId)`;
   returns null on miss → show a not-found state, never invent an item. For human-readable
   URLs, add a slug-like field to the collection and route via
@@ -68,13 +91,86 @@ includes `_id`), and writes are bound by collection permissions.
   across fields, see "Beyond the snippets" (Search Data Items).
 - **Public form** — on submit, `insertDataItem(collectionId, { name, email, message })`
   (field keys must match the collection). Requires the collection's Insert permission to be
-  "Anyone". Show success/failure from the resolved/thrown result; never fake a success.
+  "Anyone". It resolves to the **flat inserted `data` payload** (including the newly assigned
+  `_id`) — not a `{ dataItem: { … } }` wrapper — so read `_id`/fields straight off the return.
+  Show success/failure from the resolved/thrown result; never fake a success.
 - **Edit / delete (admin/author flows)** — `updateDataItem(collectionId, itemId, data)`
   (⚠ full replace — fetch + merge first to preserve other fields) and
-  `removeDataItem(collectionId, itemId)`. These need Update/Delete granted to the caller,
-  which visitors normally don't have — expect them to fail unless the collection is opened up.
+  `removeDataItem(collectionId, itemId)`. Like insert, `updateDataItem` resolves to the flat
+  updated `data` payload (with `_id`), not a `{ dataItem: { … } }` wrapper. These need
+  Update/Delete granted to the caller, which visitors normally don't have — expect them to
+  fail unless the collection is opened up.
 - **Empty state** — if `countDataItems(collectionId)` is 0, show an empty state telling
   the user to add items in their Wix dashboard. Never invent items.
+
+## Reference snippet (shape-correct; restyle freely)
+
+The item shape is **user-defined** (the field keys are the ones from your own seed/design
+plan), so this is a skeleton, not a drop-in — the data wiring is what's load-bearing:
+`queryDataItems` returns `{ items, nextCursor }`, each item is a flat `data` payload with
+`_id`, `sort` is an array of `{ fieldName, order }`, dates are `{ "$date": ISO }`, and a
+`MULTI_REFERENCE` field only populates when you pass `includeReferences`. Keep that wiring;
+swap the field keys (`title`, `photo`, `publishDate`, `ingredients`) for your own.
+
+```jsx
+import { useState, useEffect } from "react";
+import { queryDataItems, countDataItems } from "@/rest/wix-cms";
+
+// Field keys are YOUR OWN — the ones from your seed plan for this collection.
+// Carry that plan forward as the canonical list of keys to render.
+const COLLECTION = "Recipes";
+
+export default function Recipes() {
+  const [items, setItems] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    countDataItems(COLLECTION).then(setTotal);
+    queryDataItems(COLLECTION, {
+      sort: [{ fieldName: "publishDate", order: "DESC" }],        // array of { fieldName, order } — NOT { field: -1 }
+      filter: { publishDate: { $lte: { "$date": new Date().toISOString() } } }, // date wrapped in { "$date": ISO }
+      includeReferences: [{ field: "ingredients", limit: 10 }],   // expand a MULTI_REFERENCE field inline
+      limit: 24,
+    }).then(({ items, nextCursor }) => {   // destructure — queryDataItems returns { items, nextCursor }
+      setItems(items);                     // each item is the flat `data` payload, incl. _id
+      setCursor(nextCursor);
+    });
+  }, []);
+
+  const loadMore = () =>
+    // cursor follow-ups reuse the first request's filter/sort — pass ONLY the cursor
+    queryDataItems(COLLECTION, { cursor, limit: 24 }).then(({ items: more, nextCursor }) => {
+      setItems((prev) => [...prev, ...more]);
+      setCursor(nextCursor);
+    });
+
+  if (total === 0) return <p>{/* empty state — no items yet; point the user to the dashboard */}</p>;
+  return (
+    <div /* restyle */>
+      {items.map((item) => (
+        <article key={item._id} /* restyle */>
+          <h3>{item.title}</h3>
+          {/* item.ingredients is an array of referenced `data` payloads ONLY because of includeReferences */}
+          <ul>{(item.ingredients || []).map((ref) => <li key={ref._id}>{ref.name}</li>)}</ul>
+        </article>
+      ))}
+      {cursor && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
+**Image fields need conversion — don't put the field straight into `<img src>`.** A
+merchant-uploaded image field comes back as a Wix media URI like
+`wix:image://v1/<id>~mv2.jpg/<filename>#originWidth=…&originHeight=…`, which a browser
+**cannot** render directly. Only images written by your own seed step tend to be plain
+`https://static.wixstatic.com/...` URLs, which do work in `<img src>`. So branch on it:
+a value starting with `https://` (or `//`) is usable as-is; a `wix:image://` value must be
+converted to a static URL first. **Neither helper in this skill converts media URIs** — look
+up the current Wix Media image-URL conversion in the Wix docs (search "Wix Media" / "image
+URL" in the API reference under "Beyond the snippets") and use that; never hand-assemble the
+`static.wixstatic.com` URL by guessing the transform.
 
 ## Hard rules (do not violate)
 - ✅ Read/write ONLY through the helpers in `wix-cms.js` (which call the official Wix Data
@@ -84,6 +180,16 @@ includes `_id`), and writes are bound by collection permissions.
 - ❌ Never invent fields, reviews, ratings, or content not present in the collection.
 - ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
 - ✅ Use the item's `_id` as the route key and as `itemId` for get/update/remove.
+- ✅ `queryDataItems` resolves to `{ items, nextCursor }` (not a bare array) — destructure and
+  iterate `.items`; each item is a flat `data` payload with `_id`. `insert`/`update` also
+  resolve to the flat `data` payload (with `_id`), not a `{ dataItem: { … } }` wrapper.
+- ✅ `sort` is `[{ fieldName, order: "ASC"|"DESC" }]` (not Mongo `{ field: -1 }`); date filter
+  comparands are wrapped `{ "$date": "ISO" }` (not a bare string).
+- ✅ A `MULTI_REFERENCE` field is not inline — pass `includeReferences: [{ field, limit }]` and
+  only then `.map` over `item.<field>`; without it the field isn't populated.
+- ✅ Convert `wix:image://` media URIs before using them in `<img src>` (a plain `https://` /
+  `//` URL is fine as-is); look up the conversion in the Wix docs — no helper here does it.
+- ✅ The owner field is `_owner` (Wix Data v2), not `_ownerId`.
 - ✅ `updateDataItem` REPLACES the whole item — fetch with `getDataItem`, merge your
   changes, then pass the full object, or use Patch Data Item (see below) for partial edits.
 - ✅ Treat permission errors (HTTP 403) as a configuration step, not a code bug: tell the
@@ -142,7 +248,11 @@ Substitute the site's `metaSiteId` to complete the links (you have it from the h
 ## Verification checklist (before declaring done)
 - [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
 - [ ] Visitor token persists across reload (same anonymous visitor, no re-mint per load)
-- [ ] `queryDataItems` returns live items; pagination via `nextCursor` loads more
+- [ ] `queryDataItems` returns live items (destructured from `{ items, nextCursor }`);
+      pagination via `nextCursor` loads more
+- [ ] `sort` uses `[{ fieldName, order }]` and date filters wrap comparands in `{ "$date": ISO }`
+- [ ] Multi-reference fields fetched with `includeReferences` before being mapped
+- [ ] Image fields: `wix:image://` URIs converted before `<img src>`, not rendered raw
 - [ ] Detail page uses the item's `_id` (or a slug field via `getDataItemBy`) and shows a
       not-found state on miss — no invented item
 - [ ] Filter/sort produce the expected subset (operators match the field types)

--- a/skills/wix-vibe-headless/references/cms/wix-cms.js
+++ b/skills/wix-vibe-headless/references/cms/wix-cms.js
@@ -13,7 +13,7 @@ import { wixApiRequest } from "./wix-client.js";
  * Data Item — every read helper returns the item's `data` payload:
  *   _id {string} — GUID (route key, itemId for get/update/remove),
  *   _createdDate, _updatedDate {string} — ISO 8601 (use { "$date": "..." } in filters),
- *   _ownerId {string}, ...fields — collection field values keyed by field key
+ *   _owner {string}, ...fields — collection field values keyed by field key
  * Full reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/data-item-object.md
  *
  * FILTERS & SORT (Wix API Query Language):

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -49,7 +49,9 @@ adjust import paths:
 
 The `Event`, `TicketDefinition`, and `RSVP`/`Order` shapes are documented as JSDoc comments at
 the top of each helper file. Read the relevant file(s) before building the UI — they describe
-the key fields and link to the full API reference for anything not shown.
+the key fields and link to the full API reference for anything not shown. The **Reference
+components** section below shows correct usage of the browse + registration helpers (grid,
+category menu, load-more, detail page, free-ticket checkout) — adapt the logic, restyle freely.
 
 ## How to wire it (UI is the project's choice)
 - **Event grid** — `queryEvents()` lists live (UPCOMING/STARTED) events, soonest first. Render
@@ -121,6 +123,171 @@ first; never guess:
 
 Keep the snippets as the default for everything they already do; reach for the API reference only
 for the gap.
+
+## Reference components (headless — adapt the logic, restyle freely)
+
+These are the recurring events pieces, written **headless**: the data wiring (Wix field paths,
+the offset load-more math, the ticketing Money object, the free-ticket checkout shape) is correct
+and complete — the markup is deliberately plain. **Copy the logic exactly; restyle the JSX to the
+brand.** Don't re-derive the data shapes from scratch (that's where the bugs are — the category
+`label`, the `lowestPrice` Money object, and the `{ events, nextOffset }` paging especially). They
+consume the `src/rest/` helpers; you don't need to read those helpers' source.
+
+**`components/EventCard.jsx`** — grid tile. Note the date/location/teaser field paths and the
+TICKETING "from" price, read off `registration.tickets.lowestPrice` — a **Money object**
+`{ value, currency, formattedValue }`. Render `formattedValue`, **never** the raw object (React
+"objects are not valid as a child" crash). This is a different shape from the ticket-definition
+price path `pricing.fixedPrice.amount` (a plain number) used inside the ticket picker.
+
+```jsx
+import { Link } from "react-router-dom";
+
+export default function EventCard({ event }) {
+  const when = event.dateAndTimeSettings?.formatted?.dateAndTime;
+  const where = event.location?.name;
+  const isTicketing = event.registration?.type === "TICKETING";
+  // lowestPrice is a Money object { value, currency, formattedValue } — render formattedValue,
+  // NEVER the raw object (React child crash). Ticket-definition prices use pricing.fixedPrice.amount.
+  const fromPrice = event.registration?.tickets?.lowestPrice?.formattedValue;
+  const soldOut = event.registration?.tickets?.soldOut;
+  return (
+    <Link to={`/events/${event.slug}`} /* restyle */>
+      {event.mainImage?.url
+        ? <img src={event.mainImage.url} alt={event.title} loading="lazy" />
+        : <div>{/* placeholder */}</div>}
+      <h3>{event.title}</h3>
+      {when && <span>{when}</span>}
+      {where && <span>{where}</span>}
+      {event.shortDescription && <p>{event.shortDescription}</p>}
+      {isTicketing && (soldOut ? <span>Sold out</span> : fromPrice && <span>From {fromPrice}</span>)}
+    </Link>
+  );
+}
+```
+
+**`pages/Events.jsx`** — the listing (grid + category menu + empty state + load-more). Both
+`queryEvents` and `listEventsByCategory` return an **object** `{ events, total, offset, nextOffset }`,
+not a bare array — destructure `events` first; `nextOffset` is `null` when there are no more pages.
+`queryEventCategories()` returns `{ categories, total }`; render `category.label` (**not** `name` —
+the display field is `label`), key/filter by `category.id`, and show `counts.assignedEventsCount`.
+
+```jsx
+import { useState, useEffect } from "react";
+import { queryEvents, listEventsByCategory, queryEventCategories, countUpcomingEvents } from "@/rest/wix-events-browse";
+import EventCard from "@/components/EventCard";
+
+export default function Events() {
+  const [events, setEvents] = useState([]);
+  const [nextOffset, setNextOffset] = useState(null); // offset for the next page; null when no more
+  const [menu, setMenu] = useState([]);               // category menu
+  const [active, setActive] = useState(null);         // selected category id, or null for "all"
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    countUpcomingEvents().then(setTotal);
+    // queryEventCategories returns { categories, total } — destructure the array first.
+    queryEventCategories().then(({ categories }) => setMenu(categories));
+  }, []);
+
+  useEffect(() => {
+    const load = active
+      ? listEventsByCategory(active, { limit: 24 })
+      : queryEvents({ limit: 24 });
+    // Both return an OBJECT { events, total, offset, nextOffset } — not a bare array.
+    load.then(({ events, nextOffset }) => { setEvents(events); setNextOffset(nextOffset); });
+  }, [active]);
+
+  const loadMore = () => {
+    const load = active
+      ? listEventsByCategory(active, { limit: 24, offset: nextOffset })
+      : queryEvents({ limit: 24, offset: nextOffset });
+    load.then(({ events: more, nextOffset: next }) => { setEvents((e) => [...e, ...more]); setNextOffset(next); });
+  };
+
+  if (total === 0) return <p>{/* empty state — no events published yet */}</p>;
+  return (
+    <div /* restyle */>
+      <nav>
+        <button onClick={() => setActive(null)} aria-pressed={active === null}>All</button>
+        {menu.map((c) => (
+          // display field is `label`, NOT `name`; key/filter by `category.id`.
+          <button key={c.id} onClick={() => setActive(c.id)} aria-pressed={active === c.id}>
+            {c.label} ({c.counts?.assignedEventsCount ?? 0})
+          </button>
+        ))}
+      </nav>
+      <div /* grid */>{events.map((e) => <EventCard key={e.id} event={e} />)}</div>
+      {nextOffset !== null && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
+**`pages/EventDetail.jsx`** — the detail page. `getEventBySlug(slug)` returns **null** on miss —
+show a not-found state, never invent an event. Branch the registration UI on `registration.type`
+and only accept registrations while `registration.status` starts with `OPEN_`. `shortDescription`
+is a plain string (safe); the full `event.description` is **Ricos rich content** `{ nodes: [...] }`
+— render it with `@wix/ricos` or walk `nodes`; **never** call string methods on it (that crashes
+the page).
+
+```jsx
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { getEventBySlug } from "@/rest/wix-events-browse";
+
+export default function EventDetail() {
+  const { slug } = useParams();
+  const [event, setEvent] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    getEventBySlug(slug).then((e) => (e ? setEvent(e) : setNotFound(true))); // null on miss
+  }, [slug]);
+
+  if (notFound) return <div>Event not found.</div>;
+  if (!event) return <div>Loading…</div>;
+
+  const reg = event.registration ?? {};
+  const open = typeof reg.status === "string" && reg.status.startsWith("OPEN_"); // only OPEN_* takes registrations
+  return (
+    <div /* restyle */>
+      {event.mainImage?.url && <img src={event.mainImage.url} alt={event.title} />}
+      <h1>{event.title}</h1>
+      <p>{event.dateAndTimeSettings?.formatted?.dateAndTime}</p>
+      {/* shortDescription is a plain string (safe to render). event.description is Ricos rich
+          content { nodes: [...] } — render with @wix/ricos or walk nodes; NEVER call string
+          methods (.slice/.substring) on it — that crashes the page. */}
+      {event.shortDescription && <p>{event.shortDescription}</p>}
+
+      {reg.type === "RSVP" && (open ? <div>{/* RSVP form — fields from event.form.controls */}</div> : <p>Registration is closed.</p>)}
+      {reg.type === "TICKETING" && (open ? <div>{/* ticket picker — see the free-ticket checkout snippet */}</div> : <p>Ticket sales are closed.</p>)}
+      {reg.type === "EXTERNAL" && <a href={reg.external?.url}>Register</a>}
+      {reg.type === "NONE" && null}
+    </div>
+  );
+}
+```
+
+**Free-ticket checkout** — for **free** tickets you may finish in-app instead of redirecting:
+reserve, then call `checkoutTickets(eventId, { reservationId, buyer, guests })` with the guest
+sub-shape `guests: [{ firstName, lastName, email }]`. It throws for paid orders (telling you to use
+`getTicketCheckoutUrl`), so a green path is a real, confirmed order.
+
+```jsx
+import { reserveTickets, checkoutTickets, getTicketCheckoutUrl } from "@/rest/wix-events-registration";
+
+// FREE tickets only: reserve, then finish in-app with checkoutTickets — no redirect.
+// For ANY paid ticket, redirect instead: window.location.href = getTicketCheckoutUrl(event, reservation.id).
+async function claimFreeTicket(event, ticketDefinitionId, buyer /* { firstName, lastName, email } */) {
+  const reservation = await reserveTickets([{ ticketDefinitionId, quantity: 1 }]); // { id, expirationDate }
+  const order = await checkoutTickets(event.id, {
+    reservationId: reservation.id,
+    buyer,
+    guests: [{ firstName: buyer.firstName, lastName: buyer.lastName, email: buyer.email }],
+  });
+  return order; // status "FREE"; carries order.ticketsPdf and order.tickets[]. Throws if payment is owed.
+}
+```
 
 ## Point the user to their dashboard
 In some cases, users need to access the Wix dashboard in order to edit the events content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For events data those pages are:

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -44,26 +44,170 @@ The Collection, Project, and Project Item shapes are documented as JSDoc comment
 image/video, media resolutions, details rows) and link to the full API reference.
 
 ## How to wire it (UI is the project's choice)
-- **Collections gallery (home)** — `queryCollections()` for the listing (visible collections
-  only, in dashboard order); pass `nextCursor` back as `cursor` to load the next page. Render
-  `collection.title`, `collection.description`, and `collection.coverImage.imageInfo.url`. Link
-  each card to a collection page keyed on `collection.slug`.
+
+**Every list helper returns an object, not a bare array** — destructure the named key first, or
+`.map`/`.filter` on the result throws `… is not a function` (the #1 portfolio-listing bug):
+`queryCollections()` → `{ collections, nextCursor }`; `queryProjects()` /
+`queryProjectsByCollection(id)` → `{ projects, nextCursor }`; `listProjectItems(id)` →
+`{ items, total }`. Single fetches (`getCollectionBySlug`, `getProjectBySlug`, `getProject`)
+return the object or `null`; `countCollections()` returns a number.
+
+- **Collections gallery (home)** — `const { collections, nextCursor } = await queryCollections()`
+  for the listing (visible collections only, in dashboard order); pass `nextCursor` back as
+  `cursor` to load the next page. Render `collection.title`, `collection.description`, and
+  `collection.coverImage.imageInfo.url`. Link each card to a collection page keyed on
+  `collection.slug`.
 - **Collection page** — `getCollectionBySlug(slug)` for the header (returns null on miss — show
-  a not-found state, never invent one). Then `queryProjectsByCollection(collection.id, { limit?, cursor? })`
+  a not-found state, never invent one). Then
+  `const { projects, nextCursor } = await queryProjectsByCollection(collection.id, { limit?, cursor? })`
   for its project grid; paginate exactly like `queryCollections`.
-- **All-work gallery (optional)** — `queryProjects()` to list every visible project across
+- **All-work gallery (optional)** —
+  `const { projects, nextCursor } = await queryProjects()` to list every visible project across
   collections (newest-first); paginate the same way.
 - **Project grid card** — render `project.title` and the cover: use `project.coverImage.imageInfo.url`
   when present, else the `project.coverVideo.videoInfo.posters[0]` / first
   `coverVideo.videoInfo.resolutions[]` entry. Link each card to a project page keyed on `project.slug`.
 - **Project detail page** — `getProjectBySlug(slug)` for the header (title, description, and the
   `details[]` rows: each has a `label` plus either `text` or `link: { text, url, target }`).
-  Then `listProjectItems(project.id)` for the media gallery — render IMAGE items from
-  `image.imageInfo.url` and VIDEO items from the first `video.videoInfo.resolutions[]` entry
-  (with `video.videoInfo.posters[0]` as the poster). Honor each item's optional `link`.
+  Then `const { items, total } = await listProjectItems(project.id)` for the media gallery —
+  `items` is the array (the helper returns `{ items, total }`, **not** a bare array; iterate
+  `items`). Branch on **`item.type`**, which is `"IMAGE" | "VIDEO" | "UNDEFINED"`: render IMAGE
+  items from `item.image.imageInfo.url` and VIDEO items from the first
+  `item.video.videoInfo.resolutions[]` entry's `url` (with `item.video.videoInfo.posters[0]` as
+  the poster). Honor each item's optional `item.link: { text, url, target }` (same link shape as
+  the `details[]` rows above).
   - If you already hold a project id (not a slug), use `getProject(projectId)` instead.
 - **Empty state** — if `countCollections()` is 0, show an empty state telling the user to add
   collections and projects in their Wix dashboard. Never invent projects or media.
+
+## Worked snippets (headless — adapt the logic, restyle freely)
+
+Portfolio ships no UI components; these are illustrative wiring, not files to copy verbatim.
+The data paths (return-object destructuring, field paths, `item.type` branching, `details[]`
+link shape) are the load-bearing part — keep those exactly and restyle the markup to the brand.
+
+**`pages/Portfolio.jsx`** — collections gallery (grid + empty state + paging). `queryCollections`
+returns `{ collections, nextCursor }` — an object, not an array. Keep the destructuring.
+
+```jsx
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { queryCollections, countCollections } from "@/rest/wix-portfolio";
+
+export default function Portfolio() {
+  const [collections, setCollections] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    countCollections().then(setTotal);                       // number → 0 means empty state
+    // NB: destructure — queryCollections returns { collections, nextCursor }, not an array.
+    queryCollections({ limit: 24 }).then(({ collections, nextCursor }) => {
+      setCollections(collections);
+      setCursor(nextCursor);
+    });
+  }, []);
+
+  const loadMore = () =>
+    queryCollections({ limit: 24, cursor }).then(({ collections: more, nextCursor }) => {
+      setCollections((c) => [...c, ...more]);
+      setCursor(nextCursor);
+    });
+
+  if (total === 0) return <p>{/* empty state — add collections in the Wix dashboard */}</p>;
+  return (
+    <div /* restyle */>
+      <div /* grid */>
+        {collections.map((c) => (
+          <Link key={c.id} to={`/collection/${c.slug}`} /* restyle */>
+            {c.coverImage?.imageInfo?.url && (
+              <img src={c.coverImage.imageInfo.url} alt={c.title} loading="lazy" />
+            )}
+            <h3>{c.title}</h3>
+            {c.description && <p>{c.description}</p>}
+          </Link>
+        ))}
+      </div>
+      {cursor && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
+**`pages/ProjectDetail.jsx`** — project header + `details[]` rows + media gallery. Two shapes to
+keep: `listProjectItems` returns `{ items, total }` (iterate `items`), and each item branches on
+`item.type`. Videos render from `resolutions[].url` (the confirmed field).
+
+```jsx
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { getProjectBySlug, listProjectItems } from "@/rest/wix-portfolio";
+
+// media item: branch on item.type ("IMAGE" | "VIDEO" | "UNDEFINED")
+function ProjectMedia({ item }) {
+  if (item.type === "IMAGE")
+    return <img src={item.image?.imageInfo?.url} alt={item.title || ""} loading="lazy" />;
+  if (item.type === "VIDEO") {
+    const src = item.video?.videoInfo?.resolutions?.[0]?.url; // resolutions[].url is the confirmed field
+    // poster: item.video.videoInfo.posters[0] — poster-entry sub-shape isn't in the helper
+    // JSDoc; if you need the poster image URL, confirm the field in wix-docs before using it.
+    return <video src={src} controls playsInline />;
+  }
+  return null; // UNDEFINED — nothing renderable
+}
+
+export default function ProjectDetail() {
+  const { slug } = useParams();
+  const [project, setProject] = useState(null);
+  const [items, setItems] = useState([]);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    getProjectBySlug(slug).then((p) => {
+      if (!p) return setNotFound(true);                      // null on miss → not-found state
+      setProject(p);
+      // NB: destructure — listProjectItems returns { items, total }, not an array.
+      listProjectItems(p.id).then(({ items }) => setItems(items));
+    });
+  }, [slug]);
+
+  if (notFound) return <div>Project not found.</div>;
+  if (!project) return <div>Loading…</div>;
+  return (
+    <div /* restyle */>
+      <h1>{project.title}</h1>
+      {project.description && <p>{project.description}</p>}
+      {/* details[] row: { label, text? } OR { label, link: { text, url, target } } */}
+      <dl>
+        {(project.details || []).map((d, i) => (
+          <div key={i}>
+            <dt>{d.label}</dt>
+            <dd>
+              {d.link ? (
+                <a href={d.link.url} target={d.link.target}>{d.link.text}</a>
+              ) : (
+                d.text
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <div /* gallery grid */>
+        {items.map((item) => (
+          <figure key={item.id}>
+            {item.link ? (
+              <a href={item.link.url} target={item.link.target}><ProjectMedia item={item} /></a>
+            ) : (
+              <ProjectMedia item={item} />
+            )}
+            {item.title && <figcaption>{item.title}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
 
 ## Hard rules (do not violate)
 - ✅ Render only live Wix Portfolio data — collections, projects, and items as returned.

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -48,12 +48,28 @@ single-payment-for-duration, single-payment-unlimited, free, plus free trials) a
 shows exactly how to read price, cycle, and trial for display.
 
 ## How to wire it (UI is the project's choice)
-- **Plans grid** — `queryPlans()` for the listing (PUBLIC plans only); pass `nextCursor` back as
-  `cursor` to load the next page. For each plan render `name`, `description`, `perks[].description`
-  as feature bullets, and the price from `pricingVariants[0]` (see the JSDoc "Reading the price"
-  notes: `pricingStrategies[0].flatRate.amount` + plan `currency`, plus `billingCycle` for
-  recurring and `freeTrialDays` for trials). Show a "Subscribe"/"Buy" button only when
-  `plan.buyable` is true.
+- **Plans grid** — `const { plans, nextCursor } = await queryPlans()` — **destructure**: it returns
+  an object `{ plans, nextCursor }`, not a bare array, so `queryPlans().map(...)` /
+  `(await queryPlans()).map(...)` throws `… is not a function`. Returns PUBLIC plans only; pass
+  `nextCursor` back as `cursor` to load the next page, and iterate `plans`. For each plan render
+  `name`, `description`, and `perks[].description` as feature bullets. Show a "Subscribe"/"Buy"
+  button only when `plan.buyable` is true. See the `pages/Plans.jsx` snippet below for the worked
+  listing (destructure + empty state + price + paging).
+- **Price** — the amount is at `plan.pricingVariants[0].pricingStrategies[0].flatRate.amount`. It is
+  a **decimal string** like `"20.00"` (a *string*, never a number) where `"0"` means the plan is
+  **free**. Do not do math on it and do not compare `=== 0` (it's a string) — treat it as
+  display-only text and pair it with `plan.currency` (ISO-4217, e.g. `"USD"`). Wix settles the real
+  charge, tax, and proration at hosted checkout — never compute a final price yourself.
+- **Billing cycle** — for a **recurring** plan the cycle lives at
+  `plan.pricingVariants[0].billingTerms.billingCycle` = `{ period: "DAY"|"WEEK"|"MONTH"|"YEAR",
+  count }` (e.g. `{ period: "MONTH", count: 1 }` = billed monthly). It is nested under
+  `billingTerms` — there is **no** `billingCycle` directly on `pricingVariants[0]`. Free-trial
+  length is `plan.pricingVariants[0].freeTrialDays`.
+- **Plan image** — `plan.image` is a WixMedia object `{ id, width, height, altText }` with **no
+  `.url`**; the `id` is a WixMedia id that must be converted to a URL before it can render. Never
+  set `<img src={plan.image}>` or `<img src={plan.image.url}>` (both are `undefined` /
+  `[object Object]`). To show it, resolve the WixMedia `id` to a URL per the Wix Media docs (use
+  wix-docs), otherwise omit the image / use a placeholder.
 - **Plan detail** — `getPlanBySlug(slug)` keyed off the URL slug (or `getPlanById(id)`); returns
   null on miss — show a not-found state, never invent a plan. Render perks, the full price/billing
   summary, free-trial note, and `termsAndConditions` if present.
@@ -62,11 +78,18 @@ shows exactly how to read price, cycle, and trial for display.
   order form, and takes payment. On success Wix returns to `thankYouPageUrl` with a
   `?planOrderId=<GUID>` query param (and `wixMemberLoggedIn`); on abandon/interrupt it returns to
   `postFlowUrl` (defaults to the current page). Never create the order or build the URL yourself.
-- **My plans / confirmation** — `getMyPlanOrders()` for the logged-in member's purchases; filter
-  with `{ orderStatuses: ["ACTIVE"] }` for current memberships. After returning from checkout,
-  re-fetch (e.g. on mount + `visibilitychange`, or when `planOrderId` is in the URL) to show the
-  new order. Returns `[]` for anonymous visitors — show a "log in to see your plans" state, and wire
-  that log-in via the **members** vertical (`references/members/`) so they can sign in on your own UI.
+- **My plans / confirmation** — `const orders = await getMyPlanOrders({ orderStatuses: ["ACTIVE"] })`
+  for the logged-in member's current memberships (omit `orderStatuses` for all of them). It resolves
+  to an **array** — `[]` for anonymous visitors (never throws), so show a "log in to see your plans"
+  state and wire that log-in via the **members** vertical (`references/members/`) so they can sign in
+  on your own UI. Renderable Order fields (confirmed in the JSDoc): `planName`, `status`
+  (`DRAFT`/`PENDING`/`ACTIVE`/`PAUSED`/`ENDED`/`CANCELED`), `lastPaymentStatus`, `startDate`,
+  `endDate` (date strings — format for display), `freeTrialDays`, `currentCycle`
+  (`{ index, startedDate, endedDate }`), and `autoRenewCanceled`. Render only fields the order
+  actually returns; for anything not in that list (e.g. the amount paid or next-billing figure) look
+  it up in the Orders API reference (wix-docs) — never invent it. After returning from checkout,
+  re-fetch (e.g. on mount + `visibilitychange`, or when `planOrderId` is in the URL) to show the new
+  order. See the `pages/MyPlans.jsx` snippet below.
 - **Empty state** — if `queryPlans()` returns no plans, show an empty state telling the user to
   create plans in their Wix dashboard. Never invent plans.
 
@@ -105,6 +128,120 @@ Common genuine gaps and where to look:
 
 Keep the snippets as the default for everything they already do; reach for the API reference only
 for the gap.
+
+## Reference snippets (headless — adapt the logic, restyle freely)
+
+The data wiring below (destructure shapes, the exact price/billing-cycle paths, the members-only
+checkout redirect, the anonymous `[]` case) is correct and complete — the markup is deliberately
+plain. **Copy the logic exactly; restyle the JSX to the brand.** They consume the `src/rest/`
+helpers; you don't need to read their source.
+
+**`pages/Plans.jsx`** — the listing (grid + empty state + paging) with the price/billing-cycle read
+and the members-only checkout redirect. Note the destructure of `queryPlans()`, the price as a
+decimal string (`"0"` = free), and the `billingTerms.billingCycle` nesting.
+
+```jsx
+import { useState, useEffect } from "react";
+import { queryPlans, checkout } from "@/rest/wix-pricing-plans";
+
+// Display-only — never compute the final charge (Wix settles price, tax, and schedule at checkout).
+function readPrice(plan) {
+  const v = plan.pricingVariants?.[0];
+  const amount = v?.pricingStrategies?.[0]?.flatRate?.amount;   // decimal STRING e.g. "20.00"; "0" = free
+  if (amount == null) return null;
+  const cycle = v?.billingTerms?.billingCycle;                  // { period, count } for recurring; absent otherwise
+  return { amount, isFree: amount === "0", cycle, freeTrialDays: v?.freeTrialDays };
+}
+
+function PriceLabel({ plan }) {
+  const p = readPrice(plan);
+  if (!p) return null;
+  if (p.isFree) return <span>Free</span>;
+  const per = p.cycle ? ` / ${p.cycle.count} ${p.cycle.period.toLowerCase()}` : "";   // e.g. "/ 1 month"
+  return <span>{p.amount} {plan.currency}{per}{p.freeTrialDays ? ` · ${p.freeTrialDays}-day free trial` : ""}</span>;
+}
+
+export default function Plans() {
+  const [plans, setPlans] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    // NB: destructure — queryPlans returns { plans, nextCursor }, NOT a bare array.
+    queryPlans().then(({ plans, nextCursor }) => { setPlans(plans); setCursor(nextCursor); setLoaded(true); });
+  }, []);
+
+  const loadMore = () =>
+    queryPlans({ cursor }).then(({ plans: more, nextCursor }) => { setPlans((p) => [...p, ...more]); setCursor(nextCursor); });
+
+  async function buy(plan) {
+    // members-only, Wix-hosted checkout; on success Wix returns to thankYouPageUrl with ?planOrderId=<GUID>
+    window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.location.origin}/thank-you` });
+  }
+
+  if (loaded && plans.length === 0)
+    return <p>{/* empty state — no plans yet; tell the user to create plans in their Wix dashboard */}</p>;
+
+  return (
+    <div /* restyle */>
+      {plans.map((plan) => (
+        <div key={plan.id} /* restyle: plan card */>
+          {/* plan.image is a WixMedia object { id, width, height, altText } with NO .url — resolve the
+              id to a URL (wix-docs) before rendering, or omit; never <img src={plan.image}> */}
+          <h3>{plan.name}</h3>
+          {plan.description && <p>{plan.description}</p>}
+          <PriceLabel plan={plan} />
+          <ul>{(plan.perks || []).map((perk) => <li key={perk.id}>{perk.description}</li>)}</ul>
+          {plan.buyable && <button onClick={() => buy(plan)}>Subscribe</button>}
+        </div>
+      ))}
+      {cursor && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
+**`pages/MyPlans.jsx`** — the member's current memberships and the post-checkout confirmation.
+`getMyPlanOrders(...)` resolves to an array (`[]` for anonymous visitors), and the view re-syncs on
+`visibilitychange` so a plan bought via hosted checkout shows up on return.
+
+```jsx
+import { useState, useEffect, useCallback } from "react";
+import { getMyPlanOrders } from "@/rest/wix-pricing-plans";
+
+export default function MyPlans() {
+  const [orders, setOrders] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const refresh = useCallback(() => {
+    // [] for anonymous visitors (no member context) — never throws.
+    getMyPlanOrders({ orderStatuses: ["ACTIVE"] }).then((o) => { setOrders(o); setLoaded(true); });
+  }, []);
+
+  useEffect(() => {                                   // load once + re-sync on return from hosted checkout
+    refresh();
+    const onVisible = () => document.visibilityState === "visible" && refresh();
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refresh]);
+
+  if (loaded && orders.length === 0)
+    return <p>{/* not a member → "log in to see your plans" (members vertical); member with none → "no active plans" */}</p>;
+
+  return (
+    <ul /* restyle */>
+      {orders.map((order) => (
+        <li key={order.id}>
+          <span>{order.planName}</span>
+          <span>{order.status}</span>                                  {/* ACTIVE | PAUSED | ENDED | CANCELED | … */}
+          {order.startDate && <span>from {new Date(order.startDate).toLocaleDateString()}</span>}
+          {order.endDate && <span>until {new Date(order.endDate).toLocaleDateString()}</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
 
 ## Point the user to their dashboard
 In some cases, users need to access the Wix dashboard in order to edit the pricing plans content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For pricing plans data those pages are:

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -55,11 +55,26 @@ shapes are documented as JSDoc at the top of each helper file. Read the relevant
 building the UI — they describe the key fields and link to the full reference for anything not shown.
 
 ## How to wire it (UI is the project's choice)
-- **Menu page** — call `getFullMenu()` once. It returns `{ menus: [{ ...menu, sections: [{ ...section,
-  items: [assembledItem] }] }] }`, already ordered by `sectionIds` / `itemIds`. Render each item's
-  `name`, `description`, `image`, `labels` (`name` + `icon`), and `featured` flag. For price, show
-  `item.price` (single) or the `item.variants[]` (each `{ name, price }`). **Restaurants prices are
-  plain decimal strings with NO currency symbol** — format with the site's currency in the UI.
+- **Menu page** — call `getFullMenu()` once. It is the **only** pre-joined shape and the entry point
+  for the menu screen. It returns `{ menus: [{ ...menu, sections: [{ ...section, items: [assembledItem]
+  }] }] }`, already ordered by `sectionIds` / `itemIds`, each item enriched with a resolved `price` /
+  `variants`, `modifierGroups`, and `labels`. Render each item's `name`, `description`, `image`,
+  `labels` (`name` + `icon`), and `featured` flag. **`item.image`, `section.image`, and `label.icon`
+  are OBJECTS** (`{ url, width, height, altText }`, and `{ url }` for the icon) — render
+  `item.image?.url`, `section.image?.url`, `label.icon?.url`, never the object itself. For price, show
+  `item.price` (single) or the `item.variants[]` (each `{ name, price }`). **Restaurants MENU prices
+  are plain decimal strings with NO currency symbol** — format with the site's currency in the UI (the
+  eCom cart's `price.formattedAmount` DOES include it — see the cart snippet). This is the main render
+  surface: use the `MenuPage.jsx` reference snippet below.
+- **Build on `getFullMenu`, not the raw `list*` fns** — `getFullMenu` is the only helper that returns
+  a joined tree with references resolved. The raw `listSections` / `listItems` / `listVariants` /
+  `listModifiers` return **unresolved refs** (an item's `labels` and `modifierGroups` come back
+  **id-only**, price variants unresolved) and have **inconsistent return shapes**: `listMenus` → a
+  `{ menus, nextCursor }` wrapper, while `listSections` / `listItems` / `listVariants` /
+  `listModifierGroups` / `listModifiers` → **bare arrays**. Don't re-join them by hand. If you truly
+  need a partial fetch, note the signature — those fns take an **array of GUIDs** (`listSections(sectionIds)`,
+  `listItems(itemIds)`), and the join walks `menu.sectionIds` → `listSections` → each `section.itemIds`
+  → `listItems`.
 - **Item detail** — render `item.modifierGroups[]`: each group's `name`, its `rule`
   (`required`, `minSelections`, `maxSelections`), and `modifiers[]` (`name`, `additionalCharge`,
   `preSelected`, `inStock`). If `orderSettings.acceptSpecialRequests`, offer a free-text field.
@@ -73,12 +88,19 @@ building the UI — they describe the key fields and link to the full reference 
   placed and the cart is empty — re-fetch with `getCurrentCart()` on return (e.g. on mount +
   `visibilitychange`) to clear the UI.
 - **Reservations** — `listReservationLocations()` for the picker (use `location` details for the
-  label; if a location's `configuration.onlineReservations.onlineReservationsEnabled` is false, hide
-  it). Then `getTimeSlots(locationId, dateISO, partySize)` — render `availableTimeSlots` (already
-  filtered to `AVAILABLE`). On slot pick, `createHeldReservation(locationId, slot.startDate,
-  partySize)` → keep the returned `id` + `revision`. Collect the visitor's details, then
-  `reserveReservation(id, revision, { firstName, phone, lastName?, email? })`. A `RESERVED` status is
-  confirmed; `REQUESTED` means the location requires manual approval — tell the user it's pending.
+  label). **Skip archived locations** (`loc.archived === true`) — that flag IS in the location shape.
+  There is **no `onlineReservationsEnabled` field** in the location shape: the util documents
+  `configuration.onlineReservations.approval.mode` (`AUTOMATIC` / `MANUAL` / `MANUAL_FOR_LARGE_PARTIES`)
+  and `configuration.partySize`, not an enable toggle. Do **not** filter on an invented
+  `onlineReservationsEnabled` — if you need to hide locations that don't take online reservations,
+  confirm the real enable/visibility field with the **wix-docs** skill / Restaurants reference first.
+  Then `getTimeSlots(locationId, dateISO, partySize)` — render `availableTimeSlots` (already filtered
+  to `AVAILABLE`). On slot pick, `createHeldReservation(locationId, slot.startDate, partySize)` → keep
+  the returned `id` + `revision`. Collect the visitor's details, then `reserveReservation(id, revision,
+  { firstName, phone, lastName?, email? })`. Read the returned reservation's top-level `status` —
+  `RESERVED` is confirmed, `REQUESTED` means the location requires manual approval (tell the user it's
+  pending) — and echo `reservation.details.{startDate, endDate, partySize}` back as the confirmation
+  summary.
 - **Empty state** — if `getFullMenu()` returns no menus, show an empty state telling the user to add
   a menu in their Wix dashboard. Never invent menu items.
 
@@ -116,6 +138,123 @@ request body in the **official Wix API reference** first; never guess:
 
 Keep the snippets as the default for everything they already do; reach for the API reference only
 for the gap.
+
+## Reference snippets (headless — adapt the logic, restyle freely)
+
+These are the recurring restaurant pieces, written **headless**: the Wix field paths are correct and
+complete; the markup is deliberately plain. **Copy the logic exactly; restyle the JSX to the brand.**
+They consume the `src/rest/` helpers — you don't need to read those helpers' source.
+
+**`pages/MenuPage.jsx`** — the menu render surface. Drives everything off the assembled `getFullMenu()`
+tree. Note the paths that trip people up: `item.image` / `section.image` / `label.icon` are **objects**
+(render `.url`, never the object), menu prices carry **no currency symbol**, and an item is priced by
+**either** `item.price` (single) **or** `item.variants[]` (one-of, each `{ name, price }`).
+
+```jsx
+import { useState, useEffect } from "react";
+import { getFullMenu } from "@/rest/wix-restaurants-menu";
+
+// Wix media urls can come back protocol-relative (//...) — normalize to https.
+// item.image / section.image / label.icon are OBJECTS ({ url, ... }) — read .url, never render the object.
+function imageUrl(img) {
+  const url = img?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+// Restaurants MENU prices are plain decimal strings with NO currency symbol ("12.50").
+function formatPrice(price) {
+  return price == null ? "" : `$${price}`; // swap "$" for the site's currency
+}
+
+export default function MenuPage() {
+  const [menus, setMenus] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getFullMenu().then(({ menus }) => { setMenus(menus); setLoading(false); });
+  }, []);
+
+  if (loading) return <div>Loading…</div>;
+  if (menus.length === 0) return <p>{/* empty state — add a menu in the Wix dashboard */}</p>;
+
+  return (
+    <div /* restyle */>
+      {menus.map((menu) => (
+        <section key={menu.id}>
+          <h2>{menu.name}</h2>
+          {menu.description && <p>{menu.description}</p>}
+          {menu.sections.map((section) => (
+            <div key={section.id}>
+              <h3>{section.name}</h3>
+              {imageUrl(section.image) && <img src={imageUrl(section.image)} alt={section.name} />}
+              {section.items.map((item) => (
+                <article key={item.id}>
+                  {imageUrl(item.image) && <img src={imageUrl(item.image)} alt={item.name} loading="lazy" />}
+                  <h4>{item.name}{item.featured && <span> ★</span>}</h4>
+                  {item.description && <p>{item.description}</p>}
+                  {/* labels: [{ id, name, icon }] — icon is an OBJECT ({ url }); render label.icon.url */}
+                  {item.labels.map((label) => (
+                    <span key={label.id}>
+                      {imageUrl(label.icon) && <img src={imageUrl(label.icon)} alt="" />}
+                      {label.name}
+                    </span>
+                  ))}
+                  {/* price: single string, OR one-of variants [{ name, price }] — neither has a currency symbol */}
+                  {item.price != null
+                    ? <span>{formatPrice(item.price)}</span>
+                    : item.variants.map((v) => (
+                        <span key={v.variantId}>{v.name}: {formatPrice(v.price)}</span>
+                      ))}
+                  {item.orderSettings?.inStock === false && <span>Sold out</span>}
+                </article>
+              ))}
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}
+```
+
+**`Cart.jsx`** — reads the Wix **server** cart via `getCurrentCart()` (never a local copy). The line
+paths: `line.id` is the **lineItemId** used for mutations (NOT the menu item id), the display name is
+`line.productName.original`, and the line price is `line.price.formattedAmount` (the eCom cart price
+DOES include the currency symbol, unlike the menu). Re-fetch on return from checkout to clear the UI.
+
+```jsx
+import { useState, useEffect } from "react";
+import { getCurrentCart, updateCartItemQuantity, removeFromCart, checkout } from "@/rest/wix-restaurants-ordering";
+
+export default function Cart() {
+  const [cart, setCart] = useState(null);
+  const refresh = () => getCurrentCart().then(setCart);
+  useEffect(() => { // re-fetch on mount + when the tab regains focus (cart is empty after a completed checkout)
+    refresh();
+    const onVisible = () => document.visibilityState === "visible" && refresh();
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, []);
+
+  const lineItems = cart?.lineItems ?? [];
+  if (lineItems.length === 0) return <p>Your cart is empty.</p>;
+  return (
+    <div /* restyle */>
+      {lineItems.map((line) => (
+        <div key={line.id}>{/* line.id is the lineItemId for mutations — NOT the menu item id */}
+          <span>{line.productName?.original}</span>
+          <button onClick={async () => setCart(await updateCartItemQuantity(line.id, Math.max(1, line.quantity - 1)))}>−</button>
+          <span>{line.quantity}</span>
+          <button onClick={async () => setCart(await updateCartItemQuantity(line.id, line.quantity + 1))}>+</button>
+          <button onClick={async () => setCart(await removeFromCart(line.id))}>Remove</button>
+          <span>{line.price?.formattedAmount}</span>{/* eCom cart price DOES include the currency symbol (unlike menu prices) */}
+        </div>
+      ))}
+      <button onClick={async () => { window.location.href = await checkout(); }}>Checkout</button>
+    </div>
+  );
+}
+```
 
 ## Point the user to their dashboard
 In some cases, users need to access the Wix dashboard in order to edit the restaurant content for their site — across up to three apps. To facilitate this, provide the user with deep links directly to the relevant dashboard pages; only mention the apps the project actually uses. Those pages are:

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -281,6 +281,58 @@ export default function Shop() {
 }
 ```
 
+**`pages/Category.jsx`** — a category landing page. `getCategoryBySlug(slug)` returns a **bare
+category object** (or `null` on miss — show a not-found state), **not** `{ category }`. Render the
+category's own fields, then feed `category.id` (never the slug) to `queryProductsByCategory` and
+paginate exactly like `Shop.jsx`.
+
+```jsx
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { getCategoryBySlug, queryProductsByCategory } from "@/rest/wix-store-catalog";
+import ProductCard from "@/components/ProductCard";
+
+export default function Category() {
+  const { slug } = useParams();
+  const [category, setCategory] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const [products, setProducts] = useState([]);
+  const [cursor, setCursor] = useState(null);
+
+  useEffect(() => {
+    getCategoryBySlug(slug).then((c) => {              // bare category object, or null on miss
+      if (!c) return setNotFound(true);
+      setCategory(c);
+      queryProductsByCategory(c.id, { limit: 24 }).then(({ products, nextCursor }) => {  // feed id, not slug
+        setProducts(products);
+        setCursor(nextCursor);
+      });
+    });
+  }, [slug]);
+
+  const loadMore = () =>
+    queryProductsByCategory(category.id, { limit: 24, cursor }).then(({ products: more, nextCursor }) => {
+      setProducts((p) => [...p, ...more]);
+      setCursor(nextCursor);
+    });
+
+  if (notFound) return <div>Category not found.</div>;
+  if (!category) return <div>Loading…</div>;
+  return (
+    <div /* restyle */>
+      <h1>{category.name}</h1>
+      {/* category.description is a typedef field, but whether it's plain text or HTML is not
+          documented — if it renders raw tags, treat it as HTML like plainDescription; confirm via wix-docs. */}
+      {category.description && <p>{category.description}</p>}
+      {/* category.image is listed in the typedef but WITHOUT a sub-shape (no url/altText) — do NOT
+          assume category.image.url; look the category media shape up via the wix-docs skill before rendering it. */}
+      <div /* grid */>{products.map((p) => <ProductCard key={p.id} product={p} />)}</div>
+      {cursor && <button onClick={loadMore}>Load more</button>}
+    </div>
+  );
+}
+```
+
 **`CartDrawer.jsx`** — reads everything from `useCart()`; mutate by `lineItem.id` (not
 `catalogItemId`), check out via the context.
 
@@ -310,6 +362,9 @@ export default function CartDrawer() {
               <span>{item.price?.formattedAmount}</span>
             </div>
           ))}
+          {/* Order total / subtotal is NOT in the cart typedef (wix-store-cart.js lists only per-line
+              price/fullPrice) — resolve the exact cart-level total path via the wix-docs skill before
+              rendering one; do NOT invent priceSummary/subtotal. */}
           <button disabled={loading} onClick={checkout}>Checkout</button>
         </>
       )}
@@ -328,6 +383,16 @@ import { useParams } from "react-router-dom";
 import { getProductBySlug } from "@/rest/wix-store-catalog";
 import { useCart } from "@/context/CartContext";
 
+// same //→https: protocol fix as ProductCard — Wix image urls can come back protocol-relative
+function imageUrl(url) {
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+// PDP gallery: product.media.itemsInfo.items — [{ image: { url }, altText }] (see wix-store-catalog.js typedef)
+function galleryImages(product) {
+  return (product?.media?.itemsInfo?.items ?? [])
+    .map((it) => ({ url: imageUrl(it.image?.url), alt: it.altText || product?.name }))
+    .filter((i) => i.url);
+}
 // one control per product.options[] (variant choices)
 function OptionSelector({ option, selected, onSelect }) {
   return (
@@ -415,7 +480,14 @@ export default function ProductDetail() {
   if (!product) return <div>Loading…</div>;
   return (
     <div /* restyle */>
-      <img src={product.media?.main?.image?.url} alt={product.name} />
+      <img src={imageUrl(product.media?.main?.image?.url)} alt={product.name} />   {/* //→https: fix, same as ProductCard */}
+      {galleryImages(product).length > 0 && (
+        <div /* thumbnail strip */>
+          {galleryImages(product).map((img, i) => (
+            <img key={i} src={img.url} alt={img.alt} loading="lazy" />
+          ))}
+        </div>
+      )}
       <h1>{product.name}</h1>
       <p>{price}</p>
       {/* plainDescription is HTML despite the name — never render as plain text */}


### PR DESCRIPTION
## What
The `cats.filter is not a function` prod crash was the tip of a **systemic** problem: `base44.md` tells the building agent *not* to read the scaffold source and rely on `INSTRUCTIONS.md` for "every field shape" — but INSTRUCTIONS was mostly prose and omitted the shapes the agent needs to write UI. So it guessed.

An 8-vertical audit (storefront, bookings, events, blog, cms, portfolio, pricing-plans, restaurants) found two universal classes + five outright conflicts. This PR fixes all of them **the way we agreed: worked, copyable snippets** (in the storefront `Shop.jsx` style), not more prose.

## Universal fixes (every vertical)
- **List helpers destructured at the call site** — every browse util returns `{ <plural>, nextCursor|total|nextOffset }`, never a bare array; snippets show `const { products } = await queryProducts()` etc. (the exact cats.filter class).
- **Media & money objects rendered correctly** — image fields via `.url` (+ the `//`→`https:` fix), money fields via `.formattedValue` (raw object → React-child crash).
- **Null-on-miss** single-fetch guards.

## Conflicts fixed (INSTRUCTIONS actively contradicted the code → silent-wrong)
- **bookings:** "redirect to `fullUrl`" → `checkoutBooking()` returns a **bare URL string** (`bookAndCheckout` → `{ checkoutUrl }`); fixed hard rule + wiring + checklist.
- **events:** category display field is **`label`**, not `name`.
- **pricing-plans:** billing cycle is **`pricingVariants[0].billingTerms.billingCycle`**, not on the variant.
- **cms:** ownership key is **`_owner`**, not `_ownerId` (also corrected the `wix-cms.js` JSDoc typo).
- **restaurants:** removed the invented `onlineReservationsEnabled` filter (routed to wix-docs; filter on the real `archived` flag).

## Discipline
Only shapes **confirmable from the scaffold JSDoc** were documented. Anything not in ground truth — cart order-total, `category.image` sub-shape, `wix:image://` conversion, WixMedia `id`→url, the reservation enable field — is **routed to the `wix-docs` skill, never invented**.

## Verification
All **22 JSX snippets across the 8 files parse** (esbuild `--bundle=false`). Storefront's `Shop.jsx` (merged in #874) is the style exemplar; this extends the same treatment to catalog gallery/category-landing + all other verticals.

Files: 8 `INSTRUCTIONS.md` + 1 JSDoc typo. +1128/−74.