### PR TITLE
fix(storefront): banner self-offset var + two-cart header snippet + drop wix-headless note

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -31,8 +31,7 @@ This project is the **frontend for a Wix-managed business** — a REST client th
 
 The Wix skills live under \`.agents/skills/\` — on ANY turn, read them from that exact path (ignore stray copies like \`agent/skills/\`).
 
-- \`wix-vibe-headless\` — **how the CLIENT is built**: REST scaffolds + (some verticals) a ready UI client, already deployed into \`src/\`; one vertical per capability under \`references/<vertical>/\` (storefront, bookings, events, blog, portfolio, restaurants, cms, pricing-plans, members).
-- \`wix-headless\` — **seeding & admin** over the connector: \`SETUP.md\` installs apps, \`SEED.md\` + \`inline-recipes/\` create content.
+- \`wix-vibe-headless\` — **how the CLIENT is built AND how the site is seeded**: REST scaffolds + (some verticals) a ready UI client, already deployed into \`src/\`; one vertical per capability under \`references/<vertical>/\` (storefront, bookings, events, blog, portfolio, restaurants, cms, pricing-plans, members), each with a \`seed/\` module that creates content over the connector.
 - \`wix-docs\` — **fallback** for **frontend code**, **backend code**, or **runtime / API management operations** alike: search + read the Wix API reference docs.
 `;
 const amd = '/app/AGENTS.md';

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -132,8 +132,9 @@ Once the site is built and seeded:
 1. **Mount the dev-only manage banner** (required; links the app to its Wix back office): import
    `mountWixManageBanner` from `src/rest/wix-manage-banner.js` (deployed in STEP 1, `WIX_METASITE_ID`
    set in STEP 3) and call it once from the app entry. It self-gates to dev builds (via
-   `import.meta.env.DEV`) — never in production; use as-is. If a `fixed`/`absolute` app header
-   slides under it, offset that header by the banner's height.
+   `import.meta.env.DEV`) — never in production; use as-is. If your app header is `fixed`/`sticky`,
+   set its `top: var(--wix-manage-banner-height, 0px)` — the banner publishes its own height in that
+   CSS var (0 in prod / when dismissed); that's the whole offset, no measuring or state.
 2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (substitute your
    metasite id) to complete setup in Wix (required), and mention that dev builds show a dismissible
    top banner linking to this same dashboard.

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -115,9 +115,10 @@ After the site is built and seeded:
    your metasite id and call `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
    builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
    guarantee: verify the gate actually holds in this stack, and that a production build never
-   shows the banner (no dev flag → no banner at all). Also verify it really pushes the site
-   down: a `fixed`/`absolute` app header is not in normal flow and will slide under the
-   banner — offset such a header by the banner's height.
+   shows the banner (no dev flag → no banner at all). A `fixed`/`sticky` app header is not in
+   normal flow and would slide under the banner; it publishes its height as the CSS var
+   `--wix-manage-banner-height` on :root, so set that header's `top: var(--wix-manage-banner-height, 0px)`
+   (0 in prod / when dismissed) — the whole offset, no measuring or state.
 2. **Ask the user to open** this URL to complete the setup in Wix (required; substitute the
    metasite id you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since
    the banner from step 1 is mounted, also tell them: *in dev builds the site shows a slim

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -9,6 +9,10 @@
  *
  *   import { mountWixManageBanner } from "./rest/wix-manage-banner.js";
  *   mountWixManageBanner();
+ *
+ * A position:fixed/sticky app header would slide under the banner; it publishes its
+ * height as `--wix-manage-banner-height` on :root, so set that header's
+ * `top: var(--wix-manage-banner-height, 0px)` (0 in prod / when dismissed).
  */
 
 /** The site's metasite id (from the same prompt that carried WIX_CLIENT_ID). */
@@ -43,12 +47,16 @@ export function mountWixManageBanner() {
   if (document.getElementById("wix-manage-banner")) return;
 
   // A solid, full-width strip in normal flow as <body>'s first child, so it
-  // pushes the whole site down rather than floating over it. CAUTION: an app
-  // header that is position:fixed (or absolute over a hero) is NOT in normal
-  // flow and will NOT be pushed — it slides under the banner. If the app has
-  // one, offset it by this element's offsetHeight; verify visually.
+  // pushes the whole site down rather than floating over it. A position:fixed
+  // (or absolute-over-hero) app header is NOT in normal flow, so it won't be
+  // pushed — but this banner publishes its own height as the CSS var
+  // `--wix-manage-banner-height` on :root (see below), so such a header just
+  // needs `top: var(--wix-manage-banner-height, 0px)` (0 in prod / when dismissed).
   const bar = document.createElement("div");
   bar.id = "wix-manage-banner";
+  const root = document.documentElement;
+  const syncHeight = () =>
+    root.style.setProperty("--wix-manage-banner-height", `${bar.offsetHeight}px`);
   bar.style.cssText =
     "position:relative;z-index:2147483647;box-sizing:border-box;display:flex;" +
     "align-items:center;justify-content:center;gap:14px;width:100%;" +
@@ -84,6 +92,8 @@ export function mountWixManageBanner() {
     "cursor:pointer;padding:6px;";
   close.addEventListener("click", () => {
     bar.remove();
+    root.style.setProperty("--wix-manage-banner-height", "0px");
+    window.removeEventListener("resize", syncHeight);
     try {
       window.localStorage.setItem(DISMISS_KEY, "1");
     } catch {
@@ -93,4 +103,6 @@ export function mountWixManageBanner() {
 
   bar.append(text, button, close);
   document.body.prepend(bar);
+  syncHeight();                                  // publish height now that it's measurable
+  window.addEventListener("resize", syncHeight); // keep it correct if the bar wraps at narrow widths
 }

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -76,9 +76,25 @@ import { queryProducts } from "@/rest/wix-store-catalog";
 import ProductGrid from "@/components/ProductGrid";
 import CartButton from "@/components/CartButton";
 
+// Responsive header: choose ONE branch with a state flag, so <CartButton/> mounts once.
+// Do NOT render a desktop nav AND a mobile nav toggled by `hidden md:flex` / `md:hidden`:
+// these navs are inline-styled, and an inline `display` beats a Tailwind class, so `hidden`
+// never applies — BOTH branches render and you get two cart buttons. One branch = one cart.
 export function Header() {                                  // in your nav
-  // <CartButton/> is an icon button — just drop it in; it inherits currentColor.
-  return <nav>{/* brand/logo */}<Link to="/shop">Shop</Link><CartButton /></nav>;
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return (
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger + <CartButton/> here
+        : <div style={{ display: "flex", gap: 24 }}><Link to="/shop">Shop</Link><CartButton /></div>}
+    </nav>
+  );
 }
 export function Featured() {                                // on your home page
   const [products, setProducts] = useState([]);
@@ -88,13 +104,7 @@ export function Featured() {                                // on your home page
 }
 ```
 Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
