### PR TITLE
feat(bookings): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -1,336 +1,252 @@
+# Wix Bookings — ready-made client
 
-# Wix Bookings Skill
+The bookings client is **shipped as real files**, not snippets to regenerate. It's a complete
+service catalog + detail page + slot picker + booking flow (create booking → hosted checkout),
+styled entirely from `theme.css` tokens. Copy it into the app, theme the tokens, wire the routes —
+you generate almost none of the booking code (the `{ services }` / `{ slots }` destructuring, the
+local wall-clock date args, the null-slot re-validate guard, the participant cap, the eCom
+redirect-session all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and both bookings helpers from `references/bookings/`. `wix-client.js` imports from `"./wix-config.js"` and the helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`). Copy **both** helpers for the full booking flow:
->
-> | File | What it covers |
-> |---|---|
-> | `wix-bookings-services.js` | Service listing, slot availability, media URL helper |
-> | `wix-bookings-checkout.js` | Create booking, hosted checkout, bookAndCheckout convenience |
-
-Builds a real, client-only Wix Bookings front end. The browser talks to Wix directly over a
-public `WIX_CLIENT_ID`. Never mock services or slots; never hand-build a `/checkout` URL —
-always create the booking through the API and complete it via the eCom checkout + redirect-session.
-
-This skill ships the single-service booking flow for **APPOINTMENT and CLASS** services: browse
-services → pick a service → pick an available slot → enter details → book → hosted checkout.
-Appointments and classes differ only in the availability call (`listAvailableSlots` vs
-`listEventTimeSlots`); `listSlotsForService` routes by `service.type`, and `createBooking` handles
-either slot. **COURSE (whole-course enrollment) is not covered** — see "Beyond the snippets".
-
-## When to use
-- User wants a Wix Bookings appointment site or asks to "connect Wix Bookings".
-- Replacing placeholder/mock services or fake calendars with live Wix data.
-- Adding service listings, a slot picker, booking creation, or checkout over an existing
-  Wix Bookings setup.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock
+services or slots; never hand-build a `/checkout` URL — the shipped flow creates the booking through
+the API and completes it via the eCom redirect-session.
 
 ## Prerequisites
-1. A Wix site with **Wix Bookings installed and at least one appointment service created**
-   (this skill does NOT provision — it's read-only over services). Staff/resources and a
-   booking policy should be configured so slots are bookable.
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Set it
-   in `src/rest/wix-config.js` in place of the placeholder. It is a buyer-facing credential
-   (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/committing it is fine.
-3. The site must **accept payments** for paid services, and the deployed app domain must be
-   allow-listed on the OAuth client for Wix-hosted checkout to return. These are **separate Wix
-   setup flows the user completes later** — out of this skill's scope. If checkout return fails
-   before that setup is done, that's expected; flag it and continue.
+- The site's **Wix Bookings** setup is the read/book target. It's installed and seeded separately
+  (see **Seeding** below), in parallel with this build — so it may have no services at build time;
+  the client renders the shipped empty state until services (and staff/working hours, so slots are
+  bookable) land. This client is read-only over services — it does not provision them.
+- The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
+- For **paid** services, the site must accept payments and the deployed app domain must be
+  allow-listed on the OAuth client for the hosted checkout to return. Those are separate Wix setup
+  flows the user completes later — out of scope here; if checkout return fails before that, it's
+  expected, flag it and continue.
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the booking UI however the
-project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
-adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
-  `wix-config.js`. The visitor refresh token IS the booking visitor identity; it is persisted to
-  localStorage. Do not re-mint anonymously per load.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-bookings-services.js` — **Services & availability:**
-  `queryServices`, `getService`, `countServices`, `listAvailableSlots`, `getAvailableSlot`,
-  `mediaUrl` (resolve a service image to an absolute URL)
-- `src/rest/wix-bookings-checkout.js` — **Booking & checkout:**
-  `createBooking`, `checkoutBooking`, `bookAndCheckout`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole bookings UI client + REST scaffolds into
+`src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map,
+so you don't need to open them:**
 
-The `Service`, `TimeSlot`, and `Booking` shapes are documented as JSDoc comments at the top of
-each helper file. Read them before building the UI — they describe the key fields and link to
-the full API reference for anything not shown.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `hooks/useServices.js` | services-list data — one page + `loadMore` paging; `total === 0` → empty state |
+| `hooks/useServiceDetail.js` | detail + booking flow — load service, list slots, hold slot/contact/participants, re-validate + book + checkout |
+| `components/ServiceCard.jsx`, `ServiceGrid.jsx` | service listing UI (grid + card, with empty state) |
+| `components/SlotPicker.jsx` | bookable-slot chips + paging (pure UI, driven by `useServiceDetail`) |
+| `components/BookingForm.jsx` | contact + participant form (pure UI, driven by `useServiceDetail`) |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Services.jsx`, `pages/ServiceDetail.jsx` | the two shipped routes (`/services`, `/service/:serviceId`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` | REST transport — mints/persists the anonymous visitor token |
+| `rest/wix-bookings-services.js` | services + availability: `queryServices`, `getService`, `countServices`, `listSlotsForService`, `listAvailableSlots`, `listEventTimeSlots`, `getAvailableSlot`, `mediaUrl` |
+| `rest/wix-bookings-checkout.js` | booking + checkout: `createBooking`, `checkoutBooking`, `bookAndCheckout` |
 
-## How to wire it (UI is the project's choice)
-- **Service list** — `const { services, total, nextOffset } = await queryServices({ limit, offset })`
-  for the listing (visitor-visible services only); it returns an **object, not a bare array** —
-  destructure it, then render `.services`. Each service's id is `service.id`. Render `name`,
-  `tagLine`, the image via `mediaUrl(service.media?.items?.[0]?.image)`, and the price from
-  `payment.fixed.price`. `value` + `currency` are always present; `formattedValue` is
-  **optional** (it may be missing), so don't depend on it — build the price from `value`+`currency`
-  and use `formattedValue` only when present. e.g. `new Intl.NumberFormat(undefined, { style:
-  'currency', currency }).format(Number(value))`. (Rendering `formattedValue` alone leaves the price
-  blank — or your "Varies" fallback — whenever it's absent.) Pass the returned `nextOffset` back as
-  `offset` to load the next page (it is `null` on the last page). See the **`pages/Services.jsx`**
-  snippet below. Books **APPOINTMENT and CLASS** services (see the slot picker below); COURSE is
-  whole-course enrollment and out of scope.
-- **Service detail** — `getService(serviceId)` keyed off the URL/route; returns null on miss —
-  show a not-found state, never invent a service. Render `description`, price, and `locations`.
-- **Slot picker** — `const { slots, nextCursor } = await listSlotsForService(service, { fromLocalDate, toLocalDate, timeZone? })`:
-  it routes by `service.type` — APPOINTMENT → `listAvailableSlots` (staff working hours), CLASS/COURSE
-  → `listEventTimeSlots` (scheduled sessions). Both return the same `{ slots, nextCursor }` shape;
-  iterate `.slots`. (Call the specific function directly if you already know the type.) Dates are
-  **local** wall-clock strings `"YYYY-MM-DDThh:mm:ss"` (no zone), interpreted in `timeZone` (defaults
-  to the visitor's IANA zone). **Mind the date-arg naming difference:** the list calls take
-  `fromLocalDate`/`toLocalDate`, while the single-slot re-validate call (`getAvailableSlot`, below)
-  takes `localStartDate`/`localEndDate` — they are not interchangeable. Only `bookable: true` slots
-  come back. Render each `slot.localStartDate`/`localEndDate`; group by day for a calendar. Pass
-  `nextCursor` back as `cursor` to page. See the **`SlotPicker.jsx`** snippet below.
-- **Booking form** — collect the buyer's `firstName`, `lastName`, `email`, `phone`. Keep it
-  minimal; richer per-service form fields live in the service's `form.id` (see "Beyond the snippets").
-- **Participant count** — cap it by the service policy, not just slot capacity. The most a single
-  booking may reserve is `service.bookingPolicy.participantsPolicy.maxParticipantsPerBooking`. Only
-  render a participant selector when that value is `> 1`, and bound its max at
-  `min(maxParticipantsPerBooking, slot.remainingCapacity)` for a class; when it is `1` (the common
-  case) show no selector and book exactly one. Never offer a fixed range like 1–4 — the slot's
-  `remainingCapacity` tells you the class's open spots, not how many one buyer may take, so relying
-  on it alone lets the buyer pick a count that `createBooking` then rejects. Pass the chosen count
-  as `createBooking`'s `totalParticipants`.
-- **Re-validate + book** — right before submitting, call
-  `const slot = await getAvailableSlot(serviceId, { localStartDate, localEndDate, timeZone? })` to
-  confirm the slot is still open (and to pick up the staff resource). It returns the slot object or
-  **`null`** if the time was just taken — **guard for `null`** and prompt for another slot; never
-  book a null slot. Then create + check out in one step:
-  `window.location.href = (await bookAndCheckout(slot, { email, firstName, lastName, phone }, { totalParticipants })).checkoutUrl;`
-  (`bookAndCheckout` returns `{ booking, checkoutUrl }`.) Or split it — note `createBooking` is the
-  **3-arg** form `(slot, contact, options)` and `checkoutBooking` returns a **bare URL string**:
-  `const booking = await createBooking(slot, contact, { totalParticipants, timeZone }); window.location.href = await checkoutBooking(booking.id);`
-  See the **`BookingForm.jsx`** snippet below.
-- **Confirmation / return** — after the buyer returns from hosted checkout, the order is placed
-  and Wix Bookings confirms the booking automatically (status becomes `CONFIRMED`, or `PENDING`
-  if the service needs manual approval). Show a confirmation screen on return.
-- **Empty state** — if `countServices()` is 0, show an empty state telling the user to add a
-  service in their Wix dashboard. Never invent services.
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each
+is, and every field shape you need is in the snippets below. Read a shipped file's source **only**
+on a real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at
+the end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/bookings/app/` → `src/`.)
 
-## Hard rules (do not violate)
-- ✅ Book ONLY via `createBooking()` → `checkoutBooking()` (or `bookAndCheckout()`), then redirect
-  to the returned URL: `window.location.href = await checkoutBooking(bookingId)` — `checkoutBooking`
-  returns a **bare URL string** (not an object; no `.fullUrl`), and `bookAndCheckout` returns
-  `{ booking, checkoutUrl }` (redirect to `checkoutUrl`).
-- ❌ Never hand-build a `/checkout`, booking, or calendar URL.
-- ❌ Never mock services, time slots, or availability — render live Wix data or the empty state.
-- ❌ Never invent reviews, ratings, staff, or testimonials. Empty review UI only.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Send availability/booking dates as **local** `"YYYY-MM-DDThh:mm:ss"` strings plus a
-  `timeZone` — do not send UTC `Z` timestamps to the slot APIs.
-- ✅ Re-validate the slot with `getAvailableSlot()` before `createBooking()` — slots get taken.
-- ✅ Cap participant count at `service.bookingPolicy.participantsPolicy.maxParticipantsPerBooking`
-  (render no selector when it is 1); never offer a fixed range and never use slot capacity as the
-  per-buyer limit — a count above the policy makes `createBooking` fail.
-- The client fails loudly on purpose: `createBooking`/`checkoutBooking` throw on an unbookable
-  slot, a missing booking id, or a missing redirect URL. A green path means it's really bookable —
-  don't swallow these.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
-## Beyond the snippets
-The snippets cover **APPOINTMENT and CLASS** bookings (the slot picker routes by `service.type`).
-For anything beyond that, extend the client: add a new helper on `wixApiRequest`, looking up the
-exact endpoint, method, and body in the **official Wix API reference** first (never guess):
-- Official Wix API reference: https://dev.wix.com/docs/api-reference.md
-- Single-service booking flow (the full picture): https://dev.wix.com/docs/api-reference/business-solutions/bookings/flow-single-service-booking.md
-- **Courses are NOT covered — a course is enrolled as a *whole*, not booked per session.**
-  `listEventTimeSlots` returns **no** per-session slots for a COURSE (verified — empty even for admin),
-  so the slot-picker flow doesn't apply. Enrolling in a course uses a course-specific flow (whole-course
-  capacity computed from bookings) that these snippets don't implement —
-  https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings/bookings-reader-v2/query-extended-bookings.md
-- **Service variants / participants** (duration- or person-based pricing):
-  https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/service-options-and-variants/get-service-options-and-variants-by-service-id.md
-- **Add-ons:** https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/list-add-on-groups-by-service-id.md
-- **Custom booking form fields** (render `service.form.id`): Get Form Summary —
-  https://dev.wix.com/docs/rest/crm/forms/form-schemas/get-form-summary.md
-- **Member login + a "my bookings" account view** → the **members** vertical
-  (`references/members/INSTRUCTIONS.md`): booking itself works anonymously, but signing a member in
-  (custom login on your own UI) lets them see their own appointments/history.
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole site. **Do not restyle
+the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the home
+page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the dark
+tokens with `document.documentElement.dataset.theme = "dark"`.
 
