### PR TITLE
feat(blog): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -1,234 +1,235 @@
+# Wix Blog — ready-made client
 
-# Wix Blog Skill
+The blog reader is **shipped as real files**, not snippets to regenerate. It's a complete feed + post
+detail + category/tag landing pages, styled entirely from `theme.css` tokens. Copy it into the app,
+theme the tokens, wire the routes — you generate almost none of the reader code (post paging, slug
+routing, the category/tag id→label resolution, the plain-text body split all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/blog/wix-blog.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
-
-Builds a real, client-only Wix blog reader. The browser talks to Wix directly over a
-public `WIX_CLIENT_ID`. Never mock posts; never hand-build post/category/tag URLs — always
-fetch live data through the official Blog REST endpoints and route by `slug`.
-
-## When to use
-- User wants a Wix blog/news/articles section or asks to "connect my Wix blog".
-- Replacing placeholder/mock articles with live Wix Blog posts.
-- Adding a post feed, post detail pages, category pages, or tag pages over an existing
-  Wix Blog with published posts.
-
-This skill is **read-only and visitor-facing**. It does not create, edit, publish, or
-moderate posts — the author manages all content in the Wix dashboard.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). The reader is
+**read-only and visitor-facing** — it never creates, edits, or moderates content. Never mock posts;
+never hand-build a post/category/tag URL — route by `slug` through the shipped helpers.
 
 ## Prerequisites
-1. A Wix site with **Wix Blog installed and posts already published** (this skill does
-   NOT provision — it's read-only over published content). Draft/unpublished posts are
-   never returned.
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
-   Wix Business Manager surfaces a copyable prompt with the id filled in — see
-   the router `SKILL.md`). Set it in `src/rest/wix-config.js` in place of the placeholder. It is
-   a visitor-facing credential (it only mints anonymous visitor tokens), **not** a secret,
-   so hardcoding/committing it is fine.
+- The site's **Wix Blog** is the read target. It's installed and seeded separately (see **Seeding** below), in parallel with this build — so it may be empty at build time; the client renders the shipped empty state until posts land. Draft/unpublished posts are never returned.
+- The public headless **`WIX_CLIENT_ID`** from your prompt (visitor-facing, safe to hardcode/commit).
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the blog's UI however the
-project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and
-only adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
-  `wix-config.js`. The refresh token is persisted to localStorage so the same anonymous visitor is
-  reused across reloads; do not re-mint anonymously per load.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-blog.js` — exports:
-  - **Posts:** `queryPosts`, `getPostBySlug`, `queryPostsByCategory`, `queryPostsByTag`, `getTotalPosts`
-  - **Categories:** `queryCategories`, `getCategoryBySlug`
-  - **Tags:** `queryTags`, `getTagBySlug`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole blog UI client + REST scaffolds into `src/`
+(imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map, so you
+don't need to open them:**
 
-The Post, Category, and Tag shapes are documented as JSDoc comments at the top of
-`wix-blog.js`. Read them before building the UI — they describe the key fields and link to
-the full API reference for anything not shown.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `context/TaxonomyContext.jsx` | `useTaxonomy()` provider: categories + tags fetched **once**, exposed as `catById` / `tagById` id→object maps |
+| `hooks/usePostDetail.js` | post-detail data — load by slug, not-found state, resolved category/tag chips, body paragraphs |
+| `components/PostCard.jsx`, `PostGrid.jsx` | post listing UI (grid + card, with cover image + empty state) |
+| `components/PostChips.jsx` | category/tag chips for a post (resolves ids via the taxonomy, routes by slug) |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Blog.jsx` | the feed route (`/blog`) — lists posts, paginates, empty state |
+| `pages/PostDetail.jsx` | the post route (`/blog/:slug`) |
+| `pages/CategoryPage.jsx`, `TagPage.jsx` | the taxonomy landing routes (`/blog/category/:slug`, `/blog/tag/:slug`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` + `rest/wix-blog.js` | REST transport + blog helpers (posts/categories/tags) |
 
-## How to wire it (UI is the project's choice)
-Every list helper returns an **object, not a bare array** — `queryPosts` /
-`queryPostsByCategory` / `queryPostsByTag` → `{ posts, nextCursor }`; `queryCategories` →
-`{ categories, total }`; `queryTags` → `{ tags, total }`. **Destructure first** — calling
-`.map` / `.filter` on the returned object throws `… is not a function`. See the worked
-snippets below.
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each is
+and every field shape you need is in the snippets below. Read a shipped file's source **only** on a
+real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/blog/app/` → `src/`.)
 