-
-**Responsive header — one CartButton, not two.** The shipped components set their own inline
-`display`, so a Tailwind `hidden md:flex` / `md:hidden` toggle placed *on* a shipped component
-(inline style wins over the class) won't hide it — you'd ship a desktop **and** a mobile cart button
-at once. Render one header responsively instead: `const [mobile] = useState(() => window.innerWidth < 768)`
-and branch `{mobile ? <MobileNav/> : <DesktopNav/>}`, or put the `hidden md:flex` on a plain `<div>`
-wrapper you own (not on `<CartButton/>` itself).
+`<CartButton/>` is an icon button (live-count badge) — drop it in as-is, it inherits `currentColor`.
 
 **Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
 can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh


### PR DESCRIPTION
Three fixes from the live builds (Jurassic / Moomin storefronts):

## 1. Manage banner self-offset (CSS var)
The banner sits in normal flow, so a `position:fixed`/`sticky` app header slides under it — and builds hand-rolled the offset with `document.getElementById(...).offsetHeight` + state, fumbling it (*"reading document during render is fragile…"*). Now `wix-manage-banner.js` publishes its own height as **`--wix-manage-banner-height`** on `:root` (set on mount, updated on resize, reset to `0px` on dismiss). The header offsets with one deterministic line:
```css
top: var(--wix-manage-banner-height, 0px);   /* 0 in prod / when dismissed */
```
Caution comment + base44.md STEP 5 + generic.md updated to this.

## 2. Two cart icons in the header (systemic)
**Root cause (from the shipped source):** agents render a desktop nav **and** a mobile nav and toggle with `hidden md:flex` / `md:hidden` — but each nav also has an inline `display:flex`, and **inline style beats a class**, so `hidden` (`display:none`) never applies → *both* navs render → **two `<CartButton/>`s**. Replaced the minimal header example in `INSTRUCTIONS.md` with a correct responsive one — a single-branch `mobile`-state ternary with a reactive resize listener that mounts `<CartButton/>` exactly once — plus a tight comment naming the trap. Dropped the older prose rule (code carries it).

## 3. Drop wix-headless from the install note
`deploy.cjs` still pinned a `wix-headless` bullet into the app's `AGENTS.md`. Removed it; seeding is folded into the `wix-vibe-headless` bullet (per-vertical `seed/` modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)