### PR TITLE
docs(wix-vibe-headless): fan out wix-config.js convention to all verticals

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -39,7 +39,7 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
 - **Auth = one public client id.** `WIX_CLIENT_ID` is a **buyer/visitor-facing** credential —
   it only mints anonymous visitor tokens. It is **not a secret**; hardcoding and committing it
   is fine. The user provides it (their vibe/host platform surfaces a copyable prompt with the
-  id filled in). Paste it into `wix-client.js` in place of the `<YOUR-CLIENT-ID>` placeholder.
+  id filled in). Paste it into `wix-config.js` in place of the `<YOUR-CLIENT-ID>` placeholder.
 - **Money/price fields are objects, never scalars.** Every price/amount a Wix API returns —
   Stores `price.actualPrice`, Bookings service `payment.fixed.price`, Events ticket
   `registration.tickets.lowestPrice`, and the rest — has the shape `{ value, currency,
@@ -93,13 +93,15 @@ This skill is the deliberately **client-only, REST-only** path. It is independen
 
 ## How this skill is structured
 
-`<SKILL_ROOT>` is this file's directory (strip `/SKILL.md`). Two files make up each vertical's
+`<SKILL_ROOT>` is this file's directory (strip `/SKILL.md`). Three files make up each vertical's
 runtime:
 
-1. **The shared transport** — `references/shared/wix-client.js`. **Identical for every vertical.**
-   Set `WIX_CLIENT_ID` in it before use.
-2. **The vertical helper** — `references/<vertical>/<helper>.js`. It does
-   `import { wixApiRequest } from "./wix-client.js"`, so the two must sit **side by side** in the
+1. **The shared config** — `references/shared/wix-config.js`. Set `WIX_CLIENT_ID` (and
+   `WIX_METASITE_ID`) in it from the prompt before use.
+2. **The shared transport** — `references/shared/wix-client.js`. **Identical for every vertical.**
+   It reads `WIX_CLIENT_ID` from `wix-config.js`.
+3. **The vertical helper** — `references/<vertical>/<helper>.js`. It does
+   `import { wixApiRequest } from "./wix-client.js"`, so all three must sit **side by side** in the
    same folder.
 
 **Where these files live in the app, and how they get there** (pre-installed at setup, or copied
@@ -114,7 +116,7 @@ prerequisites, the exported API, how to wire it, the hard rules, and a verificat
 Load the vertical(s) the user's app needs; a project may combine several (e.g. a restaurant
 with a blog, or a store with pricing plans).
 
-| The user wants… | Vertical | Read | Helper(s) to copy (+ `shared/wix-client.js`) |
+| The user wants… | Vertical | Read | Helper(s) to copy (+ `shared/wix-client.js`, `shared/wix-config.js`) |
 |---|---|---|---|
 | Online store: products, categories, cart, checkout | **storefront** | `references/storefront/INSTRUCTIONS.md` | `wix-store-catalog.js` + `wix-store-cart.js` |
 | Appointments: services, time slots, booking, checkout | **bookings** | `references/bookings/INSTRUCTIONS.md` | `wix-bookings-services.js` + `wix-bookings-checkout.js` |
@@ -145,9 +147,9 @@ installed, not what the business is about. Never default to store/bookings on si
 2. **Pick the vertical(s)** from the routing table — and when the request doesn't name any,
    **ask or check the site** (see above) instead of guessing. Open each picked vertical's
    `INSTRUCTIONS.md`.
-3. **Ensure the two files per vertical are in place** — `shared/wix-client.js` (once) + the
-   vertical helper, side by side — and set `WIX_CLIENT_ID`. (Where they live and how they get
-   there is your platform's call — see its instructions.)
+3. **Ensure the files per vertical are in place** — `shared/wix-client.js` + `shared/wix-config.js`
+   (once) + the vertical helper, side by side — and set `WIX_CLIENT_ID` in `wix-config.js`. (Where
+   they live and how they get there is your platform's call — see its instructions.)
 4. **Wire the UI** to the exported helpers following the vertical's INSTRUCTIONS. Build the UI
    however the project wants — these scaffolds ship the REST layer only, no components.
 5. **Verify** against the vertical's checklist before declaring done: token persists across

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -111,8 +111,8 @@ back to the `wix-docs` skill where the operation isn't documented there.
 After the site is built and seeded:
 
 1. **Add the dev-only manage banner** (required) (links the app to its Wix back office): from the
-   `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js`, set `WIX_METASITE_ID` to
-   your metasite id and call `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
+   `wix-vibe-headless` skill's `references/shared/wix-manage-banner.js`, set `WIX_METASITE_ID` in
+   `references/shared/wix-config.js` to your metasite id and call `mountWixManageBanner()` once from the app entry. The file already gates itself to dev
    builds (via `import.meta.env.DEV`) — use it as-is, don't rewrite it — but you own the
    guarantee: verify the gate actually holds in this stack, and that a production build never
    shows the banner (no dev flag → no banner at all). A `fixed`/`sticky` app header is not in

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix Blog Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/blog/wix-blog.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/blog/wix-blog.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
 
 Builds a real, client-only Wix blog reader. The browser talks to Wix directly over a
 public `WIX_CLIENT_ID`. Never mock posts; never hand-build post/category/tag URLs — always