-- **Post feed** — `queryPosts()` for the listing (published posts only, newest first with
-  pinned posts leading). Destructure `{ posts, nextCursor }` and iterate `posts`; pass
-  `nextCursor` back as `cursor` to load the next page. Render `title`, `excerpt`,
-  `firstPublishedDate`, `minutesToRead`, and the cover image from
-  **`post.media.wixMedia.image.url`** (see the cover-image note below). Route to the detail page by `slug`.
-  **Author byline:** the reader helpers do **not** expose an author name (the post shape carries no
-  `author` object) — resolve it via the **members** vertical or omit the byline; never render
-  `post.author.name` (it is `undefined`).
-- **Post detail** — `getPostBySlug(slug)` keyed off the URL slug; returns `null` on miss —
-  show a not-found state, never invent a post. It returns full content:
-  - `contentText` — the body as plain text. Split on `"\n"` to render simple paragraphs.
-  - `richContent` — the body as a Ricos rich-content document (images, embeds, formatting).
-    Render it with a Ricos renderer for a faithful post. See "Beyond the snippets" if you
-    need rich rendering; `contentText` is the zero-dependency default.
-  - Resolve `categoryIds` / `tagIds` to chips by matching each id against `category.id` /
-    `tag.id` from `queryCategories()` / `queryTags()` (build an id→object map). The display
-    field is **`.label`** (not `.name`). This lookup is hit on **every** post render, so fetch
-    the categories/tags once and reuse the map — do not re-query per card.
-- **Cover image** — use **`post.media.wixMedia.image.url`** (a ready-to-use https URL) for the card
-  thumbnail and post header. `media` is returned by default (including on the list query), so no extra
-  fieldset is needed. When `post.media?.wixMedia?.image` is absent, the cover is the first image inside
-  `richContent` — fall back to the first IMAGE node there, or show a text-only card. Never substitute a
-  stock/placeholder image. (This is a **different** path from the category cover — see below.)
-- **Category page** — `queryCategories()` for a category menu; destructure `{ categories, total }`
-  (ordered by `displayPosition`; hide categories with **`postCount === 0`** if you want).
-  Display each category by **`.label`**; a category also carries a cover image at
-  **`category.coverImage.url`** (note: a different path from the post cover
-  `post.media.wixMedia.image.url`). `getCategoryBySlug(slug)` returns the category landing page;
-  pass `category.id` to `queryPostsByCategory(categoryId, { limit?, cursor? })` to list that
-  category's posts; paginate exactly like `queryPosts`.
-- **Tag page** — `queryTags()` for a tag cloud/list (most-used first); destructure
-  `{ tags, total }`. Display each tag by **`.label`**; the per-tag count is
-  **`publishedPostCount`** (note the divergence: categories use `postCount`, tags use
-  `publishedPostCount`). `getTagBySlug(slug)` for a tag landing page; pass `tag.id` to
-  `queryPostsByTag(tagId, { limit?, cursor? })`.
-- **Empty state** — if `getTotalPosts()` is 0, show an empty state telling the user to
-  publish posts in their Wix dashboard. Never invent posts.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
-## Worked snippets (adapt the logic, restyle freely)
-Headless React — the data wiring (destructuring, field paths, id→label resolution) is correct
-and complete; the markup is deliberately plain. **Copy the logic; restyle the JSX to the brand.**
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing, `--measure` (the article body line length). Every shipped component reads these vars, so
+this re-skins the whole blog. **Do not restyle the shipped components' JSX** — that's what keeps this
+a copy, not a regeneration. Style the home page / header you build (STEP 4) from the same tokens so it
+matches. Dark brand → activate the dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
-**`pages/Blog.jsx`** — the post feed (listing + empty state + paging). Destructure
-`{ posts, nextCursor }` first; the helper returns an object, not an array.
+## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it.
+- `import "@/theme.css";` once at the app entry.
+- Wrap the routed tree in `<TaxonomyProvider>` (from `@/context/TaxonomyContext`) so categories/tags
+  are fetched **once** and every card/chip reuses the shared map (never re-query per post).
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Blog` / `PostDetail` / category / tag pages — so you **never edit the
+  shipped pages to add a header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's measured height so it clears the chrome and self-corrects when the
+  banner is dismissed.
+- Routes under the Layout: `/blog` → `Blog`, `/blog/:slug` → `PostDetail`, `/blog/category/:slug` →
+  `CategoryPage`, `/blog/tag/:slug` → `TagPage` (all shipped, as-is). **You add `/` → your own Home** page.
 
 ```jsx
-import { useState, useEffect } from "react";
-import { queryPosts, getTotalPosts } from "@/rest/wix-blog";
-import PostCard from "@/components/PostCard";
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import { TaxonomyProvider } from "@/context/TaxonomyContext";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Blog from "@/pages/Blog";
+import PostDetail from "@/pages/PostDetail";
+import CategoryPage from "@/pages/CategoryPage";
+import TagPage from "@/pages/TagPage";
+import Home from "@/pages/Home";       // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
 
-export default function Blog() {
-  const [posts, setPosts] = useState([]);
-  const [cursor, setCursor] = useState(null);
-  const [total, setTotal] = useState(null);
-
-  useEffect(() => {
-    getTotalPosts().then(setTotal);
-    // NB: destructure — queryPosts returns { posts, nextCursor }, not a bare array.
-    queryPosts({ limit: 20 }).then(({ posts, nextCursor }) => {
-      setPosts(posts);
-      setCursor(nextCursor);
-    });
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
   }, []);
-
-  const loadMore = () =>
-    queryPosts({ limit: 20, cursor }).then(({ posts: more, nextCursor }) => {
-      setPosts((p) => [...p, ...more]);
-      setCursor(nextCursor);
-    });
-
-  if (total === 0) return <p>{/* empty state — tell the user to publish posts in Wix */}</p>;
-  return (
-    <div /* restyle */>
-      <div /* grid */>{posts.map((p) => <PostCard key={p.id} post={p} />)}</div>
-      {cursor && <button onClick={loadMore}>Load more</button>}
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
-  );
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Blog / PostDetail / Category / Tag render here, untouched */}
+      <Footer />
+    </div>
+  </>);
 }