-Keep the snippets as the default for everything they already do; reach for the API reference
-only for the gap.
+## STEP 4 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it. Bookings needs **no cross-page provider** (there's no cart — each booking completes on
+its own detail page), so there's nothing to wrap the tree in.
+- `import "@/theme.css";` once at the app entry.
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Services` / `ServiceDetail` — so you **never edit the shipped pages to add
+  a header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's **ResizeObserver-measured** height so it clears the chrome and
+  self-corrects when the banner is dismissed.
+- Routes under the Layout: `/services` → `Services`, `/service/:serviceId` → `ServiceDetail` (both
+  shipped, as-is). **You add `/` → your own Home** page.
 
-## Reference components (headless — adapt the logic, restyle freely)
+```jsx
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Services from "@/pages/Services";
+import ServiceDetail from "@/pages/ServiceDetail";
+import Home from "@/pages/Home";           // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
 
-These are the recurring bookings pieces, written **headless**: the data wiring (Wix field paths,
-`{ services, ... }` / `{ slots, ... }` destructuring, the local-date arg names, the null-slot guard,
-the participant cap) is correct and complete — the markup is deliberately plain. **Copy the logic
-exactly; restyle the JSX to the brand.** They consume the `src/rest/` helpers; you don't need to
-read those helpers' source.
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Services/ServiceDetail render here, untouched */}
+      <Footer />
+    </div>
+  </>);
+}
 
