### PR TITLE
fix(storefront): stop up-front read of shipped source (confirm via deploy result)

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -74,8 +74,10 @@ truth for how the client is built.
 **REST scaffolds are already in `src/rest/`** (STEP 1) — set `WIX_CLIENT_ID` in `wix-client.js`,
 `WIX_METASITE_ID` in `wix-manage-banner.js`; adapt with targeted edits, don't regenerate. Some
 verticals also ship a **ready UI client** under `src/` (STEP 1 deployed it) — theme + wire it per
-`INSTRUCTIONS.md`, don't rebuild. The vertical's `INSTRUCTIONS.md` has every field shape; no need to
-read the scaffolds' source.
+`INSTRUCTIONS.md`, don't rebuild. STEP 1's `deploy` result already lists every deployed file — that's
+your confirmation they exist; **don't `read_file` the deployed component/page source to check them.**
+Every field shape is in `INSTRUCTIONS.md`; read a deployed file only on a real fallback (an error, or
+a field the snippets don't cover).
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -74,10 +74,9 @@ truth for how the client is built.
 **REST scaffolds are already in `src/rest/`** (STEP 1) — set `WIX_CLIENT_ID` in `wix-client.js`,
 `WIX_METASITE_ID` in `wix-manage-banner.js`; adapt with targeted edits, don't regenerate. Some
 verticals also ship a **ready UI client** under `src/` (STEP 1 deployed it) — theme + wire it per
-`INSTRUCTIONS.md`, don't rebuild. STEP 1's `deploy` result already lists every deployed file — that's
-your confirmation they exist; **don't `read_file` the deployed component/page source to check them.**
-Every field shape is in `INSTRUCTIONS.md`; read a deployed file only on a real fallback (an error, or
-a field the snippets don't cover).
+`INSTRUCTIONS.md`, don't rebuild. STEP 1 already deployed these files — **don't `read_file` the
+deployed component/page source to inspect them**; every field shape is in `INSTRUCTIONS.md`. Read a
+deployed file only on a real fallback (an error, or a field the snippets don't cover).
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -10,7 +10,7 @@ products; never hand-build a `/checkout` URL — the shipped cart goes through t
 redirect-session.
 
 ## Prerequisites
-- Wix Stores installed with products (this client is read/cart over the catalog; seeding is STEP 5).
+- The site's **Wix Stores** catalog is the read/cart target. It's installed and seeded separately (see **Seeding** below), in parallel with this build — so it may be empty at build time; the client renders the shipped empty state until products land.
 - The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
 
 ## STEP 1 — The client is already in `src/`

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -18,9 +18,14 @@ The install step (base44.md STEP 1) deployed both the REST scaffolds (`src/rest/
 storefront UI client into `src/`: `src/theme.css`, `src/context/CartContext.jsx`,
 `src/hooks/useProductDetail.js`,
 `src/components/{ProductCard,ProductGrid,CartButton,CartDrawer,VariantPicker}.jsx`,
-`src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`). Nothing to copy —
-confirm the files are there, then theme + wire (below). (Missing? re-run install, or copy
-`references/storefront/app/` → `src/`.)
+`src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`).
+
+The install's `deploy` result already lists every file it wrote — that's your confirmation they
+exist. **Don't read the shipped page/component/hook source to "check" them** (no `read_file` sweep of
+`src/components`, `src/pages`, `src/hooks`, `src/context`): every field shape you need is in the
+snippets below, so go straight to theming + wiring. Read a shipped file's source **only** on a real
+fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the end).
+(Files missing? re-run install, or copy `references/storefront/app/` → `src/`.)
 
 ## STEP 2 — Credentials
 In `src/rest/wix-client.js` set `WIX_CLIENT_ID` to the value from your prompt.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -20,12 +20,12 @@ storefront UI client into `src/`: `src/theme.css`, `src/context/CartContext.jsx`
 `src/components/{ProductCard,ProductGrid,CartButton,CartDrawer,VariantPicker}.jsx`,
 `src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`).
 
-The install's `deploy` result already lists every file it wrote — that's your confirmation they
-exist. **Don't read the shipped page/component/hook source to "check" them** (no `read_file` sweep of
-`src/components`, `src/pages`, `src/hooks`, `src/context`): every field shape you need is in the
-snippets below, so go straight to theming + wiring. Read a shipped file's source **only** on a real
-fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the end).
-(Files missing? re-run install, or copy `references/storefront/app/` → `src/`.)
+They're already in place (STEP 1 deployed them) — go **straight to theming + wiring**, nothing to
+verify first. **Don't `read_file` the shipped page/component/hook source to inspect it** (`src/components`,
+`src/pages`, `src/hooks`, `src/context`): every field shape you need is in the snippets below. Read a
+shipped file's source **only** on a real fallback — a runtime error, or a field the snippets don't
+cover (see "Fallback only" at the end). (Files missing? the install's `deploy` result lists what it
+wrote; re-run install, or copy `references/storefront/app/` → `src/`.)
 
 ## STEP 2 — Credentials
 In `src/rest/wix-client.js` set `WIX_CLIENT_ID` to the value from your prompt.


### PR DESCRIPTION
## What
Every storefront build opens with a `read_file` sweep of **all 9 shipped UI files** (`theme.css`, `CartContext`, `CartButton`, `CartDrawer`, `Shop`, `ProductDetail`, `ProductCard`, `ProductGrid`, `useProductDetail`) before doing anything — ~20–35s of wall-clock plus the context it carries the rest of the build, for files the snippets already document.

## Why the old guidance didn't land
- `base44.md` STEP 3: *"no need to read the scaffolds' source"* — soft, and "scaffolds" reads as the `src/rest/` REST files, not the UI components the agent actually reads.
- `INSTRUCTIONS.md` STEP 1: *"Nothing to copy — **confirm the files are there**"* — the agent "confirms" by reading each file.
- The real *"Fallback only"* rule sat at the **bottom** of INSTRUCTIONS, after the sweep already happened.

## Fix
Both STEP 1 (INSTRUCTIONS) and STEP 3 (base44.md) now say: the install's **`deploy` result already lists every file it wrote** — that's your confirmation — so **don't `read_file` the shipped component/page/hook source to check them**; field shapes are in the snippets; read a shipped file **only** on a real fallback (a runtime error, or a field the snippets don't cover).

INSTRUCTIONS is read via `read_file` (uncapped). base44.md stays well under the fetch budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)