### PR TITLE
🦞 igor-claw: document required resources[].permissionRole for CLASS/COURSE events

### DIFF
--- a/skills/wix-manage/references/bookings/create-and-update-booking-services.md
+++ b/skills/wix-manage/references/bookings/create-and-update-booking-services.md
@@ -363,6 +363,7 @@ Once the service and staff member are available, you can define when the service
 **Event requirements**:
 
 - `event.resources` array **must include at least one resource** (a staff member/room/etc.) using the `resourceId`. CLASS and COURSE events will fail with a 400 error if no resources are provided.
+- **`event.resources[].permissionRole` must be set to `"WRITER"`** (or `"COMMENTER"`) for CLASS and COURSE events. It's omitted from every example above for brevity, but it's not optional in practice: leaving it unset defaults to `UNKNOWN_ROLE`, which the API rejects with a 400 error (see Troubleshooting below).
 - `event.scheduleId` — use the staff member's events schedule ID for APPOINTMENT availability, or `service.schedule.id` for CLASS/COURSE.
 - `event.type` — set to `WORKING_HOURS` for staff availability, `CLASS` for class sessions, or `COURSE` for course sessions.
 
@@ -398,6 +399,12 @@ Once the service and staff member are available, you can define when the service
 - **Root Cause**: Many UI implementations filter by `category.id` existence or specific category values
 - **Solution**: Query all services, identify those missing categories, and update them using bulk update operations
 - **Prevention**: Always assign categories during service creation (Step 0)
+
+**Class/Course Event Creation Fails (permissionRole required):**
+
+- **Error**: `"resources.permissionRole must not be UNKNOWN_ROLE"`
+- **Cause**: `event.resources[].permissionRole` was omitted. It defaults to `UNKNOWN_ROLE`, which `bulkCreateEvents`/`bulkUpdateEvents` reject for CLASS and COURSE events
+- **Solution**: Set `"permissionRole": "WRITER"` on every item in `event.resources`
 
 **Staff Assignment Not Working for CLASS/COURSE Services:**
 


### PR DESCRIPTION
## Summary
Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching a piece of Wix MCP user feedback: https://wix.slack.com/archives/C08P5DKLJR5/p1786093466355449

- The user was building Bookings CLASS session events via `bulkCreateEvent` following this recipe's "Event requirements"/code examples, and hit an undocumented `400 "resources.permissionRole must not be UNKNOWN_ROLE"`.
- Root cause: `event.resources[].permissionRole` is required in practice for CLASS/COURSE events (defaults to `UNKNOWN_ROLE` when omitted, which the Bookings calendar-event validator rejects — see `bookings-calendar-event-validator/.../CommonValidations.scala`), but this recipe's "Event requirements" bullets and every code example above them never mention it, and the "Troubleshooting Common Issues" section — which otherwise covers many other 400s in detail — is silent on it too.
- **Live-reproduced** via the Wix MCP against a real Bookings test site: the exact call this recipe guides you to make fails with that error; adding `"permissionRole": "WRITER"` to the resource fixes it.
- This gotcha is already known and written up in several *headless*-flow skill recipes (e.g. `skills/wix-headless/references/inline-recipes/setup-bookings.md`), but was missing from this API-first recipe — the one actually surfaced for regular (non-headless) Bookings management.

## Fix
Adds two short bullets to `skills/wix-manage/references/bookings/create-and-update-booking-services.md`:
1. Under "Event requirements": explicit callout that `permissionRole: "WRITER"` (or `"COMMENTER"`) is required for CLASS/COURSE.
2. Under "Troubleshooting Common Issues": the exact error text, cause, and fix, matching the style of the other entries in that section.

## Test plan
- [x] Reproduced the 400 live via `CallWixSiteAPI` → `calendar/v3/bulk/events/create` on a real Bookings-enabled test site, with and without `permissionRole`.
- [x] No code/behavior change — docs only.