-**`pages/Services.jsx`** — the service listing (grid + empty state + paging). `queryServices`
-returns an **object, not a bare array** — `{ services, total, nextOffset }`; destructure first
-(calling `.map` on the returned object throws `… is not a function`). The id is `service.id`;
-`payment.fixed.price.formattedValue` is optional, so format from `value`+`currency`.
+<Routes>
+  <Route element={<Layout />}>                                       {/* chrome wraps all */}
+    <Route path="/" element={<Home />} />                            {/* yours */}
+    <Route path="/services" element={<Services />} />                {/* shipped, as-is */}
+    <Route path="/service/:serviceId" element={<ServiceDetail />} /> {/* shipped, as-is */}
+  </Route>
+</Routes>
+```
+
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the
+`Layout` (STEP 4) so they wrap every route — plus the overall brand story, styled from the same
+`theme.css` tokens. **Compose the shipped pieces** — a "featured services" strip is just
+`queryServices` + the shipped `ServiceGrid`; the nav is a link to `/services`:
 
 ```jsx
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { queryServices, mediaUrl } from "@/rest/wix-bookings-services";
+import { queryServices } from "@/rest/wix-bookings-services";
+import ServiceGrid from "@/components/ServiceGrid";
 
-export default function Services() {
-  const [services, setServices] = useState([]);
-  const [nextOffset, setNextOffset] = useState(null);
-  const [total, setTotal] = useState(null);
-
+// Responsive header: choose ONE branch with a state flag (copy this pattern). Do NOT render a
+// desktop nav AND a mobile nav toggled by Tailwind `hidden md:flex` / `md:hidden`: these navs are
+// inline-styled, and an inline `display` beats a Tailwind class, so `hidden` never applies — BOTH
+// branches render. One branch = one nav.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
   useEffect(() => {
-    // queryServices returns an OBJECT, not a bare array — destructure it.
-    queryServices({ limit: 24 }).then(({ services, total, nextOffset }) => {
-      setServices(services);
-      setTotal(total);
-      setNextOffset(nextOffset);
-    });
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
   }, []);
-
-  const loadMore = () =>
-    queryServices({ limit: 24, offset: nextOffset }).then(({ services: more, nextOffset: next }) => {
-      setServices((s) => [...s, ...more]);
-      setNextOffset(next);
-    });
-
-  if (total === 0) return <p>{/* empty state — add a service in the Wix dashboard */}</p>;
   return (
-    <div /* restyle */>
-      {services.map((service) => {
-        const image = mediaUrl(service.media?.items?.[0]?.image);
-        const p = service.payment?.fixed?.price;                     // may be absent (free / custom-priced)
-        const price = p && (p.formattedValue                         // formattedValue is OPTIONAL — build from value+currency when missing
-          || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value)));
-        return (
-          <Link key={service.id} to={`/service/${service.id}`} /* the service id is service.id */>
-            {image && <img src={image} alt={service.name} loading="lazy" />}
-            <h3>{service.name}</h3>
-            {service.tagLine && <p>{service.tagLine}</p>}
-            {price && <span>{price}</span>}
-          </Link>
-        );
-      })}
-      {nextOffset != null && <button onClick={loadMore}>Load more</button>}
-    </div>
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile ? <YourMenu /> : <Link to="/services">Services</Link>}
+    </nav>
   );
 }
