### PR TITLE
fix(seed): reject /__generating__ image placeholders — pass final urls only

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -114,6 +114,12 @@ restaurant items, portfolio projects, event heroes, CMS items), generate with **
 image generation**, then import into Wix Media and attach per the capability's `wix-headless`
 inline recipe "Attach images" step.
 
+**Pass only FINAL image urls to seeding.** Wait for `generate_image` to return its final
+`https://media.base44.com/...` url before handing it to a seed call — an in-flight
+`/__generating__/<id>.png` path is a placeholder, not a real url, and Wix rejects it (you'd have to
+re-seed). To still overlap the work, create the products WITHOUT images first, then attach in a
+second pass once the real urls are in hand (`attachProductImages` takes any product ids, any time).
+
 The connector + `wix-headless` seeding are **admin-only** (STEP 4) — **not** part of the client,
 which is built solely per the `wix-vibe-headless` skill.
 

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -17,6 +17,9 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
 // to attach its image; omit it to skip images. options ONLY for real buyer choices (Size/Color); default none.
+// imageUrl must be the FINAL https://media.base44.com/... url — await generate_image first. A still-
+// generating `/__generating__/<id>.png` placeholder is not a real url and Wix rejects it. To overlap,
+// seed WITHOUT imageUrl now and call attachProductImages once the real urls are ready.
 const result = await seed.setupStore(ctx, {
   products: [
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },


### PR DESCRIPTION
## What
In the bicycle-ceramics build the agent fired `generate_image` and immediately called `setupStore`, passing Base44's **in-flight placeholder paths**:
```
imageUrl: "/__generating__/dbfbd455-…png"   ← still generating, not a real url
```
Wix rejected them, so it re-ran the **entire seed** with the real urls:
```
imageUrl: "https://media.base44.com/images/public/…/d84fda690_generated_…png"  ✅
```
Cost: ~42s + a duplicate seed exec. Distinct from the Wix re-hosting propagation issue — here the *input* url was a placeholder.

## Fix
base44.md STEP 4 + storefront `SEED.md`: await `generate_image` for the final `https://media.base44.com/...` url before seeding; a `/__generating__/<id>.png` path is a placeholder, not a url. To overlap the work, create products without images first and attach in a second pass once the real urls are ready (`attachProductImages` takes any ids, any time).

base44.md stays under the 10k fetch cap (8838 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)