### PR TITLE
feat(storefront): single wix-config.js for both Wix ids (no scaffold read/edit)

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -71,8 +71,9 @@ fails or shows nothing relevant, ask the user what they offer.
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — the single source of
 truth for how the client is built.
 
-**REST scaffolds are already in `src/rest/`** (STEP 1) — set `WIX_CLIENT_ID` in `wix-client.js`,
-`WIX_METASITE_ID` in `wix-manage-banner.js`; adapt with targeted edits, don't regenerate. Some
+**REST scaffolds are already in `src/rest/`** (STEP 1). Write `src/rest/wix-config.js` with your
+`WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the one place both ids live (a single write,
+nothing to read). Some
 verticals also ship a **ready UI client** under `src/` (STEP 1 deployed it) — theme + wire it per
 `INSTRUCTIONS.md`, don't rebuild. STEP 1 already deployed these files — **don't `read_file` the
 deployed component/page source to inspect them**; every field shape is in `INSTRUCTIONS.md`. Read a

--- a/skills/wix-vibe-headless/references/shared/wix-client.js
+++ b/skills/wix-vibe-headless/references/shared/wix-client.js
@@ -3,16 +3,14 @@
  * `storefrontApiRequest` in src/lib/shopify.ts. Plain fetch, JSON in / JSON out.
  * No SDK, no query builder, no Velo.
  *
- * WIX_CLIENT_ID is the one thing to set. The client exchanges it for a visitor
- * access token via the OAuth2 token endpoint, then sends that token on every API call.
+ * WIX_CLIENT_ID is the one thing to set — and you set it in `wix-config.js`, not here.
+ * The client exchanges it for a visitor access token via the OAuth2 token endpoint,
+ * then sends that token on every API call.
  */
 
-/**
- * The public headless OAuth client id. It is a buyer-facing credential (it only mints
- * anonymous visitor tokens), NOT a secret — so it is safe to hardcode here. Paste the
- * value from the Wix Business Manager prompt in place of the placeholder.
- */
-export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
+// The public headless OAuth client id — set it in wix-config.js (do not hardcode it here).
+export { WIX_CLIENT_ID } from "./wix-config.js";
+import { WIX_CLIENT_ID } from "./wix-config.js";
 
 export const WIX_API_BASE = "https://www.wixapis.com";
 const OAUTH_TOKEN_URL = `${WIX_API_BASE}/oauth2/token`;

--- a/skills/wix-vibe-headless/references/shared/wix-config.js
+++ b/skills/wix-vibe-headless/references/shared/wix-config.js
@@ -1,0 +1,6 @@
+// Wix credentials — the ONLY file you set these in. Paste both values from your prompt,
+// replacing the placeholders. Safe to commit: WIX_CLIENT_ID is a public, buyer-facing id
+// (it only mints anonymous visitor tokens); WIX_METASITE_ID just identifies the site.
+// wix-client.js and wix-manage-banner.js import from here — do NOT edit those two for ids.
+export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
+export const WIX_METASITE_ID = "<YOUR-METASITE-ID>";

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -4,8 +4,8 @@
  * production builds (and stacks with no dev flag at all) never show it. The
  * ✕ button dismisses it persistently (localStorage).
  *
- * Copy next to wix-client.js, set WIX_METASITE_ID, and mount once from the
- * app entry (safe to call unconditionally — it no-ops outside dev):
+ * Mounted once from the app entry (safe to call unconditionally — it no-ops outside dev).
+ * Reads WIX_METASITE_ID from wix-config.js; how/when to mount it lives in the build docs.
  *
  *   import { mountWixManageBanner } from "./rest/wix-manage-banner.js";
  *   mountWixManageBanner();
@@ -15,8 +15,8 @@
  * `top: var(--wix-manage-banner-height, 0px)` (0 in prod / when dismissed).
  */
 
-/** The site's metasite id (from the same prompt that carried WIX_CLIENT_ID). */
-export const WIX_METASITE_ID = "<YOUR-METASITE-ID>";
+// The site's metasite id — set it in wix-config.js (alongside WIX_CLIENT_ID), not here.
+import { WIX_METASITE_ID } from "./wix-config.js";
 
 const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
 const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -14,21 +14,34 @@ redirect-session.
 - The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
 
 ## STEP 1 — The client is already in `src/`
-The install step (base44.md STEP 1) deployed both the REST scaffolds (`src/rest/`) **and** this
-storefront UI client into `src/`: `src/theme.css`, `src/context/CartContext.jsx`,
-`src/hooks/useProductDetail.js`,
-`src/components/{ProductCard,ProductGrid,CartButton,CartDrawer,VariantPicker}.jsx`,
-`src/pages/{Shop,ProductDetail}.jsx`. Imports use the `@/` alias (→ `src/`).
+The install step (base44.md STEP 1) deployed the whole storefront UI client + REST scaffolds into
+`src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map,
+so you don't need to open them:**
 