-```
-`queryPostsByCategory(categoryId, …)` and `queryPostsByTag(tagId, …)` return the same
-`{ posts, nextCursor }` shape — wire the category/tag landing pages identically.
 
-**`useTaxonomy` + `PostChips`** — resolve `categoryIds`/`tagIds` to chip labels. Fetch the
-categories/tags **once** (this lookup runs on every post render) and reuse the map.
+<TaxonomyProvider>
+  <Routes>
+    <Route element={<Layout />}>                                    {/* chrome wraps all */}
+      <Route path="/" element={<Home />} />                         {/* yours */}
+      <Route path="/blog" element={<Blog />} />                     {/* shipped, as-is */}
+      <Route path="/blog/:slug" element={<PostDetail />} />         {/* shipped, as-is */}
+      <Route path="/blog/category/:slug" element={<CategoryPage />} /> {/* shipped, as-is */}
+      <Route path="/blog/tag/:slug" element={<TagPage />} />        {/* shipped, as-is */}
+    </Route>
+  </Routes>
+</TaxonomyProvider>
+```
+
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
+(STEP 4) so they wrap every route — plus the overall brand story, styled from the same `theme.css`
+tokens. **Compose the shipped pieces** — a "latest posts" strip is just `queryPosts` + the shipped
+`PostGrid`; a category nav is `useTaxonomy()` + links to `/blog/category/:slug`:
 
 ```jsx
 import { useState, useEffect } from "react";
-import { queryCategories, queryTags } from "@/rest/wix-blog";
+import { Link } from "react-router-dom";
+import { queryPosts } from "@/rest/wix-blog";
+import { useTaxonomy } from "@/context/TaxonomyContext";
+import PostGrid from "@/components/PostGrid";
 
-// Categories + tags turn a post's categoryIds/tagIds into chip labels.
-// Fetch them ONCE (a context/provider) and reuse — do NOT re-query per post card.
-export function useTaxonomy() {
-  const [categories, setCategories] = useState([]);
-  const [tags, setTags] = useState([]);
+// Responsive header: choose ONE branch with a state flag (never a Tailwind `hidden md:*` toggle —
+// these navs are inline-styled, and an inline `display` beats a Tailwind class, so `hidden` never
+// applies and BOTH branches render). One branch = one nav.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
   useEffect(() => {
-    // NB: destructure — queryCategories → { categories, total }, queryTags → { tags, total }.
-    queryCategories().then(({ categories }) => setCategories(categories));
-    queryTags().then(({ tags }) => setTags(tags));
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
   }, []);
-  const catById = new Map(categories.map((c) => [c.id, c])); // display c.label · count c.postCount
-  const tagById = new Map(tags.map((t) => [t.id, t]));       // display t.label · count t.publishedPostCount
-  return { catById, tagById };
-}
-
-// Resolve a post's ids against category.id / tag.id; display .label (NOT .name); route by .slug.
-export function PostChips({ post, catById, tagById }) {
-  const cats = (post.categoryIds || []).map((id) => catById.get(id)).filter(Boolean);
-  const tags = (post.tagIds || []).map((id) => tagById.get(id)).filter(Boolean);
   return (
-    <>
-      {cats.map((c) => <a key={c.id} href={`/blog/category/${c.slug}`}>{c.label}</a>)}
-      {tags.map((t) => <a key={t.id} href={`/blog/tag/${t.slug}`}>{t.label}</a>)}
-    </>
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger + links here
+        : <div style={{ display: "flex", gap: 24 }}><Link to="/">Home</Link><Link to="/blog">Blog</Link></div>}
+    </nav>
   );
 }
+export function Latest() {                                   // on your home page
+  const [posts, setPosts] = useState([]);
+  // NB: queryPosts returns { posts, nextCursor } — destructure the array.
+  useEffect(() => { queryPosts({ limit: 6 }).then(({ posts }) => setPosts(posts)); }, []);
+  return <PostGrid posts={posts} empty="Posts coming soon." />;
+}
+export function CategoryNav() {                              // a menu of the blog's categories
+  const { categories } = useTaxonomy();                     // fetched once by the provider
+  return categories.filter((c) => c.postCount > 0)          // hide empty categories if you want
+    .map((c) => <Link key={c.id} to={`/blog/category/${c.slug}`}>{c.label}</Link>);
+}
+```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
+
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
+
+## Using the client from your own UI
+
+```jsx
+// Every list helper returns an OBJECT, not a bare array — destructure first, or `.map` throws:
+const { posts, nextCursor } = await queryPosts({ limit: 20 });          // pass nextCursor back as `cursor`
+const { categories, total } = await queryCategories();                  // display c.label · count c.postCount
+const { tags } = await queryTags();                                     // display t.label · count t.publishedPostCount
+const { posts: inCategory } = await queryPostsByCategory(categoryId, { limit: 20 });
+const { posts: withTag }    = await queryPostsByTag(tagId, { limit: 20 });
+
+// Single-item lookups fail soft (null on miss) — show a not-found state, never invent an item:
+const post = await getPostBySlug(slug);         // null → 404 state
+const cat  = await getCategoryBySlug(slug);
+const tag  = await getTagBySlug(slug);
+
+// Cover image: post cover and category cover are DIFFERENT paths.
+const postCover = post.media?.wixMedia?.image?.url;   // post/card cover (ready-to-use https)
+const catCover  = cat.coverImage?.url;                // category landing cover
+// No post cover? fall back to the first richContent IMAGE node, or a text-only card — never a stock image.
+
+// Body: contentText is plain text (split on "\n" for paragraphs — the shipped hook does this).
+// richContent is a Ricos document for a faithful render (images/embeds) — see "Extending".
 ```
 