@@ -22,7 +22,7 @@ moderate posts — the author manages all content in the Wix dashboard.
    never returned.
 2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
    Wix Business Manager surfaces a copyable prompt with the id filled in — see
-   the router `SKILL.md`). Paste it into `src/rest/wix-client.js` in place of the placeholder. It is
+   the router `SKILL.md`). Set it in `src/rest/wix-config.js` in place of the placeholder. It is
    a visitor-facing credential (it only mints anonymous visitor tokens), **not** a secret,
    so hardcoding/committing it is fine.
 
@@ -30,10 +30,10 @@ moderate posts — the author manages all content in the Wix dashboard.
 This skill ships only the REST layer — no UI components. Build the blog's UI however the
 project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and
 only adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to
-  the id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The refresh token is
-  persisted to localStorage so the same anonymous visitor is reused across reloads; do not
-  re-mint anonymously per load.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
+  `wix-config.js`. The refresh token is persisted to localStorage so the same anonymous visitor is
+  reused across reloads; do not re-mint anonymously per load.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-blog.js` — exports:
   - **Posts:** `queryPosts`, `getPostBySlug`, `queryPostsByCategory`, `queryPostsByTag`, `getTotalPosts`
   - **Categories:** `queryCategories`, `getCategoryBySlug`

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix Bookings Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and both bookings helpers from `references/bookings/`. All helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`). Copy **both** for the full booking flow:
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and both bookings helpers from `references/bookings/`. `wix-client.js` imports from `"./wix-config.js"` and the helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`). Copy **both** helpers for the full booking flow:
 >
 > | File | What it covers |
 > |---|---|
@@ -29,8 +29,8 @@ either slot. **COURSE (whole-course enrollment) is not covered** — see "Beyond
    (this skill does NOT provision — it's read-only over services). Staff/resources and a
    booking policy should be configured so slots are bookable.
 2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Paste
-   it into `src/rest/wix-client.js` in place of the placeholder. It is a buyer-facing credential
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Set it
+   in `src/rest/wix-config.js` in place of the placeholder. It is a buyer-facing credential
    (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/committing it is fine.
 3. The site must **accept payments** for paid services, and the deployed app domain must be
    allow-listed on the OAuth client for Wix-hosted checkout to return. These are **separate Wix
@@ -41,10 +41,10 @@ either slot. **COURSE (whole-course enrollment) is not covered** — see "Beyond
 This skill ships only the REST layer — no UI components. Build the booking UI however the
 project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
 adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
-  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token IS
-  the booking visitor identity; it is persisted to localStorage. Do not re-mint anonymously per
-  load.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
+  `wix-config.js`. The visitor refresh token IS the booking visitor identity; it is persisted to
+  localStorage. Do not re-mint anonymously per load.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-bookings-services.js` — **Services & availability:**
   `queryServices`, `getService`, `countServices`, `listAvailableSlots`, `getAvailableSlot`,
   `mediaUrl` (resolve a service image to an absolute URL)

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix CMS Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/cms/wix-cms.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/cms/wix-cms.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
 
 Builds a real, client-only Wix CMS-backed app. The browser talks to Wix Data directly
 over a public `WIX_CLIENT_ID` to read and write items in the site's data collections.
