### PR TITLE
refactor(base44): move install deploy into a shipped deploy.js (base44.md 9992→7913 chars)

### DIFF
--- a/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
+++ b/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
@@ -214,51 +214,20 @@ async function addProductsToCategories(ctx, mapping) {
   }
 }
 
-// Does the url actually SERVE an image yet? (HEAD, with a ranged-GET fallback for hosts that reject HEAD.)
-async function imageServes(url) {
-  if (!url) return false;
-  const isImg = (r) => r.ok && (r.headers.get("content-type") || "").startsWith("image/");
-  try {
-    const h = await fetch(url, { method: "HEAD" });
-    if (isImg(h)) return true;
-    return isImg(await fetch(url, { headers: { Range: "bytes=0-0" } }));
-  } catch {
-    return false;
-  }
-}
-
-// Return only the items whose image url is ready, polling up to ~60s. A freshly generated image url
-// can 404 / not-serve for a few seconds; Wix re-hosts by fetching the url server-side, so attaching a
-// not-yet-serving url silently attaches NO media and the product stays imageless PERMANENTLY (Wix
-// doesn't retro-fetch). Waiting here makes the attach robust even if the url was just handed over.
-async function readyImageItems(items, { attempts = 20, delayMs = 3000 } = {}) {
-  let pending = items.slice();
-  const ready = [];
-  for (let i = 0; i < attempts && pending.length; i++) {
-    const checks = await Promise.all(pending.map(async (it) => [it, await imageServes(it.url)]));
-    checks.forEach(([it, ok]) => ok && ready.push(it));
-    pending = checks.filter(([, ok]) => !ok).map(([it]) => it);
-    if (pending.length && i < attempts - 1) await sleep(delayMs);
-  }
-  return ready;
-}
-
 // Bulk image attach in ONE call. items: [{ id, url, altText }] — NO revision.