-## Hard rules (do not violate)
-- ✅ Fetch posts/categories/tags ONLY through the shipped helpers (the official Blog REST
-  endpoints). Route between screens by `slug`.
-- ❌ Never hand-build post, category, or tag URLs to fetch content. Use `getPostBySlug`,
-  `getCategoryBySlug`, `getTagBySlug`. (For an outbound link to the live Wix page, use the
-  `url` field — `url.base + url.path` — returned on the object, not a string you assemble.)
-- ❌ Never mock posts, authors, or content — render live Wix data or the empty state.
-- ❌ Never generate fake comments, likes, view counts, or ratings. This skill is read-only
-  and does not expose engagement actions; leave such UI empty or omit it.
-- ❌ Never use a placeholder/stock cover image. If `post.media?.wixMedia?.image` is missing, fall back
-  to the first richContent image or a text-only card.
-- ❌ Never render an author name — the reader helpers don't expose one. `post.author.name` is
-  `undefined`; resolve authors via the members vertical or omit the byline.
-- ✅ Every list helper returns an object: destructure `{ posts, nextCursor }` /
-  `{ categories, total }` / `{ tags, total }` before `.map`/`.filter`.
-- ✅ Display categories and tags by **`.label`** (not `.name`); resolve `categoryIds`/`tagIds`
-  by matching `.id`. Category count is `postCount`; tag count is `publishedPostCount`.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Use `post.media.wixMedia.image.url` for the post cover; `category.coverImage.url` for the
-  category cover (they are different paths).
-- The helpers fail soft on single-item lookups: `getPostBySlug` / `getCategoryBySlug` /
-  `getTagBySlug` return `null` on a miss so you can show a proper not-found state — don't
-  swallow that into a fake item.
+**No author byline** — the reader helpers don't expose an author (`post.author` is undefined). Omit
+the byline, or resolve it via the **members** vertical. **No engagement UI** — comments/likes/views
+aren't exposed; leave them out.
 
-## Beyond the snippets
-The snippets cover the common blog-reader paths. If you hit a use case they don't cover
-(e.g. rendering `richContent` faithfully, full-text search/filtering, related posts,
-post metrics, members-only/pricing-plan posts, multilingual posts), extend the client
-yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and request
-body in the **official Wix API reference** first; never guess:
+## Extending the client
+Building something beyond the shipped pages (faithful `richContent`, full-text search, related posts,
+metrics, members-only posts)? Extend with `wixApiRequest`, but look up the exact endpoint/method/body
+in the **official Wix API reference** first — never guess. Each helper in `wix-blog.js` links its
+reference page inline.
 - Blog API reference: https://dev.wix.com/docs/api-reference/business-solutions/blog.md
-- Query Posts (filters/sort: `categoryIds`, `tagIds`, `hashtags`, `title`, dates, `featured`):
-  https://dev.wix.com/docs/api-reference/business-solutions/blog/posts-stats/query-posts.md
-- Rendering `richContent` (Ricos document format):
-  https://dev.wix.com/docs/ricos/api-reference/ricos-document
-- **Members-only posts** → the **members** vertical (`references/members/INSTRUCTIONS.md`): once a
-  member is logged in (custom login on your own UI), the existing read helpers return the content
-  gated to members — no extra code. Note this blog helper is **read-only**: member *writes* (posting
-  a comment, liking a post) aren't included — add them as a beyond-the-snippets `wixApiRequest` call,
-  authenticated as the logged-in member.
-- Each helper in `wix-blog.js` links its exact reference page inline.
+- Rendering `richContent` (Ricos document): https://dev.wix.com/docs/ricos/api-reference/ricos-document
+- **Members-only posts** → the **members** vertical: once a member is logged in, the shipped read
+  helpers return the gated content with no extra code (member *writes* — comments, likes — are not
+  included; add them as an authenticated `wixApiRequest` call).
 
