### PR TITLE
feat(wix-vibe-headless): ship storefront client as files (copy-in), not INSTRUCTIONS snippets

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -26,7 +26,7 @@ the three skills, deploys the REST scaffolds into `src/rest/`, and pins an AGENT
 
 ```js
 const { execSync } = require('child_process');
-const { readdirSync, existsSync, mkdirSync, copyFileSync, readFileSync, appendFileSync } = require('fs');
+const { readdirSync, existsSync, mkdirSync, copyFileSync, cpSync, readFileSync, appendFileSync } = require('fs');
 
 const skills = ['wix-headless', 'wix-vibe-headless', 'wix-docs'];
 const results = {};
@@ -56,6 +56,8 @@ if (existsSync(REF)) {
     for (const f of files) {
       if (f.endsWith('.js')) { copyFileSync(`${REF}/${dir}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
     }
+    // A vertical may ship a ready UI client under app/ (storefront) — deploy it into src/.
+    if (existsSync(`${REF}/${dir}/app`)) cpSync(`${REF}/${dir}/app`, '/app/src', { recursive: true });
   }
 }
 
@@ -111,14 +113,11 @@ fails or shows nothing relevant, ask the user what they offer.
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — the single source of
 truth for how the client is built.
 
-**All REST scaffolds are already in `src/rest/`** — STEP 1 deployed the shared transport
-(`wix-client.js`, `wix-manage-banner.js`) and every vertical helper (`wix-store-catalog.js`, …)
-there. Use your vertical's files, set `WIX_CLIENT_ID` in `wix-client.js` and
-`WIX_METASITE_ID` in `wix-manage-banner.js`, and adapt with targeted edits — **do not regenerate
-them**. Unused verticals are harmless. Generate only the app-specific UI (components/pages).
-
-**No need to read the scaffolds' source** (`wix-client.js`/`wix-store-*.js`) — the vertical's
-`INSTRUCTIONS.md` has every field shape + correct usage. Just import them.
+**REST scaffolds are already in `src/rest/`** (STEP 1) — set `WIX_CLIENT_ID` in `wix-client.js`,
+`WIX_METASITE_ID` in `wix-manage-banner.js`; adapt with targeted edits, don't regenerate. Some
+verticals also ship a **ready UI client** under `src/` (STEP 1 deployed it) — theme + wire it per
+`INSTRUCTIONS.md`, don't rebuild. The vertical's `INSTRUCTIONS.md` has every field shape; no need to
+read the scaffolds' source.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -13,20 +13,14 @@ redirect-session.
 - Wix Stores installed with products (this client is read/cart over the catalog; seeding is STEP 5).
 - The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
 
-## STEP 1 — Copy the client into `src/` (run as-is, via exec_tool)
-The REST scaffolds (`wix-client.js`, `wix-store-catalog.js`, `wix-store-cart.js`) are already in
-`src/rest/` from the platform install step. This adds the UI layer — context, hooks, components,
-pages, and `theme.css`:
-
-```js
-const fs = require("fs");
-// recursive; overlays into src/, leaves src/rest and App.jsx untouched
-fs.cpSync("/app/.agents/skills/wix-vibe-headless/references/storefront/app", "/app/src", { recursive: true });
-return fs.readdirSync("/app/src");
-```
-Files added: `src/theme.css`, `src/context/CartContext.jsx`, `src/hooks/useProductDetail.js`,
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed both the REST scaffolds (`src/rest/`) **and** this
+storefront UI client into `src/`: `src/theme.css`, `src/context/CartContext.jsx`,
+`src/hooks/useProductDetail.js`,
 `src/components/{ProductCard,ProductGrid,CartButton,CartDrawer,VariantPicker}.jsx`,
-`src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`).
+`src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`). Nothing to copy —
+confirm the files are there, then theme + wire (below). (Missing? re-run install, or copy
+`references/storefront/app/` → `src/`.)
 
 ## STEP 2 — Credentials
 In `src/rest/wix-client.js` set `WIX_CLIENT_ID` to the value from your prompt.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -63,8 +63,28 @@ import Home from "@/pages/Home";   // the home page YOU build
 
 ## What you build (not shipped)
 The **home / landing page**, the **header/nav** (mount `<CartButton/>` in it), and the overall
-layout & brand story — styled from the same `theme.css` tokens. The shipped `Shop`/`ProductCard`
-are your reference for pulling catalog data (see below).
+layout & brand story — styled from the same `theme.css` tokens. **Compose the shipped pieces** — a
+featured strip is just `queryProducts` + the shipped `ProductGrid`; the nav is a `<CartButton/>`
+(it shows the live count and opens the drawer) + a link to `/shop`:
+
+```jsx
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { queryProducts } from "@/rest/wix-store-catalog";
+import ProductGrid from "@/components/ProductGrid";
+import CartButton from "@/components/CartButton";
+
+export function Header() {                                  // in your nav
+  return <nav>{/* brand/logo */}<Link to="/shop">Shop</Link><CartButton /></nav>;
+}
+export function Featured() {                                // on your home page
+  const [products, setProducts] = useState([]);
+  // NB: queryProducts returns { products, nextCursor } — destructure the array.
+  useEffect(() => { queryProducts({ limit: 8 }).then(({ products }) => setProducts(products)); }, []);
+  return <ProductGrid products={products} empty="Products coming soon." />;
+}
+```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
 
 ## Extending the client (read the files, don't guess shapes)
 The shipped files under `src/` are the source of truth for field shapes and correct usage — **read

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -29,7 +29,8 @@ In `src/rest/wix-client.js` set `WIX_CLIENT_ID` to the value from your prompt.
 Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
 spacing. Every shipped component reads these vars, so this re-skins the whole storefront. **Do not
 restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
-home page / header you build (STEP 4) from the same tokens so it matches.
+home page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the
+dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
 ## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