@@ -22,7 +22,7 @@ the official Wix Data endpoints.
    collections, fields, and items in the Wix dashboard (CMS / Content Manager).
 2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
    Wix Business Manager surfaces a copyable prompt with the id filled in — see
-   the router `SKILL.md`). Paste it into `src/rest/wix-client.js` in place of the placeholder. It is
+   the router `SKILL.md`). Set it in `src/rest/wix-config.js` in place of the placeholder. It is
    a buyer-facing credential (it only mints anonymous visitor tokens), **not** a secret,
    so hardcoding/committing it is fine.
 3. **Collection permissions** must match what you're doing. This skill runs as an
@@ -44,9 +44,10 @@ the official Wix Data endpoints.
 This skill ships only the REST layer — no UI components. Build the UI however the project
 wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
 adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID`
-  to the id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor
-  refresh token is persisted to localStorage; do not re-mint anonymously per load.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID`
+  from `wix-config.js`. The visitor refresh token is persisted to localStorage; do not
+  re-mint anonymously per load.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-cms.js` — exports:
   - **Read:** `queryDataItems`, `getDataItem`, `getDataItemBy`, `countDataItems`
   - **Write:** `insertDataItem`, `updateDataItem`, `removeDataItem`

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix Events Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and the helper file(s) you need from `references/events/`. All helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`).
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and the helper file(s) you need from `references/events/`. `wix-client.js` imports from `"./wix-config.js"` and the helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`).
 >
 > | Need | Copy |
 > |---|---|
@@ -24,8 +24,8 @@ ticket form.
    does NOT create events — it's read-only over them). Selling **paid** tickets also needs a
    Wix premium plan + a configured payment method; **free** events and RSVP events work without.
 2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Paste
-   it into `src/rest/wix-client.js` in place of the placeholder. It is a visitor-facing
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Set it
+   in `src/rest/wix-config.js` in place of the placeholder. It is a visitor-facing
    credential (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/
    committing it is fine.
 3. For paid tickets the buyer completes payment on the **Wix-hosted ticket form** (the redirect
@@ -38,10 +38,10 @@ ticket form.
 This skill ships only the REST layer — no UI components. Build the events UI however the
 project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
 adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
-  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token is
-  persisted to localStorage and IS the identity of the visitor's ticket reservation/cart — do
-  not re-mint anonymously per load.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
+  `wix-config.js`. The visitor refresh token is persisted to localStorage and IS the identity of
+  the visitor's ticket reservation/cart — do not re-mint anonymously per load.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-events-browse.js` — **Browse & discovery:**
   `queryEvents`, `getEventBySlug`, `countUpcomingEvents`, `queryEventCategories`, `listEventsByCategory`
 - `src/rest/wix-events-registration.js` — **RSVP & ticketing:**

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -1,9 +1,11 @@
 
 # Wix Members — custom login (client-only REST)
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this
-> vertical's `references/members/wix-members-auth.js`. Copy **both** into your app's `src/rest/` side by
-> side — the helper does `import { … } from "./wix-client.js"`, so they must land in the same folder.
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared
+> config `references/shared/wix-config.js`, and this vertical's `references/members/wix-members-auth.js`.
+> Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does
+> `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { … } from "./wix-client.js"`,
+> so they must land in the same folder.
 
 Adds real **member accounts** to a client-only headless front end: sign up, log in, log out, and
 member-gated surfaces — all from the browser over the public `WIX_CLIENT_ID`, no SDK, no backend.
@@ -40,8 +42,8 @@ have). Don't blend their exchange calls — the helper handles each internally.
 1. A Wix site with the **Members Area app installed** if you need member *profile* data (name, photo,
    roles) or custom field definitions. Pure "logged-in vs. not" gating needs no app — see the
    identity-vs-profile split below.
