### PR TITLE
feat(pricing-plans): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -1,264 +1,245 @@
+# Wix Pricing Plans — ready-made client
 
-# Wix Pricing Plans Skill
+The Plans & Pricing client is **shipped as real files**, not snippets to regenerate. It's a complete
+plans table + plan detail + members-only hosted checkout + "my plans" area, styled entirely from
+`theme.css` tokens. Copy it into the app, theme the tokens, wire the routes — you generate almost
+none of the plans code (the destructure shapes, the price/billing-cycle field paths, the hosted
+checkout redirect, the anonymous `[]` case all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/pricing-plans/wix-pricing-plans.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
-
-Builds a real, client-only Wix pricing-plans / membership front end. The browser talks to Wix
-directly over a public `WIX_CLIENT_ID`. Never mock plans; never hand-build a `/checkout` or
-purchase URL — purchasing always goes through the Wix-hosted **redirect-session** (which also
-handles member login and payment).
-
-## When to use
-- User wants a "Plans & Pricing", membership, or subscription page on a Wix site.
-- User asks to "connect Wix pricing plans" or sell memberships / subscriptions / paid plans.
-- Replacing placeholder/mock plans with live Wix data.
-- Adding a plan detail page, a buy/subscribe button, or a "my plans" area over existing plans.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock plans;
+never hand-build a `/checkout` or purchase URL — purchasing always goes through the Wix-hosted
+**redirect-session** (which also handles member login/signup and payment).
 
 ## Prerequisites
-1. A Wix site with **Pricing Plans installed and at least one plan created** (this skill does
-   NOT provision — it's read-only over the plans the merchant added in the dashboard).
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Set it
-   in `src/rest/wix-config.js` in place of the placeholder. It is a buyer-facing credential
-   (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/committing it is fine.
-3. **Purchasing a plan is members-only and uses Wix-hosted checkout.** The hosted flow handles
-   member login/signup + the order form + payment, then returns to your site. The deployed app
-   domain must be allow-listed on the OAuth client for that return to work — this is a **separate
-   Wix setup flow the user completes later**, out of this skill's scope. If the return fails
-   before that setup is done, that's expected; flag it and continue.
-4. To actually charge for paid plans, the site needs a payment method connected and (where
-   applicable) tax/business-address configured in the Wix dashboard. Free plans work without this.
+- The site's **Wix Pricing Plans** app is the read/checkout target. It's installed and seeded
+  separately (see **Seeding** below), in parallel with this build — so it may have no plans at build
+  time; the client renders the shipped empty state until plans land.
+- The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
+- **Purchasing is members-only, via Wix-hosted checkout.** The hosted flow handles member
+  login/signup + the order form + payment, then returns to your site. The deployed app domain must
+  be allow-listed on the OAuth client for that return to work — a **separate Wix setup flow the user
+  completes later**, out of scope here. If the return fails before that setup is done, that's
+  expected; flag it and continue.
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the page's UI however the project
-wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only adjust
-import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
-  `wix-config.js`. The visitor refresh token is persisted to localStorage; after a hosted checkout
-  the same identity returns as a logged-in member. Do not re-mint anonymously per load.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-pricing-plans.js` — exports:
-  - **Plans:** `queryPlans`, `getPlanById`, `getPlanBySlug`
-  - **Purchase:** `checkout`
-  - **Member:** `getMyPlanOrders`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole Plans & Pricing UI client + REST scaffolds
+into `src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your
+map, so you don't need to open them:**
 
-The Plan and Order shapes are documented as JSDoc comments at the top of `wix-pricing-plans.js`.
-Read them before building the UI — pricing has several models (recurring subscription,
-single-payment-for-duration, single-payment-unlimited, free, plus free trials) and the JSDoc
-shows exactly how to read price, cycle, and trial for display.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `hooks/usePlans.js` | plans-listing data — first page, cursor paging, `subscribe(plan)` checkout |
+| `hooks/usePlanDetail.js` | plan-detail data — plan-by-slug + `notFound` + `subscribe()` checkout |
+| `hooks/useMyPlans.js` | member's orders + auto re-sync on return from checkout |
+| `components/PlanPrice.jsx` | price label — reads amount / cycle / free-trial (display only) |
+| `components/PlanCard.jsx` | plan card — name, description, price, perks, Subscribe (when `buyable`) |
+| `components/PlanGrid.jsx` | responsive plans grid + empty state |
+| `components/OrderCard.jsx` | one member order row for the "my plans" list |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Plans.jsx` | the plans-table route (`/plans`) — grid + paging + checkout |
+| `pages/PlanDetail.jsx` | the plan-detail route (`/plans/:slug`) — perks, terms, checkout |
+| `pages/MyPlans.jsx` | the member's memberships + post-checkout confirmation (`/my-plans`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` + `rest/wix-pricing-plans.js` | REST transport + plans/orders/checkout helpers |
 
-## How to wire it (UI is the project's choice)
-- **Plans grid** — `const { plans, nextCursor } = await queryPlans()` — **destructure**: it returns
-  an object `{ plans, nextCursor }`, not a bare array, so `queryPlans().map(...)` /
-  `(await queryPlans()).map(...)` throws `… is not a function`. Returns PUBLIC plans only; pass
-  `nextCursor` back as `cursor` to load the next page, and iterate `plans`. For each plan render
-  `name`, `description`, and `perks[].description` as feature bullets. Show a "Subscribe"/"Buy"
-  button only when `plan.buyable` is true. See the `pages/Plans.jsx` snippet below for the worked
-  listing (destructure + empty state + price + paging).
-- **Price** — the amount is at `plan.pricingVariants[0].pricingStrategies[0].flatRate.amount`. It is
-  a **decimal string** like `"20.00"` (a *string*, never a number) where `"0"` means the plan is
-  **free**. Do not do math on it and do not compare `=== 0` (it's a string) — treat it as
-  display-only text and pair it with `plan.currency` (ISO-4217, e.g. `"USD"`). Wix settles the real
-  charge, tax, and proration at hosted checkout — never compute a final price yourself.
-- **Billing cycle** — for a **recurring** plan the cycle lives at
-  `plan.pricingVariants[0].billingTerms.billingCycle` = `{ period: "DAY"|"WEEK"|"MONTH"|"YEAR",
-  count }` (e.g. `{ period: "MONTH", count: 1 }` = billed monthly). It is nested under
-  `billingTerms` — there is **no** `billingCycle` directly on `pricingVariants[0]`. Free-trial
-  length is `plan.pricingVariants[0].freeTrialDays`.
-- **Plan image** — `plan.image` is a WixMedia object `{ id, width, height, altText }` with **no
-  `.url`**; the `id` is a WixMedia id that must be converted to a URL before it can render. Never
-  set `<img src={plan.image}>` or `<img src={plan.image.url}>` (both are `undefined` /
-  `[object Object]`). To show it, resolve the WixMedia `id` to a URL per the Wix Media docs (use
-  wix-docs), otherwise omit the image / use a placeholder.
-- **Plan detail** — `getPlanBySlug(slug)` keyed off the URL slug (or `getPlanById(id)`); returns
-  null on miss — show a not-found state, never invent a plan. Render perks, the full price/billing
-  summary, free-trial note, and `termsAndConditions` if present.
-- **Purchase** — `window.location.href = await checkout(planId, { thankYouPageUrl })`. This
-  redirects to Wix-hosted checkout, which logs the member in (or signs them up), collects the
-  order form, and takes payment. On success Wix returns to `thankYouPageUrl` with a
-  `?planOrderId=<GUID>` query param (and `wixMemberLoggedIn`); on abandon/interrupt it returns to
-  `postFlowUrl` (defaults to the current page). Never create the order or build the URL yourself.
-- **My plans / confirmation** — `const orders = await getMyPlanOrders({ orderStatuses: ["ACTIVE"] })`
-  for the logged-in member's current memberships (omit `orderStatuses` for all of them). It resolves
-  to an **array** — `[]` for anonymous visitors (never throws), so show a "log in to see your plans"
-  state and wire that log-in via the **members** vertical (`references/members/`) so they can sign in
-  on your own UI. Renderable Order fields (confirmed in the JSDoc): `planName`, `status`
-  (`DRAFT`/`PENDING`/`ACTIVE`/`PAUSED`/`ENDED`/`CANCELED`), `lastPaymentStatus`, `startDate`,
-  `endDate` (date strings — format for display), `freeTrialDays`, `currentCycle`
-  (`{ index, startedDate, endedDate }`), and `autoRenewCanceled`. Render only fields the order
-  actually returns; for anything not in that list (e.g. the amount paid or next-billing figure) look
-  it up in the Orders API reference (wix-docs) — never invent it. After returning from checkout,
-  re-fetch (e.g. on mount + `visibilitychange`, or when `planOrderId` is in the URL) to show the new
-  order. See the `pages/MyPlans.jsx` snippet below.
-- **Empty state** — if `queryPlans()` returns no plans, show an empty state telling the user to
-  create plans in their Wix dashboard. Never invent plans.
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each
+is and every field shape you need is in the snippets below. Read a shipped file's source **only** on
+a real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/pricing-plans/app/` → `src/`.)
 
-## Hard rules (do not violate)
-- ✅ Purchase ONLY via `checkout()` (`/headless/v1/redirect-session` with `paidPlansCheckout`),
-  then redirect to `redirectSession.fullUrl`.
-- ❌ Never hand-build a checkout, purchase, or `/plans-checkout` URL; never call create-order
-  directly from the client to "skip" the hosted flow.
-- ❌ Never mock plans — render live Wix data or the empty state.
-- ❌ Never invent perks, prices, trials, testimonials, or member counts. Render only what the
-  plan object returns; empty perks → no feature list.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Treat plan objects as display-only — never compute the final charge; Wix settles price, tax,
-  proration, and schedule during hosted checkout.
-- ✅ Show the buy button only when `plan.buyable` is true; otherwise the plan is merchant-assigned.
-- The engine fails loudly on purpose: `checkout()` throws if it can't create the redirect session.
-  A green path means it really reached Wix-hosted checkout — don't swallow these.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
-## Beyond the snippets
-The snippets cover the common plans paths. If you hit a use case they don't cover, make the call
-yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and request body in
-the **official Wix API reference** first; never guess:
-- Pricing Plans API reference: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans.md
-- Orders (cancel / pause / resume a member's order, price preview): https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/orders.md
-- Headless redirect session (login, logout, other checkouts): https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole pricing page. **Do not
+restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
+home page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the
+dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
-Common genuine gaps and where to look:
-- **Cancel / pause / resume** a member's subscription → Orders API (`request-cancellation`,
-  `pause-order`, `resume-order`). Gate on `plan.buyerCanCancel`.
-- **Member login / logout** outside of a purchase → use the **members** vertical
-  (`references/members/INSTRUCTIONS.md`) for *custom* login (email+password / Google / Facebook / SSO)
-  on your own UI — so a member can log in *before* subscribing and see "my plans" without going through
-  a purchase. Pair it with this vertical whenever plans need a real account surface.
-- **Coupons / custom start date** at purchase → covered by the hosted checkout; for a fully
-  custom flow see Create Online Order in the Orders reference.
+## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it. Pricing Plans needs **no** cross-page provider (checkout is a redirect, not client
+state) — so unlike the storefront there's no `<CartProvider>` to wrap.
+- `import "@/theme.css";` once at the app entry.
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every**
+  page — including the shipped `Plans` / `PlanDetail` / `MyPlans` — so you **never edit the shipped
+  pages to add a header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's **ResizeObserver-measured** height so it clears the chrome and
+  self-corrects when the banner is dismissed.
+- Routes under the Layout: `/plans` → `Plans`, `/plans/:slug` → `PlanDetail`, `/my-plans` →
+  `MyPlans` (all shipped, as-is). **You add `/` → your own Home** page.
 
-Keep the snippets as the default for everything they already do; reach for the API reference only
-for the gap.
+```jsx
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Plans from "@/pages/Plans";
+import PlanDetail from "@/pages/PlanDetail";
+import MyPlans from "@/pages/MyPlans";
+import Home from "@/pages/Home";       // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
 
-## Reference snippets (headless — adapt the logic, restyle freely)
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Plans/PlanDetail/MyPlans render here, untouched */}
+      <Footer />
+    </div>
+  </>);
+}
 
-The data wiring below (destructure shapes, the exact price/billing-cycle paths, the members-only
-checkout redirect, the anonymous `[]` case) is correct and complete — the markup is deliberately
-plain. **Copy the logic exactly; restyle the JSX to the brand.** They consume the `src/rest/`
-helpers; you don't need to read their source.
+<Routes>
+  <Route element={<Layout />}>                                {/* chrome wraps all */}
+    <Route path="/" element={<Home />} />                      {/* yours */}
+    <Route path="/plans" element={<Plans />} />                {/* shipped, as-is */}
+    <Route path="/plans/:slug" element={<PlanDetail />} />     {/* shipped, as-is */}
+    <Route path="/my-plans" element={<MyPlans />} />           {/* shipped, as-is */}
+  </Route>
+</Routes>
+```
 
-**`pages/Plans.jsx`** — the listing (grid + empty state + paging) with the price/billing-cycle read
-and the members-only checkout redirect. Note the destructure of `queryPlans()`, the price as a
-decimal string (`"0"` = free), and the `billingTerms.billingCycle` nesting.
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the
+`Layout` (STEP 4) so they wrap every route — plus the overall brand story, styled from the same
+`theme.css` tokens. **Compose the shipped pieces** — a "featured plans" strip is just `queryPlans` +
+the shipped `PlanGrid`; the nav is links to `/plans` and `/my-plans`:
 
 ```jsx
 import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { queryPlans, checkout } from "@/rest/wix-pricing-plans";
+import PlanGrid from "@/components/PlanGrid";
 
-// Display-only — never compute the final charge (Wix settles price, tax, and schedule at checkout).
-function readPrice(plan) {
-  const v = plan.pricingVariants?.[0];
-  const amount = v?.pricingStrategies?.[0]?.flatRate?.amount;   // decimal STRING e.g. "20.00"; "0" = free
-  if (amount == null) return null;
-  const cycle = v?.billingTerms?.billingCycle;                  // { period, count } for recurring; absent otherwise
-  return { amount, isFree: amount === "0", cycle, freeTrialDays: v?.freeTrialDays };
-}
-
-function PriceLabel({ plan }) {
-  const p = readPrice(plan);
-  if (!p) return null;
-  if (p.isFree) return <span>Free</span>;
-  const per = p.cycle ? ` / ${p.cycle.count} ${p.cycle.period.toLowerCase()}` : "";   // e.g. "/ 1 month"
-  return <span>{p.amount} {plan.currency}{per}{p.freeTrialDays ? ` · ${p.freeTrialDays}-day free trial` : ""}</span>;
-}
-
-export default function Plans() {
-  const [plans, setPlans] = useState([]);
-  const [cursor, setCursor] = useState(null);
-  const [loaded, setLoaded] = useState(false);
-
+// Responsive header: choose ONE branch with a state flag (mount each nav item once).
+// Do NOT render a desktop nav AND a mobile nav toggled by `hidden md:flex` / `md:hidden`:
+// these navs are inline-styled, and an inline `display` beats a Tailwind class, so `hidden`
+// never applies — BOTH branches render. One branch = one nav.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
   useEffect(() => {
-    // NB: destructure — queryPlans returns { plans, nextCursor }, NOT a bare array.
-    queryPlans().then(({ plans, nextCursor }) => { setPlans(plans); setCursor(nextCursor); setLoaded(true); });
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
   }, []);
-
-  const loadMore = () =>
-    queryPlans({ cursor }).then(({ plans: more, nextCursor }) => { setPlans((p) => [...p, ...more]); setCursor(nextCursor); });
-
-  async function buy(plan) {
-    // members-only, Wix-hosted checkout; on success Wix returns to thankYouPageUrl with ?planOrderId=<GUID>
-    window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.location.origin}/thank-you` });
-  }
-
-  if (loaded && plans.length === 0)
-    return <p>{/* empty state — no plans yet; tell the user to create plans in their Wix dashboard */}</p>;
-
   return (
-    <div /* restyle */>
-      {plans.map((plan) => (
-        <div key={plan.id} /* restyle: plan card */>
-          {/* plan.image is a WixMedia object { id, width, height, altText } with NO .url — resolve the
-              id to a URL (wix-docs) before rendering, or omit; never <img src={plan.image}> */}
-          <h3>{plan.name}</h3>
-          {plan.description && <p>{plan.description}</p>}
-          <PriceLabel plan={plan} />
-          <ul>{(plan.perks || []).map((perk) => <li key={perk.id}>{perk.description}</li>)}</ul>
-          {plan.buyable && <button onClick={() => buy(plan)}>Subscribe</button>}
-        </div>
-      ))}
-      {cursor && <button onClick={loadMore}>Load more</button>}
-    </div>
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger + the same links
+        : <div style={{ display: "flex", gap: 24 }}><Link to="/plans">Plans</Link><Link to="/my-plans">My plans</Link></div>}
+    </nav>
   );
 }
-```
 
-**`pages/MyPlans.jsx`** — the member's current memberships and the post-checkout confirmation.
-`getMyPlanOrders(...)` resolves to an array (`[]` for anonymous visitors), and the view re-syncs on
-`visibilitychange` so a plan bought via hosted checkout shows up on return.
+export function Featured() {                                // on your home page
+  const [plans, setPlans] = useState([]);
+  // NB: queryPlans returns { plans, nextCursor } — destructure the array.
+  useEffect(() => { queryPlans({ limit: 3 }).then(({ plans }) => setPlans(plans)); }, []);
+  const subscribe = async (plan) =>
+    { window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.location.origin}/my-plans` }); };
+  return <PlanGrid plans={plans} onSubscribe={subscribe} empty="Plans coming soon." />;
+}
+```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
+
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev
+preview can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do
+a fresh full navigate/reload of the preview and re-check — don't keep rewriting correct code against
+a stale render.
+
+## Using the client from your own UI
 
 ```jsx
-import { useState, useEffect, useCallback } from "react";
-import { getMyPlanOrders } from "@/rest/wix-pricing-plans";
+// Every list helper returns an object — destructure it (a bare `.map` on the return throws):
+const { plans, nextCursor } = await queryPlans({ limit: 24 });   // PUBLIC plans only
+// Page: pass nextCursor back as `cursor`.
+const { plans: more } = await queryPlans({ cursor: nextCursor });
 
-export default function MyPlans() {
-  const [orders, setOrders] = useState([]);
-  const [loaded, setLoaded] = useState(false);
+// Price is DISPLAY-ONLY — never compute a final charge (Wix settles price, tax, schedule at checkout):
+const v = plan.pricingVariants[0];
+const amount = v.pricingStrategies[0].flatRate.amount;   // decimal STRING e.g. "20.00"; "0" = free (a string — don't === 0)
+const cycle  = v.billingTerms.billingCycle;              // { period:"DAY"|"WEEK"|"MONTH"|"YEAR", count } — recurring only
+const trial  = v.freeTrialDays;                          // free-trial length
+// Pair `amount` with `plan.currency` (ISO-4217, e.g. "USD"). Show the buy button only when plan.buyable.
 
-  const refresh = useCallback(() => {
-    // [] for anonymous visitors (no member context) — never throws.
-    getMyPlanOrders({ orderStatuses: ["ACTIVE"] }).then((o) => { setOrders(o); setLoaded(true); });
-  }, []);
+// Purchase — members-only, hosted; redirect to the returned URL, never hand-build it:
+window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.location.origin}/my-plans` });
+// On success Wix returns to thankYouPageUrl with ?planOrderId=<GUID> (+ wixMemberLoggedIn); on abandon → postFlowUrl.
 
-  useEffect(() => {                                   // load once + re-sync on return from hosted checkout
-    refresh();
-    const onVisible = () => document.visibilityState === "visible" && refresh();
-    document.addEventListener("visibilitychange", onVisible);
-    return () => document.removeEventListener("visibilitychange", onVisible);
-  }, [refresh]);
+// Member's memberships — resolves to [] for anonymous visitors (never throws):
+const orders = await getMyPlanOrders({ orderStatuses: ["ACTIVE"] });   // omit orderStatuses for all
 
-  if (loaded && orders.length === 0)
-    return <p>{/* not a member → "log in to see your plans" (members vertical); member with none → "no active plans" */}</p>;
-
-  return (
-    <ul /* restyle */>
-      {orders.map((order) => (
-        <li key={order.id}>
-          <span>{order.planName}</span>
-          <span>{order.status}</span>                                  {/* ACTIVE | PAUSED | ENDED | CANCELED | … */}
-          {order.startDate && <span>from {new Date(order.startDate).toLocaleDateString()}</span>}
-          {order.endDate && <span>until {new Date(order.endDate).toLocaleDateString()}</span>}
-        </li>
-      ))}
-    </ul>
-  );
-}
+// Plan image: plan.image is a WixMedia object { id, width, height, altText } with NO .url. The shipped
+// cards render text only to avoid this. To show it, resolve the WixMedia `id` to a URL (wix-docs),
+// or omit — never <img src={plan.image}> / <img src={plan.image.url}> (undefined / [object Object]).
 ```
 
+## Extending the client
+Beyond the shipped pages: **cancel / pause / resume** a member's subscription → Orders API
+(`request-cancellation`, `pause-order`, `resume-order`); gate on `plan.buyerCanCancel`. **Custom
+member login / logout** (so a member can log in *before* subscribing and see "my plans" without a
+purchase) → pair the **members** vertical (`references/members/INSTRUCTIONS.md`). For anything the
+snippets don't cover, make the call yourself with `wixApiRequest` — but look up the exact endpoint,
+method, and body first (never guess):
+- Pricing Plans: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans.md
+- Orders: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/orders.md
+- Headless redirect session: https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
+
+Fallback only — when you hit an error or need something not shown here: read the relevant shipped
+file under `src/`, or look it up via the **`wix-docs`** skill.
+
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+  `Plans`/`PlanDetail`/`MyPlans` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
+  `Header` is plain in-flow markup (not `position:fixed`).
+- Purchase goes through the shipped `checkout()` (redirect-session) — never a hand-built URL.
+- Treat plan objects as display-only — show the buy button only when `plan.buyable`; never compute
+  the final charge. Never invent perks, prices, trials, testimonials, or member counts.
+- Render live Wix data or the shipped empty state — never mock plans.
+
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the pricing plans content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For pricing plans data those pages are:
-- **Pricing Plans** — `https://manage.wix.com/dashboard/{metaSiteId}/pricing-plans` (`Dashboard → Pricing Plans`) → **+ Create Plan** (set the name, pricing model, perks, and connect the plan to the content/services it unlocks)
+Provide deep links so the owner can edit content (substitute the site's `metaSiteId`):
+- **Pricing Plans** — `https://manage.wix.com/dashboard/{metaSiteId}/pricing-plans` (`Dashboard →
+  Pricing Plans`) → **+ Create Plan** (set the name, pricing model, perks, and connect the plan to
+  the content/services it unlocks)
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed plans per `seed/SEED.md` (the build-time setup module) — separate from this client build; run
+in parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps
+      all routes; shipped `Plans`/`PlanDetail`/`MyPlans` untouched; content clears the fixed chrome.
 - [ ] Plans list renders live data; price, billing cycle, and free trial read correctly across
-      pricing models (recurring, single-payment, free)
-- [ ] Plan detail loads by slug and shows a not-found state on a bad slug
-- [ ] Buy button shown only for `buyable` plans
-- [ ] Purchase redirects via redirect-session `fullUrl` (no hand-built URL) and reaches
-      Wix-hosted login + payment
-- [ ] On return, the new order appears via `getMyPlanOrders()` (and a "log in" state shows for
-      anonymous visitors)
-- [ ] Empty state shown when `queryPlans()` returns no plans
-- [ ] No mock plans, perks, or prices anywhere
-- [ ] Told the user at least once that they can continue setting up their plans in the dashboard and provided deep links.
+      pricing models (recurring, single-payment, free); buy button only for `buyable` plans.
+- [ ] Plan detail loads by slug and shows a not-found state on a bad slug.
+- [ ] Purchase redirects via the redirect-session `fullUrl` (no hand-built URL) and reaches
+      Wix-hosted login + payment; on return the new order appears on `/my-plans`.
+- [ ] Empty catalog shows the shipped empty state; no mock plans anywhere.

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
@@ -1,0 +1,37 @@
+// Member plan-order row — pure UI for the "My plans" screen. Renders only fields the Order object
+// actually returns (planName, status, start/end dates); for anything else (amount paid, next-billing)
+// look it up in the Orders API reference (wix-docs) — never invent it. Token-styled via theme.css.
+
+const STATUS_COLORS = {
+  ACTIVE: "var(--color-accent)",
+  PAUSED: "var(--color-muted)",
+  ENDED: "var(--color-muted)",
+  CANCELED: "var(--color-danger)",
+};
+
+export default function OrderCard({ order }) {
+  return (
+    <li style={{
+      listStyle: "none", display: "flex", flexWrap: "wrap", alignItems: "center", gap: 12,
+      background: "var(--color-surface)", color: "var(--color-text)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      boxShadow: "var(--shadow)", padding: "var(--space)",
+    }}>
+      <span style={{ fontFamily: "var(--font-display)", fontWeight: 600, flex: 1 }}>{order.planName}</span>
+      <span style={{
+        fontSize: 13, fontWeight: 600, padding: "2px 10px", borderRadius: 999,
+        color: "var(--color-on-primary)", background: STATUS_COLORS[order.status] || "var(--color-muted)",
+      }}>{order.status}</span>
+      {order.startDate && (
+        <span style={{ color: "var(--color-muted)", fontSize: 13 }}>
+          from {new Date(order.startDate).toLocaleDateString()}
+        </span>
+      )}
+      {order.endDate && (
+        <span style={{ color: "var(--color-muted)", fontSize: 13 }}>
+          until {new Date(order.endDate).toLocaleDateString()}
+        </span>
+      )}
+    </li>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/PlanCard.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/PlanCard.jsx
@@ -1,0 +1,59 @@
+// Plan card — pure UI. Styled entirely from theme.css tokens (var(--...)) — re-skin via those
+// tokens, not this JSX. Renders name, description, price, perks as feature bullets, and a
+// Subscribe button ONLY when plan.buyable is true (otherwise the plan is merchant-assigned).
+// The card links to the plan detail route by slug. `onSubscribe(plan)` runs the hosted checkout.
+//
+// plan.image is a WixMedia object { id, width, height, altText } with NO .url — its id must be
+// resolved to a URL before it can render. Rendering plan text only here avoids that trap; see
+// INSTRUCTIONS ("Plan image") for the resolve-or-omit fallback if you want the image.
+import { Link } from "react-router-dom";
+import PlanPrice from "./PlanPrice";
+
+export default function PlanCard({ plan, onSubscribe, featured = false }) {
+  return (
+    <div style={{
+      display: "flex", flexDirection: "column", gap: "var(--space)",
+      background: "var(--color-surface)", color: "var(--color-text)",
+      border: `1px solid ${featured ? "var(--color-accent)" : "var(--color-border)"}`,
+      borderRadius: "var(--radius)", overflow: "hidden", boxShadow: "var(--shadow)",
+      padding: "calc(var(--space) * 1.5)",
+    }}>
+      <div>
+        <h3 style={{ margin: "0 0 4px", fontFamily: "var(--font-display)", fontSize: 20, fontWeight: 700 }}>
+          {plan.name}
+        </h3>
+        {plan.description && (
+          <p style={{ margin: 0, color: "var(--color-muted)", lineHeight: 1.5 }}>{plan.description}</p>
+        )}
+      </div>
+
+      <PlanPrice plan={plan} />
+
+      {(plan.perks || []).length > 0 && (
+        <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 8 }}>
+          {plan.perks.map((perk) => (
+            <li key={perk.id} style={{ display: "flex", gap: 8, color: "var(--color-text)", lineHeight: 1.4 }}>
+              <span style={{ color: "var(--color-accent)" }} aria-hidden>✓</span>
+              <span>{perk.description}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div style={{ marginTop: "auto", display: "flex", flexDirection: "column", gap: 8 }}>
+        {plan.buyable && (
+          <button onClick={() => onSubscribe?.(plan)} style={{
+            padding: "12px 24px", cursor: "pointer",
+            background: "var(--color-primary)", color: "var(--color-on-primary)",
+            border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+          }}>Subscribe</button>
+        )}
+        <Link to={`/plans/${plan.slug}`} style={{
+          textAlign: "center", padding: "10px 24px", textDecoration: "none",
+          color: "var(--color-text)", border: "1px solid var(--color-border)",
+          borderRadius: "var(--radius-sm)", fontSize: 14, fontWeight: 600,
+        }}>View details</Link>
+      </div>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/PlanGrid.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/PlanGrid.jsx
@@ -1,0 +1,21 @@
+// Responsive plans grid + empty state. Token-styled; re-skin via theme.css.
+// Renders the shipped empty state when there are no plans — never invent plans.
+import PlanCard from "./PlanCard";
+
+export default function PlanGrid({ plans, onSubscribe, empty = "No plans yet." }) {
+  if (!plans?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+      gap: "var(--space)",
+      alignItems: "stretch",
+    }}>
+      {plans.map((plan) => <PlanCard key={plan.id} plan={plan} onSubscribe={onSubscribe} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/PlanPrice.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/PlanPrice.jsx
@@ -1,0 +1,35 @@
+// Plan price label — display only. The price is a decimal STRING at
+// pricingVariants[0].pricingStrategies[0].flatRate.amount ("0" = free); the recurring cycle is
+// nested at billingTerms.billingCycle; free-trial length at pricingVariants[0].freeTrialDays. These
+// exact paths are load-bearing — keep them. Never compute a final charge (Wix settles price, tax,
+// and schedule at hosted checkout). Token-styled; re-skin via theme.css.
+
+function readPrice(plan) {
+  const v = plan?.pricingVariants?.[0];
+  const amount = v?.pricingStrategies?.[0]?.flatRate?.amount;   // decimal STRING e.g. "20.00"; "0" = free
+  if (amount == null) return null;
+  const cycle = v?.billingTerms?.billingCycle;                  // { period, count } for recurring; absent otherwise
+  return { amount, isFree: amount === "0", cycle, freeTrialDays: v?.freeTrialDays };
+}
+
+export default function PlanPrice({ plan }) {
+  const p = readPrice(plan);
+  if (!p) return null;
+  if (p.isFree) {
+    return <span style={{ fontFamily: "var(--font-display)", fontSize: 28, fontWeight: 700 }}>Free</span>;
+  }
+  const per = p.cycle ? ` / ${p.cycle.count} ${p.cycle.period.toLowerCase()}` : "";   // e.g. "/ 1 month"
+  return (
+    <span>
+      <span style={{ fontFamily: "var(--font-display)", fontSize: 28, fontWeight: 700 }}>
+        {p.amount} {plan.currency}
+      </span>
+      {per && <span style={{ color: "var(--color-muted)", fontSize: 14 }}>{per}</span>}
+      {p.freeTrialDays ? (
+        <span style={{ display: "block", color: "var(--color-accent)", fontSize: 13, marginTop: 4 }}>
+          {p.freeTrialDays}-day free trial
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/hooks/useMyPlans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/hooks/useMyPlans.js
@@ -1,0 +1,25 @@
+// useMyPlans — "My plans" logic, no markup: load the logged-in member's orders and re-sync on
+// visibilitychange so a plan bought via hosted checkout shows up on return. getMyPlanOrders()
+// resolves to an ARRAY ([] for anonymous visitors — never throws), so the view can show a
+// "log in to see your plans" state. Keep the visibilitychange re-sync — it is load-bearing.
+import { useState, useEffect, useCallback } from "react";
+import { getMyPlanOrders } from "@/rest/wix-pricing-plans";
+
+export function useMyPlans({ orderStatuses = ["ACTIVE"] } = {}) {
+  const [orders, setOrders] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const refresh = useCallback(() => {
+    // [] for anonymous visitors (no member context) — never throws.
+    getMyPlanOrders({ orderStatuses }).then((o) => { setOrders(o); setLoaded(true); });
+  }, [orderStatuses]);
+
+  useEffect(() => {                                   // load once + re-sync on return from hosted checkout
+    refresh();
+    const onVisible = () => document.visibilityState === "visible" && refresh();
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refresh]);
+
+  return { orders, loaded, refresh };
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/hooks/usePlanDetail.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/hooks/usePlanDetail.js
@@ -1,0 +1,28 @@
+// usePlanDetail — plan-detail logic, no markup: load a single PUBLIC plan by its URL slug, expose a
+// notFound flag (getPlanBySlug returns null on a miss — show a not-found state, never invent a
+// plan), and start the members-only hosted checkout. Mirrors the storefront's useProductDetail.
+// The detail page only renders what this returns.
+import { useState, useEffect } from "react";
+import { getPlanBySlug, checkout } from "@/rest/wix-pricing-plans";
+
+export function usePlanDetail(slug) {
+  const [plan, setPlan] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    setPlan(null);
+    setNotFound(false);
+    getPlanBySlug(slug).then((p) => {
+      if (!p) return setNotFound(true);
+      setPlan(p);
+    });
+  }, [slug]);
+
+  // members-only, Wix-hosted checkout; on success Wix returns to thankYouPageUrl with ?planOrderId=<GUID>
+  async function subscribe() {
+    if (!plan) return;
+    window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.location.origin}/my-plans` });
+  }
+
+  return { plan, notFound, subscribe };
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/hooks/usePlans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/hooks/usePlans.js
@@ -1,0 +1,30 @@
+// usePlans — Plans-listing logic, no markup: load the first page of PUBLIC plans, page through with
+// the cursor, and start a members-only hosted checkout. The destructure of queryPlans() (returns
+// { plans, nextCursor }, NOT a bare array) and the checkout-then-redirect are load-bearing — keep
+// them. The Plans page only renders what this returns.
+import { useState, useEffect } from "react";
+import { queryPlans, checkout } from "@/rest/wix-pricing-plans";
+
+export function usePlans() {
+  const [plans, setPlans] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    // NB: destructure — queryPlans returns { plans, nextCursor }, NOT a bare array.
+    queryPlans().then(({ plans, nextCursor }) => { setPlans(plans); setCursor(nextCursor); setLoaded(true); });
+  }, []);
+
+  const loadMore = () =>
+    queryPlans({ cursor }).then(({ plans: more, nextCursor }) => {
+      setPlans((p) => [...p, ...more]);
+      setCursor(nextCursor);
+    });
+
+  // members-only, Wix-hosted checkout; on success Wix returns to thankYouPageUrl with ?planOrderId=<GUID>
+  async function subscribe(plan) {
+    window.location.href = await checkout(plan.id, { thankYouPageUrl: `${window.location.origin}/my-plans` });
+  }
+
+  return { plans, cursor, loaded, loadMore, subscribe };
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/pages/MyPlans.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/pages/MyPlans.jsx
@@ -1,0 +1,29 @@
+// My plans page — thin view over useMyPlans (all logic lives in the hook). Shows the logged-in
+// member's active memberships and doubles as the post-checkout confirmation (re-syncs on
+// visibilitychange). getMyPlanOrders() resolves to [] for anonymous visitors, so the empty branch
+// covers both "not a member → log in" and "member with no active plans". Token-styled via theme.css.
+import { useMyPlans } from "@/hooks/useMyPlans";
+import OrderCard from "@/components/OrderCard";
+
+export default function MyPlans() {
+  const { orders, loaded } = useMyPlans({ orderStatuses: ["ACTIVE"] });
+
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "calc(var(--space) * 2) var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>My plans</h1>
+      {!loaded ? (
+        <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+      ) : orders.length === 0 ? (
+        // [] = anonymous visitor OR a member with no active plans. Wire log-in via the members
+        // vertical (references/members/) so a member can sign in on your own UI, then re-check.
+        <p style={{ color: "var(--color-muted)" }}>
+          No active plans. Log in to see your plans, or choose one from the pricing page.
+        </p>
+      ) : (
+        <ul style={{ margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "var(--space)" }}>
+          {orders.map((order) => <OrderCard key={order.id} order={order} />)}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/pages/PlanDetail.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/pages/PlanDetail.jsx
@@ -1,0 +1,56 @@
+// Plan detail page — thin view over usePlanDetail (all logic lives in the hook). Shows the full
+// price/billing summary, perks, terms & conditions if present, and a Subscribe button (only when
+// plan.buyable). Not-found state on a bad slug — never invent a plan. Token-styled; re-skin via
+// theme.css. termsAndConditions is plain text; render as-is.
+import { useParams } from "react-router-dom";
+import { usePlanDetail } from "@/hooks/usePlanDetail";
+import PlanPrice from "@/components/PlanPrice";
+
+export default function PlanDetail() {
+  const { slug } = useParams();
+  const { plan, notFound, subscribe } = usePlanDetail(slug);
+
+  if (notFound) return <Centered>Plan not found.</Centered>;
+  if (!plan) return <Centered>Loading…</Centered>;
+
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "calc(var(--space) * 2) var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px" }}>{plan.name}</h1>
+      {plan.description && (
+        <p style={{ color: "var(--color-muted)", lineHeight: 1.6, margin: "0 0 var(--space)" }}>{plan.description}</p>
+      )}
+
+      <div style={{ margin: "var(--space) 0" }}><PlanPrice plan={plan} /></div>
+
+      {(plan.perks || []).length > 0 && (
+        <ul style={{ margin: "var(--space) 0", padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 10 }}>
+          {plan.perks.map((perk) => (
+            <li key={perk.id} style={{ display: "flex", gap: 8, lineHeight: 1.4 }}>
+              <span style={{ color: "var(--color-accent)" }} aria-hidden>✓</span>
+              <span>{perk.description}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {plan.buyable && (
+        <button onClick={subscribe} style={{
+          padding: "12px 32px", cursor: "pointer",
+          background: "var(--color-primary)", color: "var(--color-on-primary)",
+          border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+        }}>Subscribe</button>
+      )}
+
+      {plan.termsAndConditions && (
+        <div style={{ marginTop: "calc(var(--space) * 2)", paddingTop: "var(--space)", borderTop: "1px solid var(--color-border)" }}>
+          <h2 style={{ fontFamily: "var(--font-display)", fontSize: 16 }}>Terms &amp; conditions</h2>
+          <p style={{ color: "var(--color-muted)", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>{plan.termsAndConditions}</p>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/pages/Plans.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/pages/Plans.jsx
@@ -1,0 +1,31 @@
+// Plans / pricing page — thin view over usePlans (all logic lives in the hook). Lists PUBLIC plans
+// with an empty state, pages through with the cursor, and subscribes via the members-only hosted
+// checkout. Token-styled; re-skin via theme.css.
+import { usePlans } from "@/hooks/usePlans";
+import PlanGrid from "@/components/PlanGrid";
+
+export default function Plans() {
+  const { plans, cursor, loaded, loadMore, subscribe } = usePlans();
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Plans &amp; Pricing</h1>
+      {!loaded
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <PlanGrid
+            plans={plans}
+            onSubscribe={subscribe}
+            empty="No plans yet — create plans from your Wix dashboard."
+          />}
+      {cursor && (
+        <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 1.5)" }}>
+          <button onClick={loadMore} style={{
+            padding: "10px 24px", cursor: "pointer",
+            background: "var(--color-surface)", color: "var(--color-text)",
+            border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)", fontWeight: 600,
+          }}>Load more</button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/pricing-plans/app/theme.css
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/theme.css
@@ -1,0 +1,36 @@
+/* theme.css — THE styling surface. Theme the whole Plans & Pricing client by editing these tokens
+   to the brand; do NOT restyle the components' JSX. Every template component reads these variables,
+   so changing them here re-skins the entire pricing page. Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* plan cards, wells */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text, descriptions */
+  --color-border:    #e5e7eb;   /* hairlines, card borders */
+  --color-primary:   #111827;   /* buy/subscribe buttons, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* highlighted / "most popular" plan, badges */
+  --color-danger:    #dc2626;   /* errors */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1200px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **pricing-plans** to the storefront-as-files model: plans grid + detail + my-plans; hosted-checkout redirect (no provider).

- `references/pricing-plans/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (13 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)