+export function Featured() {                                // on your home page
+  const [services, setServices] = useState([]);
+  // NB: queryServices returns { services, total, nextOffset } — destructure the array.
+  useEffect(() => { queryServices({ limit: 6 }).then(({ services }) => setServices(services)); }, []);
+  return <ServiceGrid services={services} empty="Services coming soon." />;
+}
 ```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
 
-**`SlotPicker.jsx`** — lists bookable slots for a chosen service. `listSlotsForService` routes by
-`service.type` and returns `{ slots, nextCursor }`; iterate `.slots`, page with `nextCursor`. The
-**list** call takes `fromLocalDate`/`toLocalDate` (local wall-clock, no zone) — a different arg
-naming than the single-slot `getAvailableSlot`.
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev
+preview can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a
+fresh full navigate/reload of the preview and re-check — don't keep rewriting correct code against a
+stale render.
+
+## Using the client from your own UI
+The two shipped hooks are the whole flow. If you build a custom surface, drive it the same way:
 
 ```jsx
-import { useState, useEffect } from "react";
-import { listSlotsForService } from "@/rest/wix-bookings-services";
+// LIST — every list helper returns an OBJECT, not a bare array. Destructure it:
+const { services, total, nextOffset } = await queryServices({ limit: 24 });   // total 0 → empty state
+if ((await countServices()) === 0) { /* show the empty state — never invent services */ }
 