-2. The site's public headless **`WIX_CLIENT_ID`** (from the handoff prompt), pasted into
-   `src/rest/wix-client.js`. Public, buyer-facing credential — safe to hardcode/commit.
+2. The site's public headless **`WIX_CLIENT_ID`** (from the handoff prompt), set in
+   `src/rest/wix-config.js`. Public, buyer-facing credential — safe to hardcode/commit.
 3. **OAuth-app allow-listing — the #1 gotcha. Two *different* fields gate the two mechanisms:**
 
    | Mechanism | What must be allow-listed | OAuth-app field | On `localhost:4321`? |
@@ -69,8 +71,8 @@ have). Don't blend their exchange calls — the helper handles each internally.
    > See "Point the user to their dashboard" below for the deep link and the exact values.
 
 ## The API (copy as-is; do not re-derive it)
-Copy `wix-client.js` + `wix-members-auth.js` into `src/rest/` and set `WIX_CLIENT_ID`. Exports of
-`wix-members-auth.js`:
+Copy `wix-client.js`, `wix-config.js`, and `wix-members-auth.js` into `src/rest/` and set
+`WIX_CLIENT_ID` in `wix-config.js`. Exports of `wix-members-auth.js`:
 - **Direct-credential:** `register(email, password, profile?)`, `login(email, password)`,
   `verifyEmail(code, stateToken)`, `sendPasswordResetEmail(email, redirectUri)`
 - **Social / SSO:** `startSocialLogin(idp, callbackUri, returnTo?)`, `completeSocialLogin()`, `IDP`

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix Portfolio Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/portfolio/wix-portfolio.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/portfolio/wix-portfolio.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
 
 Builds a real, client-only Wix portfolio showcase. The browser talks to Wix directly over a
 public `WIX_CLIENT_ID`. Portfolio is **read-only**: never mock projects, never invent media,
@@ -20,7 +20,7 @@ and always render live Wix data (or an honest empty state). The content tree is
    read-only over the content).
 2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
    Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`).
-   Paste it into `src/rest/wix-client.js` in place of the placeholder. It is a visitor-facing
+   Set it in `src/rest/wix-config.js` in place of the placeholder. It is a visitor-facing
    credential (it only mints anonymous visitor tokens), **not** a secret, so
    hardcoding/committing it is fine.
 3. If the read calls return `403`/`428` before content is published, the Portfolio app or its
@@ -31,9 +31,10 @@ and always render live Wix data (or an honest empty state). The content tree is
 This skill ships only the REST layer — no UI components. Build the portfolio's UI however the
 project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
 adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
-  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token is
-  persisted to localStorage; do not re-mint anonymously per load.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
+  `wix-config.js`. The visitor refresh token is persisted to localStorage; do not re-mint
+  anonymously per load.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-portfolio.js` — exports:
   - **Collections:** `queryCollections`, `getCollectionBySlug`, `countCollections`
   - **Projects:** `queryProjects`, `queryProjectsByCollection`, `getProjectBySlug`, `getProject`

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix Pricing Plans Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and this vertical's `references/pricing-plans/wix-pricing-plans.js`. Copy **both** into your app's `src/rest/` side by side — the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/pricing-plans/wix-pricing-plans.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
 
 Builds a real, client-only Wix pricing-plans / membership front end. The browser talks to Wix
 directly over a public `WIX_CLIENT_ID`. Never mock plans; never hand-build a `/checkout` or
@@ -18,8 +18,8 @@ handles member login and payment).
 1. A Wix site with **Pricing Plans installed and at least one plan created** (this skill does
    NOT provision — it's read-only over the plans the merchant added in the dashboard).
 2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Paste
-   it into `src/rest/wix-client.js` in place of the placeholder. It is a buyer-facing credential
+   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Set it
+   in `src/rest/wix-config.js` in place of the placeholder. It is a buyer-facing credential
    (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/committing it is fine.
 3. **Purchasing a plan is members-only and uses Wix-hosted checkout.** The hosted flow handles
    member login/signup + the order form + payment, then returns to your site. The deployed app
@@ -33,10 +33,10 @@ handles member login and payment).
 This skill ships only the REST layer — no UI components. Build the page's UI however the project
 wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only adjust
 import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the
-  id from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token is
-  persisted to localStorage; after a hosted checkout the same identity returns as a logged-in
-  member. Do not re-mint anonymously per load.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
+  `wix-config.js`. The visitor refresh token is persisted to localStorage; after a hosted checkout
+  the same identity returns as a logged-in member. Do not re-mint anonymously per load.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-pricing-plans.js` — exports:
   - **Plans:** `queryPlans`, `getPlanById`, `getPlanBySlug`
   - **Purchase:** `checkout`

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -1,7 +1,7 @@
 
 # Wix Restaurants Skill
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js` and the helper file(s) you need from `references/restaurants/`. All helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`).
+> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and the helper file(s) you need from `references/restaurants/`. `wix-client.js` imports from `"./wix-config.js"` and the helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`).
 >
 > | Need | Copy |
 > |---|---|
