### PR TITLE
fix(storefront): image-gen guidance (no split) + dev-banner Layout integration & scroll-gap fix

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -131,12 +131,12 @@ parallelize independent work (API calls, multiple entities).
 
 Once the site is built and seeded:
 
-1. **Mount the dev-only manage banner** (required; links the app to its Wix back office): import
-   `mountWixManageBanner` from `src/rest/wix-manage-banner.js` (deployed in STEP 1, `WIX_METASITE_ID`
-   set in STEP 3) and call it once from the app entry. It self-gates to dev builds (via
-   `import.meta.env.DEV`) — never in production; use as-is. If your app header is `fixed`/`sticky`,
-   set its `top: var(--wix-manage-banner-height, 0px)` — the banner publishes its own height in that
-   CSS var (0 in prod / when dismissed); that's the whole offset, no measuring or state.
+1. **Mount the dev-only manage banner** (required; links the app to its Wix back office; shipped,
+   self-gates to dev builds, never in production). **Storefront:** render `<WixManageBanner/>` in your
+   Layout's fixed top region above the header (per INSTRUCTIONS STEP 4). **Other verticals:** import
+   `mountWixManageBanner` from `src/rest/wix-manage-banner.js` and call it once from the app entry; a
+   `fixed`/`sticky` app header then offsets with `top: var(--wix-manage-banner-height, 0px)` (the
+   banner keeps that CSS var in sync as it scrolls — the whole offset, no measuring or state).
 2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (substitute your
    metasite id) to complete setup in Wix (required), and mention that dev builds show a dismissible
    top banner linking to this same dashboard.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -113,11 +113,11 @@ restaurant items, portfolio projects, event heroes, CMS items), generate with **
 image generation**, then attach via the vertical seed module's image-attach step — `wix-docs` if the
 module doesn't cover that entity.
 
-**Pass only FINAL image urls to seeding.** Wait for `generate_image` to return its final
-`https://media.base44.com/...` url before handing it to a seed call — an in-flight
-`/__generating__/<id>.png` path is a placeholder, not a real url, and Wix rejects it (you'd have to
-re-seed). To still overlap the work, create the products WITHOUT images first, then attach in a
-second pass once the real urls are in hand (`attachProductImages` takes any product ids, any time).
+**Seed images with the FINAL url, in one call.** Seeding writes to Wix, so use the real
+`https://media.base44.com/...` url from the **completed** `generate_image` result and pass it straight
+into your single `setupStore`/seed call (images included). A still-generating `/__generating__/<id>.png`
+placeholder is not a real url — Wix can't fetch it. `generate_image` runs in the background while you
+build the client, so the urls are ready by the time you seed.
 
 The connector + seeding are **admin-only** (STEP 4) — **not** part of the client, which is built
 solely per the `wix-vibe-headless` skill.
@@ -142,9 +142,9 @@ Once the site is built and seeded:
    top banner linking to this same dashboard.
 
 **Preview briefly, don't chase images.** A quick preview to confirm the app renders is enough.
-Seeded product images and any hero you generated are re-hosted by Wix from their urls server-side,
-so they can be missing or still loading right after seeding — that's normal propagation timing that
-resolves on its own. Don't debug it, re-seed, or re-attach; leave it and finish.
+Generated images — the hero in your own code and the seeded product images alike — can still be
+resolving right after the build; that's normal. Don't debug, re-seed, re-attach, or swap a generated
+image's url in your code; leave them and finish.
 
 ## Later admin requests
 