-// Local wall-clock "YYYY-MM-DDThh:mm:ss" (NO zone / Z) — the slot APIs interpret it in timeZone.
-function localMidnight(daysFromNow = 0) {
-  const d = new Date();
-  d.setDate(d.getDate() + daysFromNow);
-  const pad = (n) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T00:00:00`;
-}
+// DETAIL — getService(id) is keyed off the route param; returns null on a miss (not-found, never invent):
+const service = await getService(serviceId);
 
-export default function SlotPicker({ service, onPick }) {
-  const [slots, setSlots] = useState([]);
-  const [cursor, setCursor] = useState(null);
+// PRICE — payment.fixed.price.formattedValue is OPTIONAL; build from value+currency when missing:
+const p = service.payment?.fixed?.price;
+const price = p && (p.formattedValue
+  || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value)));
 
-  useEffect(() => {
-    // listSlotsForService routes by service.type and returns { slots, nextCursor }. Note the arg names:
-    // the LIST call uses fromLocalDate / toLocalDate (getAvailableSlot, the single-slot re-validate
-    // call, uses localStartDate / localEndDate instead).
-    listSlotsForService(service, { fromLocalDate: localMidnight(0), toLocalDate: localMidnight(14) })
-      .then(({ slots, nextCursor }) => { setSlots(slots); setCursor(nextCursor); });
-  }, [service]);
+// IMAGE — resolve through mediaUrl (Wix media can be a bare handle, not a full URL):
+const img = mediaUrl(service.media?.items?.[0]?.image);
 
-  const loadMore = () =>
-    listSlotsForService(service, { cursor }).then(({ slots: more, nextCursor }) => {
-      setSlots((s) => [...s, ...more]);
-      setCursor(nextCursor);
-    });
+// SLOTS — listSlotsForService routes by service.type and returns { slots, nextCursor }; iterate .slots.
+// Dates are LOCAL wall-clock "YYYY-MM-DDThh:mm:ss" (NO zone / Z). The LIST call takes
+// fromLocalDate/toLocalDate — the single-slot re-validate (getAvailableSlot) takes
+// localStartDate/localEndDate. They are NOT interchangeable.
+const { slots, nextCursor } = await listSlotsForService(service, { fromLocalDate, toLocalDate });
 
-  return (
-    <div /* restyle: group slots by day for a calendar */>
-      {slots.map((slot) => (
-        <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
-          onClick={() => onPick(slot)}>
-          {new Date(slot.localStartDate).toLocaleString()}
-        </button>
-      ))}
-      {cursor && <button onClick={loadMore}>Load more</button>}
-    </div>
-  );
-}
+// BOOK — re-validate the picked slot (getAvailableSlot returns the slot or NULL — guard it), then
+// book + check out and redirect. Participants: cap at
+// service.bookingPolicy.participantsPolicy.maxParticipantsPerBooking (commonly 1 → no selector);
+// never use slot.remainingCapacity as the per-buyer limit.
+const fresh = await getAvailableSlot(service.id, { localStartDate, localEndDate });
+if (!fresh) { /* "that time was just taken — pick another" */ }
+const { checkoutUrl } = await bookAndCheckout(fresh, { email, firstName, lastName, phone }, { totalParticipants });
+window.location.href = checkoutUrl;   // hosted checkout; on return the booking is CONFIRMED/PENDING
 ```
 
-**`BookingForm.jsx`** — re-validate the picked slot, then book + check out. `getAvailableSlot`
-returns the slot **or `null`** (guard it — the time may have just been taken). `createBooking` is
-the 3-arg form `(slot, contact, { totalParticipants, timeZone })`, and `checkoutBooking` returns a
-**bare URL string** you redirect straight to.
+## Extending the client
+The shipped flow covers **APPOINTMENT and CLASS** services (`listSlotsForService` routes by
+`service.type`). For anything beyond that, add a helper on `wixApiRequest`, looking the endpoint up
+in the **`wix-docs`** skill first (never guess):
+- **COURSE** enrollment — a course is enrolled as a *whole*, not per session; `listEventTimeSlots`
+  returns no slots for it, so the slot-picker flow doesn't apply (course-specific flow).
+- **Service variants / participants** (duration- or person-based pricing), **add-ons**, and
+  **custom booking form fields** (render `service.form.id`).
+- **Member login + a "my bookings" view** → the **members** vertical
+  (`references/members/INSTRUCTIONS.md`): booking works anonymously, but signing a member in lets
+  them see their own appointments.
 
-```jsx
-import { useState } from "react";
-import { getAvailableSlot } from "@/rest/wix-bookings-services";
-import { createBooking, checkoutBooking } from "@/rest/wix-bookings-checkout";
+Fallback only — when you hit an error or need something not shown here: read the relevant shipped
+file under `src/`, or look it up via the **`wix-docs`** skill.
 
-export default function BookingForm({ service, slot }) {
-  const [contact, setContact] = useState({ firstName: "", lastName: "", email: "", phone: "" });
-  const [submitting, setSubmitting] = useState(false);
-
-  // maxParticipantsPerBooking is the per-booking cap (commonly 1 → no selector at all). Never use
-  // slot.remainingCapacity as the per-buyer limit — a count above the policy makes createBooking fail.
-  const maxParticipants = service.bookingPolicy?.participantsPolicy?.maxParticipantsPerBooking ?? 1;
-  const [participants, setParticipants] = useState(1);
-  const set = (k) => (e) => setContact((c) => ({ ...c, [k]: e.target.value }));
-
-  async function handleSubmit(e) {
-    e.preventDefault();
-    setSubmitting(true);
-    try {
-      // Re-validate right before booking — slots get taken. getAvailableSlot returns the slot or NULL;
-      // the single-slot call uses localStartDate / localEndDate (not from/toLocalDate).
-      const fresh = await getAvailableSlot(service.id, {
-        localStartDate: slot.localStartDate,
-        localEndDate: slot.localEndDate,
-      });
-      if (!fresh) { alert("That time was just taken — please pick another."); return; }
-
-      // createBooking is the 3-arg form: (slot, contact, options). Pass the chosen count as totalParticipants.
-      const booking = await createBooking(fresh, contact, { totalParticipants: participants });
-      // checkoutBooking returns a BARE URL string (not an object) — redirect straight to it.
-      window.location.href = await checkoutBooking(booking.id);
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  return (
-    <form onSubmit={handleSubmit} /* restyle */>
-      <input required type="email" placeholder="Email" value={contact.email} onChange={set("email")} />
-      <input placeholder="First name" value={contact.firstName} onChange={set("firstName")} />
-      <input placeholder="Last name" value={contact.lastName} onChange={set("lastName")} />
-      <input placeholder="Phone" value={contact.phone} onChange={set("phone")} />
-      {maxParticipants > 1 && (
-        <input type="number" min={1} max={maxParticipants} value={participants}
-          onChange={(e) => setParticipants(Number(e.target.value))} />
-      )}
-      <button type="submit" disabled={submitting}>Book</button>
-    </form>
-  );
-}
-```
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+  `Services`/`ServiceDetail` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
+  `Header` is plain in-flow markup (not `position:fixed`).
+- Send availability/booking dates as **local** `"YYYY-MM-DDThh:mm:ss"` strings + a `timeZone` — never
+  UTC `Z` timestamps to the slot APIs.
+- Re-validate the slot with `getAvailableSlot()` before booking; guard the `null` — slots get taken.
+- Cap participants at `maxParticipantsPerBooking` (no selector when 1); never offer a fixed range and
+  never use slot capacity as the per-buyer limit.
+- Book only through the shipped flow (`bookAndCheckout` / `createBooking`→`checkoutBooking`) and
+  redirect to the returned URL — never a hand-built `/checkout` or calendar URL.
+- Render live Wix data or the shipped empty state — never mock services, slots, or availability, and
+  never invent reviews, ratings, staff, or testimonials.
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the bookings content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For bookings data those pages are:
-- **Booking Services** — `https://manage.wix.com/dashboard/{metaSiteId}/bookings/services` (`Dashboard → Bookings → Booking Services`; add services and service categories)
-- **Staff** — `https://manage.wix.com/dashboard/{metaSiteId}/bookings/staff` (`Dashboard → Bookings → Staff`; add staff and set working hours, so slots are actually bookable)
+Provide deep links so the owner can manage bookings content (substitute the site's `metaSiteId`):
+- **Booking Services** — `https://manage.wix.com/dashboard/{metaSiteId}/bookings/services` (add
+  services and service categories)
+- **Staff** — `https://manage.wix.com/dashboard/{metaSiteId}/bookings/staff` (add staff and set
+  working hours, so slots are actually bookable)
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed the services per `seed/SEED.md` (the build-time setup module) — separate from this client
+build; run in parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (same visitor identity across reloads)
-- [ ] `queryServices()` renders live services; `countServices()` 0 → empty state (no mock services)
-- [ ] `listAvailableSlots()` returns real bookable slots for a chosen service and date range
-- [ ] Slot is re-validated with `getAvailableSlot()` immediately before booking
-- [ ] Participant selector capped by `maxParticipantsPerBooking` (hidden when 1) — a count above the policy is not offerable
-- [ ] `createBooking()` returns a booking with `status: "CREATED"` and a real id
-- [ ] Checkout redirects to the URL `checkoutBooking()` returns (a bare string) — or `bookAndCheckout()`'s `checkoutUrl` — with no hand-built URL
-- [ ] On return from checkout the booking is confirmed (status `CONFIRMED`/`PENDING`)
-- [ ] No mock services, slots, or availability anywhere
-- [ ] Told the user at least once that they can continue setting up their bookings in the dashboard and provided deep links.
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all
+      routes; shipped `Services`/`ServiceDetail` untouched; content clears the fixed chrome.
+- [ ] Visitor token persists across reload (same visitor identity across reloads).
+- [ ] `queryServices()` renders live services; empty catalog shows the shipped empty state (no mock services).
+- [ ] Slot picker shows real bookable slots; the slot is re-validated with `getAvailableSlot()` right before booking.
+- [ ] Participant selector capped by `maxParticipantsPerBooking` (hidden when 1).
+- [ ] Booking redirects to the hosted checkout URL the client returns; on return the booking is CONFIRMED/PENDING.
+- [ ] No mock services, slots, or availability anywhere.

--- a/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
@@ -1,0 +1,44 @@
+// Contact + participants form — pure UI. All state/handlers (field setters, participant cap,
+// submit, submitting, error) come from useServiceDetail; this only renders them. The participant
+// selector shows ONLY when maxParticipants > 1 (commonly 1 → no selector, book exactly one).
+// Token-styled; re-skin via theme.css.
+const field = {
+  width: "100%", padding: "10px 12px", boxSizing: "border-box", fontFamily: "var(--font-body)",
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-bg)", color: "var(--color-text)",
+};
+
+export default function BookingForm({
+  contact, setContactField, maxParticipants, participants, setParticipants,
+  onSubmit, submitting, canSubmit, error,
+}) {
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }}
+      style={{ display: "flex", flexDirection: "column", gap: "var(--space)" }}>
+      <input required type="email" placeholder="Email" value={contact.email} onChange={setContactField("email")} style={field} />
+      <div style={{ display: "flex", gap: "var(--space)" }}>
+        <input placeholder="First name" value={contact.firstName} onChange={setContactField("firstName")} style={field} />
+        <input placeholder="Last name" value={contact.lastName} onChange={setContactField("lastName")} style={field} />
+      </div>
+      <input placeholder="Phone" value={contact.phone} onChange={setContactField("phone")} style={field} />
+
+      {maxParticipants > 1 && (
+        <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: 13, color: "var(--color-muted)" }}>
+          Participants
+          <input type="number" min={1} max={maxParticipants} value={participants}
+            onChange={(e) => setParticipants(Math.max(1, Math.min(maxParticipants, Number(e.target.value) || 1)))}
+            style={{ ...field, width: 100 }} />
+        </label>
+      )}
+
+      {error && <p style={{ margin: 0, color: "var(--color-danger)", fontSize: 14 }}>{error}</p>}
+
+      <button type="submit" disabled={!canSubmit} style={{
+        padding: "12px 24px", cursor: canSubmit ? "pointer" : "not-allowed",
+        background: "var(--color-primary)", color: "var(--color-on-primary)",
+        border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+        opacity: canSubmit ? 1 : 0.5,
+      }}>{submitting ? "Booking…" : "Book"}</button>
+    </form>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
@@ -1,0 +1,41 @@
+// Grid tile for one bookable service. Styled entirely from theme.css tokens (var(--...)) — re-skin
+// via those tokens, not this JSX. The load-bearing bits: the image goes through mediaUrl() (Wix
+// media can be a bare handle), the id is `service.id`, and the price is built from value+currency
+// because `formattedValue` is OPTIONAL (rendering it alone leaves the price blank when it's absent).
+import { Link } from "react-router-dom";
+import { mediaUrl } from "@/rest/wix-bookings-services";
+
+function servicePrice(service) {
+  const p = service?.payment?.fixed?.price;
+  if (!p) return null;                                      // free / custom-priced
+  return p.formattedValue
+    || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value));
+}
+
+export default function ServiceCard({ service }) {
+  const image = mediaUrl(service.media?.items?.[0]?.image);
+  const price = servicePrice(service);
+
+  return (
+    <Link to={`/service/${service.id}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      <div style={{ position: "relative", aspectRatio: "4 / 3", background: "var(--color-bg)" }}>
+        {image
+          ? <img src={image} alt={service.name} loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          : <div style={{ width: "100%", height: "100%" }} />}
+      </div>
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 4 }}>
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 15, fontWeight: 600 }}>{service.name}</h3>
+        {service.tagLine && (
+          <p style={{ margin: 0, color: "var(--color-muted)", fontSize: 13 }}>{service.tagLine}</p>
+        )}
+        {price && <span style={{ fontWeight: 600, color: "var(--color-accent)" }}>{price}</span>}
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/components/ServiceGrid.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/ServiceGrid.jsx
@@ -1,0 +1,19 @@
+// Responsive service grid + empty state. Token-styled; re-skin via theme.css.
+import ServiceCard from "./ServiceCard";
+
+export default function ServiceGrid({ services, empty = "No services yet." }) {
+  if (!services?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+      gap: "var(--space)",
+    }}>
+      {services.map((s) => <ServiceCard key={s.id} service={s} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
@@ -1,0 +1,41 @@
+// Bookable-slot picker — pure UI. Slots, paging cursor, and the pick handler come from
+// useServiceDetail (all the slot data wiring lives in that hook). Each slot's key must combine the
+// start time with its schedule/event id so appointment and class slots stay distinct. Token-styled;
+// re-skin via theme.css (e.g. group `slots` by day for a fuller calendar).
+const chipBase = {
+  padding: "8px 12px", cursor: "pointer", fontSize: 14, fontFamily: "var(--font-body)",
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-surface)", color: "var(--color-text)",
+};
+const chipActive = { background: "var(--color-primary)", color: "var(--color-on-primary)", borderColor: "var(--color-primary)" };
+
+export default function SlotPicker({ slots, cursor, onLoadMore, selectedSlot, onPick }) {
+  if (!slots?.length) {
+    return <p style={{ color: "var(--color-muted)" }}>No available times in this range — try later.</p>;
+  }
+  return (
+    <div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {slots.map((slot) => {
+          const active = selectedSlot?.localStartDate === slot.localStartDate;
+          return (
+            <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
+              aria-pressed={active} onClick={() => onPick(slot)}
+              style={{ ...chipBase, ...(active ? chipActive : null) }}>
+              {new Date(slot.localStartDate).toLocaleString(undefined, {
+                weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+              })}
+            </button>
+          );
+        })}
+      </div>
+      {cursor && (
+        <button onClick={onLoadMore} style={{
+          marginTop: "var(--space)", padding: "8px 16px", cursor: "pointer",
+          background: "var(--color-surface)", color: "var(--color-text)",
+          border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+        }}>Load more times</button>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/hooks/useServiceDetail.js
+++ b/skills/wix-vibe-headless/references/bookings/app/hooks/useServiceDetail.js
@@ -1,0 +1,101 @@
+// useServiceDetail — all detail + booking-flow logic, no markup: load a service by id, list its
+// bookable slots, hold the buyer's slot/contact/participant selections, then re-validate and book +
+// check out in one step. The data paths here are the bug-prone part — keep them verbatim; the
+// ServiceDetail page and the SlotPicker/BookingForm components only render what this returns.
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { getService, listSlotsForService, getAvailableSlot } from "@/rest/wix-bookings-services";
+import { bookAndCheckout } from "@/rest/wix-bookings-checkout";
+
+// Local wall-clock "YYYY-MM-DDThh:mm:ss" (NO zone / Z) — the slot APIs interpret it in the
+// visitor's timeZone. Sending a UTC `Z` timestamp to the slot APIs is wrong.
+function localMidnight(daysFromNow = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T00:00:00`;
+}
+
+export function useServiceDetail(serviceId) {
+  const [service, setService] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const [slots, setSlots] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [selectedSlot, setSelectedSlot] = useState(null);
+  const [contact, setContact] = useState({ firstName: "", lastName: "", email: "", phone: "" });
+  const [participants, setParticipants] = useState(1);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    // getService returns null on a miss — show not-found, never invent a service.
+    getService(serviceId).then((s) => (s ? setService(s) : setNotFound(true)));
+  }, [serviceId]);
+
+  useEffect(() => {
+    if (!service) return;
+    // listSlotsForService routes by service.type (APPOINTMENT → working hours, CLASS → sessions) and
+    // returns { slots, nextCursor }. The LIST call takes fromLocalDate / toLocalDate — a different
+    // arg naming than the single-slot re-validate call (getAvailableSlot: localStartDate/localEndDate).
+    listSlotsForService(service, { fromLocalDate: localMidnight(0), toLocalDate: localMidnight(14) })
+      .then(({ slots, nextCursor }) => { setSlots(slots); setCursor(nextCursor); });
+  }, [service]);
+
+  const loadMoreSlots = useCallback(() => {
+    if (!service || !cursor) return;
+    listSlotsForService(service, { cursor }).then(({ slots: more, nextCursor }) => {
+      setSlots((s) => [...s, ...more]);
+      setCursor(nextCursor);
+    });
+  }, [service, cursor]);
+
+  // maxParticipantsPerBooking is the per-booking cap (commonly 1 → no selector; book exactly one).
+  // Never use slot.remainingCapacity as the per-buyer limit — a count above the policy makes
+  // createBooking fail.
+  const maxParticipants = service?.bookingPolicy?.participantsPolicy?.maxParticipantsPerBooking ?? 1;
+
+  const price = useMemo(() => {
+    const p = service?.payment?.fixed?.price;
+    if (!p) return "";                                     // free / custom-priced
+    return p.formattedValue                                // formattedValue is OPTIONAL — build from value+currency when missing
+      || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value));
+  }, [service]);
+
+  const setContactField = (k) => (e) => setContact((c) => ({ ...c, [k]: e.target.value }));
+  const canSubmit = Boolean(selectedSlot && contact.email && !submitting);
+
+  const submit = useCallback(async () => {
+    if (!selectedSlot || !service) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Re-validate right before booking — slots get taken. getAvailableSlot returns the slot or NULL
+      // (guard it); the single-slot call uses localStartDate / localEndDate (not from/toLocalDate).
+      const fresh = await getAvailableSlot(service.id, {
+        localStartDate: selectedSlot.localStartDate,
+        localEndDate: selectedSlot.localEndDate,
+      });
+      if (!fresh) {
+        setSelectedSlot(null);
+        setError("That time was just taken — please pick another.");
+        return;
+      }
+      // bookAndCheckout = createBooking(slot, contact, options) then checkoutBooking; it returns
+      // { booking, checkoutUrl } — redirect straight to the hosted checkout, never a hand-built URL.
+      const { checkoutUrl } = await bookAndCheckout(fresh, contact, { totalParticipants: participants });
+      window.location.href = checkoutUrl;
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [service, selectedSlot, contact, participants]);
+
+  return {
+    service, notFound, price,
+    slots, cursor, loadMoreSlots,
+    selectedSlot, pickSlot: setSelectedSlot,
+    contact, setContactField,
+    maxParticipants, participants, setParticipants,
+    submitting, error, canSubmit, submit,
+  };
+}