@@ -26,7 +26,7 @@ always go through the official cart + redirect-session and the reservations hold
    and online reservations enabled. If a flow's backing app/config isn't set up, that flow returns
    empty — flag it and continue; don't fabricate data.
 3. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (see the router `SKILL.md`).
-   Paste it into `src/rest/wix-client.js` in place of the placeholder. It is a buyer-facing
+   Set it in `src/rest/wix-config.js` in place of the placeholder. It is a buyer-facing
    credential (it only mints anonymous visitor tokens), **not** a secret — hardcoding/committing
    it is fine.
 4. The deployed app domain must be allow-listed on the OAuth client for Wix-hosted checkout to
@@ -37,10 +37,10 @@ always go through the official cart + redirect-session and the reservations hold
 This skill ships only the REST layer — no UI components. Build the restaurant UI however the
 project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
 adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Set `WIX_CLIENT_ID` to the id
-  from the prompt (replace the `<YOUR-CLIENT-ID>` placeholder). The visitor refresh token IS the
-  cart identity; it is persisted to localStorage. Do not re-mint anonymously per load or the cart
-  silently empties.
+- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
+  `wix-config.js`. The visitor refresh token IS the cart identity; it is persisted to localStorage.
+  Do not re-mint anonymously per load or the cart silently empties.
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
 - `src/rest/wix-restaurants-menu.js` — **Menu (read-only):**
   `getFullMenu` (the assembled tree — start here), `listMenus`, `listSections`, `listItems`,
   `listVariants`, `listModifierGroups`, `listModifiers`, `listLabels`

--- a/skills/wix-vibe-headless/references/shared/wix-config.js
+++ b/skills/wix-vibe-headless/references/shared/wix-config.js
@@ -1,6 +1,6 @@
 // Wix credentials — the ONLY file you set these in. Paste both values from your prompt,
 // replacing the placeholders. Safe to commit: WIX_CLIENT_ID is a public, buyer-facing id
 // (it only mints anonymous visitor tokens); WIX_METASITE_ID just identifies the site.
-// wix-client.js and wix-manage-banner.js import from here — do NOT edit those two for ids.
+// wix-client.js and wix-manage-banner.js read their ids from here.
 export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
 export const WIX_METASITE_ID = "<YOUR-METASITE-ID>";


### PR DESCRIPTION
## What
#889 introduced the shared `references/shared/wix-config.js` (both Wix ids) that `wix-client.js` / `wix-manage-banner.js` now import from — but only **storefront** docs + `base44.md` were updated. This fans the convention out to the rest so the credential protocol is uniform.

Across **SKILL.md**, **generic.md**, and the **8 non-storefront verticals'** `INSTRUCTIONS.md`:
- **Credential step** → set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) in `wix-config.js`, not `wix-client.js`.
- **Copy-lists (critical)** — every "copy into `src/rest/`" source-list that named `wix-client.js` now also names `wix-config.js`. Since `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"`, copying it without `wix-config.js` would break the import in the generic/manual flow.
- **File-description bullets** — `wix-client.js` now "reads `WIX_CLIENT_ID` from `wix-config.js`", plus a `wix-config.js` bullet.
- Positive framing throughout (no "don't edit" warnings); softened the one such comment in `wix-config.js` itself.

## Verified
- No vertical still instructs setting the id *in* `wix-client.js`.
- Every doc that names `wix-client.js` in a copy context also names `wix-config.js` (no broken imports).
- `wix-config.js` `node --check` clean.

## Not in scope (deliberate)
- **Layout-route** — storefront-only (only storefront ships pages to protect).
- **Storefront-as-files** for other verticals — a separate product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)