-They're already in place (STEP 1 deployed them) — go **straight to theming + wiring**, nothing to
-verify first. **Don't `read_file` the shipped page/component/hook source to inspect it** (`src/components`,
-`src/pages`, `src/hooks`, `src/context`): every field shape you need is in the snippets below. Read a
-shipped file's source **only** on a real fallback — a runtime error, or a field the snippets don't
-cover (see "Fallback only" at the end). (Files missing? the install's `deploy` result lists what it
-wrote; re-run install, or copy `references/storefront/app/` → `src/`.)
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `context/CartContext.jsx` | `useCart()` provider: server cart, add/update/remove, checkout |
+| `hooks/useProductDetail.js` | PDP data — product + variant resolution for a slug |
+| `components/ProductCard.jsx`, `ProductGrid.jsx` | product listing UI (grid + card, with empty state) |
+| `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
+| `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
+| `components/VariantPicker.jsx` | option/variant selector used on the PDP |
+| `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` + `rest/wix-store-*.js` | REST transport + catalog/cart helpers |
+| `rest/wix-manage-banner.js` | dev-only manage banner — mount it once (base44.md STEP 5) |
+
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each is
+and every field shape you need is in the snippets below. Read a shipped file's source **only** on a
+real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/storefront/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-In `src/rest/wix-client.js` set `WIX_CLIENT_ID` to the value from your prompt.
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
 ## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
 Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,


### PR DESCRIPTION
## What
Setting credentials still forced the agent to open `wix-client.js` / `wix-manage-banner.js` and find-replace the placeholders. Move both ids into **one tiny shared file** the scaffolds import from, so credentials become a single `write_file` with nothing to read.

- **New `references/shared/wix-config.js`** — exports `WIX_CLIENT_ID` + `WIX_METASITE_ID`. `deploy.cjs` already copies `shared/*.js` → `src/rest/`, so it ships automatically (no deploy change).
- **`wix-client.js` / `wix-manage-banner.js`** import the ids from it (no local declaration; the banner's `startsWith("<")` placeholder guard still works). Banner docstring trimmed — copy/set/mount *instructions* belong in the build docs, not in code the agent is told not to read.
- **base44.md STEP 3** — "write `src/rest/wix-config.js`" (one write, nothing to read).
- **storefront INSTRUCTIONS** — STEP 1 gains a **one-line-per-file manifest** (the map that makes "don't read the source" actually land — includes the manage banner); STEP 2 writes `wix-config.js`.

## Scope / follow-up
Storefront + the shared wiring only. `base44.md` STEP 3 is generic, so **base44 builds of every vertical** already get the `wix-config.js` instruction. The per-vertical INSTRUCTIONS (credential line + generic/manual-flow copy-lists), `SKILL.md`, `generic.md`, and the `wix-base44-headless` template are a deliberate **follow-up fan-out** — non-storefront *generic-flow* builds should wait for it.

Verified: all three shared files `node --check` clean and the ESM import graph resolves. base44.md 8786 chars (fetched ~9584, headroom 416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)