--- a/skills/wix-vibe-headless/references/bookings/app/hooks/useServices.js
+++ b/skills/wix-vibe-headless/references/bookings/app/hooks/useServices.js
@@ -1,0 +1,30 @@
+// useServices — the services-list data, no markup: load one page of visitor-visible services and
+// page with the returned offset. queryServices returns an OBJECT ({ services, total, nextOffset }),
+// NOT a bare array — destructure it (calling .map on the object throws). `total === 0` is the
+// empty-state signal; `services === null` means still loading.
+import { useState, useEffect, useCallback } from "react";
+import { queryServices } from "@/rest/wix-bookings-services";
+
+export function useServices({ limit = 24 } = {}) {
+  const [services, setServices] = useState(null);
+  const [total, setTotal] = useState(null);
+  const [nextOffset, setNextOffset] = useState(null);
+
+  useEffect(() => {
+    queryServices({ limit }).then(({ services, total, nextOffset }) => {
+      setServices(services);
+      setTotal(total);
+      setNextOffset(nextOffset);
+    });
+  }, [limit]);
+
+  const loadMore = useCallback(() => {
+    if (nextOffset == null) return;                        // null on the last page
+    queryServices({ limit, offset: nextOffset }).then(({ services: more, nextOffset: next }) => {
+      setServices((s) => [...(s || []), ...more]);
+      setNextOffset(next);
+    });
+  }, [limit, nextOffset]);
+
+  return { services, total, nextOffset, loadMore };
+}