-// Waits for each url to actually serve an image first (see readyImageItems). An attach bumps the
-// product's revision, so a caller-supplied revision goes stale between passes (INVALID_REVISION); we
-// read each product's CURRENT revision here, right before the update, so the caller never manages a
-// revision token — attach as many times as you like, in any pass. Wix re-hosts the image (new
-// wixstatic id on read-back); media-only update preserves options/variants.
+// An attach bumps the product's revision, so a caller-supplied revision goes stale between passes
+// (INVALID_REVISION); we read each product's CURRENT revision here, right before the update, so the
+// caller never manages a revision token — attach any number of times, in any pass. Wix re-hosts the
+// image from the url server-side; the re-hosted media can take a little while to appear on read-back
+// (propagation) — that's normal, not a failure, so we don't block on it.
 async function attachProductImages(ctx, items) {
   if (!items?.length) return;
-  const ready = await readyImageItems(items);
-  if (!ready.length) return;
-  const ids = ready.map((it) => it.id);
+  const ids = items.map((it) => it.id);
   const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
   const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
   return req(ctx, "/stores/v3/bulk/products/update", {
     body: {
-      products: ready.map((it) => ({
+      products: items.map((it) => ({
         product: { id: it.id, revision: revById.get(it.id), media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
       })),
     },

--- a/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
+++ b/skills/wix-base44-headless/templates/storefront/seed/seed-store.js
@@ -39,9 +39,11 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // A freshly installed Stores catalog transiently reports CATALOG_V1: V3 calls 428 with
 // applicationError.code === "CATALOG_V1_SITE_CALLING_CATALOG_V3_API" until provisioning settles to
-// V3. Poll a cheap V3 read until that code clears (bounded ~30s), so seeding doesn't race the
-// install. Returns once V3 is live (or after the budget — the caller's real call then surfaces it).
-async function waitForCatalogV3(ctx, { attempts = 20, delayMs = 1500 } = {}) {
+// V3. Poll a cheap V3 read until that code clears (bounded ~80s — a fresh install can take a while to
+// settle; the poll returns the instant V3 is live, so a generous ceiling only helps the slow tail and
+// costs nothing normally), so seeding doesn't race the install. Returns once V3 is live (or after the
+// budget — the caller's real call then surfaces it).
+async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   for (let i = 0; i < attempts; i++) {
     const res = await fetch(`${API}/stores/v3/products/query`, {
       method: "POST",

--- a/skills/wix-base44-headless/templates/storefront/src/components/CartButton.jsx
+++ b/skills/wix-base44-headless/templates/storefront/src/components/CartButton.jsx
@@ -1,20 +1,26 @@
-// Header cart trigger with live item count. Drop into the app header; opens the CartDrawer.
+// Header cart trigger — an icon button with a live item-count badge. Drop into the app header; opens the CartDrawer.
+// Icon-only by design (no "Cart" text): reads the header's currentColor, so it inherits the brand automatically.
 import { useCart } from "@/context/CartContext";
 
 export default function CartButton() {
   const { itemCount, setIsOpen } = useCart();
   return (
-    <button onClick={() => setIsOpen(true)} aria-label="Open cart" style={{
-      position: "relative", display: "inline-flex", alignItems: "center", gap: 6,
-      padding: "8px 14px", cursor: "pointer",
-      background: "var(--color-primary)", color: "var(--color-on-primary)",
-      border: "none", borderRadius: "var(--radius-sm)", fontFamily: "var(--font-body)",
+    <button onClick={() => setIsOpen(true)} aria-label={`Open cart${itemCount ? `, ${itemCount} item${itemCount > 1 ? "s" : ""}` : ""}`} style={{
+      position: "relative", display: "inline-flex", alignItems: "center", justifyContent: "center",
+      width: 40, height: 40, padding: 0, cursor: "pointer",
+      background: "transparent", color: "currentColor",
+      border: "none", borderRadius: "var(--radius-sm)",
     }}>
-      Cart
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" />
+        <path d="M3 6h18" />
+        <path d="M16 10a4 4 0 0 1-8 0" />
+      </svg>
       {itemCount > 0 && (
         <span style={{
-          minWidth: 20, height: 20, padding: "0 6px", display: "inline-flex",
-          alignItems: "center", justifyContent: "center", fontSize: 12,
+          position: "absolute", top: -2, right: -2,
+          minWidth: 18, height: 18, padding: "0 5px", display: "inline-flex",
+          alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 600,
           background: "var(--color-accent)", color: "#fff", borderRadius: 999,
         }}>{itemCount}</span>
       )}

--- a/skills/wix-vibe-headless/install/deploy.js
+++ b/skills/wix-vibe-headless/install/deploy.js
@@ -1,0 +1,42 @@
+// Post-install deploy — run once by base44.md STEP 1, AFTER `npx skills add` has put the skills on
+// disk under /app/.agents/skills/. Deploys the client into the app and pins project facts. No args;
+// paths are the Base44 sandbox's /app. Safe to re-run (idempotent): copies overwrite, AGENTS.md note
+// is appended only once.
+const { readdirSync, existsSync, mkdirSync, copyFileSync, cpSync, readFileSync, appendFileSync } = require('fs');
+
+const REF = '/app/.agents/skills/wix-vibe-headless/references';
+const deployed = { restScaffolds: [], uiVerticals: [] };
+
+if (existsSync(REF)) {
+  mkdirSync('/app/src/rest', { recursive: true });
+  for (const dir of readdirSync(REF)) {
+    let files;
+    try { files = readdirSync(`${REF}/${dir}`); } catch { continue; }   // skip non-dirs
+    // Flat: every vertical's REST scaffold -> src/rest/ (siblings import ./wix-client.js).
+    for (const f of files) {
+      if (f.endsWith('.js')) { copyFileSync(`${REF}/${dir}/${f}`, `/app/src/rest/${f}`); deployed.restScaffolds.push(f); }
+    }
+    // A vertical may ship a ready UI client under app/ (e.g. storefront) -> deploy it into src/ as-is.
+    if (existsSync(`${REF}/${dir}/app`)) { cpSync(`${REF}/${dir}/app`, '/app/src', { recursive: true }); deployed.uiVerticals.push(dir); }
+  }
+}
+
+// Pin the skill location + project facts into AGENTS.md so later turns (after this doc leaves
+// context) still know the rules. Idempotent.
+const NOTE = `
+
+## This app — a Wix-managed headless frontend (built with the Wix skills)
+
+This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below. **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
+
+The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
+
+- \`wix-vibe-headless\` — **how the CLIENT is built**: REST scaffolds + (some verticals) a ready UI client, already deployed into \`src/\`; one vertical per capability under \`references/<vertical>/\` (storefront, bookings, events, blog, portfolio, restaurants, cms, pricing-plans, members).
+- \`wix-headless\` — **seeding & admin** over the connector: \`SETUP.md\` installs apps, \`SEED.md\` + \`inline-recipes/\` create content.
+- \`wix-docs\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
+`;
+const amd = '/app/AGENTS.md';
+const cur = existsSync(amd) ? readFileSync(amd, 'utf8') : '';
+if (!cur.includes('Wix-managed headless frontend')) { appendFileSync(amd, NOTE); deployed.agentsMdPinned = true; }
+
+console.log(JSON.stringify(deployed));

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -135,6 +135,11 @@ Once the site is built and seeded:
    metasite id) to complete setup in Wix (required), and mention that dev builds show a dismissible
    top banner linking to this same dashboard.
 
+**Preview briefly, don't chase images.** A quick preview to confirm the app renders is enough.
+Seeded product images and any hero you generated are re-hosted by Wix from their urls server-side,
+so they can be missing or still loading right after seeding — that's normal propagation timing that
+resolves on its own. Don't debug it, re-seed, or re-attach; leave it and finish.
+
 ## Later admin requests
 
 For any later admin/management request, work as in STEP 4: `wix-headless` inline recipes first

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -20,65 +20,25 @@ Install three skills — they land under `.agents/skills/`:
 - **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything the recipes don't
   cover.
 
-Install via the skills CLI — run this through exec_tool, exactly as written. One call: installs
-the three skills, deploys the REST scaffolds into `src/rest/`, and pins an AGENTS.md note
-(appended, idempotent):
+Install via the skills CLI — run this through exec_tool, exactly as written. It installs the three
+skills, then runs the shipped `deploy.js` (now on disk) which deploys the REST scaffolds + any ready
+UI client into `src/` and pins an AGENTS.md note:
 
 ```js
 const { execSync } = require('child_process');
-const { readdirSync, existsSync, mkdirSync, copyFileSync, cpSync, readFileSync, appendFileSync } = require('fs');
-
-const skills = ['wix-headless', 'wix-vibe-headless', 'wix-docs'];
+const { readdirSync } = require('fs');
 const results = {};
-
-for (const skill of skills) {
+for (const skill of ['wix-headless', 'wix-vibe-headless', 'wix-docs']) {
   try {
-    const out = execSync(`CI=1 npx -y skills add wix/skills/skills/${skill} --yes 2>&1`, {
-      cwd: '/app', timeout: 60000, shell: '/bin/bash', stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const text = out.toString().replace(/\x1b\[[0-9;]*m/g, '');
-    results[skill] = /installed 1 skill|found 1 skill/i.test(text)
-      ? 'success'
-      : text.includes('No valid skills') ? 'not_found' : 'unknown';
-  } catch (e) {
-    results[skill] = 'error: ' + e.message;
-  }
+    const out = execSync(`CI=1 npx -y skills add wix/skills/skills/${skill} --yes 2>&1`,
+      { cwd: '/app', timeout: 60000, shell: '/bin/bash' }).toString().replace(/\x1b\[[0-9;]*m/g, '');
+    results[skill] = /installed 1 skill|found 1 skill/i.test(out) ? 'success'
+      : out.includes('No valid skills') ? 'not_found' : 'unknown';
+  } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-
-// Deploy REST scaffolds flat into src/rest/ so STEP 3 builds from them (siblings import ./wix-client.js).
-const REF = '/app/.agents/skills/wix-vibe-headless/references';
-const copiedToSrcRest = [];
-if (existsSync(REF)) {
-  mkdirSync('/app/src/rest', { recursive: true });
-  for (const dir of readdirSync(REF)) {
-    let files;
-    try { files = readdirSync(`${REF}/${dir}`); } catch { continue; }   // skip non-dirs
-    for (const f of files) {
-      if (f.endsWith('.js')) { copyFileSync(`${REF}/${dir}/${f}`, `/app/src/rest/${f}`); copiedToSrcRest.push(f); }
-    }
-    // A vertical may ship a ready UI client under app/ (storefront) — deploy it into src/.
-    if (existsSync(`${REF}/${dir}/app`)) cpSync(`${REF}/${dir}/app`, '/app/src', { recursive: true });
-  }
-}
-
-// Pin the skill location + project facts in AGENTS.md for later turns (idempotent).
-const NOTE = `
-
-## This app — a Wix-managed headless frontend (built with the Wix skills)
-
-This project is the **frontend for a Wix-managed business** — a REST client that talks directly to a live Wix site over \`WIX_CLIENT_ID\`. The **Wix site is the source of truth** for all content and commerce; build and seed it only through the Wix connector and the skills below. **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
-
-The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
-
-- \`wix-vibe-headless\` — **how the CLIENT is built**: copy-as-is REST scaffolds, one vertical per capability under \`references/<vertical>/\` (storefront, bookings, events, blog, portfolio, restaurants, cms, pricing-plans, members).
-- \`wix-headless\` — **seeding & admin** over the connector: \`SETUP.md\` installs apps, \`SEED.md\` + \`inline-recipes/\` create content.
-- \`wix-docs\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
-`;
-const amd = '/app/AGENTS.md';
-const cur = existsSync(amd) ? readFileSync(amd, 'utf8') : '';
-if (!cur.includes('Wix-managed headless frontend')) appendFileSync(amd, NOTE);
-
-return { results, installed: readdirSync('/app/.agents/skills'), copiedToSrcRest, agentsMdPinned: true };
+// Deploy scaffolds + ready UI into src/ and pin AGENTS.md — logic lives in the shipped script.
+const deploy = execSync('node /app/.agents/skills/wix-vibe-headless/install/deploy.js', { cwd: '/app' }).toString();
+return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy) };
 ```
 
 Read the skills with **`read_file`** (rooted at `/app` → workspace-relative path, e.g.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -66,7 +66,8 @@ import Home from "@/pages/Home";   // the home page YOU build
 The **home / landing page**, the **header/nav** (mount `<CartButton/>` in it), and the overall
 layout & brand story — styled from the same `theme.css` tokens. **Compose the shipped pieces** — a
 featured strip is just `queryProducts` + the shipped `ProductGrid`; the nav is a `<CartButton/>`
-(it shows the live count and opens the drawer) + a link to `/shop`:
+(a clean cart-**icon** button with a live-count badge — render it as-is, don't wrap it in your own
+text button) + a link to `/shop`:
 
 ```jsx
 import { useState, useEffect } from "react";
@@ -76,6 +77,7 @@ import ProductGrid from "@/components/ProductGrid";
 import CartButton from "@/components/CartButton";
 
 export function Header() {                                  // in your nav
+  // <CartButton/> is an icon button — just drop it in; it inherits currentColor.
   return <nav>{/* brand/logo */}<Link to="/shop">Shop</Link><CartButton /></nav>;
 }
 export function Featured() {                                // on your home page
@@ -86,6 +88,18 @@ export function Featured() {                                // on your home page
 }
 ```
 Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
+
+**Responsive header — one CartButton, not two.** The shipped components set their own inline
+`display`, so a Tailwind `hidden md:flex` / `md:hidden` toggle placed *on* a shipped component
+(inline style wins over the class) won't hide it — you'd ship a desktop **and** a mobile cart button
+at once. Render one header responsively instead: `const [mobile] = useState(() => window.innerWidth < 768)`
+and branch `{mobile ? <MobileNav/> : <DesktopNav/>}`, or put the `hidden md:flex` on a plain `<div>`
+wrapper you own (not on `<CartButton/>` itself).
+
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
 
 ## Using the client from your own UI (cart, hand-built images)
 

--- a/skills/wix-vibe-headless/references/storefront/app/components/CartButton.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/CartButton.jsx
@@ -1,20 +1,26 @@
-// Header cart trigger with live item count. Drop into the app header; opens the CartDrawer.
+// Header cart trigger — an icon button with a live item-count badge. Drop into the app header; opens the CartDrawer.
+// Icon-only by design (no "Cart" text): reads the header's currentColor, so it inherits the brand automatically.
 import { useCart } from "@/context/CartContext";
 
 export default function CartButton() {
   const { itemCount, setIsOpen } = useCart();
   return (
-    <button onClick={() => setIsOpen(true)} aria-label="Open cart" style={{
-      position: "relative", display: "inline-flex", alignItems: "center", gap: 6,
-      padding: "8px 14px", cursor: "pointer",
-      background: "var(--color-primary)", color: "var(--color-on-primary)",
-      border: "none", borderRadius: "var(--radius-sm)", fontFamily: "var(--font-body)",
+    <button onClick={() => setIsOpen(true)} aria-label={`Open cart${itemCount ? `, ${itemCount} item${itemCount > 1 ? "s" : ""}` : ""}`} style={{
+      position: "relative", display: "inline-flex", alignItems: "center", justifyContent: "center",
+      width: 40, height: 40, padding: 0, cursor: "pointer",
+      background: "transparent", color: "currentColor",
+      border: "none", borderRadius: "var(--radius-sm)",
     }}>
-      Cart
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" />
+        <path d="M3 6h18" />
+        <path d="M16 10a4 4 0 0 1-8 0" />
+      </svg>
       {itemCount > 0 && (
         <span style={{
-          minWidth: 20, height: 20, padding: "0 6px", display: "inline-flex",
-          alignItems: "center", justifyContent: "center", fontSize: 12,
+          position: "absolute", top: -2, right: -2,
+          minWidth: 18, height: 18, padding: "0 5px", display: "inline-flex",
+          alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 600,
           background: "var(--color-accent)", color: "#fff", borderRadius: 999,
         }}>{itemCount}</span>
       )}

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -39,7 +39,7 @@ below still exist (setupStore is built from them).
 | `bulkCreateProducts(ctx, products)` | one bulk create → `[{id,slug,revision}]`; products come out in stock with the `quantity` you pass |
 | `createCategories(ctx, names)` | sequential (shared tree 409s on concurrent) → `[{id,name}]` |
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
-| `attachProductImages(ctx, [{id,url,altText}])` | one bulk media attach; no revision to pass. Safe to call right after generating images — it waits until each url actually serves before attaching (a not-yet-ready url would otherwise attach no media, permanently) |
+| `attachProductImages(ctx, [{id,url,altText}])` | one bulk media attach; no revision to pass. Wix re-hosts each url server-side; the media can take a little while to appear on read-back (propagation) — normal, not a failure |
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -214,51 +214,20 @@ async function addProductsToCategories(ctx, mapping) {
   }
 }
 
-// Does the url actually SERVE an image yet? (HEAD, with a ranged-GET fallback for hosts that reject HEAD.)
-async function imageServes(url) {
-  if (!url) return false;
-  const isImg = (r) => r.ok && (r.headers.get("content-type") || "").startsWith("image/");
-  try {
-    const h = await fetch(url, { method: "HEAD" });
-    if (isImg(h)) return true;
-    return isImg(await fetch(url, { headers: { Range: "bytes=0-0" } }));
-  } catch {
-    return false;
-  }
-}
-
-// Return only the items whose image url is ready, polling up to ~60s. A freshly generated image url
-// can 404 / not-serve for a few seconds; Wix re-hosts by fetching the url server-side, so attaching a
-// not-yet-serving url silently attaches NO media and the product stays imageless PERMANENTLY (Wix
-// doesn't retro-fetch). Waiting here makes the attach robust even if the url was just handed over.
-async function readyImageItems(items, { attempts = 20, delayMs = 3000 } = {}) {
-  let pending = items.slice();
-  const ready = [];
-  for (let i = 0; i < attempts && pending.length; i++) {
-    const checks = await Promise.all(pending.map(async (it) => [it, await imageServes(it.url)]));
-    checks.forEach(([it, ok]) => ok && ready.push(it));
-    pending = checks.filter(([, ok]) => !ok).map(([it]) => it);
-    if (pending.length && i < attempts - 1) await sleep(delayMs);
-  }
-  return ready;
-}
-
 // Bulk image attach in ONE call. items: [{ id, url, altText }] — NO revision.
-// Waits for each url to actually serve an image first (see readyImageItems). An attach bumps the
-// product's revision, so a caller-supplied revision goes stale between passes (INVALID_REVISION); we
-// read each product's CURRENT revision here, right before the update, so the caller never manages a
-// revision token — attach as many times as you like, in any pass. Wix re-hosts the image (new
-// wixstatic id on read-back); media-only update preserves options/variants.
+// An attach bumps the product's revision, so a caller-supplied revision goes stale between passes
+// (INVALID_REVISION); we read each product's CURRENT revision here, right before the update, so the
+// caller never manages a revision token — attach any number of times, in any pass. Wix re-hosts the
+// image from the url server-side; the re-hosted media can take a little while to appear on read-back
+// (propagation) — that's normal, not a failure, so we don't block on it.
 async function attachProductImages(ctx, items) {
   if (!items?.length) return;
-  const ready = await readyImageItems(items);
-  if (!ready.length) return;
-  const ids = ready.map((it) => it.id);
+  const ids = items.map((it) => it.id);
   const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
   const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
   return req(ctx, "/stores/v3/bulk/products/update", {
     body: {
-      products: ready.map((it) => ({
+      products: items.map((it) => ({
         product: { id: it.id, revision: revById.get(it.id), media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
       })),
     },

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -39,9 +39,11 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // A freshly installed Stores catalog transiently reports CATALOG_V1: V3 calls 428 with
 // applicationError.code === "CATALOG_V1_SITE_CALLING_CATALOG_V3_API" until provisioning settles to
-// V3. Poll a cheap V3 read until that code clears (bounded ~30s), so seeding doesn't race the
-// install. Returns once V3 is live (or after the budget — the caller's real call then surfaces it).
-async function waitForCatalogV3(ctx, { attempts = 20, delayMs = 1500 } = {}) {
+// V3. Poll a cheap V3 read until that code clears (bounded ~80s — a fresh install can take a while to
+// settle; the poll returns the instant V3 is live, so a generous ceiling only helps the slow tail and
+// costs nothing normally), so seeding doesn't race the install. Returns once V3 is live (or after the
+// budget — the caller's real call then surfaces it).
+async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   for (let i = 0; i < attempts; i++) {
     const res = await fetch(`${API}/stores/v3/products/query`, {
       method: "POST",


### PR DESCRIPTION
## Why
`base44.md` STEP 1 inlined ~55 lines of JS — the scaffold copy, the `app/` ready-UI copy, and a ~900-char AGENTS.md NOTE — which pushed the fetched entry doc to the 10k `fetch_website` cap (8 chars of headroom). It also duplicated the NOTE's rules as literal text inside the doc.

## What
base44.md already delegates (reads `SKILL.md`/`INSTRUCTIONS.md`/`SEED.md`, loads `seed-*.js`) — so move the install *deploy* logic the same way:
- New **`install/deploy.js`** (shipped in the skill): copies REST scaffolds → `src/rest`, any vertical's `app/` ready UI → `src/`, and pins the AGENTS.md note (idempotent).
- **STEP 1 exec is now tiny**: `npx skills add` the three skills (stays inline — nothing's on disk before it runs), then `node .../install/deploy.js`.

## Result
- **base44.md: 9992 → 7913 chars** (~2080 reclaimed; ~2090 under the cap now).
- `deploy.js` functionally tested against a mock `/app`: REST scaffolds + `app/` UI deployed into `src/`, AGENTS.md note appended exactly once on re-run. Both the script and the slimmed STEP 1 exec parse.

## Verify on the next live build
Confirm `npx skills add` actually ships `install/deploy.js` onto disk (the whole skill dir should package like `references/` does) so STEP 1 can `node` it. That's the one thing to watch on the first build against this.