--- a/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
+++ b/skills/wix-vibe-headless/references/shared/wix-manage-banner.js
@@ -49,14 +49,21 @@ export function mountWixManageBanner() {
   // A solid, full-width strip in normal flow as <body>'s first child, so it
   // pushes the whole site down rather than floating over it. A position:fixed
   // (or absolute-over-hero) app header is NOT in normal flow, so it won't be
-  // pushed — but this banner publishes its own height as the CSS var
-  // `--wix-manage-banner-height` on :root (see below), so such a header just
-  // needs `top: var(--wix-manage-banner-height, 0px)` (0 in prod / when dismissed).
+  // pushed — so this banner publishes its own CURRENTLY-VISIBLE height as the CSS
+  // var `--wix-manage-banner-height` on :root: it's the full height at the top and
+  // shrinks to 0 as the banner scrolls away. A fixed/sticky header that sets
+  // `top: var(--wix-manage-banner-height, 0px)` therefore rides glued to the
+  // banner's bottom edge and lands flush at the top once it's scrolled off — no gap.
   const bar = document.createElement("div");
   bar.id = "wix-manage-banner";
   const root = document.documentElement;
-  const syncHeight = () =>
-    root.style.setProperty("--wix-manage-banner-height", `${bar.offsetHeight}px`);
+  let raf = 0;
+  const syncHeight = () => {
+    raf = 0;
+    const visible = Math.max(0, bar.offsetHeight - window.scrollY);
+    root.style.setProperty("--wix-manage-banner-height", `${visible}px`);
+  };
+  const onScrollOrResize = () => { if (!raf) raf = requestAnimationFrame(syncHeight); };
   bar.style.cssText =
     "position:relative;z-index:2147483647;box-sizing:border-box;display:flex;" +
     "align-items:center;justify-content:center;gap:14px;width:100%;" +
@@ -93,7 +100,8 @@ export function mountWixManageBanner() {
   close.addEventListener("click", () => {
     bar.remove();
     root.style.setProperty("--wix-manage-banner-height", "0px");
-    window.removeEventListener("resize", syncHeight);
+    window.removeEventListener("scroll", onScrollOrResize);
+    window.removeEventListener("resize", onScrollOrResize);
     try {
       window.localStorage.setItem(DISMISS_KEY, "1");
     } catch {
@@ -104,5 +112,6 @@ export function mountWixManageBanner() {
   bar.append(text, button, close);
   document.body.prepend(bar);
   syncHeight();                                  // publish height now that it's measurable
-  window.addEventListener("resize", syncHeight); // keep it correct if the bar wraps at narrow widths
+  window.addEventListener("scroll", onScrollOrResize, { passive: true });  // shrink the var as it scrolls off
+  window.addEventListener("resize", onScrollOrResize); // keep it correct if the bar wraps at narrow widths
 }

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -27,10 +27,10 @@ so you don't need to open them:**
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
 | `components/VariantPicker.jsx` | option/variant selector used on the PDP |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
 | `rest/wix-client.js` + `rest/wix-store-*.js` | REST transport + catalog/cart helpers |
-| `rest/wix-manage-banner.js` | dev-only manage banner — mount it once (base44.md STEP 5) |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
 `read_file` the shipped page/component/hook source to inspect it** — the table above says what each is
@@ -59,33 +59,51 @@ replace it.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Shop` / `ProductDetail` — so you **never edit the shipped pages to add a
   header/footer** (they render inside `<Outlet/>` as-is). Mount `<CartDrawer/>` once in the Layout.
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's measured height so it clears the chrome and self-corrects when the
+  banner is dismissed.
 - Routes under the Layout: `/shop` → `Shop`, `/product/:slug` → `ProductDetail` (both shipped, as-is).
   **You add `/` → your own Home** page.
 
 ```jsx
 import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 import { CartProvider } from "@/context/CartContext";
 import CartDrawer from "@/components/CartDrawer";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
 import Shop from "@/pages/Shop";
 import ProductDetail from "@/pages/ProductDetail";
 import Home from "@/pages/Home";       // YOU build
-import Header from "@/components/Header";   // YOU build (see "What you build")
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
 import Footer from "@/components/Footer";   // YOU build
 
-// Your brand chrome around EVERY route. Shipped pages render in <Outlet/> untouched.
 function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
   return (<>
-    <Header />
-    <Outlet />
-    <Footer />
-    <CartDrawer />               {/* overlays every page */}
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Shop/ProductDetail render here, untouched */}
+      <Footer />
+    </div>
+    <CartDrawer />                           {/* overlays every page */}
   </>);
 }
 
 <CartProvider>
   <Routes>
-    <Route element={<Layout />}>                                   {/* header/footer wrap all */}
+    <Route element={<Layout />}>                                   {/* chrome wraps all */}
       <Route path="/" element={<Home />} />                        {/* yours */}
       <Route path="/shop" element={<Shop />} />                    {/* shipped, as-is */}
       <Route path="/product/:slug" element={<ProductDetail />} />  {/* shipped, as-is */}
@@ -201,6 +219,7 @@ these snippets don't have): read the relevant shipped file under `src/`, or look
 - Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Theme via `theme.css` tokens, never by rewriting the shipped components.
 - Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Shop`/`ProductDetail` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Checkout goes through the shipped cart (redirect-session) — never a hand-built `/checkout` URL.
 - Render live Wix data or the shipped empty state — never mock products.
 
@@ -216,6 +235,6 @@ client build; run in parallel.
 ## Verify (before declaring done)
 - [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
 - [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
-- [ ] `Layout` (Header + `<Outlet/>` + Footer) wraps all routes; shipped `Shop`/`ProductDetail` untouched; `<CartProvider>` wraps the tree; `<CartDrawer/>` mounted; `<CartButton/>` in the header.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Shop`/`ProductDetail` untouched; content clears the fixed chrome; `<CartProvider>` wraps the tree; `<CartDrawer/>` mounted; `<CartButton/>` in the header.
 - [ ] Cart survives reload (same visitor); add / update-qty / remove work; checkout redirects.
 - [ ] Empty catalog shows the shipped empty state; no mock products anywhere.

--- a/skills/wix-vibe-headless/references/storefront/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -17,9 +17,9 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
 // to attach its image; omit it to skip images. options ONLY for real buyer choices (Size/Color); default none.
-// imageUrl must be the FINAL https://media.base44.com/... url — await generate_image first. A still-
-// generating `/__generating__/<id>.png` placeholder is not a real url and Wix rejects it. To overlap,
-// seed WITHOUT imageUrl now and call attachProductImages once the real urls are ready.
+// imageUrl must be the FINAL https://media.base44.com/... url from the COMPLETED generate_image
+// result — not a still-generating /__generating__/<id>.png placeholder (Wix can't fetch that).
+// generate_image runs in the background while you build, so the urls are ready by seed time.
 const result = await seed.setupStore(ctx, {
   products: [
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },


### PR DESCRIPTION
Two storefront build-flow fixes.

## 1. Image generation — seed with the final url, in one call (no split)
`generate_image` is async: it returns a `/__generating__/<id>.png` placeholder immediately and resolves to the real `https://media.base44.com/…` url in the background; after the loop Base44 swaps placeholders → real urls **in the app's own source + entities**, but has **no hook into external Wix**. So:
- **Seeding (writes to Wix):** use the **final `image_url` from the completed `generate_image` result**, in the **single `setupStore` call**. Removed #885's "create products WITHOUT images first, attach in a second pass" — the split loses `setupStore`'s in-memory ids and forced a re-query (wrong V1 endpoint → 0 matches) in the Chimera & Clay build.
- **Frontend images:** don't intervene — a placeholder mid-build is normal; don't swap it in code.

Files: base44.md STEP 4 + STEP 5; storefront `SEED.md`.

## 2. Dev manage banner — Layout integration + scroll-gap fix
The banner pushed the fixed header but, being in normal flow, scrolled away and left the header floating below a gap.
- **Storefront (Layout world):** new React `<WixManageBanner/>` component rendered **above `<Header/>` inside one `position:fixed` top region**; content padded by the region's **measured** height (ResizeObserver, self-corrects on dismiss). Header becomes plain in-flow markup — the region owns positioning. Banner + header ride together → no drift, no gap. (INSTRUCTIONS STEP 1 manifest / STEP 4 Layout / Hard rules / Verify; base44.md STEP 5 routes storefront to the component.)
- **Other verticals (imperative `mountWixManageBanner`):** the banner now publishes its **currently-visible** height in `--wix-manage-banner-height` (`max(0, H − scrollY)`, rAF-throttled), so a fixed/sticky header with `top: var(...)` stays glued to the banner's bottom edge and lands flush at the top once it scrolls off — no gap.

Verified: shared banner + config `node --check` clean; base44.md 8764 chars (headroom 438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)