--- a/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
@@ -1,0 +1,65 @@
+// Service detail + booking page — thin view over useServiceDetail (all logic lives in the hook):
+// pick a slot, enter details, book → hosted checkout. Token-styled; re-skin via theme.css.
+import { useParams } from "react-router-dom";
+import { useServiceDetail } from "@/hooks/useServiceDetail";
+import { mediaUrl } from "@/rest/wix-bookings-services";
+import SlotPicker from "@/components/SlotPicker";
+import BookingForm from "@/components/BookingForm";
+
+export default function ServiceDetail() {
+  const { serviceId } = useParams();
+  const d = useServiceDetail(serviceId);
+
+  if (d.notFound) return <Centered>Service not found.</Centered>;
+  if (!d.service) return <Centered>Loading…</Centered>;
+
+  const image = mediaUrl(d.service.media?.items?.[0]?.image);
+  const locations = (d.service.locations || []).map((l) => l.name || l.formattedAddress).filter(Boolean);
+
+  return (
+    <main style={{
+      maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)",
+      display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: "calc(var(--space) * 2)",
+    }}>
+      <div>
+        <div style={{
+          aspectRatio: "4 / 3", background: "var(--color-surface)",
+          borderRadius: "var(--radius)", overflow: "hidden", marginBottom: "var(--space)",
+        }}>
+          {image && <img src={image} alt={d.service.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />}
+        </div>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px" }}>{d.service.name}</h1>
+        {d.price && <p style={{ fontSize: 22, fontWeight: 600, color: "var(--color-accent)", margin: "0 0 var(--space)" }}>{d.price}</p>}
+        {d.service.description && (
+          <p style={{ color: "var(--color-muted)", lineHeight: 1.6, marginBottom: "var(--space)" }}>{d.service.description}</p>
+        )}
+        {locations.length > 0 && (
+          <p style={{ color: "var(--color-muted)", fontSize: 14, margin: 0 }}>{locations.join(" · ")}</p>
+        )}
+      </div>
+
+      <div>
+        <h2 style={{ fontFamily: "var(--font-display)", fontSize: 18, margin: "0 0 var(--space)" }}>Pick a time</h2>
+        <SlotPicker
+          slots={d.slots} cursor={d.cursor} onLoadMore={d.loadMoreSlots}
+          selectedSlot={d.selectedSlot} onPick={d.pickSlot}
+        />
+
+        {d.selectedSlot && (
+          <div style={{ marginTop: "calc(var(--space) * 1.5)" }}>
+            <h2 style={{ fontFamily: "var(--font-display)", fontSize: 18, margin: "0 0 var(--space)" }}>Your details</h2>
+            <BookingForm
+              contact={d.contact} setContactField={d.setContactField}
+              maxParticipants={d.maxParticipants} participants={d.participants} setParticipants={d.setParticipants}
+              onSubmit={d.submit} submitting={d.submitting} canSubmit={d.canSubmit} error={d.error}
+            />
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/bookings/app/pages/Services.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/Services.jsx
@@ -1,0 +1,28 @@
+// Services / listing page — lists visitor-visible services, empty state when none exist. Thin view
+// over useServices (all data lives in the hook). Token-styled; re-skin via theme.css.
+import { useServices } from "@/hooks/useServices";
+import ServiceGrid from "@/components/ServiceGrid";
+
+export default function Services() {
+  const { services, total, nextOffset, loadMore } = useServices({ limit: 24 });
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Services</h1>
+      {services === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <>
+            <ServiceGrid services={services} empty="No services yet — add one from your Wix dashboard." />
+            {total > 0 && nextOffset != null && (
+              <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 1.5)" }}>
+                <button onClick={loadMore} style={{
+                  padding: "10px 20px", cursor: "pointer",
+                  background: "var(--color-surface)", color: "var(--color-text)",
+                  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+                }}>Load more</button>
+              </div>
+            )}
+          </>}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/bookings/app/theme.css
+++ b/skills/wix-vibe-headless/references/bookings/app/theme.css
@@ -1,0 +1,37 @@
+/* theme.css — THE styling surface. Theme the whole bookings site by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every shipped component (service cards, slot picker,
+   booking form) reads these variables, so changing them here re-skins the entire site. Import this
+   once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, wells, slot chips */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text, tag lines */
+  --color-border:    #e5e7eb;   /* hairlines, dividers, inputs */
+  --color-primary:   #111827;   /* buttons, links, selected slot */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* highlights, price, badges */
+  --color-danger:    #dc2626;   /* booking errors, unavailable */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1200px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **bookings** to the storefront-as-files model: services + service detail; SlotPicker + BookingForm (no provider).

- `references/bookings/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (11 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)