### PR TITLE
docs(seed): drop option-less impl detail from bulkCreateProducts' agent surface

### DIFF
--- a/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
+++ b/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
@@ -138,8 +138,7 @@ async function deleteProducts(ctx, ids) {
  *   options?: [{ name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}] }] }]
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
- *   visible/physicalProperties/variant-expansion handled here. Products are left IN STOCK
- *   (quantity > 0) whether or not they have options — option-less products are stocked here too.
+ *   visible/physicalProperties/variant-expansion handled here. `quantity` is the stock created.
  * @returns [{ id, slug, revision }]
  */
 async function bulkCreateProducts(ctx, products) {

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -36,7 +36,7 @@ below still exist (setupStore is built from them).
 |---|---|
 | `setupStore(ctx, {products, categories?})` | **one-call**: install+wait → products → categories → images |
 | `installStoresApp(ctx)` | install the Wix Stores app on the site (waits for the V3 catalog) |
-| `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]`; leaves products IN STOCK whether or not they have options (option-less ones are stocked internally) |
+| `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]`; products come out in stock with the `quantity` you pass |
 | `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
 | `attachProductImages(ctx, [{id,url,altText}])` | one bulk media attach — reads each product's current revision internally, so a 2nd/manual attach (images generated later) is safe; no revision to pass |

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -138,8 +138,7 @@ async function deleteProducts(ctx, ids) {
  *   options?: [{ name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}] }] }]
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
- *   visible/physicalProperties/variant-expansion handled here. Products are left IN STOCK
- *   (quantity > 0) whether or not they have options — option-less products are stocked here too.
+ *   visible/physicalProperties/variant-expansion handled here. `quantity` is the stock created.
  * @returns [{ id, slug, revision }]
  */
 async function bulkCreateProducts(ctx, products) {


### PR DESCRIPTION
The stock-fix docs leaked the internal option-less mechanism ("stocked whether or not they have options — option-less ones stocked internally") into the agent-facing JSDoc + SEED.md table. That re-introduces the options-vs-not mental model we abstracted away. Simplified to what the agent actually needs: **pass `quantity`, products come out in stock.** The private `stockOptionlessProducts` helper keeps its own impl comment for maintainers. node --check clean; base44 copy synced.