### PR TITLE
refactor(seed): attachProductImages self-fetches revision; drop imagery-mode lingo

### DIFF
--- a/skills/wix-base44-headless/templates/bookings/seed/seed-bookings.js
+++ b/skills/wix-base44-headless/templates/bookings/seed/seed-bookings.js
@@ -32,7 +32,7 @@
 //   await seed.scheduleClassSessions(ctx, services.filter(s => s.type === "CLASS").map(s => ({
 //     scheduleId: s.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
 //   })));
-//   // imagery ON only: generate per IMAGE_GENERATION.md, then patch each service (revision-checked).
+//   // optional — generate an image, then patch each service (revision-checked).
 //   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
 //
 // If any call fails with a shape the caller didn't expect, or you need an operation this module
@@ -217,7 +217,7 @@ async function getService(ctx, serviceId) {
 }
 
 /**
- * Attach images (imagery ON only). Writes under media.mainMedia + media.coverMedia; revision-checked.
+ * Attach images (optional). Writes under media.mainMedia + media.coverMedia; revision-checked.
  * @param it { serviceId, revision, image: { id, url, width, height } }  (image.id is the binding field)
  * ⚠️ Writing under media.image (not mainMedia/coverMedia) returns 200 but SILENTLY drops the image — a 200
  * is not proof; confirm with getService and check media.mainMedia is populated. Never block on failure.

--- a/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
+++ b/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
@@ -11,7 +11,7 @@
 //   const products = await seed.bulkCreateProducts(ctx, [{ name, description, price, quantity, options? }]);
 //   const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);
 //   await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
-//   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, revision:p.revision, url:imageUrls[i], altText:p.slug })));
+//   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, url:imageUrls[i], altText:p.slug })));
 //
 // If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
@@ -139,7 +139,7 @@ async function deleteProducts(ctx, ids) {
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
  *   visible/physicalProperties/variant-expansion handled here.
- * @returns [{ id, slug, revision }]  (revision feeds attachProductImages)
+ * @returns [{ id, slug, revision }]
  */
 async function bulkCreateProducts(ctx, products) {
   const body = {
@@ -187,15 +187,21 @@ async function addProductsToCategories(ctx, mapping) {
   }
 }
 
-// Bulk image attach in ONE call. items: [{ id, revision, url, altText }]
-// revision comes from bulkCreateProducts' return. Wix re-hosts the image (new wixstatic id on
-// read-back) and bumps revision; media-only update preserves options/variants. Read success from
-// results[].itemMetadata.success + bulkActionMetadata.totalSuccesses.
+// Bulk image attach in ONE call. items: [{ id, url, altText }] — NO revision.
+// An attach bumps the product's revision, so a caller-supplied revision goes stale between passes
+// (INVALID_REVISION). We read each product's CURRENT revision here, right before the update, so the
+// caller never manages a revision token — attach as many times as you like, in any pass. Wix
+// re-hosts the image (new wixstatic id on read-back); media-only update preserves options/variants.
+// Read success from results[].itemMetadata.success + bulkActionMetadata.totalSuccesses.
 async function attachProductImages(ctx, items) {
+  if (!items?.length) return;
+  const ids = items.map((it) => it.id);
+  const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
+  const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
   return req(ctx, "/stores/v3/bulk/products/update", {
     body: {
       products: items.map((it) => ({
-        product: { id: it.id, revision: it.revision, media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
+        product: { id: it.id, revision: revById.get(it.id), media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
       })),
     },
   });
@@ -233,7 +239,7 @@ async function setupStore(ctx, { products = [], categories = {} } = {}) {
   }
 
   const imageItems = withNames
-    .map((p, i) => ({ id: p.id, revision: p.revision, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
+    .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
     .filter((it) => it.url);
   if (imageItems.length) await attachProductImages(ctx, imageItems);
 

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -30,7 +30,7 @@ const result = await seed.setupBlog(ctx, {
         { type: "paragraph", text: "Every batch starts with beans from a single estate." },
         { type: "quote", text: "Great coffee is grown, not made." },
       ],
-      // imagery ON only: import per IMAGE_GENERATION.md, then pass the WixMedia file id here
+      // optional — import an image, then pass the WixMedia file id here
       coverImageUrl: fileIds[0],
     },
   ],
@@ -58,7 +58,7 @@ const posts = await seed.createPosts(ctx, [
   ] },
 ]);   // → [{ id, index, success }] — check each .success (bulk returns 200 even on partial failure)
 
-// imagery ON only: import images per IMAGE_GENERATION.md, then attach covers (PATCH + re-publish)
+// optional — import images, then attach covers (PATCH + re-publish)
 await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fileIds[i] })));
 ```
 
@@ -70,7 +70,7 @@ await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fi
 | `createPosts(ctx, posts, { memberId })` | STEP 2 — auto single-vs-bulk create, published → `[{id,index,success}]` |
 | `createCategories(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.categoryIds`) |
 | `createTags(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.tagIds`) |
-| `attachPostCovers(ctx, [{postId,fileId}])` | imagery-on: PATCH cover (`displayed+custom+wixMedia.image.id`) + re-publish |
+| `attachPostCovers(ctx, [{postId,fileId}])` | optional — PATCH cover (`displayed+custom+wixMedia.image.id`) + re-publish |
 
 `content` blocks: `{type:"heading",text,level?}` · `{type:"paragraph",text}` · `{type:"quote",text}` ·
 `{type:"bulleted"|"ordered",items:[…]}`. For node types the recipe doesn't cover (code, images),

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -17,7 +17,7 @@
 //       { type: "quote", text: "Great coffee is grown, not made." },
 //     ] },
 //   ], { memberId });
-//   // imagery ON only: import images per IMAGE_GENERATION.md, then attach covers + re-publish
+//   // optional — import images, then attach covers + re-publish
 //   await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fileIds[i] })));
 //
 // **NOT yet live-verified — transcribed from setup-blog.md.** If any call fails with a shape the
@@ -85,7 +85,7 @@ function mkRichContent(blocks = [], postIdx = 0) {
 
 // One post's plain data -> a flat Blog V3 draft-post object.
 // `content` (block list) is turned into Ricos richContent unless a pre-built `richContent` is given.
-// media is omitted here — covers are a separate pass (attachPostCovers), imagery-gated. Per recipe.
+// media is omitted here — covers are a separate pass (attachPostCovers), optional (a separate covers pass). Per recipe.
 function buildPost(p, i, memberId) {
   return {
     title: p.title,
@@ -158,7 +158,7 @@ async function createTags(ctx, names) {
   return out;
 }
 
-// Attach images step (imagery ON only). covers: [{ postId, fileId }] where fileId is the WixMedia
+// Attach images step (optional). covers: [{ postId, fileId }] where fileId is the WixMedia
 // file.id from IMAGE_GENERATION.md import (Blog binds the cover by id, not url). Per post:
 //   PATCH /blog/v3/draft-posts/{id}  (NOT POST …/{id}/update — that 404s for a single post),
 // setting media.displayed:true + media.custom:true + wixMedia.image.id (id ALONE is a silent no-op),

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -30,7 +30,7 @@ const result = await seed.setupBookings(ctx, {
 });
 // result: { services:[...], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
 
-// imagery ON only: generate per IMAGE_GENERATION.md, then patch each service (revision-checked):
+// optional — generate an image, then patch each service (revision-checked):
 // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
 ```
 
@@ -50,7 +50,7 @@ functions below still exist (setupBookings is built from them, in the order show
 | `createServices(ctx, services)` | STEP 3 — one bulk create (APPOINTMENT/CLASS mixed) → `[{id,slug,revision,type,scheduleId,success,error}]` |
 | `scheduleClassSessions(ctx, sessions)` | STEP 4 (CLASS only) — one bulk Calendar-Events-V3 create → `[{id,success,error}]` |
 | `getService(ctx, serviceId)` | fetch a service (current `revision`; confirm an image landed) |
-| `attachServiceImage(ctx, {serviceId,revision,image})` | imagery ON — patch `media.mainMedia`/`coverMedia` (revision-checked) |
+| `attachServiceImage(ctx, {serviceId,revision,image})` | optional — patch `media.mainMedia`/`coverMedia` (revision-checked) |
 
 Both bulk calls report per-item `success`/`error` — retry only the failed items **once** with the
 same body; don't loop and don't re-create the ones that already succeeded.

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -32,7 +32,7 @@
 //   await seed.scheduleClassSessions(ctx, services.filter(s => s.type === "CLASS").map(s => ({
 //     scheduleId: s.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
 //   })));
-//   // imagery ON only: generate per IMAGE_GENERATION.md, then patch each service (revision-checked).
+//   // optional — generate an image, then patch each service (revision-checked).
 //   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
 //
 // If any call fails with a shape the caller didn't expect, or you need an operation this module
@@ -217,7 +217,7 @@ async function getService(ctx, serviceId) {
 }
 
 /**
- * Attach images (imagery ON only). Writes under media.mainMedia + media.coverMedia; revision-checked.
+ * Attach images (optional). Writes under media.mainMedia + media.coverMedia; revision-checked.
  * @param it { serviceId, revision, image: { id, url, width, height } }  (image.id is the binding field)
  * ⚠️ Writing under media.image (not mainMedia/coverMedia) returns 200 but SILENTLY drops the image — a 200
  * is not proof; confirm with getService and check media.mainMedia is populated. Never block on failure.

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -88,7 +88,7 @@ await seed.insertReferences(ctx, "recipes", [
   { referringItemFieldName: "categories", referringItemId: recipeId, referencedItemId: categoryId },
 ]);
 
-// imagery ON only: generate per IMAGE_GENERATION.md, then read-merge-PUT the url onto the item's IMAGE field
+// optional — generate an image, then read-merge-PUT the url onto the item's IMAGE field
 await seed.attachItemImage(ctx, "team-members", { itemId: items[0].id, imageFieldKey: "photo", url: fileUrl });
 ```
 
@@ -102,7 +102,7 @@ await seed.attachItemImage(ctx, "team-members", { itemId: items[0].id, imageFiel
 | `insertItem(ctx, collectionId, data)` | STEP 2 (single) — insert one item → `{id,data}` |
 | `queryItems(ctx, collectionId)` | STEP 3 — query for verification → `[{id,data}]` |
 | `insertReferences(ctx, collectionId, [{referringItemFieldName, referringItemId, referencedItemId}])` | STEP 4 — wire multi-references |
-| `attachItemImage(ctx, collectionId, {itemId, imageFieldKey, url})` | imagery ON only — read-merge-PUT the image url onto an item |
+| `attachItemImage(ctx, collectionId, {itemId, imageFieldKey, url})` | optional — read-merge-PUT the image url onto an item |
 | `PERMISSIONS` | preset blocks: `publicRead`, `collaborative`, `memberPrivate`, `memberSharedReadOnly` |
 
 ## Fallback

--- a/skills/wix-vibe-headless/references/cms/seed/seed-cms.js
+++ b/skills/wix-vibe-headless/references/cms/seed/seed-cms.js
@@ -20,7 +20,7 @@
 //   await seed.insertReferences(ctx, "recipes", [                        // STEP 4 (only if collections relate)
 //     { referringItemFieldName: "categories", referringItemId: recipeId, referencedItemId: categoryId },
 //   ]);
-//   await seed.attachItemImage(ctx, "team-members", { itemId, imageFieldKey: "photo", url: fileUrl }); // imagery ON only
+//   await seed.attachItemImage(ctx, "team-members", { itemId, imageFieldKey: "photo", url: fileUrl }); // optional
 //
 // **NOT yet live-verified — transcribed from setup-cms.md.**
 //
@@ -155,7 +155,7 @@ async function insertReferences(ctx, dataCollectionId, references) {
   });
 }
 
-// Attach a generated image to an item (imagery ON only). Read-merge-PUT — a partial PUT wipes omitted
+// Attach a generated image to an item (optional). Read-merge-PUT — a partial PUT wipes omitted
 // fields, so query the item, merge the url into its IMAGE field key, and PUT the WHOLE record back.
 // Never block on image failure — on failure skip and leave the item text-only. url = the permanent
 // wixstatic.com file.url (an IMAGE field stores the URL string).

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -26,7 +26,7 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // category NAMES → ids + assigns and attaches main images. Ids are kept in memory; nothing is
 // hand-threaded across exec calls. Dates MUST be in the future (ISO-8601 UTC); default ~60–90 days
 // out and note it if the request gives none. price is a decimal STRING; ticket name <= 30 chars;
-// omit ticketTiers for RSVP/free, omit image when imagery is off. height/width REQUIRED or it won't render.
+// omit ticketTiers for RSVP/free, omit image if you have none. height/width REQUIRED or it won't render.
 const summary = await seed.setupEvents(ctx, {
   events: [{
     title: "Summer Synth Festival", shortDescription: "One night of analog sound.",
@@ -65,7 +65,7 @@ await seed.publishEvent(ctx, ev.id);
 const cats = await seed.createEventCategories(ctx, ["Talks"]);
 await seed.assignEventsToCategory(ctx, cats[0].id, [ev.id]);
 
-// Attach images (imagery ON only): generate per IMAGE_GENERATION.md, then set mainImage. height/width REQUIRED or it won't render.
+// Attach images (optional): generate per IMAGE_GENERATION.md, then set mainImage. height/width REQUIRED or it won't render.
 await seed.setEventMainImage(ctx, { eventId: ev.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: ev.slug });
 ```
 
@@ -83,7 +83,7 @@ Free/RSVP events need neither.
 | `publishEvent(ctx, eventId)` | STEP 3 — publish (one-way) |
 | `createEventCategories(ctx, names)` | STEP 4 (opt) — v1 Categories, one call each → `[{id,name}]` |
 | `assignEventsToCategory(ctx, categoryId, eventIds)` | STEP 4 (opt) — path `/{categoryId}/events`, body `{eventId:[…]}` |
-| `setEventMainImage(ctx, {eventId,id,url,height,width,altText})` | imagery ON — PATCH `mainImage` (no revision) |
+| `setEventMainImage(ctx, {eventId,id,url,height,width,altText})` | optional — PATCH `mainImage` (no revision) |
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -28,7 +28,7 @@
 //   // STEP 4 (optional): group by format/track
 //   const cats = await seed.createEventCategories(ctx, ["Talks"]);
 //   await seed.assignEventsToCategory(ctx, cats[0].id, [ev.id]);
-//   // Attach images (imagery ON only): height/width REQUIRED or it won't render
+//   // Attach images (optional): height/width REQUIRED or it won't render
 //   await seed.setEventMainImage(ctx, { eventId: ev.id, id: fileId, url: fileUrl, height: 1024, width: 1024, altText: ev.slug });
 //
 // If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
@@ -151,7 +151,7 @@ async function assignEventsToCategory(ctx, categoryId, eventIds) {
   return req(ctx, `/events/v1/categories/${categoryId}/events`, { body: { eventId: eventIds } });
 }
 
-// Attach images (imagery ON only). mainImage is an Image OBJECT; height/width are REQUIRED or it won't
+// Attach images (optional). mainImage is an Image OBJECT; height/width are REQUIRED or it won't
 // render. Events V3 uses NO revision — partial PATCH keyed by event.id. Works before OR after publish.
 // item: { eventId, id, url, height, width, altText }  (id = the WixMedia image id)
 async function setEventMainImage(ctx, item) {
@@ -175,7 +175,7 @@ async function setEventMainImage(ctx, item) {
  *   ...createEvent fields (title, shortDescription?, type, startDate, endDate, timeZoneId, location, …),
  *   ticketTiers?: [{ name, price, initialLimit?, … }],   // TICKETING only; omit to skip
  *   category?: string,                                     // category NAME; resolved to id + assigned
- *   image?: { id, url, height, width, altText? }           // imagery ON only; omit to skip
+ *   image?: { id, url, height, width, altText? }           // optional; omit to skip
  * }] }}
  * Cleanup is intentionally NOT here — deleting existing content is a judgment call.
  */

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -12,8 +12,7 @@ first, then thread their real ids into each project.
 "sample" data, don't reset. Just add.
 
 **DEFAULT — one call.** `setupPortfolio(ctx, plan)` runs the whole flow in the right order
-(collections → projects → items → covers), threading ids in memory. Pass covers/items only when
-imagery is on. Drop to the individual functions below only for step-by-step control.
+(collections → projects → items → covers), threading ids in memory. Pass covers/items only when you have them. Drop to the individual functions below only for step-by-step control.
 
 ```js
 // build-time exec_tool
@@ -33,7 +32,7 @@ const summary = await seed.setupPortfolio(ctx, {
     { title: "Northwind Rebrand", description: "Full identity refresh for a logistics firm.",
       collection: "Brand Identity",                    // resolved to that collection's id
       details: [{ label: "Year", text: "2025" }],
-      // imagery ON only — generate + import per IMAGE_GENERATION.md, then pass ids/dims:
+      // optional — generate + import per IMAGE_GENERATION.md, then pass ids/dims:
       cover: { imageId: ids[0], height: 2880, width: 1920 },
       items: [{ sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }] },
   ],
@@ -53,7 +52,7 @@ const projects = await seed.createProjects(ctx, [                               
     collectionIds: [collections[0].id], details: [{ label: "Year", text: "2025" }] },
 ]);
 
-// imagery ON only: generate + import images per IMAGE_GENERATION.md, then attach
+// optional — generate + import images, then attach
 await seed.attachProjectCovers(ctx, projects.map((p, i) => ({ id: p.id, revision: p.revision, imageId: ids[i], height: 2880, width: 1920 })));
 await seed.attachCollectionCovers(ctx, collections.map((c, i) => ({ id: c.id, revision: c.revision, imageId: cids[i], height: 2880, width: 1920 })));
 await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }]);
@@ -65,9 +64,9 @@ await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, t
 | `setupPortfolio(ctx, plan)` | **DEFAULT** — one call: collections → projects → items → covers; returns `{collections,projects,itemsCreated,coversAttached}` |
 | `createCollections(ctx, collections)` | STEP 1 — `[{title,description?,hidden?}]` → `[{id,slug,revision}]` |
 | `createProjects(ctx, projects)` | STEP 2 — `[{title,description?,collectionIds,details?,hidden?}]` → `[{id,slug,revision}]` |
-| `attachProjectCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each project's cover (imagery on) |
-| `attachCollectionCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each collection's cover (imagery on) |
-| `createProjectItems(ctx, [{projectId,sortOrder,title,imageId,height,width}])` | one POST per gallery image (imagery on) |
+| `attachProjectCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each project's cover (optional) |
+| `attachCollectionCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each collection's cover (optional) |
+| `createProjectItems(ctx, [{projectId,sortOrder,title,imageId,height,width}])` | one POST per gallery image (optional) |
 
 `hidden` defaults to `false` (shown) — omit it for visible entities; send `hidden: true` only to
 hide. On `428` / `APP_NOT_INSTALLED`, the Setup step was skipped — fail loudly, don't self-install.

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -20,7 +20,7 @@
 //   const projects = await seed.createProjects(ctx, [                                        // STEP 2
 //     { title, description, collectionIds: [collections[0].id], details: [{ label, text }] },
 //   ]);
-//   // imagery ON only:
+//   // optional —
 //   await seed.attachProjectCovers(ctx, projects.map((p,i) => ({ id:p.id, revision:p.revision, imageId:ids[i], height:2880, width:1920 })));
 //   await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title, imageId, height:896, width:1200 }]);
 //
@@ -115,7 +115,7 @@ async function createProjects(ctx, projects) {
   return out;
 }
 
-// Imagery opt-in — skip when imagery is off. Cover = the listing-card thumbnail. PATCH per entity,
+// Optional — pass a cover/items to attach, omit to skip. Cover = the listing-card thumbnail. PATCH per entity,
 // echoing the current revision (a missing/stale revision fails). height + width are required
 // alongside the imported WixMedia image id. items: [{ id, revision, imageId, height, width }].
 async function attachProjectCovers(ctx, items) {
@@ -135,7 +135,7 @@ async function attachCollectionCovers(ctx, items) {
   }
 }
 
-// Imagery opt-in — the project's media gallery (detail-page images) is a SEPARATE `item` entity,
+// Optional — the project's media gallery (detail-page images) is a SEPARATE `item` entity,
 // one POST per image. sortOrder (1,2,3…) sets render order. lowercase `items` — `/Items` 404s.
 // There is NO public list endpoint. items: [{ projectId, sortOrder, title, imageId, height, width }].
 async function createProjectItems(ctx, items) {
@@ -160,7 +160,7 @@ async function createProjectItems(ctx, items) {
  *                   items?: [{ sortOrder, title, imageId, height, width }],
  *                   cover?: { imageId, height, width } }],
  * }
- *   Covers/items are opt-in (imagery on) — a project/collection without a `cover`/`items` skips it.
+ *   Covers/items are optional — a project/collection without a `cover`/`items` skips it.
  * @returns { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
  */
 async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -63,7 +63,7 @@ const menu = await seed.createMenu(ctx, {           // builds items → sections
   ],
 });                                                 // → { menuId, sectionIds, itemIds }
 
-// imagery ON only: generate per IMAGE_GENERATION.md, then attach (full-replace — echo revision + price)
+// optional — generate an image, then attach (full-replace — echo revision + price)
 // await seed.attachItemImages(ctx, [{ id, revision, price, image: { id, url, height, width } }]);
 
 // ── ONLINE ORDERING (add-on, on demand; MENU-FIRST) ──────────────────────────────────────────────
@@ -93,7 +93,7 @@ await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Expe
 |---|---|
 | `installMenusApp(ctx)` | install the Wix Restaurants Menus app |
 | `createMenu(ctx, {name,description?,sections})` | items → sections → menu bottom-up → `{menuId,sectionIds,itemIds}` |
-| `attachItemImages(ctx, [{id,revision,price,image}])` | imagery pass — full-replace PATCH (echo revision + priceInfo) |
+| `attachItemImages(ctx, [{id,revision,price,image}])` | image pass — full-replace PATCH (echo revision + priceInfo) |
 
 **Shared** (ordering + reservations STEP 0)
 | fn | does |

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -130,7 +130,7 @@ async function deleteMenu(ctx, menuId) {
  *   price -> priceInfo.price as a decimal STRING; currency is the site's (send none).
  *   description is a plain string (NOT rich-text nodes); omit for a name-only item/section.
  *   visible:true is baked in at every level (item, section, menu) — required to render on the live site.
- * @returns { menuId, sectionIds:[…], itemIds:[…] }  (revisions available via listMenuItems for imagery pass)
+ * @returns { menuId, sectionIds:[…], itemIds:[…] }  (revisions available via listMenuItems for image pass)
  */
 async function createMenu(ctx, menu) {
   // STEP 1 — bulk-create every item across all sections in ONE request; track which section each belongs to.
@@ -184,7 +184,7 @@ async function createMenu(ctx, menu) {
   return { menuId: menuRes.menu?.id, sectionIds, itemIds: createdItems.map((it) => it?.id) };
 }
 
-// Imagery ON only (pass-2). The ITEM is the image-bearing entity. Update Item is a FULL-ENTITY REPLACE
+// Optional (pass-2). The ITEM is the image-bearing entity. Update Item is a FULL-ENTITY REPLACE
 // with NO field mask — you MUST echo each item's current `revision` AND `priceInfo`, or it fails
 // `428 MISSING_ITEM_PRICING` and the image does NOT apply. `image` is an OBJECT { id, url, height, width }
 // (never a bare string); the binding field is the Wix Media file `id`. Never block on image failure.
@@ -383,7 +383,7 @@ async function setupRestaurants(ctx, plan) {
   const flatItems = plan.menu.sections.flatMap((s) => s.items || []);
   const itemNameToId = new Map(flatItems.map((it, i) => [it.name, itemIds[i]]));
 
-  // imagery pass — map each plan item that carries an image to its created id (revision "1", fresh).
+  // image pass — map each plan item that carries an image to its created id (revision "1", fresh).
   const imageItems = flatItems
     .filter((it) => it.image || it.imageUrl)
     .map((it) => ({

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -16,7 +16,8 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. imageUrl per product only
-// when imagery is on. options ONLY for real buyer choices (Size/Color); default none.
+// when imagery is on — passing it here does the image attach in the SAME pass, on the fresh
+// create-time revision. options ONLY for real buyer choices (Size/Color); default none.
 const result = await seed.setupStore(ctx, {
   products: [
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },
@@ -39,7 +40,7 @@ below still exist (setupStore is built from them).
 | `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]` |
 | `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
-| `attachProductImages(ctx, [{id,revision,url,altText}])` | one bulk media attach |
+| `attachProductImages(ctx, [{id,revision,url,altText}])` | one bulk media attach — each attach **bumps `revision`**; before a 2nd/manual attach (images generated later) re-read the current revision (`listProducts`), don't reuse the create-time one, else `INVALID_REVISION` |
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -15,9 +15,8 @@ const seed = (() => { const m = { exports: {} };
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
-// in memory (no hand-threading). Categories map name -> product NAMES. imageUrl per product only
-// when imagery is on — passing it here does the image attach in the SAME pass, on the fresh
-// create-time revision. options ONLY for real buyer choices (Size/Color); default none.
+// in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
+// to attach its image; omit it to skip images. options ONLY for real buyer choices (Size/Color); default none.
 const result = await seed.setupStore(ctx, {
   products: [
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },
@@ -40,7 +39,7 @@ below still exist (setupStore is built from them).
 | `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]` |
 | `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
-| `attachProductImages(ctx, [{id,revision,url,altText}])` | one bulk media attach — each attach **bumps `revision`**; before a 2nd/manual attach (images generated later) re-read the current revision (`listProducts`), don't reuse the create-time one, else `INVALID_REVISION` |
+| `attachProductImages(ctx, [{id,url,altText}])` | one bulk media attach — reads each product's current revision internally, so a 2nd/manual attach (images generated later) is safe; no revision to pass |
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -191,6 +191,10 @@ async function addProductsToCategories(ctx, mapping) {
 // revision comes from bulkCreateProducts' return. Wix re-hosts the image (new wixstatic id on
 // read-back) and bumps revision; media-only update preserves options/variants. Read success from
 // results[].itemMetadata.success + bulkActionMetadata.totalSuccesses.
+// Each attach BUMPS the product's revision. Attaching all images in this ONE call is why the
+// create-time revision works. If you attach in a SECOND/manual pass (e.g. images generated later),
+// re-read the current revision first (listProducts / getProduct) — reusing the create-time revision
+// throws INVALID_REVISION ("Outdated revision for entity id").
 async function attachProductImages(ctx, items) {
   return req(ctx, "/stores/v3/bulk/products/update", {
     body: {

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -11,7 +11,7 @@
 //   const products = await seed.bulkCreateProducts(ctx, [{ name, description, price, quantity, options? }]);
 //   const cats = await seed.createCategories(ctx, ["Legends", "Rising Stars"]);
 //   await seed.addProductsToCategories(ctx, { [cats[0].id]: products.map(p => p.id) });
-//   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, revision:p.revision, url:imageUrls[i], altText:p.slug })));
+//   await seed.attachProductImages(ctx, products.map((p,i) => ({ id:p.id, url:imageUrls[i], altText:p.slug })));
 //
 // If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
@@ -139,7 +139,7 @@ async function deleteProducts(ctx, ids) {
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
  *   visible/physicalProperties/variant-expansion handled here.
- * @returns [{ id, slug, revision }]  (revision feeds attachProductImages)
+ * @returns [{ id, slug, revision }]
  */
 async function bulkCreateProducts(ctx, products) {
   const body = {
@@ -187,19 +187,21 @@ async function addProductsToCategories(ctx, mapping) {
   }
 }
 
-// Bulk image attach in ONE call. items: [{ id, revision, url, altText }]
-// revision comes from bulkCreateProducts' return. Wix re-hosts the image (new wixstatic id on
-// read-back) and bumps revision; media-only update preserves options/variants. Read success from
-// results[].itemMetadata.success + bulkActionMetadata.totalSuccesses.
-// Each attach BUMPS the product's revision. Attaching all images in this ONE call is why the
-// create-time revision works. If you attach in a SECOND/manual pass (e.g. images generated later),
-// re-read the current revision first (listProducts / getProduct) — reusing the create-time revision
-// throws INVALID_REVISION ("Outdated revision for entity id").
+// Bulk image attach in ONE call. items: [{ id, url, altText }] — NO revision.
+// An attach bumps the product's revision, so a caller-supplied revision goes stale between passes
+// (INVALID_REVISION). We read each product's CURRENT revision here, right before the update, so the
+// caller never manages a revision token — attach as many times as you like, in any pass. Wix
+// re-hosts the image (new wixstatic id on read-back); media-only update preserves options/variants.
+// Read success from results[].itemMetadata.success + bulkActionMetadata.totalSuccesses.
 async function attachProductImages(ctx, items) {
+  if (!items?.length) return;
+  const ids = items.map((it) => it.id);
+  const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
+  const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
   return req(ctx, "/stores/v3/bulk/products/update", {
     body: {
       products: items.map((it) => ({
-        product: { id: it.id, revision: it.revision, media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
+        product: { id: it.id, revision: revById.get(it.id), media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
       })),
     },
   });
@@ -237,7 +239,7 @@ async function setupStore(ctx, { products = [], categories = {} } = {}) {
   }
 
   const imageItems = withNames
-    .map((p, i) => ({ id: p.id, revision: p.revision, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
+    .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
     .filter((it) => it.url);
   if (imageItems.length) await attachProductImages(ctx, imageItems);
 


### PR DESCRIPTION
Two "stop making the agent manage state" changes to the in-house seed modules.

## 1. `attachProductImages` no longer takes a caller `revision`
A prod build ("Plushie Pal") generated images in two waves and did a **second** `attachProductImages` reusing the create-time revision → `INVALID_REVISION` ("Outdated revision for entity id"), costing a re-query + retry. `revision` is Wix's optimistic-concurrency token and an attach **bumps** it, so any caller-held value goes stale.

**Fix:** the function now reads each product's **current** revision internally (`products/query` by id) right before the bulk update. Caller passes only `[{ id, url, altText }]` — attach as many times as you like, in any pass, no revision to track. `setupStore` and the usage docs updated to match; the `wix-base44-headless` storefront copy synced.

(This supersedes the earlier "re-read the revision before a 2nd attach" doc note in this same PR — the code now handles it, so there's nothing to remember.)

## 2. Dropped the "imagery ON only / when imagery is on/off" mode lingo
Across **every** vertical's seed module + `SEED.md`, removed the framing that implied the agent tracks an imagery on/off state. Images are just optional data: **pass a url/id to attach one, omit to skip.** ~35 occurrences neutralized; no `imagery` mode wording remains.

## Verification
All seed modules parse (`node --check`). The only remaining `revision` mention in the storefront call surface is the descriptive SEED.md note ("reads the revision internally").