@@ -86,17 +87,58 @@ export function Featured() {                                // on your home page
 ```
 Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
 
-## Extending the client (read the files, don't guess shapes)
-The shipped files under `src/` are the source of truth for field shapes and correct usage — **read
-them before writing a new Wix call.** Two things bite otherwise:
-- Every catalog/cart list helper returns a **wrapper object, not a bare array** — `queryProducts`/
-  `queryCategories`/… → `{ <plural>, nextCursor }`. Destructure the array (`Shop.jsx` shows it);
-  calling `.map`/`.filter` on the return throws `… is not a function`.
-- `product.plainDescription` is **HTML** despite the name (the PDP renders it correctly); image URLs
-  come as objects — `product.media.main.image.url`, `lineItems[].image.url`.
+## Using the client from your own UI (cart, hand-built images)
 
-For anything the shipped client doesn't cover (coupons, members, a field not used yet), look up the
-exact endpoint/shape in the **`wix-docs`** skill — never guess.
+```jsx
+import { Link } from "react-router-dom";
+import { useCart } from "@/context/CartContext";
+
+// useCart() gives:
+// { cart, itemCount, isOpen, setIsOpen, loading,
+//   addToCart(productId, variantId?, qty=1, { modifierChoices?, customTextFields? }?),
+//   removeItem(lineItemId), updateQuantity(lineItemId, qty), checkout(), refreshCart() }
+
+function CartCount() {                                   // header badge
+  const { itemCount, setIsOpen } = useCart();
+  return <button onClick={() => setIsOpen(true)}>Cart ({itemCount})</button>;
+}
+
+// Buy from a card → link to the PDP; the shipped ProductDetail owns options/variants + add-to-cart.
+// (Listing helpers return no variants — only getProductBySlug does — so buying happens on the PDP.)
+const CardBuy = ({ product }) => <Link to={`/product/${product.slug}`}>View</Link>;
+
+// Doing add-to-cart yourself? addToCart resolves for an option-less product; wrap it — it rejects on
+// out-of-stock / empty cart / a missing required selection, and you show that message.
+async function quickAdd(addToCart, product) {
+  try { await addToCart(product.id); } catch (e) { alert(e.message); }
+}
+
+// An image you render yourself (hero / custom card): make the url https + keep a token bg so a
+// just-generated url that 404s for a second reads as a surface, not a blank block.
+function BrandImage({ url, alt }) {
+  const src = url?.startsWith("//") ? `https:${url}` : url;      // ProductCard already does this
+  return <div style={{ background: "var(--color-surface)" }}><img src={src} alt={alt} /></div>;
+}
+```
+
+## Extending the client
+Building something beyond the shipped pages? Copy these:
+
+```jsx
+// Every catalog/cart list helper returns { <plural>, nextCursor } — destructure the array:
+const { products, nextCursor } = await queryProducts({ limit: 24 });
+const { categories } = await queryCategories();
+const menu = categories.filter((c) => c.slug !== "all-products");   // drop Wix's system category
+const { products: inCategory } = await queryProductsByCategory(menu[0].id, { limit: 24 });
+
+// product.plainDescription is HTML → render as HTML (the PDP does this):
+<div dangerouslySetInnerHTML={{ __html: product.plainDescription }} />
+// image urls live at: product.media.main.image.url  ·  cart lineItems[].image.url
+```
+
+Fallback only — when you hit an error or need something not shown here (coupons, members, a field
+these snippets don't have): read the relevant shipped file under `src/`, or look it up via the
+**`wix-docs`** skill.
 
 ## Hard rules
 - Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -1,530 +1,107 @@
+# Wix Storefront — ready-made client
 
-# Wix Storefront Skill
+The storefront client is **shipped as real files**, not snippets to regenerate. It's a complete
+catalog + PDP + server-cart + checkout, styled entirely from `theme.css` tokens. Copy it into the
+app, theme the tokens, wire the routes — you generate almost none of the commerce code (variant
+resolution, modifiers, stock gating, the server cart all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and both storefront helpers from `references/storefront/`. All helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`). Copy **both** for a full storefront:
->
-> | File | What it covers |
-> |---|---|
-> | `wix-store-catalog.js` | Products, categories, product detail, search |
-> | `wix-store-cart.js` | Add to cart, cart management, checkout |
-
-Builds a real, client-only Wix storefront. The browser talks to Wix directly over a
-public `WIX_CLIENT_ID`. Never mock products; never hand-build `/checkout` URLs — always
-go through the eCom cart + redirect-session.
-
-## When to use
-- User wants a Wix eCommerce store or asks to "connect Wix".
-- Replacing placeholder/mock products with live Wix data.
-- Adding cart, checkout, categories, or product detail pages over an existing Wix Stores catalog.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock
+products; never hand-build a `/checkout` URL — the shipped cart goes through the eCom
+redirect-session.
 
 ## Prerequisites
-1. A Wix site with **Wix Stores installed and products already added** (this skill does
-   NOT provision — it's read-only over the catalog).
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
-   Wix Business Manager surfaces a copyable prompt with the id filled in — see
-   the router `SKILL.md`). Paste it into `src/rest/wix-client.js` in place of the placeholder. It is a
-   buyer-facing credential (it only mints anonymous visitor tokens), **not** a secret, so
-   hardcoding/committing it is fine.
-3. The deployed app domain must be allow-listed on the OAuth client for Wix-hosted
-   checkout to return. This is a **separate Wix setup flow the user completes later** —
-   out of this skill's scope. If checkout return fails before that setup is done, that's
-   expected; flag it and continue.
+- Wix Stores installed with products (this client is read/cart over the catalog; seeding is STEP 5).
+- The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the storefront's UI
-however the project wants; wire it to these two snippets. Copy them into the app (e.g.
-`src/api/`) and only adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to
-  the id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh
-  token IS the cart identity; it is persisted to localStorage. Do not re-mint anonymously
-  per load or the cart silently empties.
-- `src/rest/wix-store-catalog.js` — **Catalog:**
-  `queryProducts`, `queryProductsByCategory`, `getProductBySlug`, `countProducts`,
-  `queryCategories`, `getCategoryBySlug`
-- `src/rest/wix-store-cart.js` — **Cart & checkout:**
-  `addToCart`, `getCurrentCart`, `updateCartItemQuantity`, `removeFromCart`, `checkout`
+## STEP 1 — Copy the client into `src/` (run as-is, via exec_tool)
+The REST scaffolds (`wix-client.js`, `wix-store-catalog.js`, `wix-store-cart.js`) are already in
+`src/rest/` from the platform install step. This adds the UI layer — context, hooks, components,
+pages, and `theme.css`:
 
-Every field shape and gotcha you need is in this file (the prose below + the **Reference
-components** section), and those components show correct usage of every helper — `import` from
-`wix-client.js` / `wix-store-*.js`, adapt the components' logic, and restyle to the brand.
+```js
+const fs = require("fs");
+// recursive; overlays into src/, leaves src/rest and App.jsx untouched
+fs.cpSync("/app/.agents/skills/wix-vibe-headless/references/storefront/app", "/app/src", { recursive: true });
+return fs.readdirSync("/app/src");
+```
+Files added: `src/theme.css`, `src/context/CartContext.jsx`, `src/hooks/useProductDetail.js`,
+`src/components/{ProductCard,ProductGrid,CartButton,CartDrawer,VariantPicker}.jsx`,
+`src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`).
 