-Keep the snippets as the default for everything they already do; reach for the API
-reference only for the gap.
+Fallback only — when you hit an error or need something not shown here: read the relevant shipped file
+under `src/`, or look it up via the **`wix-docs`** skill.
+
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Blog`/`PostDetail`/category/tag pages to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
+- Route by `slug` through the shipped helpers — never hand-build a post/category/tag URL. Display categories/tags by `.label` (not `.name`).
+- Render live Wix data or the shipped empty state — never mock posts, authors, comments, likes, or view counts; never use a stock/placeholder cover image.
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the blog content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For blog data those pages are:
-- **Posts** — `https://manage.wix.com/dashboard/{metaSiteId}/blog/posts` (`Dashboard → Blog → Posts`; write, edit, and publish posts; only published posts appear in the app)
-- **Categories** — `https://manage.wix.com/dashboard/{metaSiteId}/blog/categories` (`Dashboard → Blog → Categories`)
+Provide deep links so the owner can edit content (substitute the site's `metaSiteId`):
+- **Posts** — `https://manage.wix.com/dashboard/{metaSiteId}/blog/posts` (write, edit, publish; only published posts appear in the app)
+- **Categories** — `https://manage.wix.com/dashboard/{metaSiteId}/blog/categories`
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed the blog per `seed/SEED.md` (the build-time module that creates posts/categories over the
+connector) — separate from this client build; run in parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (no re-mint storm; same anonymous visitor)
-- [ ] Post feed lists live published posts, newest first, and paginates via `nextCursor` (destructured from `{ posts, nextCursor }`)
-- [ ] Post detail loads by `slug` and renders real `contentText` (or rendered `richContent`)
-- [ ] `getPostBySlug` on a bad slug shows a not-found state (no invented post)
-- [ ] Cover images come from `post.media.wixMedia.image.url` (or richContent fallback) — no stock placeholders
-- [ ] Category/tag menus destructure `{ categories }` / `{ tags }` and display `.label` (category cover from `category.coverImage.url`)
-- [ ] No author byline rendered from the post (no `post.author.name`) — omitted or sourced from members
-- [ ] Category and tag pages list the right posts via `queryPostsByCategory` / `queryPostsByTag`
-- [ ] Empty state shown when `getTotalPosts()` is 0
-- [ ] No mock posts, authors, comments, likes, or view counts anywhere
-- [ ] Told the user at least once that they can continue setting up their blog in the dashboard and provided deep links.
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Blog`/`PostDetail`/`CategoryPage`/`TagPage` untouched; content clears the fixed chrome; `<TaxonomyProvider>` wraps the tree.
+- [ ] Feed lists live published posts (newest first) and paginates via `nextCursor`; post detail loads by `slug`; a bad slug shows the not-found state (no invented post).
+- [ ] Category/tag pages list the right posts; chips display `.label` and route by `.slug`; taxonomy fetched once (no re-query per card).
+- [ ] Cover images come from `post.media.wixMedia.image.url` (category cover from `category.coverImage.url`) — no stock placeholders; no author byline / engagement UI invented.
+- [ ] Empty catalog shows the shipped empty state; no mock posts anywhere.

--- a/skills/wix-vibe-headless/references/blog/app/components/PostCard.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/components/PostCard.jsx
@@ -1,0 +1,47 @@
+// Feed tile. Styled entirely from theme.css tokens (var(--...)) — re-skin via those tokens, not this
+// JSX. The cover-image path (post.media.wixMedia.image.url) and the text-only fallback are
+// load-bearing: never substitute a stock/placeholder image. Routes to the detail page by slug.
+import { Link } from "react-router-dom";
+
+function coverImage(post) {
+  const url = post?.media?.wixMedia?.image?.url;         // ready-to-use https url; //-fix is defensive
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+function formatDate(iso) {
+  if (!iso) return null;
+  try { return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }); }
+  catch { return null; }
+}
+
+export default function PostCard({ post }) {
+  const image = coverImage(post);
+  const date = formatDate(post?.firstPublishedDate);
+
+  return (
+    <Link to={`/blog/${post.slug}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      {image && (
+        <div style={{ aspectRatio: "16 / 9", background: "var(--color-bg)" }}>
+          <img src={image} alt={post.media?.wixMedia?.image?.altText || post.title} loading="lazy"
+            style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+        </div>
+      )}
+      <div style={{ padding: "var(--space)", display: "flex", flexDirection: "column", gap: 8 }}>
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 18, fontWeight: 600, lineHeight: 1.3 }}>{post.title}</h3>
+        {post.excerpt && (
+          <p style={{ margin: 0, color: "var(--color-muted)", fontSize: 14, lineHeight: 1.5 }}>{post.excerpt}</p>
+        )}
+        <div style={{ display: "flex", gap: 8, alignItems: "center", color: "var(--color-muted)", fontSize: 12 }}>
+          {date && <span>{date}</span>}
+          {date && post.minutesToRead ? <span aria-hidden="true">·</span> : null}
+          {post.minutesToRead ? <span>{post.minutesToRead} min read</span> : null}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/blog/app/components/PostChips.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/components/PostChips.jsx
@@ -1,0 +1,30 @@
+// Category + tag chips for a post. Resolves the post's categoryIds/tagIds against the SHARED
+// taxonomy maps (fetched once by TaxonomyProvider — never re-query here), displays each by .label
+// (NOT .name), and routes by .slug. Token-styled; re-skin via theme.css.
+import { Link } from "react-router-dom";
+import { useTaxonomy } from "@/context/TaxonomyContext";
+
+const chip = {
+  display: "inline-flex", alignItems: "center", padding: "4px 10px", fontSize: 12,
+  textDecoration: "none", color: "var(--color-text)",
+  background: "var(--color-surface)", border: "1px solid var(--color-border)",
+  borderRadius: 999,
+};
+
+export default function PostChips({ post }) {
+  const { catById, tagById } = useTaxonomy();
+  const cats = (post.categoryIds || []).map((id) => catById.get(id)).filter(Boolean);
+  const tags = (post.tagIds || []).map((id) => tagById.get(id)).filter(Boolean);
+  if (!cats.length && !tags.length) return null;
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+      {cats.map((c) => (
+        <Link key={c.id} to={`/blog/category/${c.slug}`} style={{ ...chip, color: "var(--color-accent)", borderColor: "var(--color-accent)" }}>{c.label}</Link>
+      ))}
+      {tags.map((t) => (
+        <Link key={t.id} to={`/blog/tag/${t.slug}`} style={chip}>#{t.label}</Link>
+      ))}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/blog/app/components/PostGrid.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/components/PostGrid.jsx
@@ -1,0 +1,19 @@
+// Responsive post grid + empty state. Token-styled; re-skin via theme.css.
+import PostCard from "./PostCard";
+
+export default function PostGrid({ posts, empty = "No posts yet." }) {
+  if (!posts?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+      gap: "calc(var(--space) * 1.5)",
+    }}>
+      {posts.map((p) => <PostCard key={p.id} post={p} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/blog/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/blog/app/context/TaxonomyContext.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/context/TaxonomyContext.jsx
@@ -1,0 +1,35 @@
+// Taxonomy state — categories + tags fetched ONCE and shared across every page/card. Wrap the app
+// in <TaxonomyProvider>; components read useTaxonomy(). Resolving a post's categoryIds/tagIds to
+// chip labels runs on every post render, so this MUST be a single shared fetch — never re-query per
+// card. Data wiring (destructuring, .label display, id→object maps) is correct as-is; don't re-derive.
+import { createContext, useContext, useState, useEffect, useMemo } from "react";
+import { queryCategories, queryTags } from "@/rest/wix-blog";
+
+const TaxonomyContext = createContext(null);
+
+export function TaxonomyProvider({ children }) {
+  const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+
+  useEffect(() => {
+    // NB: destructure — queryCategories → { categories, total }, queryTags → { tags, total }.
+    queryCategories().then(({ categories }) => setCategories(categories));
+    queryTags().then(({ tags }) => setTags(tags));
+  }, []);
+
+  // display c.label · count c.postCount  /  display t.label · count t.publishedPostCount
+  const catById = useMemo(() => new Map(categories.map((c) => [c.id, c])), [categories]);
+  const tagById = useMemo(() => new Map(tags.map((t) => [t.id, t])), [tags]);
+
+  return (
+    <TaxonomyContext.Provider value={{ categories, tags, catById, tagById }}>
+      {children}
+    </TaxonomyContext.Provider>
+  );
+}
+
+export function useTaxonomy() {
+  const ctx = useContext(TaxonomyContext);
+  if (!ctx) throw new Error("useTaxonomy must be used within <TaxonomyProvider>");
+  return ctx;
+}

--- a/skills/wix-vibe-headless/references/blog/app/hooks/usePostDetail.js
+++ b/skills/wix-vibe-headless/references/blog/app/hooks/usePostDetail.js
@@ -1,0 +1,38 @@
+// usePostDetail — all post-detail logic, no markup: load a post by slug, expose a not-found state,
+// resolve its categoryIds/tagIds to full category/tag objects via the shared taxonomy, and split the
+// plain-text body into paragraphs. The field paths (media cover, id→label resolution, contentText
+// split) are the bug-prone part — keep them verbatim; the PostDetail page only renders what this
+// returns. richContent is available on the loaded post for a richer render (see INSTRUCTIONS).
+import { useState, useEffect, useMemo } from "react";
+import { getPostBySlug } from "@/rest/wix-blog";
+import { useTaxonomy } from "@/context/TaxonomyContext";
+
+export function usePostDetail(slug) {
+  const { catById, tagById } = useTaxonomy();
+  const [post, setPost] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    setPost(null);
+    setNotFound(false);
+    getPostBySlug(slug).then((p) => (p ? setPost(p) : setNotFound(true)));
+  }, [slug]);
+
+  // Resolve ids → full objects; display .label, route by .slug (drop ids with no match).
+  const cats = useMemo(
+    () => (post?.categoryIds || []).map((id) => catById.get(id)).filter(Boolean),
+    [post, catById],
+  );
+  const tags = useMemo(
+    () => (post?.tagIds || []).map((id) => tagById.get(id)).filter(Boolean),
+    [post, tagById],
+  );
+
+  // contentText is plain text — split on "\n" for simple paragraphs (drop blank lines).
+  const paragraphs = useMemo(
+    () => (post?.contentText || "").split("\n").map((s) => s.trim()).filter(Boolean),
+    [post],
+  );
+
+  return { post, notFound, cats, tags, paragraphs };
+}

--- a/skills/wix-vibe-headless/references/blog/app/pages/Blog.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/pages/Blog.jsx
@@ -1,0 +1,43 @@
+// Blog feed — lists published posts (newest first, pinned lead), paginates via nextCursor, and
+// shows the shipped empty state when the blog has no posts. Token-styled; re-skin via theme.css.
+import { useEffect, useState } from "react";
+import { queryPosts, getTotalPosts } from "@/rest/wix-blog";
+import PostGrid from "@/components/PostGrid";
+
+export default function Blog() {
+  const [posts, setPosts] = useState(null);
+  const [cursor, setCursor] = useState(null);
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    getTotalPosts().then(setTotal);
+    // NB: destructure — queryPosts returns { posts, nextCursor }, not a bare array.
+    queryPosts({ limit: 20 }).then(({ posts, nextCursor }) => { setPosts(posts); setCursor(nextCursor); });
+  }, []);
+
+  const loadMore = () =>
+    queryPosts({ limit: 20, cursor }).then(({ posts: more, nextCursor }) => {
+      setPosts((p) => [...(p || []), ...more]);
+      setCursor(nextCursor);
+    });
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Blog</h1>
+      {posts === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <PostGrid posts={posts} empty={total === 0
+            ? "No posts yet — publish posts from your Wix dashboard to see them here."
+            : "No posts to show."} />}
+      {cursor && (
+        <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 2)" }}>
+          <button onClick={loadMore} style={{
+            padding: "12px 24px", cursor: "pointer", fontSize: 15, fontWeight: 600,
+            background: "var(--color-primary)", color: "var(--color-on-primary)",
+            border: "none", borderRadius: "var(--radius-sm)",
+          }}>Load more</button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/blog/app/pages/CategoryPage.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/pages/CategoryPage.jsx
@@ -1,0 +1,57 @@
+// Category landing page — resolves the URL slug to a category (getCategoryBySlug → null on miss),
+// then lists that category's posts via queryPostsByCategory (same { posts, nextCursor } shape as the
+// feed, so paging is identical). Displays the category by .label; cover from category.coverImage.url
+// (a DIFFERENT path from the post cover). Token-styled; re-skin via theme.css.
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getCategoryBySlug, queryPostsByCategory } from "@/rest/wix-blog";
+import PostGrid from "@/components/PostGrid";
+
+export default function CategoryPage() {
+  const { slug } = useParams();
+  const [category, setCategory] = useState(undefined);   // undefined=loading, null=not found
+  const [posts, setPosts] = useState(null);
+  const [cursor, setCursor] = useState(null);
+
+  useEffect(() => {
+    setCategory(undefined); setPosts(null); setCursor(null);
+    getCategoryBySlug(slug).then((c) => {
+      setCategory(c);
+      if (!c) return;
+      queryPostsByCategory(c.id, { limit: 20 }).then(({ posts, nextCursor }) => { setPosts(posts); setCursor(nextCursor); });
+    });
+  }, [slug]);
+
+  const loadMore = () =>
+    queryPostsByCategory(category.id, { limit: 20, cursor }).then(({ posts: more, nextCursor }) => {
+      setPosts((p) => [...(p || []), ...more]);
+      setCursor(nextCursor);
+    });
+
+  if (category === null) return <Centered>Category not found.</Centered>;
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: 4 }}>{category?.label || "…"}</h1>
+      {category?.description && (
+        <p style={{ color: "var(--color-muted)", marginBottom: "var(--space)" }}>{category.description}</p>
+      )}
+      {posts === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <PostGrid posts={posts} empty="No posts in this category yet." />}
+      {cursor && (
+        <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 2)" }}>
+          <button onClick={loadMore} style={{
+            padding: "12px 24px", cursor: "pointer", fontSize: 15, fontWeight: 600,
+            background: "var(--color-primary)", color: "var(--color-on-primary)",
+            border: "none", borderRadius: "var(--radius-sm)",
+          }}>Load more</button>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/blog/app/pages/PostDetail.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/pages/PostDetail.jsx
@@ -1,0 +1,65 @@
+// Post detail — thin view over usePostDetail (all logic lives in the hook). Renders the cover, meta,
+// category/tag chips, and the plain-text body as paragraphs. For a faithful render of embeds/images/
+// formatting, render `d.post.richContent` with a Ricos renderer (see INSTRUCTIONS "Extending").
+// Token-styled; re-skin via theme.css.
+import { useParams } from "react-router-dom";
+import { usePostDetail } from "@/hooks/usePostDetail";
+import PostChips from "@/components/PostChips";
+
+function coverImage(post) {
+  const url = post?.media?.wixMedia?.image?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+function formatDate(iso) {
+  if (!iso) return null;
+  try { return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }); }
+  catch { return null; }
+}
+
+export default function PostDetail() {
+  const { slug } = useParams();
+  const d = usePostDetail(slug);
+
+  if (d.notFound) return <Centered>Post not found.</Centered>;
+  if (!d.post) return <Centered>Loading…</Centered>;
+
+  const image = coverImage(d.post);
+  const date = formatDate(d.post.firstPublishedDate);
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <article style={{ maxWidth: "var(--measure)", margin: "0 auto" }}>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px", lineHeight: 1.2 }}>{d.post.title}</h1>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", color: "var(--color-muted)", fontSize: 13, marginBottom: "var(--space)" }}>
+          {date && <span>{date}</span>}
+          {date && d.post.minutesToRead ? <span aria-hidden="true">·</span> : null}
+          {d.post.minutesToRead ? <span>{d.post.minutesToRead} min read</span> : null}
+        </div>
+
+        {image && (
+          <div style={{ borderRadius: "var(--radius)", overflow: "hidden", marginBottom: "calc(var(--space) * 1.5)" }}>
+            <img src={image} alt={d.post.media?.wixMedia?.image?.altText || d.post.title}
+              style={{ width: "100%", height: "auto", display: "block" }} />
+          </div>
+        )}
+
+        <div style={{ color: "var(--color-text)", lineHeight: 1.7, fontSize: 17 }}>
+          {d.paragraphs.map((para, i) => (
+            <p key={i} style={{ margin: "0 0 var(--space)" }}>{para}</p>
+          ))}
+        </div>
+
+        {(d.cats.length || d.tags.length) ? (
+          <div style={{ marginTop: "calc(var(--space) * 2)", paddingTop: "var(--space)", borderTop: "1px solid var(--color-border)" }}>
+            <PostChips post={d.post} />
+          </div>
+        ) : null}
+      </article>
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/blog/app/pages/TagPage.jsx
+++ b/skills/wix-vibe-headless/references/blog/app/pages/TagPage.jsx
@@ -1,0 +1,53 @@
+// Tag landing page — resolves the URL slug to a tag (getTagBySlug → null on miss), then lists that
+// tag's posts via queryPostsByTag (same { posts, nextCursor } shape as the feed). Displays the tag by
+// .label (per-tag count is publishedPostCount). Token-styled; re-skin via theme.css.
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getTagBySlug, queryPostsByTag } from "@/rest/wix-blog";
+import PostGrid from "@/components/PostGrid";
+
+export default function TagPage() {
+  const { slug } = useParams();
+  const [tag, setTag] = useState(undefined);   // undefined=loading, null=not found
+  const [posts, setPosts] = useState(null);
+  const [cursor, setCursor] = useState(null);
+
+  useEffect(() => {
+    setTag(undefined); setPosts(null); setCursor(null);
+    getTagBySlug(slug).then((t) => {
+      setTag(t);
+      if (!t) return;
+      queryPostsByTag(t.id, { limit: 20 }).then(({ posts, nextCursor }) => { setPosts(posts); setCursor(nextCursor); });
+    });
+  }, [slug]);
+
+  const loadMore = () =>
+    queryPostsByTag(tag.id, { limit: 20, cursor }).then(({ posts: more, nextCursor }) => {
+      setPosts((p) => [...(p || []), ...more]);
+      setCursor(nextCursor);
+    });
+
+  if (tag === null) return <Centered>Tag not found.</Centered>;
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>#{tag?.label || "…"}</h1>
+      {posts === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <PostGrid posts={posts} empty="No posts with this tag yet." />}
+      {cursor && (
+        <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 2)" }}>
+          <button onClick={loadMore} style={{
+            padding: "12px 24px", cursor: "pointer", fontSize: 15, fontWeight: 600,
+            background: "var(--color-primary)", color: "var(--color-on-primary)",
+            border: "none", borderRadius: "var(--radius-sm)",
+          }}>Load more</button>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/blog/app/theme.css
+++ b/skills/wix-vibe-headless/references/blog/app/theme.css
@@ -1,0 +1,36 @@
+/* theme.css — THE styling surface. Theme the whole blog by editing these tokens to the brand; do
+   NOT restyle the components' JSX. Every shipped component reads these variables, so changing them
+   here re-skins the entire reader. Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, wells, chips */
+  --color-text:      #16181d;   /* primary text / article body */
+  --color-muted:     #6b7280;   /* excerpts, dates, read-time, secondary text */
+  --color-border:    #e5e7eb;   /* hairlines, dividers, card borders */
+  --color-primary:   #111827;   /* links, active chip, buttons */
+  --color-on-primary:#ffffff;   /* text on primary */
+  --color-accent:    #d97757;   /* category/tag highlights, badges */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display/serif face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1100px;        /* content max width (feed/detail column) */
+  --measure:     72ch;          /* article body line length for comfortable reading */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **blog** to the storefront-as-files model: post feed + detail + category/tag pages; TaxonomyProvider for category/tag maps.

- `references/blog/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (12 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)