### PR TITLE
fix(seed): stock option-less products (create only stocks variants with choices)

### DIFF
--- a/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
+++ b/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
@@ -138,7 +138,8 @@ async function deleteProducts(ctx, ids) {
  *   options?: [{ name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}] }] }]
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
- *   visible/physicalProperties/variant-expansion handled here.
+ *   visible/physicalProperties/variant-expansion handled here. Products are left IN STOCK
+ *   (quantity > 0) whether or not they have options — option-less products are stocked here too.
  * @returns [{ id, slug, revision }]
  */
 async function bulkCreateProducts(ctx, products) {
@@ -157,9 +158,36 @@ async function bulkCreateProducts(ctx, products) {
   };
   const r = await req(ctx, "/stores/v3/bulk/products-with-inventory/create", { body });
   // NB: results nest under productResults.results[].item — NOT a top-level `results`.
-  return (r.productResults?.results ?? []).map((x) => ({
+  const created = (r.productResults?.results ?? []).map((x, i) => ({
     id: x.item?.id, slug: x.item?.slug, revision: x.item?.revision,
+    variantId: x.item?.variantsInfo?.variants?.[0]?.id,
+    hasOptions: (products[i]?.options?.length ?? 0) > 0,
+    quantity: products[i]?.quantity ?? 0,
   }));
+  await stockOptionlessProducts(ctx, created);
+  return created.map((p) => ({ id: p.id, slug: p.slug, revision: p.revision }));
+}
+
+// products-with-inventory/create stocks a variant via its choices; an OPTION-LESS product has a
+// single choiceless (default) variant that the create does NOT stock — it lands OUT_OF_STOCK. So
+// set stock on those default variants explicitly (bulk/inventory-items/create). Products WITH options
+// are already stocked by the create above, so they're skipped. Backfills the default variantId from a
+// query if the create response didn't return it.
+async function stockOptionlessProducts(ctx, created) {
+  const need = created.filter((p) => !p.hasOptions && p.id);
+  if (!need.length) return;
+  const missing = need.filter((p) => !p.variantId).map((p) => p.id);
+  if (missing.length) {
+    const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: missing } }, paging: { limit: missing.length } } } });
+    const vById = new Map((q.products ?? []).map((p) => [p.id, p.variantsInfo?.variants?.[0]?.id]));
+    need.forEach((p) => { if (!p.variantId) p.variantId = vById.get(p.id); });
+  }
+  const inventoryItems = need
+    .filter((p) => p.variantId)
+    .map((p) => ({ productId: p.id, variantId: p.variantId, quantity: p.quantity }));
+  if (inventoryItems.length) {
+    await req(ctx, "/stores/v3/bulk/inventory-items/create", { body: { inventoryItems } });
+  }
 }
 
 // Categories: no bulk create, and MUST be sequential — they share the @wix/stores tree revision,

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -36,7 +36,7 @@ below still exist (setupStore is built from them).
 |---|---|
 | `setupStore(ctx, {products, categories?})` | **one-call**: install+wait → products → categories → images |
 | `installStoresApp(ctx)` | install the Wix Stores app on the site (waits for the V3 catalog) |
-| `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]` |
+| `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]`; leaves products IN STOCK whether or not they have options (option-less ones are stocked internally) |
 | `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
 | `attachProductImages(ctx, [{id,url,altText}])` | one bulk media attach — reads each product's current revision internally, so a 2nd/manual attach (images generated later) is safe; no revision to pass |

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -138,7 +138,8 @@ async function deleteProducts(ctx, ids) {
  *   options?: [{ name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}] }] }]
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
- *   visible/physicalProperties/variant-expansion handled here.
+ *   visible/physicalProperties/variant-expansion handled here. Products are left IN STOCK
+ *   (quantity > 0) whether or not they have options — option-less products are stocked here too.
  * @returns [{ id, slug, revision }]
  */
 async function bulkCreateProducts(ctx, products) {
@@ -157,9 +158,36 @@ async function bulkCreateProducts(ctx, products) {
   };
   const r = await req(ctx, "/stores/v3/bulk/products-with-inventory/create", { body });
   // NB: results nest under productResults.results[].item — NOT a top-level `results`.
-  return (r.productResults?.results ?? []).map((x) => ({
+  const created = (r.productResults?.results ?? []).map((x, i) => ({
     id: x.item?.id, slug: x.item?.slug, revision: x.item?.revision,
+    variantId: x.item?.variantsInfo?.variants?.[0]?.id,
+    hasOptions: (products[i]?.options?.length ?? 0) > 0,
+    quantity: products[i]?.quantity ?? 0,
   }));
+  await stockOptionlessProducts(ctx, created);
+  return created.map((p) => ({ id: p.id, slug: p.slug, revision: p.revision }));
+}
+
+// products-with-inventory/create stocks a variant via its choices; an OPTION-LESS product has a
+// single choiceless (default) variant that the create does NOT stock — it lands OUT_OF_STOCK. So
+// set stock on those default variants explicitly (bulk/inventory-items/create). Products WITH options
+// are already stocked by the create above, so they're skipped. Backfills the default variantId from a
+// query if the create response didn't return it.
+async function stockOptionlessProducts(ctx, created) {
+  const need = created.filter((p) => !p.hasOptions && p.id);
+  if (!need.length) return;
+  const missing = need.filter((p) => !p.variantId).map((p) => p.id);
+  if (missing.length) {
+    const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: missing } }, paging: { limit: missing.length } } } });
+    const vById = new Map((q.products ?? []).map((p) => [p.id, p.variantsInfo?.variants?.[0]?.id]));
+    need.forEach((p) => { if (!p.variantId) p.variantId = vById.get(p.id); });
+  }
+  const inventoryItems = need
+    .filter((p) => p.variantId)
+    .map((p) => ({ productId: p.id, variantId: p.variantId, quantity: p.quantity }));
+  if (inventoryItems.length) {
+    await req(ctx, "/stores/v3/bulk/inventory-items/create", { body: { inventoryItems } });
+  }
 }
 
 // Categories: no bulk create, and MUST be sequential — they share the @wix/stores tree revision,


### PR DESCRIPTION
## Root cause (from comparing a working pre-change build vs the broken one)
`POST /stores/v3/bulk/products-with-inventory/create` stocks a variant **via its choices**. So:
- A product **with options** → real variants with `choices` → **stocked by the create**. ✅
- A product **option-less** → a single **choiceless** default variant → the create **does not stock it** → `OUT_OF_STOCK` (a live "Whale Plushie Store" build hit a 404 on `inventoryItems/product/{id}`).

Why it "used to work": the authoritative `wix-headless` recipe's *only* worked example is an option'd product (Size+Color sneaker), so recipe-following agents tended to add options → stocked. Our `setupStore` correctly makes plush/pillow products **option-less** (per "options ONLY for real buyer choices"), which **exposed** the latent gap the recipe never covered. Same create call in both eras — the only difference is whether products carry options.

## Fix — one surface, it just works
`bulkCreateProducts` / `setupStore` take products **with or without options** and stock them either way. No new construct, no agent-facing choice. Internally a **private** `stockOptionlessProducts` step sets stock on the default variant of option-less products via:
```
POST /stores/v3/bulk/inventory-items/create   { inventoryItems: [{ productId, variantId, quantity }] }
```
— the exact call that flipped the Whale build's products `IN_STOCK`. It backfills the default `variantId` from a `products/query` if the create response didn't include it. Products **with** options are skipped (already stocked). Public exports unchanged; base44-headless storefront copy synced.

`node --check` clean on both modules.