### PR TITLE
feat(restaurants): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -1,277 +1,258 @@
+# Wix Restaurants — ready-made client
 
-# Wix Restaurants Skill
+The restaurant client is **shipped as real files**, not snippets to regenerate. It's a complete
+menu + item ordering + server-cart + checkout, plus a table-reservation flow, styled entirely from
+`theme.css` tokens. Copy it into the app, theme the tokens, wire the routes — you generate almost
+none of the restaurant code (the menu tree join, the order cart, the reservation hold→reserve flow
+all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and the helper file(s) you need from `references/restaurants/`. `wix-client.js` imports from `"./wix-config.js"` and the helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`).
->
-> | Need | Copy |
-> |---|---|
-> | Menu display (always) | `wix-restaurants-menu.js` |
-> | Online ordering (cart + checkout) | `wix-restaurants-ordering.js` |
-> | Table reservations | `wix-restaurants-reservations.js` |
-
-Builds a real, client-only Wix restaurant experience. The browser talks to Wix directly over a
-public `WIX_CLIENT_ID`. Never mock the menu; never hand-build `/checkout` or reservation URLs —
-always go through the official cart + redirect-session and the reservations hold/reserve flow.
-
-## When to use
-- User wants a Wix restaurant site, an online food-ordering page, or a table-reservation page.
-- User asks to "connect Wix Restaurants" or replace placeholder menu/ordering/booking UI with live data.
-- Adding a menu, cart + checkout, or reservations over an existing Wix Restaurants setup.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock the
+menu; never hand-build `/checkout` or reservation URLs — the shipped cart goes through the eCom
+redirect-session and reservations go through the hold/reserve flow.
 
 ## Prerequisites
-1. A Wix site with the **Wix Restaurants Menus** app installed and **menu content already added**
-   (this skill is read-only over the menu — it does NOT create menus/items).
-2. For **online ordering**: at least one online-ordering **Operation** configured (Wix Restaurants
-   Orders). For **reservations**: the **Table Reservations** app installed with at least one location
-   and online reservations enabled. If a flow's backing app/config isn't set up, that flow returns
-   empty — flag it and continue; don't fabricate data.
-3. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (see the router `SKILL.md`).
-   Set it in `src/rest/wix-config.js` in place of the placeholder. It is a buyer-facing
-   credential (it only mints anonymous visitor tokens), **not** a secret — hardcoding/committing
-   it is fine.
-4. The deployed app domain must be allow-listed on the OAuth client for Wix-hosted checkout to
-   return. This is a **separate Wix setup flow the user completes later** — out of this skill's
-   scope. If checkout return fails before that setup is done, that's expected; flag it and continue.
+- The site's **Wix Restaurants Menus** app is the read target for the menu; **Restaurant Orders**
+  backs online ordering; **Table Reservations** backs the booking page. They're installed and seeded
+  separately (see **Seeding** below), in parallel with this build — so the menu may be empty and
+  ordering / reservations may be unconfigured at build time. The client renders the shipped empty /
+  "unavailable" states until content and operations land.
+- The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
+- For Wix-hosted checkout to return, the deployed app domain must be allow-listed on the OAuth
+  client — a **separate Wix setup the user completes later**, out of scope here. If checkout return
+  fails before that, it's expected; flag it and continue.
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the restaurant UI however the
-project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
-adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
-  `wix-config.js`. The visitor refresh token IS the cart identity; it is persisted to localStorage.
-  Do not re-mint anonymously per load or the cart silently empties.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-restaurants-menu.js` — **Menu (read-only):**
-  `getFullMenu` (the assembled tree — start here), `listMenus`, `listSections`, `listItems`,
-  `listVariants`, `listModifierGroups`, `listModifiers`, `listLabels`
-- `src/rest/wix-restaurants-ordering.js` — **Online ordering:**
-  `listOperations`, `getDefaultOperation`, `addItemToCart`, `getCurrentCart`,
-  `updateCartItemQuantity`, `removeFromCart`, `checkout`
-- `src/rest/wix-restaurants-reservations.js` — **Reservations:**
-  `listReservationLocations`, `getTimeSlots`, `createHeldReservation`, `reserveReservation`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole restaurant UI client + REST scaffolds into
+`src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map,
+so you don't need to open them:**
 
-The Menu, Item, ModifierGroup, Operation, Cart, ReservationLocation, TimeSlot, and Reservation
-shapes are documented as JSDoc at the top of each helper file. Read the relevant file(s) before
-building the UI — they describe the key fields and link to the full reference for anything not shown.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `context/OrderCartContext.jsx` | `useOrderCart()` provider: resolves the ordering Operation, server cart, add/update/remove, checkout, `ordering` flag |
+| `hooks/useItemOrder.js` | item-dialog add-to-order logic (stock + ordering-available gating, quantity) |
+| `hooks/useReservation.js` | reservation flow (locations → date/party → AVAILABLE slots → hold → reserve) |
+| `components/MenuItemCard.jsx`, `MenuList.jsx` | menu render UI (dish card + the menus→sections→items tree, with empty state) |
+| `components/ItemDialog.jsx` | dish detail modal — description, price/variants, modifier groups (display), quantity, add-to-order |
+| `components/OrderCartButton.jsx` | header order **icon** button with a live-count badge |
+| `components/OrderCartDrawer.jsx` | slide-over order cart (mount once; opens from `useOrderCart`) |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Menu.jsx`, `pages/Reservations.jsx` | the two shipped routes (`/menu`, `/reservations`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` | REST transport + visitor-token mint/refresh (the refresh token IS the cart identity) |
+| `rest/wix-restaurants-menu.js` | menu read helpers — `getFullMenu` (the assembled tree; start here) + raw `list*` |
+| `rest/wix-restaurants-ordering.js` | ordering — operations, add/update/remove, `checkout` |
+| `rest/wix-restaurants-reservations.js` | reservations — locations, time slots, hold, reserve |
 
-## How to wire it (UI is the project's choice)
-- **Menu page** — call `getFullMenu()` once. It is the **only** pre-joined shape and the entry point
-  for the menu screen. It returns `{ menus: [{ ...menu, sections: [{ ...section, items: [assembledItem]
-  }] }] }`, already ordered by `sectionIds` / `itemIds`, each item enriched with a resolved `price` /
-  `variants`, `modifierGroups`, and `labels`. Render each item's `name`, `description`, `image`,
-  `labels` (`name` + `icon`), and `featured` flag. **`item.image`, `section.image`, and `label.icon`
-  are OBJECTS** (`{ url, width, height, altText }`, and `{ url }` for the icon) — render
-  `item.image?.url`, `section.image?.url`, `label.icon?.url`, never the object itself. For price, show
-  `item.price` (single) or the `item.variants[]` (each `{ name, price }`). **Restaurants MENU prices
-  are plain decimal strings with NO currency symbol** — format with the site's currency in the UI (the
-  eCom cart's `price.formattedAmount` DOES include it — see the cart snippet). This is the main render
-  surface: use the `MenuPage.jsx` reference snippet below.
-- **Build on `getFullMenu`, not the raw `list*` fns** — `getFullMenu` is the only helper that returns
-  a joined tree with references resolved. The raw `listSections` / `listItems` / `listVariants` /
-  `listModifiers` return **unresolved refs** (an item's `labels` and `modifierGroups` come back
-  **id-only**, price variants unresolved) and have **inconsistent return shapes**: `listMenus` → a
-  `{ menus, nextCursor }` wrapper, while `listSections` / `listItems` / `listVariants` /
-  `listModifierGroups` / `listModifiers` → **bare arrays**. Don't re-join them by hand. If you truly
-  need a partial fetch, note the signature — those fns take an **array of GUIDs** (`listSections(sectionIds)`,
-  `listItems(itemIds)`), and the join walks `menu.sectionIds` → `listSections` → each `section.itemIds`
-  → `listItems`.
-- **Item detail** — render `item.modifierGroups[]`: each group's `name`, its `rule`
-  (`required`, `minSelections`, `maxSelections`), and `modifiers[]` (`name`, `additionalCharge`,
-  `preSelected`, `inStock`). If `orderSettings.acceptSpecialRequests`, offer a free-text field.
-- **Online ordering** — resolve an operation with `getDefaultOperation()` (or let the user pick from
-  `listOperations()`); if it's `null`, show an "ordering unavailable" state. Add a dish with
-  `addItemToCart(item.id, { operationId, menuId, sectionId, quantity })` — `menuId`/`sectionId` are
-  the menu and section the item was shown under. Read the cart back with `getCurrentCart()`; mutate
-  with `updateCartItemQuantity(lineItemId, qty)` / `removeFromCart(lineItemId)` using
-  `cart.lineItems[].id` (not the item id).
-- **Checkout** — `window.location.href = await checkout()`. After the visitor returns, the order is
-  placed and the cart is empty — re-fetch with `getCurrentCart()` on return (e.g. on mount +
-  `visibilitychange`) to clear the UI.
-- **Reservations** — `listReservationLocations()` for the picker (use `location` details for the
-  label). **Skip archived locations** (`loc.archived === true`) — that flag IS in the location shape.
-  There is **no `onlineReservationsEnabled` field** in the location shape: the util documents
-  `configuration.onlineReservations.approval.mode` (`AUTOMATIC` / `MANUAL` / `MANUAL_FOR_LARGE_PARTIES`)
-  and `configuration.partySize`, not an enable toggle. Do **not** filter on an invented
-  `onlineReservationsEnabled` — if you need to hide locations that don't take online reservations,
-  confirm the real enable/visibility field with the **wix-docs** skill / Restaurants reference first.
-  Then `getTimeSlots(locationId, dateISO, partySize)` — render `availableTimeSlots` (already filtered
-  to `AVAILABLE`). On slot pick, `createHeldReservation(locationId, slot.startDate, partySize)` → keep
-  the returned `id` + `revision`. Collect the visitor's details, then `reserveReservation(id, revision,
-  { firstName, phone, lastName?, email? })`. Read the returned reservation's top-level `status` —
-  `RESERVED` is confirmed, `REQUESTED` means the location requires manual approval (tell the user it's
-  pending) — and echo `reservation.details.{startDate, endDate, partySize}` back as the confirmation
-  summary.
-- **Empty state** — if `getFullMenu()` returns no menus, show an empty state telling the user to add
-  a menu in their Wix dashboard. Never invent menu items.
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each is
+and every field shape you need is in the snippets below. Read a shipped file's source **only** on a
+real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/restaurants/app/` → `src/`.)
 
-## Hard rules (do not violate)
-- ✅ Order ONLY through the cart: `addItemToCart()` → `checkout()` (`create-checkout` →
-  `/headless/v1/redirect-session` `fullUrl`), then redirect.
-- ❌ Never hand-build `/checkout`, ordering, or reservation URLs.
-- ❌ Never mock menus, items, prices, operations, locations, or time slots — render live Wix data or
-  the empty state.
-- ❌ Never generate fake reviews, ratings, or testimonials. Empty review UI only.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ `addItemToCart` requires `operationId`, `menuId`, and `sectionId` — it throws if any is missing.
-- ✅ `lineItemId` for cart mutations is `cart.lineItems[].id`, not the item id.
-- ✅ Reservations: offer only `AVAILABLE` slots; a HELD reservation expires in 10 minutes — pass the
-  `revision` from the hold into `reserveReservation`, and restart the flow if it expired.
-- ✅ Reservee `firstName` + `phone` (E.164, e.g. `+15551234567`) are mandatory to confirm.
-- The engine fails loudly on purpose: `addItemToCart`/`checkout` throw on out-of-stock or empty
-  carts; reservation helpers throw on unavailable slots or expired holds. A green path means it is
-  really orderable/bookable — don't swallow these.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
-## Beyond the snippets
-The snippets cover the common menu / ordering / reservation paths. For the "20%" they don't cover,
-make the call yourself with `wixApiRequest` — but look up the exact endpoint, HTTP method, and
-request body in the **official Wix API reference** first; never guess:
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole restaurant. **Do not
+restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
+home page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the
+dark tokens with `document.documentElement.dataset.theme = "dark"`.
+
+## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it.
+- `import "@/theme.css";` once at the app entry.
+- Wrap the routed tree in `<OrderCartProvider>` (from `@/context/OrderCartContext`).
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Menu` / `Reservations` — so you **never edit the shipped pages to add a
+  header/footer** (they render inside `<Outlet/>` as-is). Mount `<OrderCartDrawer/>` once in the Layout.
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's measured height so it clears the chrome and self-corrects when the
+  banner is dismissed.
+- Routes under the Layout: `/menu` → `Menu`, `/reservations` → `Reservations` (both shipped, as-is).
+  **You add `/` → your own Home** page.
+
+```jsx
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import { OrderCartProvider } from "@/context/OrderCartContext";
+import OrderCartDrawer from "@/components/OrderCartDrawer";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Menu from "@/pages/Menu";
+import Reservations from "@/pages/Reservations";
+import Home from "@/pages/Home";       // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
+
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Menu/Reservations render here, untouched */}
+      <Footer />
+    </div>
+    <OrderCartDrawer />                       {/* overlays every page */}
+  </>);
+}
+
+<OrderCartProvider>
+  <Routes>
+    <Route element={<Layout />}>                                {/* chrome wraps all */}
+      <Route path="/" element={<Home />} />                     {/* yours */}
+      <Route path="/menu" element={<Menu />} />                 {/* shipped, as-is */}
+      <Route path="/reservations" element={<Reservations />} /> {/* shipped, as-is */}
+    </Route>
+  </Routes>
+</OrderCartProvider>
+```
+
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** (mount `<OrderCartButton/>` in it) and a **`Footer`** —
+the two you drop into the `Layout` (STEP 4) so they wrap every route — plus the overall brand story,
+styled from the same `theme.css` tokens. The nav is an `<OrderCartButton/>` (a clean order-**icon**
+button with a live-count badge — render it as-is, don't wrap it in your own text button) + links to
+`/menu` and `/reservations`:
+
+```jsx
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import OrderCartButton from "@/components/OrderCartButton";
+
+// Responsive header: choose ONE branch with a state flag, so <OrderCartButton/> mounts once.
+// Do NOT render a desktop nav AND a mobile nav toggled by `hidden md:flex` / `md:hidden`:
+// these navs are inline-styled, and an inline `display` beats a Tailwind class, so `hidden`
+// never applies — BOTH branches render and you get two order buttons. One branch = one button.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return (
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger + <OrderCartButton/> here
+        : <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+            <Link to="/menu">Menu</Link><Link to="/reservations">Reserve</Link><OrderCartButton />
+          </div>}
+    </nav>
+  );
+}
+```
+
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
+`<OrderCartButton/>` is an icon button (live-count badge) — drop it in as-is, it inherits `currentColor`.
+
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
+
+## Using the client from your own UI (menu, order cart)
+
+```jsx
+import { getFullMenu } from "@/rest/wix-restaurants-menu";
+import { useOrderCart } from "@/context/OrderCartContext";
+
+// getFullMenu() is the ONLY pre-joined shape and the entry point for any menu surface. It returns
+// { menus: [{ ...menu, sections: [{ ...section, items: [assembledItem] }] }] }, already ordered.
+// Each item is enriched with a resolved price / variants, modifierGroups, and labels.
+const { menus } = await getFullMenu();            // [] when no menus → show the shipped empty state
+
+// useOrderCart() gives:
+// { cart, operation, ordering, itemCount, isOpen, setIsOpen, loading,
+//   addItem(item, { menuId, sectionId }, qty=1),   // needs the menu/section the item was shown under
+//   removeItem(lineItemId), updateQuantity(lineItemId, qty), checkout(), refreshCart() }
+// `ordering` is false when no ordering Operation is configured — show an "ordering unavailable" state.
+
+// Load-bearing field paths (the shipped components already do these):
+// - item.image / section.image / label.icon are OBJECTS → render `.url`, never the object; //-urls → https:
+// - MENU prices are plain decimal strings with NO currency symbol ("12.50") — format in the UI.
+//   The eCom cart line price (line.price.formattedAmount) DOES include the symbol.
+// - an item is priced by EITHER item.price (single) OR item.variants[] (one-of, each { name, price }).
+// - a cart mutation uses cart.lineItems[].id (the lineItemId), NOT the menu item id.
+```
+
+Buying happens in the shipped `ItemDialog` (opened from `MenuList`) — it owns quantity + add-to-order
+and surfaces out-of-stock / ordering-unavailable errors. Compose a featured strip on your Home from
+`getFullMenu()` + the shipped `MenuItemCard` if you want.
+
+## Extending the client
+Building something beyond the shipped pages, or need a path these snippets don't cover?
+
+```jsx
+// The raw list* helpers return UNRESOLVED refs and INCONSISTENT shapes (listMenus → { menus,
+// nextCursor }; listSections/listItems/listVariants/listModifierGroups/listModifiers → bare arrays).
+// Don't re-join them by hand — build on getFullMenu(). If you truly need a partial fetch, note they
+// take an array of GUIDs: listSections(sectionIds), listItems(itemIds).
+
+// Reservation status after reserve: RESERVED = confirmed, REQUESTED = manual approval pending
+// (tell the user). firstName + phone (E.164, e.g. "+15551234567") are mandatory; a HELD reservation
+// expires in 10 minutes — the hook passes the hold's { id, revision } into reserve for you.
+```
+
+Modifier up-charges / price-variant selection / special requests on the **cart line** are **not**
+wired into `addItemToCart` — the restaurants `catalogReference.options` shape for these isn't
+documented for client add-to-cart, so `ItemDialog` displays modifier groups for the diner but sends
+only quantity. To wire them, confirm the shape via the **`wix-docs`** skill / the reference first,
+never guess:
 - Restaurants API reference: https://dev.wix.com/docs/api-reference/business-solutions/restaurants.md
-- Selecting a specific **price variant** or applying **modifier up-charges** on the cart line: the
-  restaurants `catalogReference.options` shape for these is not documented for client add-to-cart.
-  The menu UI still displays them; confirm the shape before wiring them into `addItemToCart`:
-  https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
-- Fulfillment methods, delivery-address validation, scheduled (preorder) time slots, service fees:
-  see the Online Orders section of the reference.
+- Sample flows (cart options): https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/sample-flows.md
 - **Member login + a "my orders" account view** → the **members** vertical
   (`references/members/INSTRUCTIONS.md`): ordering/reserving works anonymously, but signing a member
-  in (custom login on your own UI) lets them see their own order/reservation history.
+  in lets them see their own order/reservation history.
 
-Keep the snippets as the default for everything they already do; reach for the API reference only
-for the gap.
+Fallback only — when you hit an error or need something not shown here: read the relevant shipped
+file under `src/`, or look it up via the **`wix-docs`** skill.
 
-## Reference snippets (headless — adapt the logic, restyle freely)
-
-These are the recurring restaurant pieces, written **headless**: the Wix field paths are correct and
-complete; the markup is deliberately plain. **Copy the logic exactly; restyle the JSX to the brand.**
-They consume the `src/rest/` helpers — you don't need to read those helpers' source.
-
-**`pages/MenuPage.jsx`** — the menu render surface. Drives everything off the assembled `getFullMenu()`
-tree. Note the paths that trip people up: `item.image` / `section.image` / `label.icon` are **objects**
-(render `.url`, never the object), menu prices carry **no currency symbol**, and an item is priced by
-**either** `item.price` (single) **or** `item.variants[]` (one-of, each `{ name, price }`).
-
-```jsx
-import { useState, useEffect } from "react";
-import { getFullMenu } from "@/rest/wix-restaurants-menu";
-
-// Wix media urls can come back protocol-relative (//...) — normalize to https.
-// item.image / section.image / label.icon are OBJECTS ({ url, ... }) — read .url, never render the object.
-function imageUrl(img) {
-  const url = img?.url;
-  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
-}
-
-// Restaurants MENU prices are plain decimal strings with NO currency symbol ("12.50").
-function formatPrice(price) {
-  return price == null ? "" : `$${price}`; // swap "$" for the site's currency
-}
-
-export default function MenuPage() {
-  const [menus, setMenus] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    getFullMenu().then(({ menus }) => { setMenus(menus); setLoading(false); });
-  }, []);
-
-  if (loading) return <div>Loading…</div>;
-  if (menus.length === 0) return <p>{/* empty state — add a menu in the Wix dashboard */}</p>;
-
-  return (
-    <div /* restyle */>
-      {menus.map((menu) => (
-        <section key={menu.id}>
-          <h2>{menu.name}</h2>
-          {menu.description && <p>{menu.description}</p>}
-          {menu.sections.map((section) => (
-            <div key={section.id}>
-              <h3>{section.name}</h3>
-              {imageUrl(section.image) && <img src={imageUrl(section.image)} alt={section.name} />}
-              {section.items.map((item) => (
-                <article key={item.id}>
-                  {imageUrl(item.image) && <img src={imageUrl(item.image)} alt={item.name} loading="lazy" />}
-                  <h4>{item.name}{item.featured && <span> ★</span>}</h4>
-                  {item.description && <p>{item.description}</p>}
-                  {/* labels: [{ id, name, icon }] — icon is an OBJECT ({ url }); render label.icon.url */}
-                  {item.labels.map((label) => (
-                    <span key={label.id}>
-                      {imageUrl(label.icon) && <img src={imageUrl(label.icon)} alt="" />}
-                      {label.name}
-                    </span>
-                  ))}
-                  {/* price: single string, OR one-of variants [{ name, price }] — neither has a currency symbol */}
-                  {item.price != null
-                    ? <span>{formatPrice(item.price)}</span>
-                    : item.variants.map((v) => (
-                        <span key={v.variantId}>{v.name}: {formatPrice(v.price)}</span>
-                      ))}
-                  {item.orderSettings?.inStock === false && <span>Sold out</span>}
-                </article>
-              ))}
-            </div>
-          ))}
-        </section>
-      ))}
-    </div>
-  );
-}
-```
-
-**`Cart.jsx`** — reads the Wix **server** cart via `getCurrentCart()` (never a local copy). The line
-paths: `line.id` is the **lineItemId** used for mutations (NOT the menu item id), the display name is
-`line.productName.original`, and the line price is `line.price.formattedAmount` (the eCom cart price
-DOES include the currency symbol, unlike the menu). Re-fetch on return from checkout to clear the UI.
-
-```jsx
-import { useState, useEffect } from "react";
-import { getCurrentCart, updateCartItemQuantity, removeFromCart, checkout } from "@/rest/wix-restaurants-ordering";
-
-export default function Cart() {
-  const [cart, setCart] = useState(null);
-  const refresh = () => getCurrentCart().then(setCart);
-  useEffect(() => { // re-fetch on mount + when the tab regains focus (cart is empty after a completed checkout)
-    refresh();
-    const onVisible = () => document.visibilityState === "visible" && refresh();
-    document.addEventListener("visibilitychange", onVisible);
-    return () => document.removeEventListener("visibilitychange", onVisible);
-  }, []);
-
-  const lineItems = cart?.lineItems ?? [];
-  if (lineItems.length === 0) return <p>Your cart is empty.</p>;
-  return (
-    <div /* restyle */>
-      {lineItems.map((line) => (
-        <div key={line.id}>{/* line.id is the lineItemId for mutations — NOT the menu item id */}
-          <span>{line.productName?.original}</span>
-          <button onClick={async () => setCart(await updateCartItemQuantity(line.id, Math.max(1, line.quantity - 1)))}>−</button>
-          <span>{line.quantity}</span>
-          <button onClick={async () => setCart(await updateCartItemQuantity(line.id, line.quantity + 1))}>+</button>
-          <button onClick={async () => setCart(await removeFromCart(line.id))}>Remove</button>
-          <span>{line.price?.formattedAmount}</span>{/* eCom cart price DOES include the currency symbol (unlike menu prices) */}
-        </div>
-      ))}
-      <button onClick={async () => { window.location.href = await checkout(); }}>Checkout</button>
-    </div>
-  );
-}
-```
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Menu`/`Reservations` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
+- Order through the shipped cart: `addItem()` → `checkout()` (redirect-session) — never a hand-built `/checkout`, ordering, or reservation URL.
+- Reservations: offer only `AVAILABLE` slots; pass the hold's `revision` into reserve; `firstName` + `phone` (E.164) are mandatory.
+- Render live Wix data or the shipped empty / "unavailable" state — never mock menus, items, prices, operations, locations, slots, or reviews.
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the restaurant content for their site — across up to three apps. To facilitate this, provide the user with deep links directly to the relevant dashboard pages; only mention the apps the project actually uses. Those pages are:
+Provide deep links so the owner can edit content across the apps they actually use (substitute the
+site's `metaSiteId` from the handoff / `ListWixSites`):
 - **Menu** (always) — `https://manage.wix.com/dashboard/{metaSiteId}/wix-restaurants-menus-new` (`Dashboard → Restaurant Menus`; click **Manage Items** to add dishes; only visible menus appear in the app)
-- **Online ordering** (if wired) — `https://manage.wix.com/dashboard/{metaSiteId}/wix-restaurants-orders-new/settings` (`Dashboard → Restaurant Orders → Settings`). Enable at least one fulfillment method before the site accepts orders — each has its own page: pickup `https://manage.wix.com/dashboard/{metaSiteId}/wix-restaurants-orders-new/settings/pickup`, delivery `.../wix-restaurants-orders-new/settings/delivery`, dine-in `.../wix-restaurants-orders-new/settings/dine-in`.
+- **Online ordering** (if wired) — `https://manage.wix.com/dashboard/{metaSiteId}/wix-restaurants-orders-new/settings` (`Dashboard → Restaurant Orders → Settings`). Enable at least one fulfillment method before the site accepts orders: pickup `.../wix-restaurants-orders-new/settings/pickup`, delivery `.../settings/delivery`, dine-in `.../settings/dine-in`.
 - **Table reservations** (if wired) — `https://manage.wix.com/dashboard/{metaSiteId}/wix-table-reservations/table-reservations` (`Dashboard → Table Reservations` → **Settings**; configure tables, availability, and enable online reservations)
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+Tell the user at least once that they can keep setting up their restaurant (menu / ordering /
+reservations) in the dashboard, and include the in-dashboard navigation as a fallback.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (cart survives reload, same visitor)
-- [ ] `getFullMenu()` renders real sections/items with prices, variants, modifiers, and labels
-- [ ] Empty state shown when there are no menus (never invented items)
-- [ ] Add to cart works with a real `operationId`/`menuId`/`sectionId`; out-of-stock items throw
-- [ ] Quantity update / remove reflect in `getCurrentCart()`
-- [ ] Checkout redirects via redirect-session `fullUrl` (no hand-built URL); cart re-fetched on return
-- [ ] Reservations: only `AVAILABLE` slots offered; hold → reserve produces `RESERVED`/`REQUESTED`
-- [ ] No mock data anywhere
-- [ ] Told the user at least once that they can continue setting up their restaurant (menu / ordering / reservations) in the dashboard and provided deep links.
+## Seeding
+Seed the menu (and ordering/reservation setup) per `seed/SEED.md` — separate from this client build;
+run in parallel.
+
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Menu`/`Reservations` untouched; content clears the fixed chrome; `<OrderCartProvider>` wraps the tree; `<OrderCartDrawer/>` mounted; `<OrderCartButton/>` in the header.
+- [ ] `getFullMenu()` renders real sections/items with prices, variants, modifiers, and labels; empty catalog shows the shipped empty state (no mock items).
+- [ ] Add to order works with a real operation (or shows "ordering unavailable"); order survives reload (same visitor); update-qty / remove work; checkout redirects and re-fetches on return.
+- [ ] Reservations: only `AVAILABLE` slots offered; hold → reserve produces `RESERVED`/`REQUESTED`; no locations shows the shipped empty state.
+- [ ] Told the user they can continue setting up in the dashboard, with deep links.

--- a/skills/wix-vibe-headless/references/restaurants/app/components/ItemDialog.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/ItemDialog.jsx
@@ -1,0 +1,97 @@
+// Item detail modal — thin view over useItemOrder (all add-to-cart logic lives in the hook). Shows
+// the dish's image, description, price/variants, and modifier groups (name + rule + each modifier's
+// up-charge / stock), a quantity stepper, and an add-to-cart button. Modifier groups are shown for
+// the diner's information only — the shipped addItemToCart does not send selections (see the hook).
+// Token-styled; re-skin via theme.css. Pass the item plus the { menuId, sectionId } it was shown under.
+import { useItemOrder } from "@/hooks/useItemOrder";
+
+function imageUrl(img) {
+  const url = img?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+function formatPrice(price) {
+  return price == null ? "" : `$${price}`; // swap "$" for the site's currency
+}
+
+export default function ItemDialog({ item, menuId, sectionId, onClose }) {
+  const d = useItemOrder(item, { menuId, sectionId });
+  if (!item) return null;
+  const image = imageUrl(item.image);
+
+  return (
+    <div onClick={onClose} style={{
+      position: "fixed", inset: 0, zIndex: 60,
+      background: "rgba(0,0,0,.45)", display: "flex", alignItems: "flex-end", justifyContent: "center",
+    }}>
+      <div onClick={(e) => e.stopPropagation()} style={{
+        width: "min(560px, 100%)", maxHeight: "92vh", overflowY: "auto",
+        background: "var(--color-bg)", color: "var(--color-text)",
+        borderTopLeftRadius: "var(--radius)", borderTopRightRadius: "var(--radius)",
+        fontFamily: "var(--font-body)",
+      }}>
+        {image && (
+          <div style={{ aspectRatio: "16 / 9", background: "var(--color-surface)" }}>
+            <img src={image} alt={item.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          </div>
+        )}
+        <div style={{ padding: "var(--space)", display: "flex", flexDirection: "column", gap: "var(--space)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+            <h2 style={{ margin: 0, fontFamily: "var(--font-display)" }}>{item.name}</h2>
+            <button onClick={onClose} aria-label="Close" style={{
+              border: "none", background: "none", cursor: "pointer", fontSize: 22, lineHeight: 1, color: "var(--color-muted)",
+            }}>×</button>
+          </div>
+          {item.description && <p style={{ margin: 0, color: "var(--color-muted)", lineHeight: 1.55 }}>{item.description}</p>}
+
+          {/* price: single string OR one-of variants — neither carries a currency symbol */}
+          {item.price != null
+            ? <p style={{ margin: 0, fontSize: 20, fontWeight: 600 }}>{formatPrice(item.price)}</p>
+            : item.variants?.length > 0 && (
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+                  {item.variants.map((v) => (
+                    <span key={v.variantId}>{v.name}: <strong>{formatPrice(v.price)}</strong></span>
+                  ))}
+                </div>
+              )}
+
+          {/* modifier groups — displayed for the diner; selections are not sent by the shipped add-to-cart */}
+          {item.modifierGroups?.map((group) => (
+            <div key={group.id} style={{ borderTop: "1px solid var(--color-border)", paddingTop: "var(--space)" }}>
+              <h4 style={{ margin: "0 0 8px", fontFamily: "var(--font-display)" }}>
+                {group.name}
+                {group.rule?.required && <span style={{ color: "var(--color-accent)", fontSize: 13 }}> · required</span>}
+              </h4>
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {group.modifiers.map((m) => (
+                  <div key={m.id} style={{ display: "flex", justifyContent: "space-between", color: m.inStock ? "var(--color-text)" : "var(--color-muted)" }}>
+                    <span>{m.name}{!m.inStock && " (sold out)"}</span>
+                    {m.additionalCharge && m.additionalCharge !== "0" && <span>+{formatPrice(m.additionalCharge)}</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 4 }}>
+            <input type="number" min={1} value={d.quantity}
+              onChange={(e) => d.setQuantity(Math.max(1, Number(e.target.value) || 1))}
+              style={{
+                width: 72, padding: "10px", textAlign: "center",
+                border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+                background: "var(--color-bg)", color: "var(--color-text)",
+              }} />
+            <button disabled={!d.canAdd} onClick={d.submit} style={{
+              flex: 1, padding: "12px 24px", cursor: d.canAdd ? "pointer" : "not-allowed",
+              background: "var(--color-primary)", color: "var(--color-on-primary)",
+              border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+              opacity: d.canAdd ? 1 : 0.5,
+            }}>
+              {!d.ordering ? "Ordering unavailable" : d.inStock ? (d.adding ? "Adding…" : "Add to order") : "Sold out"}
+            </button>
+          </div>
+          {d.error && <p style={{ margin: 0, color: "var(--color-danger)", fontSize: 14 }}>{d.error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/MenuItemCard.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/MenuItemCard.jsx
@@ -1,0 +1,80 @@
+// One dish/drink tile. Styled entirely from theme.css tokens (var(--...)) — re-skin via those
+// tokens, not this JSX. The load-bearing bits: item.image is an OBJECT (render .url, never the
+// object) with a `//`-protocol fix; price is EITHER item.price (single) OR item.variants[] (one-of,
+// each { name, price }); MENU prices carry NO currency symbol (formatPrice adds one — swap it for
+// the site's currency). Clicking the card opens the item dialog (add-to-cart lives there).
+function imageUrl(img) {
+  const url = img?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+// Restaurants MENU prices are plain decimal strings with NO currency symbol ("12.50").
+function formatPrice(price) {
+  return price == null ? "" : `$${price}`; // swap "$" for the site's currency
+}
+
+export default function MenuItemCard({ item, onOpen }) {
+  const image = imageUrl(item.image);
+  const soldOut = item.orderSettings?.inStock === false;
+
+  return (
+    <article
+      onClick={() => onOpen?.(item)}
+      style={{
+        display: "flex", flexDirection: "column", cursor: onOpen ? "pointer" : "default",
+        color: "var(--color-text)", background: "var(--color-surface)",
+        border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+        overflow: "hidden", boxShadow: "var(--shadow)",
+      }}>
+      {image && (
+        <div style={{ position: "relative", aspectRatio: "4 / 3", background: "var(--color-bg)" }}>
+          <img src={image} alt={item.name} loading="lazy"
+            style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          {soldOut && (
+            <span style={{
+              position: "absolute", top: 8, left: 8, padding: "2px 8px", fontSize: 12,
+              background: "var(--color-danger)", color: "#fff", borderRadius: "var(--radius-sm)",
+            }}>Sold out</span>
+          )}
+        </div>
+      )}
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 6 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+          <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 16, fontWeight: 600 }}>
+            {item.name}{item.featured && <span style={{ color: "var(--color-accent)" }}> ★</span>}
+          </h3>
+          {/* price: single string, OR one-of variants — render one label per variant */}
+          {item.price != null
+            ? <span style={{ fontWeight: 600, whiteSpace: "nowrap" }}>{formatPrice(item.price)}</span>
+            : null}
+        </div>
+        {item.description && (
+          <p style={{ margin: 0, color: "var(--color-muted)", fontSize: 14, lineHeight: 1.45 }}>{item.description}</p>
+        )}
+        {item.price == null && item.variants?.length > 0 && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {item.variants.map((v) => (
+              <span key={v.variantId} style={{ fontSize: 13, color: "var(--color-text)" }}>
+                {v.name}: <strong>{formatPrice(v.price)}</strong>
+              </span>
+            ))}
+          </div>
+        )}
+        {item.labels?.length > 0 && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 2 }}>
+            {item.labels.map((label) => (
+              <span key={label.id} style={{
+                display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12,
+                color: "var(--color-muted)", border: "1px solid var(--color-border)",
+                borderRadius: 999, padding: "2px 8px",
+              }}>
+                {imageUrl(label.icon) && <img src={imageUrl(label.icon)} alt="" style={{ width: 12, height: 12 }} />}
+                {label.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/MenuList.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/MenuList.jsx
@@ -1,0 +1,46 @@
+// Renders the assembled getFullMenu() tree: menus → sections → item cards, with the empty state.
+// This is the menu render surface's body (the Menu page is a thin wrapper). Ordered already by
+// the helper (sectionIds / itemIds). Token-styled; re-skin via theme.css. Each card's onOpen gets
+// the item plus the menuId/sectionId it was shown under — ordering needs both.
+import MenuItemCard from "./MenuItemCard";
+
+function imageUrl(img) {
+  const url = img?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+export default function MenuList({ menus, onOpenItem, empty = "No menu yet — add one from your Wix dashboard." }) {
+  if (!menus?.length) {
+    return <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>;
+  }
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "calc(var(--space) * 2)" }}>
+      {menus.map((menu) => (
+        <section key={menu.id}>
+          <h2 style={{ fontFamily: "var(--font-display)", margin: "0 0 4px" }}>{menu.name}</h2>
+          {menu.description && (
+            <p style={{ color: "var(--color-muted)", margin: "0 0 var(--space)" }}>{menu.description}</p>
+          )}
+          {menu.sections.map((section) => (
+            <div key={section.id} style={{ marginBottom: "calc(var(--space) * 1.5)" }}>
+              <h3 style={{ fontFamily: "var(--font-display)", margin: "0 0 var(--space)" }}>{section.name}</h3>
+              {imageUrl(section.image) && (
+                <img src={imageUrl(section.image)} alt={section.name} loading="lazy"
+                  style={{ width: "100%", maxHeight: 220, objectFit: "cover", borderRadius: "var(--radius)", marginBottom: "var(--space)" }} />
+              )}
+              <div style={{
+                display: "grid", gap: "var(--space)",
+                gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+              }}>
+                {section.items.map((item) => (
+                  <MenuItemCard key={item.id} item={item}
+                    onOpen={() => onOpenItem?.(item, { menuId: menu.id, sectionId: section.id })} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/OrderCartButton.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/OrderCartButton.jsx
@@ -1,0 +1,30 @@
+// Header order trigger — an icon button with a live item-count badge. Drop into the app header;
+// opens the OrderCartDrawer. Icon-only by design (no text): reads the header's currentColor, so it
+// inherits the brand automatically.
+import { useOrderCart } from "@/context/OrderCartContext";
+
+export default function OrderCartButton() {
+  const { itemCount, setIsOpen } = useOrderCart();
+  return (
+    <button onClick={() => setIsOpen(true)} aria-label={`Open order${itemCount ? `, ${itemCount} item${itemCount > 1 ? "s" : ""}` : ""}`} style={{
+      position: "relative", display: "inline-flex", alignItems: "center", justifyContent: "center",
+      width: 40, height: 40, padding: 0, cursor: "pointer",
+      background: "transparent", color: "currentColor",
+      border: "none", borderRadius: "var(--radius-sm)",
+    }}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" />
+        <path d="M3 6h18" />
+        <path d="M16 10a4 4 0 0 1-8 0" />
+      </svg>
+      {itemCount > 0 && (
+        <span style={{
+          position: "absolute", top: -2, right: -2,
+          minWidth: 18, height: 18, padding: "0 5px", display: "inline-flex",
+          alignItems: "center", justifyContent: "center", fontSize: 11, fontWeight: 600,
+          background: "var(--color-accent)", color: "#fff", borderRadius: 999,
+        }}>{itemCount}</span>
+      )}
+    </button>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/OrderCartDrawer.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/OrderCartDrawer.jsx
@@ -1,0 +1,82 @@
+// Slide-over order cart. Reads everything from useOrderCart(); mutate by lineItem.id (NOT the menu
+// item id), check out via the context (redirect-session URL). The eCom cart price
+// (line.price.formattedAmount) DOES include the currency symbol, unlike menu prices. Token-styled;
+// re-skin via theme.css. Mount it once in the Layout.
+import { useOrderCart } from "@/context/OrderCartContext";
+
+export default function OrderCartDrawer() {
+  const { cart, isOpen, setIsOpen, removeItem, updateQuantity, checkout, loading } = useOrderCart();
+  const lineItems = cart?.lineItems ?? [];
+  if (!isOpen) return null;
+
+  return (
+    <div onClick={() => setIsOpen(false)} style={{
+      position: "fixed", inset: 0, zIndex: 50,
+      background: "rgba(0,0,0,.4)", display: "flex", justifyContent: "flex-end",
+    }}>
+      <aside onClick={(e) => e.stopPropagation()} style={{
+        width: "min(420px, 100%)", height: "100%", display: "flex", flexDirection: "column",
+        background: "var(--color-bg)", color: "var(--color-text)",
+        borderLeft: "1px solid var(--color-border)", fontFamily: "var(--font-body)",
+      }}>
+        <header style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          padding: "var(--space)", borderBottom: "1px solid var(--color-border)",
+        }}>
+          <strong style={{ fontFamily: "var(--font-display)" }}>Your order</strong>
+          <button onClick={() => setIsOpen(false)} aria-label="Close order" style={{
+            border: "none", background: "none", cursor: "pointer", fontSize: 20, color: "var(--color-muted)",
+          }}>×</button>
+        </header>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "var(--space)" }}>
+          {lineItems.length === 0 ? (
+            <p style={{ color: "var(--color-muted)" }}>Your order is empty.</p>
+          ) : lineItems.map((line) => (
+            <div key={line.id} style={{
+              display: "flex", gap: 12, padding: "12px 0",
+              borderBottom: "1px solid var(--color-border)",
+            }}>
+              {/* line.id is the lineItemId for mutations — NOT the menu item id */}
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontWeight: 600 }}>{line.productName?.original}</span>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 4 }}>
+                  <QtyButton onClick={() => updateQuantity(line.id, Math.max(1, line.quantity - 1))}>−</QtyButton>
+                  <span style={{ minWidth: 20, textAlign: "center" }}>{line.quantity}</span>
+                  <QtyButton onClick={() => updateQuantity(line.id, line.quantity + 1)}>+</QtyButton>
+                  <button onClick={() => removeItem(line.id)} style={{
+                    marginLeft: "auto", border: "none", background: "none", cursor: "pointer",
+                    color: "var(--color-muted)", fontSize: 13, textDecoration: "underline",
+                  }}>Remove</button>
+                </div>
+              </div>
+              {/* eCom cart price DOES include the currency symbol (unlike menu prices) */}
+              <span style={{ fontWeight: 600 }}>{line.price?.formattedAmount}</span>
+            </div>
+          ))}
+        </div>
+
+        {lineItems.length > 0 && (
+          <footer style={{ padding: "var(--space)", borderTop: "1px solid var(--color-border)" }}>
+            <button disabled={loading} onClick={checkout} style={{
+              width: "100%", padding: "12px", cursor: loading ? "wait" : "pointer",
+              background: "var(--color-primary)", color: "var(--color-on-primary)",
+              border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+              opacity: loading ? 0.6 : 1,
+            }}>Checkout</button>
+          </footer>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+function QtyButton({ children, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      width: 28, height: 28, cursor: "pointer", lineHeight: 1,
+      background: "var(--color-surface)", color: "var(--color-text)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+    }}>{children}</button>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/context/OrderCartContext.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/context/OrderCartContext.jsx
@@ -1,0 +1,63 @@
+// Order-cart state — mirrors the Wix SERVER cart (never a local copy). Wrap the app in
+// <OrderCartProvider>; every component reads useOrderCart(). It also resolves the ordering
+// Operation once on mount (restaurant lines REQUIRE an operationId) and exposes `ordering` — false
+// when no operation is configured, so the UI shows an "ordering unavailable" state instead of
+// throwing. Data wiring is correct as-is — do not restyle or re-derive it.
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import {
+  getCurrentCart,
+  getDefaultOperation,
+  addItemToCart,
+  removeFromCart as apiRemove,
+  updateCartItemQuantity as apiQty,
+  checkout as apiCheckout,
+} from "@/rest/wix-restaurants-ordering";
+
+const OrderCartContext = createContext(null);
+
+export function OrderCartProvider({ children }) {
+  const [cart, setCart] = useState(null);
+  const [operation, setOperation] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const refreshCart = useCallback(async () => setCart(await getCurrentCart()), []);
+  useEffect(() => {
+    getDefaultOperation().then(setOperation);              // null when no operation is configured
+    refreshCart();
+    const onVisible = () => document.visibilityState === "visible" && refreshCart();
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refreshCart]);
+
+  const itemCount = (cart?.lineItems ?? []).reduce((n, li) => n + (li.quantity || 0), 0);
+
+  // A menu item carries its menuId/sectionId from the getFullMenu tree — the caller passes both.
+  // addItemToCart throws on a missing operation/menu/section or an unavailable line; let it propagate.
+  const addItem = async (item, { menuId, sectionId }, qty = 1) => {
+    if (!operation) throw new Error("Online ordering isn't available for this restaurant right now.");
+    setLoading(true);
+    try {
+      setCart(await addItemToCart(item.id, { operationId: operation.id, menuId, sectionId, quantity: qty }));
+      setIsOpen(true);
+    } finally { setLoading(false); }
+  };
+  const removeItem = async (lineItemId) => { setLoading(true); try { setCart(await apiRemove(lineItemId)); } finally { setLoading(false); } };
+  const updateQuantity = async (lineItemId, qty) => { setLoading(true); try { setCart(await apiQty(lineItemId, qty)); } finally { setLoading(false); } };
+  const checkout = async () => { setLoading(true); try { window.location.href = await apiCheckout(); } finally { setLoading(false); } };
+
+  return (
+    <OrderCartContext.Provider value={{
+      cart, operation, ordering: Boolean(operation), itemCount, isOpen, setIsOpen, loading,
+      addItem, removeItem, updateQuantity, checkout, refreshCart,
+    }}>
+      {children}
+    </OrderCartContext.Provider>
+  );
+}
+
+export function useOrderCart() {
+  const ctx = useContext(OrderCartContext);
+  if (!ctx) throw new Error("useOrderCart must be used within <OrderCartProvider>");
+  return ctx;
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/hooks/useItemOrder.js
+++ b/skills/wix-vibe-headless/references/restaurants/app/hooks/useItemOrder.js
@@ -1,0 +1,32 @@
+// useItemOrder — the item-dialog's add-to-cart logic, no markup: gate on stock + whether ordering
+// is available, hold the quantity, and add the line through the order cart. The shipped
+// addItemToCart sends operationId + menuId + sectionId + quantity only — the restaurants
+// catalogReference.options shape for price-variant / modifier selections is NOT documented for
+// client add-to-cart, so modifier groups are DISPLAYED for the diner but not sent (see the dialog
+// and INSTRUCTIONS "Extending"). Keep this gating verbatim; the dialog only renders what it returns.
+import { useState } from "react";
+import { useOrderCart } from "@/context/OrderCartContext";
+
+export function useItemOrder(item, { menuId, sectionId }) {
+  const { addItem, ordering } = useOrderCart();
+  const [quantity, setQuantity] = useState(1);
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState(null);
+
+  const inStock = item?.orderSettings?.inStock !== false;
+  const canAdd = ordering && inStock && !adding;
+
+  async function submit() {
+    setError(null);
+    setAdding(true);
+    try {
+      await addItem(item, { menuId, sectionId }, quantity);   // opens the cart drawer on success
+    } catch (e) {
+      setError(e.message);                                     // out-of-stock / no operation surfaces here
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  return { quantity, setQuantity, inStock, ordering, canAdd, adding, error, submit };
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/hooks/useReservation.js
+++ b/skills/wix-vibe-headless/references/restaurants/app/hooks/useReservation.js
@@ -1,0 +1,73 @@
+// useReservation — all table-reservation flow logic, no markup. The bug-prone parts are here and
+// must stay verbatim: skip archived locations; offer only AVAILABLE slots; a HELD reservation
+// carries the { id, revision } that reserveReservation NEEDS and expires in 10 minutes; the
+// confirmed status is RESERVED (auto-approved) or REQUESTED (manual approval pending). firstName +
+// phone (E.164, e.g. "+15551234567") are mandatory. The page only renders what this returns.
+import { useState, useEffect, useCallback } from "react";
+import {
+  listReservationLocations,
+  getTimeSlots,
+  createHeldReservation,
+  reserveReservation,
+} from "@/rest/wix-restaurants-reservations";
+
+const today = () => new Date().toISOString().slice(0, 10);   // yyyy-mm-dd for the date input
+
+export function useReservation() {
+  const [locations, setLocations] = useState(null);
+  const [locationId, setLocationId] = useState(null);
+  const [date, setDate] = useState(today());
+  const [partySize, setPartySize] = useState(2);
+  const [slots, setSlots] = useState(null);                  // AVAILABLE slots for the current query
+  const [held, setHeld] = useState(null);                    // { id, revision, ... } after hold
+  const [reservee, setReservee] = useState({ firstName: "", lastName: "", phone: "", email: "" });
+  const [confirmed, setConfirmed] = useState(null);          // reservation after reserve
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    listReservationLocations().then((locs) => {
+      const active = locs.filter((l) => l.archived !== true);   // archived locations are hidden
+      setLocations(active);
+      setLocationId(active.find((l) => l.default)?.id ?? active[0]?.id ?? null);
+    });
+  }, []);
+
+  // The chosen slot's ISO datetime is passed to hold (getTimeSlots wants an ISO datetime for `date`).
+  const findSlots = useCallback(async () => {
+    if (!locationId) return;
+    setError(null); setSlots(null); setHeld(null); setConfirmed(null); setLoading(true);
+    try {
+      const iso = new Date(`${date}T19:00:00`).toISOString();
+      const { availableTimeSlots } = await getTimeSlots(locationId, iso, partySize);
+      setSlots(availableTimeSlots);
+    } catch (e) { setError(e.message); } finally { setLoading(false); }
+  }, [locationId, date, partySize]);
+
+  const holdSlot = async (slot) => {
+    setError(null); setLoading(true);
+    try { setHeld(await createHeldReservation(locationId, slot.startDate, partySize)); }
+    catch (e) { setError(e.message); } finally { setLoading(false); }
+  };
+
+  const confirm = async () => {
+    if (!held) return;
+    setError(null); setLoading(true);
+    try {
+      const clean = { firstName: reservee.firstName, phone: reservee.phone };
+      if (reservee.lastName) clean.lastName = reservee.lastName;
+      if (reservee.email) clean.email = reservee.email;
+      setConfirmed(await reserveReservation(held.id, held.revision, clean));
+    } catch (e) { setError(e.message); setHeld(null); } finally { setLoading(false); }
+  };
+
+  const reset = () => { setHeld(null); setConfirmed(null); setSlots(null); setError(null); };
+
+  return {
+    locations, locationId, setLocationId,
+    date, setDate, partySize, setPartySize,
+    slots, findSlots, held, holdSlot,
+    reservee, setReservee, confirm, confirmed, reset,
+    loading, error,
+  };
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/pages/Menu.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/pages/Menu.jsx
@@ -1,0 +1,28 @@
+// Menu page — the restaurant's main render surface. Loads the assembled getFullMenu() tree once,
+// renders it via MenuList, and opens ItemDialog for a tapped dish (add-to-order lives there).
+// Empty state when there are no menus. Token-styled; re-skin via theme.css.
+import { useEffect, useState } from "react";
+import { getFullMenu } from "@/rest/wix-restaurants-menu";
+import MenuList from "@/components/MenuList";
+import ItemDialog from "@/components/ItemDialog";
+
+export default function Menu() {
+  const [menus, setMenus] = useState(null);
+  const [active, setActive] = useState(null);   // { item, menuId, sectionId }
+
+  useEffect(() => { getFullMenu().then(({ menus }) => setMenus(menus)); }, []);
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Menu</h1>
+      {menus === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <MenuList menus={menus} onOpenItem={(item, ctx) => setActive({ item, ...ctx })}
+            empty="No menu yet — add one from your Wix dashboard." />}
+      {active && (
+        <ItemDialog item={active.item} menuId={active.menuId} sectionId={active.sectionId}
+          onClose={() => setActive(null)} />
+      )}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/pages/Reservations.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/pages/Reservations.jsx
@@ -1,0 +1,112 @@
+// Reservations page — thin view over useReservation (all flow logic lives in the hook). Location
+// picker → date + party size → AVAILABLE slots → hold → details → confirm. Reads the confirmed
+// reservation's top-level status: RESERVED is confirmed, REQUESTED means the location needs manual
+// approval (pending). Token-styled; re-skin via theme.css.
+import { useReservation } from "@/hooks/useReservation";
+
+const field = {
+  width: "100%", padding: "10px 12px", boxSizing: "border-box",
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-bg)", color: "var(--color-text)", fontFamily: "var(--font-body)",
+};
+const primaryBtn = {
+  padding: "12px 24px", cursor: "pointer", border: "none", borderRadius: "var(--radius-sm)",
+  background: "var(--color-primary)", color: "var(--color-on-primary)", fontSize: 15, fontWeight: 600,
+};
+
+function slotLabel(iso) {
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+function locationLabel(loc) {
+  return loc.location?.name || loc.location?.address?.formatted || "Main location";
+}
+
+export default function Reservations() {
+  const r = useReservation();
+
+  if (r.locations === null) return <Centered>Loading…</Centered>;
+  if (r.locations.length === 0) return <Centered>Reservations aren't set up yet — enable Table Reservations in your Wix dashboard.</Centered>;
+
+  if (r.confirmed) {
+    const d = r.confirmed.details || {};
+    const pending = r.confirmed.status === "REQUESTED";
+    return (
+      <main style={wrap}>
+        <h1 style={{ fontFamily: "var(--font-display)" }}>{pending ? "Reservation requested" : "You're booked!"}</h1>
+        <p style={{ color: "var(--color-muted)" }}>
+          {pending
+            ? "The restaurant will confirm your request shortly."
+            : "Your table is confirmed. See you soon!"}
+        </p>
+        <p>{d.partySize} guests · {d.startDate && new Date(d.startDate).toLocaleString()}</p>
+        <button style={primaryBtn} onClick={r.reset}>Make another reservation</button>
+      </main>
+    );
+  }
+
+  return (
+    <main style={wrap}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Reserve a table</h1>
+
+      <div style={{ display: "grid", gap: "var(--space)", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))" }}>
+        {r.locations.length > 1 && (
+          <label>Location
+            <select value={r.locationId ?? ""} onChange={(e) => r.setLocationId(e.target.value)} style={field}>
+              {r.locations.map((loc) => <option key={loc.id} value={loc.id}>{locationLabel(loc)}</option>)}
+            </select>
+          </label>
+        )}
+        <label>Date
+          <input type="date" value={r.date} onChange={(e) => r.setDate(e.target.value)} style={field} />
+        </label>
+        <label>Guests
+          <input type="number" min={1} value={r.partySize}
+            onChange={(e) => r.setPartySize(Math.max(1, Number(e.target.value) || 1))} style={field} />
+        </label>
+      </div>
+
+      <div style={{ marginTop: "var(--space)" }}>
+        <button style={primaryBtn} disabled={r.loading} onClick={r.findSlots}>Find a table</button>
+      </div>
+
+      {r.error && <p style={{ color: "var(--color-danger)" }}>{r.error}</p>}
+
+      {r.slots && !r.held && (
+        r.slots.length === 0
+          ? <p style={{ color: "var(--color-muted)", marginTop: "var(--space)" }}>No tables available then — try another date or party size.</p>
+          : <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: "var(--space)" }}>
+              {r.slots.map((slot) => (
+                <button key={slot.startDate} onClick={() => r.holdSlot(slot)} disabled={r.loading} style={{
+                  padding: "10px 16px", cursor: "pointer",
+                  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+                  background: "var(--color-surface)", color: "var(--color-text)", fontWeight: 600,
+                }}>{slotLabel(slot.startDate)}</button>
+              ))}
+            </div>
+      )}
+
+      {r.held && (
+        <form onSubmit={(e) => { e.preventDefault(); r.confirm(); }}
+          style={{ marginTop: "calc(var(--space) * 1.5)", display: "flex", flexDirection: "column", gap: 12, maxWidth: 420 }}>
+          <p style={{ margin: 0, color: "var(--color-muted)" }}>
+            Holding your table for 10 minutes — enter your details to confirm.
+          </p>
+          <input required placeholder="First name *" value={r.reservee.firstName}
+            onChange={(e) => r.setReservee({ ...r.reservee, firstName: e.target.value })} style={field} />
+          <input placeholder="Last name" value={r.reservee.lastName}
+            onChange={(e) => r.setReservee({ ...r.reservee, lastName: e.target.value })} style={field} />
+          <input required placeholder="Phone (e.g. +15551234567) *" value={r.reservee.phone}
+            onChange={(e) => r.setReservee({ ...r.reservee, phone: e.target.value })} style={field} />
+          <input type="email" placeholder="Email" value={r.reservee.email}
+            onChange={(e) => r.setReservee({ ...r.reservee, email: e.target.value })} style={field} />
+          <button type="submit" style={primaryBtn} disabled={r.loading}>Confirm reservation</button>
+        </form>
+      )}
+    </main>
+  );
+}
+
+const wrap = { maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" };
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/restaurants/app/theme.css
+++ b/skills/wix-vibe-headless/references/restaurants/app/theme.css
@@ -1,0 +1,37 @@
+/* theme.css — THE styling surface. Theme the whole restaurant by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every template component reads these variables, so
+   changing them here re-skins the entire site (menu, item dialog, order cart, reservations).
+   Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f5f2;   /* cards, dialogs, wells */
+  --color-text:      #1c1a17;   /* primary text */
+  --color-muted:     #6b6357;   /* secondary text (descriptions, meta) */
+  --color-border:    #e7e3db;   /* hairlines, dividers */
+  --color-primary:   #1c1a17;   /* buttons, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #c1440e;   /* featured, price highlight, badges */
+  --color-danger:    #b42318;   /* sold out, errors */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display/serif face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      14px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1040px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#12100d; --color-surface:#1c1913; --color-text:#f3efe8; --color-muted:#a89f90;
+  --color-border:#2c2820; --color-primary:#f3efe8; --color-on-primary:#12100d;
+}


### PR DESCRIPTION
Converts **restaurants** to the storefront-as-files model: menu (getFullMenu tree) + item dialog + reservations; OrderCartProvider.

- `references/restaurants/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (13 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)