-## How to wire it (UI is the project's choice)
-- **Product grid** — `queryProducts()` for the listing (visible products only); pass
-  `nextCursor` back as `cursor` to load the next page. Render most fields directly from the Wix
-  product object (see the `Product` typedef in `wix-store-catalog.js` for key fields) — the one
-  exception is `plainDescription`, which is HTML (see PDP below). For price, use
-  `actualPriceRange.minValue.formattedAmount` (already includes the currency symbol) — no
-  manual formatting needed.
-- **PDP** — `getProductBySlug(slug)` keyed off the URL slug; returns null on miss — show
-  a not-found state, never invent a product. **Drive the whole PDP from the returned product
-  object at runtime — build it generically, not around the one product you happened to inspect.**
-  A catalog is heterogeneous: some products have `options`, some have `modifiers` (mandatory or
-  optional), some track inventory, some none of these. Render a selector for **every** entry the
-  product actually carries: one control per `product.options` (variant choices) **and** one per
-  `product.modifiers` (TEXT_CHOICES → choice buttons/select; FREE_TEXT → a text input); render
-  neither when the arrays are empty. Skipping modifiers is a common miss — a product with a
-  **mandatory** modifier (e.g. "gift wrap?") whose control isn't rendered can never be added: the
-  buyer can't satisfy the requirement, so `add-to-cart` returns 200 with an **empty** `lineItems`
-  and the add silently no-ops.
-  Render `product.plainDescription` as **HTML** — despite the name it contains markup (`<p>`,
-  `<br>`, `<strong>`), so `dangerouslySetInnerHTML={{ __html: product.plainDescription }}` (React)
-  or `el.innerHTML = product.plainDescription`, never as a plain text node (that shows raw `<p>`
-  tags). Strip tags only for plain-text contexts (SEO/meta description, a truncated card teaser).
-- **Gate the Add-to-cart button** — disable it only until the requirements the product *actually
-  has* are met, computed from the product object (never assume every product has options or
-  modifiers): if `product.options` is non-empty, a variant must resolve from the selections; every
-  `modifier.mandatory === true` must have a value. A product with no options and no mandatory
-  modifiers is immediately addable — don't leave the button stuck. Optional modifiers never block.
-  Then pass the selections to `addToCart` (see Cart below); never call it with a required selection missing.
-- **Reflect stock in the UI** — the product object already carries availability at three levels; surface
-  it rather than letting the buyer discover it only on click. Read it from the data at runtime (never
-  hardcode):
-  - **Grid / card:** `product.inventory.availabilityStatus` (`IN_STOCK` / `OUT_OF_STOCK` /
-    `PARTIALLY_OUT_OF_STOCK`) — badge an out-of-stock product as sold out.
-  - **Option choice:** `product.options[].choicesSettings.choices[].inStock` — disable/strike a choice
-    (e.g. size L) that has no in-stock variant, before a full variant is even resolved.
-  - **Variant:** `variantsInfo.variants[].inventoryStatus.inStock` — once selections resolve to a
-    variant, disable Add-to-cart (label "Out of stock") when that variant is `inStock: false`.
-  A product/variant with inventory tracking **off** reports `availabilityStatus: IN_STOCK` /
-  `inStock: true` and stays freely addable — tracking-off is not "no data", it's "always available".
-  `addToCart` still throws on a sold-out line as a backstop, but the UI should prevent reaching it.
-- **Categories** — `queryCategories()` for a category menu; `getCategoryBySlug(slug)` for
-  a category landing page. **`queryCategories()` returns `{ categories, nextCursor }`** (same shape
-  as `queryProducts`) — destructure the array first; it is **not** itself an array, so
-  `queryCategories().filter(...)` / `(await queryCategories()).filter(...)` throws
-  `filter is not a function`. Pass `category.id` to `queryProductsByCategory(categoryId, { limit?, cursor? })`
-  to list only the products in that category; paginate exactly like `queryProducts`.
-  The result includes Wix's auto-created **"All Products" system category** (`slug: "all-products"`) —
-  it mirrors the full catalog, so drop it from the menu:
-  `const { categories } = await queryCategories(); const menu = categories.filter(c => c.slug !== "all-products");`
-  Filter by that slug, not by name (renames/localizes) or `visible` (it's `visible: true` like any other).
-- **Cart** — `addToCart(catalogItemId, variantId?, qty?, { modifierChoices?, customTextFields? }?)`,
-  `updateCartItemQuantity(lineItemId, qty)`, `removeFromCart(lineItemId)`.
-  - `variantId` (`variantsInfo.variants[].id` from `getProductBySlug`) — required for products with
-    options; resolve it by matching the buyer's selections to `variant.choices[].optionChoiceIds`.
-  - `modifierChoices` — `{ [modifier.key]: choiceKey }` for `TEXT_CHOICES` modifiers.
-  - `customTextFields` — `{ [modifier.freeTextSettings.key]: userInput }` for `FREE_TEXT` modifiers.
-    Mandatory modifiers must be included. See the eCommerce integration guide:
-    https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/e-commerce-integration.md
-  - Use `cart.lineItems[].id` as `lineItemId` (not `catalogItemId`) for mutations.
-  - Read the cart back with `getCurrentCart()` rather than mirroring it locally.
-- **Checkout** — `window.location.href = await checkout()`. After the buyer returns from
-  hosted checkout the order is placed and the cart is empty — re-fetch with
-  `getCurrentCart()` on return (e.g. on mount + `visibilitychange`) to clear the UI.
-- **Empty state** — if `countProducts()` is 0, show an empty state telling the user to
-  add products in their Wix dashboard. Never invent products.
+## STEP 2 — Credentials
+In `src/rest/wix-client.js` set `WIX_CLIENT_ID` to the value from your prompt.
 
-## Hard rules (do not violate)
-- ✅ Checkout ONLY via `checkout()` (`create-checkout` → `/headless/v1/redirect-session`
-  `fullUrl`), then redirect.
-- ❌ Never hand-build `/checkout`, cart-add, or product permalinks for purchase.
-- ❌ Never mock products — render live Wix data or the empty state.
-- ❌ Never generate fake reviews, ratings, or testimonials. Empty review UI only.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ `lineItemId` for cart mutations is `cart.lineItems[].id`, not `catalogItemId`.
-- ✅ On the PDP, render a control for **every** `product.options` entry **and** every `product.modifiers`
-  entry — never only variants. Keep Add-to-cart disabled until a variant resolves and every
-  `modifier.mandatory === true` has a value; a mandatory modifier with no rendered control makes the
-  product unbuyable (add-to-cart returns 200 with empty `lineItems`).
-- ✅ Pass `addToCart`'s `variantId` (`variantsInfo.variants[].id`) for products with variants; omit for products without.
-- ✅ Pass `modifierChoices` (`{ [modifier.key]: choiceKey }`) for TEXT_CHOICES modifiers; pass `customTextFields`
-  (`{ [modifier.freeTextSettings.key]: userInput }`) for FREE_TEXT modifiers. Include mandatory modifiers.
-- The engine fails loudly on purpose: `addToCart`/`checkout` throw on out-of-stock or
-  empty carts. A green path means it is really buyable — don't swallow these.
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole storefront. **Do not
+restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
+home page / header you build (STEP 4) from the same tokens so it matches.
 
-## Beyond the snippets
-The snippets cover the common storefront paths. If you hit a use case they don't cover
-(e.g. coupons, members/auth, a product field not shown in the typedef), make the call
-yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and request
-body in the **official Wix API reference** first; never guess:
-- Official Wix API reference: https://dev.wix.com/docs/api-reference.md
-- eCommerce integration guide (modifiers, custom text, variants): https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/e-commerce-integration.md
-- Member login + a "my orders" account view → the **members** vertical (`references/members/INSTRUCTIONS.md`): custom login on your own UI so buyers can sign in and see their account.
-
-Keep the snippets as the default for everything they already do; reach for the API
-reference only for the gap.
-
-## Reference components (headless — adapt the logic, restyle freely)
-
-These are the recurring storefront pieces, written **headless**: the data wiring (Wix field
-paths, variant resolution, modifier handling, stock gating, cart) is correct and complete — the
-markup is deliberately plain. **Copy the logic exactly; restyle the JSX to the brand.** Don't
-re-derive the data shape from scratch (that's where the bugs are — the variant/modifier/stock
-paths especially). They consume the `src/rest/` helpers; you don't need to read those helpers'
-source.
-
-**`src/context/CartContext.jsx`** — cart state, mirroring the Wix **server** cart (never a
-local copy). Wrap the app in `<CartProvider>`; everything reads `useCart()`.
+## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it.
+- `import "@/theme.css";` once at the app entry.
+- Wrap the routed tree in `<CartProvider>` (from `@/context/CartContext`).
+- Mount `<CartDrawer />` once inside the provider (outside `<Routes>` so it overlays every page), and
+  `<CartButton />` in the header you build.
+- Routes: `/shop` → `Shop`, `/product/:slug` → `ProductDetail` (both shipped). **You add `/` → your
+  own Home** page.
 
 ```jsx
-import { createContext, useContext, useState, useEffect, useCallback } from "react";
-import { getCurrentCart, addToCart as apiAdd, removeFromCart as apiRemove,
-         updateCartItemQuantity as apiQty, checkout as apiCheckout } from "@/rest/wix-store-cart";
+import "@/theme.css";
+import { CartProvider } from "@/context/CartContext";
+import CartDrawer from "@/components/CartDrawer";
+import CartButton from "@/components/CartButton";
+import Shop from "@/pages/Shop";
+import ProductDetail from "@/pages/ProductDetail";
+import Home from "@/pages/Home";   // the home page YOU build
 
-const CartContext = createContext(null);
-
-export function CartProvider({ children }) {
-  const [cart, setCart] = useState(null);
-  const [isOpen, setIsOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
-
-  const refreshCart = useCallback(async () => setCart(await getCurrentCart()), []);
-  useEffect(() => {                                   // load once + re-sync when tab regains focus
-    refreshCart();
-    const onVisible = () => document.visibilityState === "visible" && refreshCart();
-    document.addEventListener("visibilitychange", onVisible);
-    return () => document.removeEventListener("visibilitychange", onVisible);
-  }, [refreshCart]);
-
-  const itemCount = (cart?.lineItems ?? []).reduce((n, li) => n + (li.quantity || 0), 0);
-  const addToCart = async (id, variantId, qty = 1, extras) => {
-    setLoading(true);
-    try { setCart(await apiAdd(id, variantId, qty, extras)); setIsOpen(true); } finally { setLoading(false); }
-  };
-  const removeItem = async (lineItemId) => { setLoading(true); try { setCart(await apiRemove(lineItemId)); } finally { setLoading(false); } };
-  const updateQuantity = async (lineItemId, qty) => { setLoading(true); try { setCart(await apiQty(lineItemId, qty)); } finally { setLoading(false); } };
-  const checkout = async () => { setLoading(true); try { window.location.href = await apiCheckout(); } finally { setLoading(false); } };
-
-  return (
-    <CartContext.Provider value={{ cart, itemCount, isOpen, setIsOpen, loading, addToCart, removeItem, updateQuantity, checkout, refreshCart }}>
-      {children}
-    </CartContext.Provider>
-  );
-}
-export function useCart() {
-  const ctx = useContext(CartContext);
-  if (!ctx) throw new Error("useCart must be used within <CartProvider>");
-  return ctx;
-}
+<CartProvider>
+  {/* your header: mount <CartButton /> */}
+  <Routes>
+    <Route path="/" element={<Home />} />                        {/* yours */}
+    <Route path="/shop" element={<Shop />} />                    {/* shipped */}
+    <Route path="/product/:slug" element={<ProductDetail />} />  {/* shipped */}
+  </Routes>
+  <CartDrawer />
+</CartProvider>
 ```
 
-**`ProductCard.jsx`** — grid tile. Note the `//`-protocol fix on the image URL and the exact
-price / out-of-stock field paths.
+## What you build (not shipped)
+The **home / landing page**, the **header/nav** (mount `<CartButton/>` in it), and the overall
+layout & brand story — styled from the same `theme.css` tokens. The shipped `Shop`/`ProductCard`
+are your reference for pulling catalog data (see below).
 
-```jsx
-import { Link } from "react-router-dom";
+## Extending the client (read the files, don't guess shapes)
+The shipped files under `src/` are the source of truth for field shapes and correct usage — **read
+them before writing a new Wix call.** Two things bite otherwise:
+- Every catalog/cart list helper returns a **wrapper object, not a bare array** — `queryProducts`/
+  `queryCategories`/… → `{ <plural>, nextCursor }`. Destructure the array (`Shop.jsx` shows it);
+  calling `.map`/`.filter` on the return throws `… is not a function`.
+- `product.plainDescription` is **HTML** despite the name (the PDP renders it correctly); image URLs
+  come as objects — `product.media.main.image.url`, `lineItems[].image.url`.
 
-function productImage(product) {
-  const url = product?.media?.main?.image?.url;
-  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
-}
+For anything the shipped client doesn't cover (coupons, members, a field not used yet), look up the
+exact endpoint/shape in the **`wix-docs`** skill — never guess.
 
-export default function ProductCard({ product }) {
-  const image = productImage(product);
-  const price = product?.actualPriceRange?.minValue?.formattedAmount;           // includes currency symbol
-  const compareAt = product?.compareAtPriceRange?.minValue?.formattedAmount;    // present only when on sale
-  const soldOut = product?.inventory?.availabilityStatus === "OUT_OF_STOCK";
-  return (
-    <Link to={`/product/${product.slug}`} /* restyle */>
-      {image ? <img src={image} alt={product.name} loading="lazy" /> : <div>{/* placeholder */}</div>}
-      {soldOut && <span>Sold out</span>}
-      <h3>{product.name}</h3>
-      <span>{price}</span>
-      {compareAt && compareAt !== price && <span style={{ textDecoration: "line-through" }}>{compareAt}</span>}
-    </Link>
-  );
-}
-```
-
-**`pages/Shop.jsx`** — the catalog listing (grid + category menu + empty state + paging). Every
-catalog helper returns an **object, not a bare array** — `queryProducts`/`queryProductsByCategory`
-→ `{ products, nextCursor }`, `queryCategories` → `{ categories, nextCursor }`, `countProducts` → a
-number. Destructure first: calling `.filter`/`.map` on the returned object throws
-`… is not a function` (the #1 catalog-listing bug). Keep the destructuring exactly.
-
-```jsx
-import { useState, useEffect } from "react";
-import { queryProducts, queryProductsByCategory, queryCategories, countProducts } from "@/rest/wix-store-catalog";
-import ProductCard from "@/components/ProductCard";
-
-export default function Shop() {
-  const [products, setProducts] = useState([]);
-  const [cursor, setCursor] = useState(null);
-  const [menu, setMenu] = useState([]);         // category menu (system category dropped)
-  const [active, setActive] = useState(null);   // selected category id, or null for "all"
-  const [total, setTotal] = useState(null);
-
-  useEffect(() => {
-    // NB: destructure — these return objects, not arrays.
-    countProducts().then(setTotal);
-    queryCategories().then(({ categories }) =>
-      setMenu(categories.filter((c) => c.slug !== "all-products")));   // drop Wix's "All Products" system category
-  }, []);
-
-  useEffect(() => {
-    const load = active
-      ? queryProductsByCategory(active, { limit: 24 })
-      : queryProducts({ limit: 24 });
-    load.then(({ products, nextCursor }) => { setProducts(products); setCursor(nextCursor); });
-  }, [active]);
-
-  const loadMore = () => {
-    const load = active
-      ? queryProductsByCategory(active, { limit: 24, cursor })
-      : queryProducts({ limit: 24, cursor });
-    load.then(({ products: more, nextCursor }) => { setProducts((p) => [...p, ...more]); setCursor(nextCursor); });
-  };
-
-  if (total === 0) return <p>{/* empty state — no products yet */}</p>;
-  return (
-    <div /* restyle */>
-      <nav>
-        <button onClick={() => setActive(null)} aria-pressed={active === null}>All</button>
-        {menu.map((c) => (
-          <button key={c.id} onClick={() => setActive(c.id)} aria-pressed={active === c.id}>{c.name}</button>
-        ))}
-      </nav>
-      <div /* grid */>{products.map((p) => <ProductCard key={p.id} product={p} />)}</div>
-      {cursor && <button onClick={loadMore}>Load more</button>}
-    </div>
-  );
-}
-```
-
-**`pages/Category.jsx`** — a category landing page. `getCategoryBySlug(slug)` returns a **bare
-category object** (or `null` on miss — show a not-found state), **not** `{ category }`. Render the
-category's own fields, then feed `category.id` (never the slug) to `queryProductsByCategory` and
-paginate exactly like `Shop.jsx`.
-
-```jsx
-import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import { getCategoryBySlug, queryProductsByCategory } from "@/rest/wix-store-catalog";
-import ProductCard from "@/components/ProductCard";
-
-export default function Category() {
-  const { slug } = useParams();
-  const [category, setCategory] = useState(null);
-  const [notFound, setNotFound] = useState(false);
-  const [products, setProducts] = useState([]);
-  const [cursor, setCursor] = useState(null);
-
-  useEffect(() => {
-    getCategoryBySlug(slug).then((c) => {              // bare category object, or null on miss
-      if (!c) return setNotFound(true);
-      setCategory(c);
-      queryProductsByCategory(c.id, { limit: 24 }).then(({ products, nextCursor }) => {  // feed id, not slug
-        setProducts(products);
-        setCursor(nextCursor);
-      });
-    });
-  }, [slug]);
-
-  const loadMore = () =>
-    queryProductsByCategory(category.id, { limit: 24, cursor }).then(({ products: more, nextCursor }) => {
-      setProducts((p) => [...p, ...more]);
-      setCursor(nextCursor);
-    });
-
-  if (notFound) return <div>Category not found.</div>;
-  if (!category) return <div>Loading…</div>;
-  return (
-    <div /* restyle */>
-      <h1>{category.name}</h1>
-      {/* category.description is a typedef field, but whether it's plain text or HTML is not
-          documented — if it renders raw tags, treat it as HTML like plainDescription; confirm via wix-docs. */}
-      {category.description && <p>{category.description}</p>}
-      {/* category.image is listed in the typedef but WITHOUT a sub-shape (no url/altText) — do NOT
-          assume category.image.url; look the category media shape up via the wix-docs skill before rendering it. */}
-      <div /* grid */>{products.map((p) => <ProductCard key={p.id} product={p} />)}</div>
-      {cursor && <button onClick={loadMore}>Load more</button>}
-    </div>
-  );
-}
-```
-
-**`CartDrawer.jsx`** — reads everything from `useCart()`; mutate by `lineItem.id` (not
-`catalogItemId`), check out via the context.
-
-```jsx
-import { useCart } from "@/context/CartContext";
-
-export default function CartDrawer() {
-  const { cart, isOpen, setIsOpen, removeItem, updateQuantity, checkout, loading } = useCart();
-  const lineItems = cart?.lineItems ?? [];
-  if (!isOpen) return null;
-  return (
-    <div /* restyle: slide-over panel */>
-      <button onClick={() => setIsOpen(false)}>Close</button>
-      {lineItems.length === 0 ? <p>Your cart is empty.</p> : (
-        <>
-          {lineItems.map((item) => (
-            <div key={item.id}>
-              <img src={item.image?.url} alt={item.productName?.original} />   {/* cart image is an object: item.image.url (NOT a bare string — don't apply the ProductCard //-fix to it) */}
-              <span>{item.productName?.original}</span>
-              {item.descriptionLines?.map((dl, i) => (               // variant/modifier summary Wix supplies
-                <small key={i}>{dl.name?.original}: {dl.plainText?.original || dl.colorInfo?.original}</small>
-              ))}
-              <button onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}>−</button>
-              <span>{item.quantity}</span>
-              <button onClick={() => updateQuantity(item.id, item.quantity + 1)}>+</button>
-              <button onClick={() => removeItem(item.id)}>Remove</button>
-              <span>{item.price?.formattedAmount}</span>
-            </div>
-          ))}
-          {/* Order total / subtotal is NOT in the cart typedef (wix-store-cart.js lists only per-line
-              price/fullPrice) — resolve the exact cart-level total path via the wix-docs skill before
-              rendering one; do NOT invent priceSummary/subtotal. */}
-          <button disabled={loading} onClick={checkout}>Checkout</button>
-        </>
-      )}
-    </div>
-  );
-}
-```
-
-**`pages/ProductDetail.jsx`** — the PDP. This carries the trickiest logic: resolving the
-buyer's option selections to a variant, gating add-to-cart on mandatory modifiers + stock, and
-rendering the HTML description. Keep all of it.
-
-```jsx
-import { useState, useEffect, useMemo } from "react";
-import { useParams } from "react-router-dom";
-import { getProductBySlug } from "@/rest/wix-store-catalog";
-import { useCart } from "@/context/CartContext";
-
-// same //→https: protocol fix as ProductCard — Wix image urls can come back protocol-relative
-function imageUrl(url) {
-  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
-}
-// PDP gallery: product.media.itemsInfo.items — [{ image: { url }, altText }] (see wix-store-catalog.js typedef)
-function galleryImages(product) {
-  return (product?.media?.itemsInfo?.items ?? [])
-    .map((it) => ({ url: imageUrl(it.image?.url), alt: it.altText || product?.name }))
-    .filter((i) => i.url);
-}
-// one control per product.options[] (variant choices)
-function OptionSelector({ option, selected, onSelect }) {
-  return (
-    <div>
-      <label>{option.name}</label>
-      {option.choicesSettings?.choices?.map((c) => (
-        <button key={c.choiceId} disabled={c.inStock === false}      // choice with no in-stock variant
-          aria-pressed={selected === c.choiceId} onClick={() => onSelect(option.id, c.choiceId)}>{c.name}</button>
-      ))}
-    </div>
-  );
-}
-// one control per product.modifiers[] — TEXT_CHOICES → buttons, FREE_TEXT → input
-function ModifierSelector({ modifier, value, onChange }) {
-  const key = modifier.modifierRenderType === "FREE_TEXT" ? modifier.freeTextSettings?.key : modifier.key;
-  if (modifier.modifierRenderType === "FREE_TEXT")
-    return <label>{modifier.name}{modifier.mandatory && " *"}<input value={value || ""} onChange={(e) => onChange(key, e.target.value)} /></label>;
-  return (
-    <div>
-      <label>{modifier.name}{modifier.mandatory && " *"}</label>
-      {modifier.choicesSettings?.choices?.map((c) => (
-        <button key={c.key} aria-pressed={value === c.key} onClick={() => onChange(key, c.key)}>{c.name}</button>
-      ))}
-    </div>
-  );
-}
-
-export default function ProductDetail() {
-  const { slug } = useParams();
-  const { addToCart } = useCart();
-  const [product, setProduct] = useState(null);
-  const [notFound, setNotFound] = useState(false);
-  const [selectedOptions, setSelectedOptions] = useState({});
-  const [modifierValues, setModifierValues] = useState({});
-  const [quantity, setQuantity] = useState(1);
-
-  useEffect(() => {
-    getProductBySlug(slug).then((p) => {
-      if (!p) return setNotFound(true);
-      setProduct(p);
-      const initial = {};                                            // pre-select first in-stock choice per option
-      (p.options || []).forEach((o) => {
-        const first = o.choicesSettings?.choices?.find((c) => c.inStock !== false);
-        if (first) initial[o.id] = first.choiceId;
-      });
-      setSelectedOptions(initial);
-    });
-  }, [slug]);
-
-  const options = product?.options || [];
-  const modifiers = product?.modifiers || [];
-  const variants = product?.variantsInfo?.variants || [];
-
-  const variant = useMemo(() => {                                    // match selections → variant
-    if (options.length === 0) return variants[0] || null;           // option-less → single variant
-    if (!options.every((o) => selectedOptions[o.id])) return null;  // not all chosen yet
-    return variants.find((v) => (v.choices || []).every((c) =>
-      selectedOptions[c.optionChoiceIds?.optionId] === c.optionChoiceIds?.choiceId)) || null;
-  }, [options, variants, selectedOptions]);
-
-  const inStock = variant ? variant.inventoryStatus?.inStock !== false : true;
-  const canAdd = useMemo(() => {
-    if (options.length > 0 && !variant) return false;               // options exist but unresolved
-    if (variant && !inStock) return false;
-    return modifiers.filter((m) => m.mandatory).every((m) =>        // every mandatory modifier filled
-      m.modifierRenderType === "FREE_TEXT" ? !!modifierValues[m.freeTextSettings?.key] : !!modifierValues[m.key]);
-  }, [options, variant, inStock, modifiers, modifierValues]);
-
-  const price = variant?.price?.actualPrice?.formattedAmount || product?.actualPriceRange?.minValue?.formattedAmount || "";
-
-  async function handleAdd() {
-    const modifierChoices = {}, customTextFields = {};
-    modifiers.forEach((m) => {
-      const k = m.modifierRenderType === "FREE_TEXT" ? m.freeTextSettings?.key : m.key;
-      if (!k || !modifierValues[k]) return;
-      (m.modifierRenderType === "FREE_TEXT" ? customTextFields : modifierChoices)[k] = modifierValues[k];
-    });
-    await addToCart(product.id, variant?.id, quantity, {
-      modifierChoices: Object.keys(modifierChoices).length ? modifierChoices : undefined,
-      customTextFields: Object.keys(customTextFields).length ? customTextFields : undefined,
-    });
-  }
-
-  if (notFound) return <div>Product not found.</div>;
-  if (!product) return <div>Loading…</div>;
-  return (
-    <div /* restyle */>
-      <img src={imageUrl(product.media?.main?.image?.url)} alt={product.name} />   {/* //→https: fix, same as ProductCard */}
-      {galleryImages(product).length > 0 && (
-        <div /* thumbnail strip */>
-          {galleryImages(product).map((img, i) => (
-            <img key={i} src={img.url} alt={img.alt} loading="lazy" />
-          ))}
-        </div>
-      )}
-      <h1>{product.name}</h1>
-      <p>{price}</p>
-      {/* plainDescription is HTML despite the name — never render as plain text */}
-      <div dangerouslySetInnerHTML={{ __html: product.plainDescription || "" }} />
-      {options.map((o) => (
-        <OptionSelector key={o.id} option={o} selected={selectedOptions[o.id]}
-          onSelect={(id, cid) => setSelectedOptions((s) => ({ ...s, [id]: cid }))} />
-      ))}
-      {modifiers.map((m) => (
-        <ModifierSelector key={m.key || m.freeTextSettings?.key} modifier={m}
-          value={modifierValues[m.key || m.freeTextSettings?.key]}
-          onChange={(k, v) => setModifierValues((s) => ({ ...s, [k]: v }))} />
-      ))}
-      <button disabled={!canAdd} onClick={handleAdd}>{inStock ? "Add to cart" : "Out of stock"}</button>
-    </div>
-  );
-}
-```
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Checkout goes through the shipped cart (redirect-session) — never a hand-built `/checkout` URL.
+- Render live Wix data or the shipped empty state — never mock products.
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the store content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For store data those pages are:
-- **Products** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-stores/products` (`Dashboard → Store → Products`; add/edit products, variants, inventory)
-- **Categories** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-stores/categories/list` (`Dashboard → Store → Categories`; organize products into the category menu)
+Provide deep links so the owner can edit content (substitute the site's `metaSiteId`):
+- **Products** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-stores/products`
+- **Categories** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-stores/categories/list`
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed the catalog per `seed/SEED.md` (the build-time `setupStore` module) — separate from this
+client build; run in parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (cart survives reload, same visitor)
-- [ ] Every product choice renders on the PDP — variant options **and** modifiers (mandatory ones included)
-- [ ] Add-to-cart button stays disabled until all required choices are made (variant + mandatory modifiers)
-- [ ] A product with a mandatory modifier adds successfully (its selection is sent, cart line appears)
-- [ ] Stock reflected in the UI — sold-out product badged (grid), out-of-stock option choices and variants disabled/labelled (PDP)
-- [ ] Add to cart works; out-of-stock items throw rather than add a dead line
-- [ ] Quantity update / remove reflect in `getCurrentCart()`
-- [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL)
-- [ ] Cart re-fetched on return from checkout (clears once the order is placed)
-- [ ] Empty state shown when `countProducts()` is 0
-- [ ] No mock products anywhere
-- [ ] Told the user at least once that they can continue setting up their store in the dashboard and provided deep links.
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components not restyled.
+- [ ] Routes wired; `<CartProvider>` wraps the tree; `<CartDrawer/>` mounted; `<CartButton/>` in the header.
+- [ ] Cart survives reload (same visitor); add / update-qty / remove work; checkout redirects.
+- [ ] Empty catalog shows the shipped empty state; no mock products anywhere.

--- a/skills/wix-vibe-headless/references/storefront/app/components/CartButton.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/CartButton.jsx
@@ -1,0 +1,23 @@
+// Header cart trigger with live item count. Drop into the app header; opens the CartDrawer.
+import { useCart } from "@/context/CartContext";
+
+export default function CartButton() {
+  const { itemCount, setIsOpen } = useCart();
+  return (
+    <button onClick={() => setIsOpen(true)} aria-label="Open cart" style={{
+      position: "relative", display: "inline-flex", alignItems: "center", gap: 6,
+      padding: "8px 14px", cursor: "pointer",
+      background: "var(--color-primary)", color: "var(--color-on-primary)",
+      border: "none", borderRadius: "var(--radius-sm)", fontFamily: "var(--font-body)",
+    }}>
+      Cart
+      {itemCount > 0 && (
+        <span style={{
+          minWidth: 20, height: 20, padding: "0 6px", display: "inline-flex",
+          alignItems: "center", justifyContent: "center", fontSize: 12,
+          background: "var(--color-accent)", color: "#fff", borderRadius: 999,
+        }}>{itemCount}</span>
+      )}
+    </button>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/app/components/CartDrawer.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/CartDrawer.jsx
@@ -1,0 +1,87 @@
+// Slide-over cart. Reads everything from useCart(); mutate by lineItem.id (NOT catalogItemId),
+// check out via the context (redirect-session URL). Token-styled; re-skin via theme.css.
+import { useCart } from "@/context/CartContext";
+
+export default function CartDrawer() {
+  const { cart, isOpen, setIsOpen, removeItem, updateQuantity, checkout, loading } = useCart();
+  const lineItems = cart?.lineItems ?? [];
+  if (!isOpen) return null;
+
+  return (
+    <div onClick={() => setIsOpen(false)} style={{
+      position: "fixed", inset: 0, zIndex: 50,
+      background: "rgba(0,0,0,.4)", display: "flex", justifyContent: "flex-end",
+    }}>
+      <aside onClick={(e) => e.stopPropagation()} style={{
+        width: "min(420px, 100%)", height: "100%", display: "flex", flexDirection: "column",
+        background: "var(--color-bg)", color: "var(--color-text)",
+        borderLeft: "1px solid var(--color-border)", fontFamily: "var(--font-body)",
+      }}>
+        <header style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          padding: "var(--space)", borderBottom: "1px solid var(--color-border)",
+        }}>
+          <strong style={{ fontFamily: "var(--font-display)" }}>Your cart</strong>
+          <button onClick={() => setIsOpen(false)} aria-label="Close cart" style={{
+            border: "none", background: "none", cursor: "pointer", fontSize: 20, color: "var(--color-muted)",
+          }}>×</button>
+        </header>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "var(--space)" }}>
+          {lineItems.length === 0 ? (
+            <p style={{ color: "var(--color-muted)" }}>Your cart is empty.</p>
+          ) : lineItems.map((item) => (
+            <div key={item.id} style={{
+              display: "flex", gap: 12, padding: "12px 0",
+              borderBottom: "1px solid var(--color-border)",
+            }}>
+              <img src={item.image?.url} alt={item.productName?.original} style={{
+                width: 64, height: 64, objectFit: "cover", borderRadius: "var(--radius-sm)",
+                background: "var(--color-surface)",
+              }} />
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontWeight: 600 }}>{item.productName?.original}</span>
+                {item.descriptionLines?.map((dl, i) => (
+                  <small key={i} style={{ color: "var(--color-muted)" }}>
+                    {dl.name?.original}: {dl.plainText?.original || dl.colorInfo?.original}
+                  </small>
+                ))}
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+                  <QtyButton onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}>−</QtyButton>
+                  <span style={{ minWidth: 20, textAlign: "center" }}>{item.quantity}</span>
+                  <QtyButton onClick={() => updateQuantity(item.id, item.quantity + 1)}>+</QtyButton>
+                  <button onClick={() => removeItem(item.id)} style={{
+                    marginLeft: "auto", border: "none", background: "none", cursor: "pointer",
+                    color: "var(--color-muted)", fontSize: 13, textDecoration: "underline",
+                  }}>Remove</button>
+                </div>
+              </div>
+              <span style={{ fontWeight: 600 }}>{item.price?.formattedAmount}</span>
+            </div>
+          ))}
+        </div>
+
+        {lineItems.length > 0 && (
+          <footer style={{ padding: "var(--space)", borderTop: "1px solid var(--color-border)" }}>
+            <button disabled={loading} onClick={checkout} style={{
+              width: "100%", padding: "12px", cursor: loading ? "wait" : "pointer",
+              background: "var(--color-primary)", color: "var(--color-on-primary)",
+              border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+              opacity: loading ? 0.6 : 1,
+            }}>Checkout</button>
+          </footer>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+function QtyButton({ children, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      width: 28, height: 28, cursor: "pointer", lineHeight: 1,
+      background: "var(--color-surface)", color: "var(--color-text)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+    }}>{children}</button>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
@@ -1,0 +1,46 @@
+// Grid tile. Styled entirely from theme.css tokens (var(--...)) — re-skin via those tokens, not
+// this JSX. The image `//`-protocol fix and the price / out-of-stock field paths are load-bearing.
+import { Link } from "react-router-dom";
+
+function productImage(product) {
+  const url = product?.media?.main?.image?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+export default function ProductCard({ product }) {
+  const image = productImage(product);
+  const price = product?.actualPriceRange?.minValue?.formattedAmount;
+  const compareAt = product?.compareAtPriceRange?.minValue?.formattedAmount;
+  const soldOut = product?.inventory?.availabilityStatus === "OUT_OF_STOCK";
+
+  return (
+    <Link to={`/product/${product.slug}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      <div style={{ position: "relative", aspectRatio: "1 / 1", background: "var(--color-bg)" }}>
+        {image
+          ? <img src={image} alt={product.name} loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          : <div style={{ width: "100%", height: "100%" }} />}
+        {soldOut && (
+          <span style={{
+            position: "absolute", top: 8, left: 8, padding: "2px 8px", fontSize: 12,
+            background: "var(--color-danger)", color: "#fff", borderRadius: "var(--radius-sm)",
+          }}>Sold out</span>
+        )}
+      </div>
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 4 }}>
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 15, fontWeight: 600 }}>{product.name}</h3>
+        <div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+          <span style={{ fontWeight: 600 }}>{price}</span>
+          {compareAt && compareAt !== price && (
+            <span style={{ color: "var(--color-muted)", textDecoration: "line-through", fontSize: 13 }}>{compareAt}</span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductGrid.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductGrid.jsx
@@ -1,0 +1,19 @@
+// Responsive product grid + empty state. Token-styled; re-skin via theme.css.
+import ProductCard from "./ProductCard";
+
+export default function ProductGrid({ products, empty = "No products yet." }) {
+  if (!products?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+      gap: "var(--space)",
+    }}>
+      {products.map((p) => <ProductCard key={p.id} product={p} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
@@ -1,0 +1,71 @@
+// PDP choice controls: one OptionSelector per product.options[] (variant choices) and one
+// ModifierSelector per product.modifiers[] (TEXT_CHOICES → buttons, FREE_TEXT → input). Driven by
+// useProductDetail — pass its selection state/handlers in. Token-styled; re-skin via theme.css.
+
+const chipBase = {
+  padding: "6px 12px", cursor: "pointer", fontSize: 14, fontFamily: "var(--font-body)",
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-surface)", color: "var(--color-text)",
+};
+const chipActive = { background: "var(--color-primary)", color: "var(--color-on-primary)", borderColor: "var(--color-primary)" };
+const label = { display: "block", marginBottom: 6, fontSize: 13, fontWeight: 600, color: "var(--color-muted)" };
+
+function OptionSelector({ option, selected, onSelect }) {
+  return (
+    <div style={{ marginBottom: "var(--space)" }}>
+      <label style={label}>{option.name}</label>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {option.choicesSettings?.choices?.map((c) => (
+          <button key={c.choiceId} disabled={c.inStock === false}
+            aria-pressed={selected === c.choiceId} onClick={() => onSelect(option.id, c.choiceId)}
+            style={{
+              ...chipBase, ...(selected === c.choiceId ? chipActive : null),
+              opacity: c.inStock === false ? 0.4 : 1,
+              textDecoration: c.inStock === false ? "line-through" : "none",
+            }}>{c.name}</button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ModifierSelector({ modifier, value, onChange }) {
+  const key = modifier.modifierRenderType === "FREE_TEXT" ? modifier.freeTextSettings?.key : modifier.key;
+  if (modifier.modifierRenderType === "FREE_TEXT") {
+    return (
+      <div style={{ marginBottom: "var(--space)" }}>
+        <label style={label}>{modifier.name}{modifier.mandatory && " *"}</label>
+        <input value={value || ""} onChange={(e) => onChange(key, e.target.value)} style={{
+          width: "100%", padding: "8px 12px", fontFamily: "var(--font-body)",
+          border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+          background: "var(--color-bg)", color: "var(--color-text)",
+        }} />
+      </div>
+    );
+  }
+  return (
+    <div style={{ marginBottom: "var(--space)" }}>
+      <label style={label}>{modifier.name}{modifier.mandatory && " *"}</label>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {modifier.choicesSettings?.choices?.map((c) => (
+          <button key={c.key} aria-pressed={value === c.key} onClick={() => onChange(key, c.key)}
+            style={{ ...chipBase, ...(value === c.key ? chipActive : null) }}>{c.name}</button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function VariantPicker({ options, modifiers, selectedOptions, selectOption, modifierValues, setModifier }) {
+  return (
+    <>
+      {options.map((o) => (
+        <OptionSelector key={o.id} option={o} selected={selectedOptions[o.id]} onSelect={selectOption} />
+      ))}
+      {modifiers.map((m) => (
+        <ModifierSelector key={m.key || m.freeTextSettings?.key} modifier={m}
+          value={modifierValues[m.key || m.freeTextSettings?.key]} onChange={setModifier} />
+      ))}
+    </>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/app/context/CartContext.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/context/CartContext.jsx
@@ -1,0 +1,47 @@
+// Cart state — mirrors the Wix SERVER cart (never a local copy). Wrap the app in <CartProvider>;
+// every component reads useCart(). Data wiring is correct as-is — do not restyle or re-derive it.
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import {
+  getCurrentCart,
+  addToCart as apiAdd,
+  removeFromCart as apiRemove,
+  updateCartItemQuantity as apiQty,
+  checkout as apiCheckout,
+} from "@/rest/wix-store-cart";
+
+const CartContext = createContext(null);
+
+export function CartProvider({ children }) {
+  const [cart, setCart] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const refreshCart = useCallback(async () => setCart(await getCurrentCart()), []);
+  useEffect(() => {
+    refreshCart();
+    const onVisible = () => document.visibilityState === "visible" && refreshCart();
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refreshCart]);
+
+  const itemCount = (cart?.lineItems ?? []).reduce((n, li) => n + (li.quantity || 0), 0);
+  const addToCart = async (id, variantId, qty = 1, extras) => {
+    setLoading(true);
+    try { setCart(await apiAdd(id, variantId, qty, extras)); setIsOpen(true); } finally { setLoading(false); }
+  };
+  const removeItem = async (lineItemId) => { setLoading(true); try { setCart(await apiRemove(lineItemId)); } finally { setLoading(false); } };
+  const updateQuantity = async (lineItemId, qty) => { setLoading(true); try { setCart(await apiQty(lineItemId, qty)); } finally { setLoading(false); } };
+  const checkout = async () => { setLoading(true); try { window.location.href = await apiCheckout(); } finally { setLoading(false); } };
+
+  return (
+    <CartContext.Provider value={{ cart, itemCount, isOpen, setIsOpen, loading, addToCart, removeItem, updateQuantity, checkout, refreshCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("useCart must be used within <CartProvider>");
+  return ctx;
+}

--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
@@ -1,0 +1,73 @@
+// useProductDetail — all PDP logic, no markup: load product by slug, pre-select first in-stock
+// choice per option, resolve the buyer's selections to a Wix variant, gate add-to-cart on stock +
+// mandatory modifiers, and build the addToCart payload. The data paths here (variant resolution,
+// modifier keys, stock gating) are the bug-prone part — keep them verbatim; the PDP page only
+// renders what this returns.
+import { useState, useEffect, useMemo } from "react";
+import { getProductBySlug } from "@/rest/wix-store-catalog";
+import { useCart } from "@/context/CartContext";
+
+export function useProductDetail(slug) {
+  const { addToCart } = useCart();
+  const [product, setProduct] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const [selectedOptions, setSelectedOptions] = useState({});
+  const [modifierValues, setModifierValues] = useState({});
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    getProductBySlug(slug).then((p) => {
+      if (!p) return setNotFound(true);
+      setProduct(p);
+      const initial = {};
+      (p.options || []).forEach((o) => {
+        const first = o.choicesSettings?.choices?.find((c) => c.inStock !== false);
+        if (first) initial[o.id] = first.choiceId;
+      });
+      setSelectedOptions(initial);
+    });
+  }, [slug]);
+
+  const options = product?.options || [];
+  const modifiers = product?.modifiers || [];
+  const variants = product?.variantsInfo?.variants || [];
+
+  const variant = useMemo(() => {
+    if (options.length === 0) return variants[0] || null;
+    if (!options.every((o) => selectedOptions[o.id])) return null;
+    return variants.find((v) => (v.choices || []).every((c) =>
+      selectedOptions[c.optionChoiceIds?.optionId] === c.optionChoiceIds?.choiceId)) || null;
+  }, [options, variants, selectedOptions]);
+
+  const inStock = variant ? variant.inventoryStatus?.inStock !== false : true;
+  const canAdd = useMemo(() => {
+    if (options.length > 0 && !variant) return false;
+    if (variant && !inStock) return false;
+    return modifiers.filter((m) => m.mandatory).every((m) =>
+      m.modifierRenderType === "FREE_TEXT" ? !!modifierValues[m.freeTextSettings?.key] : !!modifierValues[m.key]);
+  }, [options, variant, inStock, modifiers, modifierValues]);
+
+  const price = variant?.price?.actualPrice?.formattedAmount || product?.actualPriceRange?.minValue?.formattedAmount || "";
+
+  const selectOption = (optionId, choiceId) => setSelectedOptions((s) => ({ ...s, [optionId]: choiceId }));
+  const setModifier = (key, value) => setModifierValues((s) => ({ ...s, [key]: value }));
+
+  async function submit() {
+    const modifierChoices = {}, customTextFields = {};
+    modifiers.forEach((m) => {
+      const k = m.modifierRenderType === "FREE_TEXT" ? m.freeTextSettings?.key : m.key;
+      if (!k || !modifierValues[k]) return;
+      (m.modifierRenderType === "FREE_TEXT" ? customTextFields : modifierChoices)[k] = modifierValues[k];
+    });
+    await addToCart(product.id, variant?.id, quantity, {
+      modifierChoices: Object.keys(modifierChoices).length ? modifierChoices : undefined,
+      customTextFields: Object.keys(customTextFields).length ? customTextFields : undefined,
+    });
+  }
+
+  return {
+    product, notFound, options, modifiers,
+    selectedOptions, selectOption, modifierValues, setModifier,
+    quantity, setQuantity, variant, inStock, canAdd, price, submit,
+  };
+}

--- a/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
@@ -1,0 +1,67 @@
+// PDP — thin view over useProductDetail (all logic lives in the hook). plainDescription is HTML
+// despite the name; render via dangerouslySetInnerHTML. Token-styled; re-skin via theme.css.
+import { useParams } from "react-router-dom";
+import { useProductDetail } from "@/hooks/useProductDetail";
+import VariantPicker from "@/components/VariantPicker";
+
+function productImage(product) {
+  const url = product?.media?.main?.image?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+export default function ProductDetail() {
+  const { slug } = useParams();
+  const d = useProductDetail(slug);
+
+  if (d.notFound) return <Centered>Product not found.</Centered>;
+  if (!d.product) return <Centered>Loading…</Centered>;
+
+  const image = productImage(d.product);
+  return (
+    <main style={{
+      maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)",
+      display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: "calc(var(--space) * 2)",
+    }}>
+      <div style={{
+        aspectRatio: "1 / 1", background: "var(--color-surface)",
+        borderRadius: "var(--radius)", overflow: "hidden",
+      }}>
+        {image && <img src={image} alt={d.product.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />}
+      </div>
+
+      <div>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px" }}>{d.product.name}</h1>
+        <p style={{ fontSize: 22, fontWeight: 600, margin: "0 0 var(--space)" }}>{d.price}</p>
+
+        <div style={{ color: "var(--color-muted)", lineHeight: 1.6, marginBottom: "calc(var(--space) * 1.5)" }}
+          dangerouslySetInnerHTML={{ __html: d.product.plainDescription || "" }} />
+
+        <VariantPicker
+          options={d.options} modifiers={d.modifiers}
+          selectedOptions={d.selectedOptions} selectOption={d.selectOption}
+          modifierValues={d.modifierValues} setModifier={d.setModifier}
+        />
+
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: "var(--space)" }}>
+          <input type="number" min={1} value={d.quantity}
+            onChange={(e) => d.setQuantity(Math.max(1, Number(e.target.value) || 1))}
+            style={{
+              width: 72, padding: "10px", textAlign: "center",
+              border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+              background: "var(--color-bg)", color: "var(--color-text)",
+            }} />
+          <button disabled={!d.canAdd} onClick={d.submit} style={{
+            flex: 1, padding: "12px 24px", cursor: d.canAdd ? "pointer" : "not-allowed",
+            background: "var(--color-primary)", color: "var(--color-on-primary)",
+            border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+            opacity: d.canAdd ? 1 : 0.5,
+          }}>{d.inStock ? "Add to cart" : "Out of stock"}</button>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/storefront/app/pages/Shop.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/Shop.jsx
@@ -1,0 +1,19 @@
+// Shop / catalog page — lists visible products, empty state when the catalog is empty.
+import { useEffect, useState } from "react";
+import { queryProducts } from "@/rest/wix-store-catalog";
+import ProductGrid from "@/components/ProductGrid";
+
+export default function Shop() {
+  const [products, setProducts] = useState(null);
+
+  useEffect(() => { queryProducts({ limit: 100 }).then((r) => setProducts(r.products)); }, []);
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Shop</h1>
+      {products === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <ProductGrid products={products} empty="No products yet — add some from your Wix dashboard." />}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/app/theme.css
+++ b/skills/wix-vibe-headless/references/storefront/app/theme.css
@@ -1,0 +1,36 @@
+/* theme.css — THE styling surface. Theme the whole storefront by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every template component reads these variables, so
+   changing them here re-skins the entire site. Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, drawers, wells */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text */
+  --color-border:    #e5e7eb;   /* hairlines, dividers */
+  --color-primary:   #111827;   /* buttons, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* highlights, sale, badges */
+  --color-danger:    #dc2626;   /* out-of-stock, errors */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1200px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
## Why
Across every storefront build we viewed, the single biggest cost is **one UI-generation turn — 150–240s** (Snake 178s, Perch 236s, …) — because vibe-headless ships the storefront components as **snippets in INSTRUCTIONS.md that the agent re-emits**. That turn is also where the shape bugs (cats.filter, image path, stock) got re-introduced.

## What
Ship the storefront client as **real files** (the "one more step toward the template skill" idea):
- New `references/storefront/app/` — theme-neutral, token-styled client: `context/CartContext.jsx`, `hooks/useProductDetail.js`, `components/{ProductCard,ProductGrid,CartButton,CartDrawer,VariantPicker}.jsx`, `pages/{Shop,ProductDetail}.jsx`, `theme.css`. Same components as the `wix-base44-headless` storefront template (shared shape); they consume the existing `src/rest` scaffolds unchanged (no `wix.config.json` dependency — vibe-headless keeps `WIX_CLIENT_ID` in `wix-client.js`).
- `INSTRUCTIONS.md`: **530 → 107 lines**. Now: copy the client into `src/` (one `cpSync` exec) → set `WIX_CLIENT_ID` → theme `theme.css` tokens → wire routes in `App.jsx` → build only the home/nav. No component snippets to regenerate.

## Expected effect
The ~150–240s gen turn collapses to a copy + token edit; the shape-bug class disappears from the shipped surface (agent copies working files instead of hand-writing data wiring).

## Scope / safety
- **Storefront only** — the verified vertical. Others stay snippet-based until this is proven live.
- `app/` is copied by the new STEP 1 exec in INSTRUCTIONS; base44.md's flat `.js→src/rest` install copy does **not** touch the nested `app/` tree (verified) → no collision.
- All JSX parse (esbuild); the copy snippet parses.
- Open question to settle later: dedupe with `wix-base44-headless` (make its storefront template the shared source both consume) vs. keeping this copy.

Next: live-verify a real build and confirm the UI-gen turn drops.