### PR TITLE
feat(cms): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -1,265 +1,271 @@
+# Wix CMS — ready-made client
 
-# Wix CMS Skill
+The CMS client is **shipped as real files**, not snippets to regenerate. It's a complete
+list + detail over any Wix Data collection, styled entirely from `theme.css` tokens and pointed at
+your collection from one `collection.config.js`. Copy it into the app, theme the tokens, map your
+fields, wire the routes — you generate almost none of the data code (query/cursor pagination, detail
+resolution by slug-or-id, image-URI conversion, empty state all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/cms/wix-cms.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
-
-Builds a real, client-only Wix CMS-backed app. The browser talks to Wix Data directly
-over a public `WIX_CLIENT_ID` to read and write items in the site's data collections.
-Never mock data; never hand-build API URLs — always go through the helpers, which call
-the official Wix Data endpoints.
-
-## When to use
-- User wants to display Wix CMS / Content Manager content (a collection of posts,
-  tutorials, recipes, team members, listings, FAQs, etc.) on a site.
-- Replacing placeholder/mock content with live Wix Data items.
-- Adding list pages, detail pages, category/tag filtering, or free-text search over an
-  existing Wix data collection.
-- Wiring a public form (contact, RSVP, review, signup) that writes a row into a collection.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens) using the official
+Wix Data endpoints. Never mock items; never hand-build a Wix Data URL — the shipped helpers call
+`/wix-data/v2/items`.
 
 ## Prerequisites
-1. A Wix site with **a data collection already created and populated** (this skill does
-   NOT provision collections — it reads/writes existing ones). The merchant creates
-   collections, fields, and items in the Wix dashboard (CMS / Content Manager).
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the
-   Wix Business Manager surfaces a copyable prompt with the id filled in — see
-   the router `SKILL.md`). Set it in `src/rest/wix-config.js` in place of the placeholder. It is
-   a buyer-facing credential (it only mints anonymous visitor tokens), **not** a secret,
-   so hardcoding/committing it is fine.
-3. **Collection permissions** must match what you're doing. This skill runs as an
-   anonymous visitor, so a call only works if the collection grants that action to
-   "Anyone": Read for listing content, Insert for a public form. Update/Delete are
-   almost always admin- or author-only and will fail for a visitor. The site owner sets
-   these in the Wix dashboard (CMS → collection → Permissions). This is a **separate Wix
-   setup step the user completes** — out of this skill's scope. If a read/insert fails
-   with a permission error (HTTP 403) before that's set, that's expected; flag it and
-   continue.
-4. You need each collection's **collection ID** (its name, e.g. `Tutorials`) and its
-   **field keys** (e.g. `title`, `publishDate`). Read field keys off a fetched item, or
-   from the collection schema (see "Beyond the snippets"). **Carry your own seed/design
-   plan's field keys forward as the canonical list for rendering** — the item shape here is
-   user-defined (these are the keys *you* planned for the collection), so drive the UI off
-   that known list rather than guessing keys or reverse-engineering them from a single row.
+- A Wix site with **a data collection** (CMS / Content Manager) as the read target. It's created and
+  seeded separately (see **Seeding** below), in parallel with this build — so it may be empty at
+  build time; the client renders the shipped empty state until items land. This skill does NOT
+  provision collections.
+- **Collection permissions** must grant the action you do to "Anyone" — this client runs as an
+  anonymous visitor. Read for listing/detail (**Show content → Everyone**); Insert only if you add a
+  public form. Update/Delete are admin/author-only and will 403 for a visitor. The owner sets these
+  in the dashboard (CMS → collection → Permissions) — a **separate Wix setup step**, out of scope. A
+  403 before it's set is expected; flag it and continue.
+- The public headless **`WIX_CLIENT_ID`** (and `WIX_METASITE_ID`) from your prompt (buyer-facing,
+  safe to hardcode/commit).
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the UI however the project
-wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
-adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID`
-  from `wix-config.js`. The visitor refresh token is persisted to localStorage; do not
-  re-mint anonymously per load.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-cms.js` — exports:
-  - **Read:** `queryDataItems`, `getDataItem`, `getDataItemBy`, `countDataItems`
-  - **Write:** `insertDataItem`, `updateDataItem`, `removeDataItem`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole CMS UI client + REST scaffolds into `src/`
+(imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map, so you
+don't need to open them:**
 
-The Data Item shape, the per-collection **permissions model**, and the **filter/sort
-syntax** are documented as JSDoc comments at the top of `wix-cms.js`. Read them before
-building the UI — read helpers return the item's flat `data` payload (which always
-includes `_id`), and writes are bound by collection permissions.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `collection.config.js` | **you point at your collection + map field keys here** (STEP 2) |
+| `hooks/useCollection.js` | list data — count, first page, cursor pagination for the configured collection |
+| `hooks/useItemDetail.js` | detail data — resolves one item by slug (or `_id`) for a route |
+| `components/ItemCard.jsx`, `ItemGrid.jsx` | list UI (grid + card, with empty state) |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `lib/wixImage.js` | converts a `wix:image://` media field to a renderable URL (used by the UI) |
+| `pages/Collection.jsx`, `pages/ItemDetail.jsx` | the two shipped routes (list + detail) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` + `rest/wix-cms.js` | REST transport + Wix Data helpers |
 
-**Owner field — use `_owner`.** The system field that holds the item's owner (the member
-who inserted it) is **`_owner`** in Wix Data v2 — this is the key to filter on for a "my
-items" view (`filter: { _owner: <memberId> }`) and the one Wix stamps on member inserts.
-(The JSDoc comment in `wix-cms.js` currently labels it `_ownerId`; that is a typo in the
-comment — the live field is `_owner`.)
+They're already in place — go **straight to config + theming + wiring**, nothing to verify first.
+**Don't `read_file` the shipped page/component/hook source to inspect it** — the table says what each
+is and every field shape you need is in the snippets below. Read a shipped file's source **only** on
+a real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/cms/app/` → `src/`.)
 
-## How to wire it (UI is the project's choice)
-- **Content list** — `queryDataItems(collectionId, { filter?, sort?, limit?, cursor? })`
-  **resolves to `{ items, nextCursor }`** (not a bare array) — destructure it, iterate
-  `.items`, and render fields directly off each item (`item.title`, etc.). Each item is
-  the flat `data` payload and always carries `_id`. Pass the returned `nextCursor` back as
-  `cursor` to load the next page. Define `filter`/`sort` on the first request only — cursor
-  follow-ups reuse the original query (pass only the cursor). See the reference snippet below.
-- **Sort & date filters** — `sort` is an **array** of `{ fieldName, order: "ASC"|"DESC" }`
-  (e.g. `sort: [{ fieldName: "publishDate", order: "DESC" }]`) — **not** a Mongo
-  `{ field: -1 }` object. In a `filter`, date comparands must be wrapped as
-  `{ "$date": "2026-05-05T00:00:00.000Z" }` (ISO string), not a bare string — e.g.
-  `{ publishDate: { $lte: { "$date": new Date().toISOString() } } }`.
-- **Reference fields** — a `MULTI_REFERENCE` field is **not** inline by default: without
-  asking for it, `item.<field>` is not populated, so don't `.map` over it. Pass
-  `includeReferences: [{ field: "<field>", limit: N }]` to `queryDataItems`; the referenced
-  items then come back under `item.<field>`, and you render them by mapping that (see the
-  snippet). The exact expanded shape (an array of referenced `data` payloads, each with its
-  own `_id`) and any beyond-the-inline-limit expansion — confirm against the Query Referenced
-  Data Items reference under "Beyond the snippets"; it is not spelled out in the helper's JSDoc.
-- **Detail page** — route by the item's `_id` and call `getDataItem(collectionId, itemId)`;
-  returns null on miss → show a not-found state, never invent an item. For human-readable
-  URLs, add a slug-like field to the collection and route via
-  `getDataItemBy(collectionId, "slug", slugFromUrl)`.
-- **Filter & search** — pass a `filter` to `queryDataItems` using the operators documented
-  in `wix-cms.js` (`$eq`, `$in`, `$gte`, `$startsWith`, `$hasSome`, `$and`/`$or`, …). For a
-  simple text search, `{ title: { $startsWith: term } }`; for richer free-text/fuzzy search
-  across fields, see "Beyond the snippets" (Search Data Items).
-- **Public form** — on submit, `insertDataItem(collectionId, { name, email, message })`
-  (field keys must match the collection). Requires the collection's Insert permission to be
-  "Anyone". It resolves to the **flat inserted `data` payload** (including the newly assigned
-  `_id`) — not a `{ dataItem: { … } }` wrapper — so read `_id`/fields straight off the return.
-  Show success/failure from the resolved/thrown result; never fake a success.
-- **Edit / delete (admin/author flows)** — `updateDataItem(collectionId, itemId, data)`
-  (⚠ full replace — fetch + merge first to preserve other fields) and
-  `removeDataItem(collectionId, itemId)`. Like insert, `updateDataItem` resolves to the flat
-  updated `data` payload (with `_id`), not a `{ dataItem: { … } }` wrapper. These need
-  Update/Delete granted to the caller, which visitors normally don't have — expect them to
-  fail unless the collection is opened up.
-- **Empty state** — if `countDataItems(collectionId)` is 0, show an empty state telling
-  the user to add items in their Wix dashboard. Never invent items.
+## STEP 2 — Credentials + point at your collection
+Two one-file edits (the CMS equivalent of storefront's credentials step):
+- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt (the one place
+  both ids live).
+- `src/collection.config.js` — set `COLLECTION_ID` to your collection's **name** (e.g. `"Recipes"` —
+  it's the id in Wix Data, not a GUID), and map `FIELDS` (`title`, `image`, `summary`, `body`,
+  `date`, `slug`) to your collection's field keys. **Use the field keys from your own seed / design
+  plan** as the canonical list — don't guess or reverse-engineer them from a fetched row. Set any
+  role you don't have to `null` and the UI omits it; `title` is the only required role. If you map a
+  `slug` field, detail URLs use it; otherwise they fall back to the item's `_id`.
 
-## Reference snippet (shape-correct; restyle freely)
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole client. **Do not
+restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
+home page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the
+dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
-The item shape is **user-defined** (the field keys are the ones from your own seed/design
-plan), so this is a skeleton, not a drop-in — the data wiring is what's load-bearing:
-`queryDataItems` returns `{ items, nextCursor }`, each item is a flat `data` payload with
-`_id`, `sort` is an array of `{ fieldName, order }`, dates are `{ "$date": ISO }`, and a
-`MULTI_REFERENCE` field only populates when you pass `includeReferences`. Keep that wiring;
-swap the field keys (`title`, `photo`, `publishDate`, `ingredients`) for your own.
+## STEP 4 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it.
+- `import "@/theme.css";` once at the app entry.
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Collection` / `ItemDetail` — so you **never edit the shipped pages to add a
+  header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's **ResizeObserver-measured** height so it clears the chrome and
+  self-corrects when the banner is dismissed.
+- Routes under the Layout: your list path → `Collection`, `/item/:key` → `ItemDetail` (both shipped,
+  as-is). **You add `/` → your own Home** page. (The list path and `/item/:key` are conventions — the
+  card links to `/item/:key`; if you rename that route, keep the two in sync.)
+
+CMS has **no cross-page state** (no cart), so there's **no provider to wrap** — this is the one place
+the CMS Layout is simpler than storefront's `<CartProvider>`/`<CartDrawer>`.
+
+```jsx
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Collection from "@/pages/Collection";
+import ItemDetail from "@/pages/ItemDetail";
+import Home from "@/pages/Home";           // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
+
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Collection/ItemDetail render here, untouched */}
+      <Footer />
+    </div>
+  </>);
+}
+
+<Routes>
+  <Route element={<Layout />}>                              {/* chrome wraps all */}
+    <Route path="/" element={<Home />} />                   {/* yours */}
+    <Route path="/browse" element={<Collection />} />       {/* shipped — rename the path to your content */}
+    <Route path="/item/:key" element={<ItemDetail />} />    {/* shipped, as-is */}
+  </Route>
+</Routes>
+```
+
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
+(STEP 4) so they wrap every route — plus the overall brand story, styled from the same `theme.css`
+tokens. **Compose the shipped pieces** — a featured strip is just `useCollection` + the shipped
+`ItemGrid`; the nav is a link to your list route. Build the `Header` responsive via a **single-branch
+`mobile`-state ternary** (copy storefront's pattern) — **never** a Tailwind `hidden md:*` toggle on an
+inline-styled component (an inline `display` beats a Tailwind class, so both branches would render).
 
 ```jsx
 import { useState, useEffect } from "react";
-import { queryDataItems, countDataItems } from "@/rest/wix-cms";
+import { Link } from "react-router-dom";
+import { useCollection } from "@/hooks/useCollection";
+import ItemGrid from "@/components/ItemGrid";
 
-// Field keys are YOUR OWN — the ones from your seed plan for this collection.
-// Carry that plan forward as the canonical list of keys to render.
-const COLLECTION = "Recipes";
-
-export default function Recipes() {
-  const [items, setItems] = useState([]);
-  const [cursor, setCursor] = useState(null);
-  const [total, setTotal] = useState(null);
-
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
   useEffect(() => {
-    countDataItems(COLLECTION).then(setTotal);
-    queryDataItems(COLLECTION, {
-      sort: [{ fieldName: "publishDate", order: "DESC" }],        // array of { fieldName, order } — NOT { field: -1 }
-      filter: { publishDate: { $lte: { "$date": new Date().toISOString() } } }, // date wrapped in { "$date": ISO }
-      includeReferences: [{ field: "ingredients", limit: 10 }],   // expand a MULTI_REFERENCE field inline
-      limit: 24,
-    }).then(({ items, nextCursor }) => {   // destructure — queryDataItems returns { items, nextCursor }
-      setItems(items);                     // each item is the flat `data` payload, incl. _id
-      setCursor(nextCursor);
-    });
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
   }, []);
-
-  const loadMore = () =>
-    // cursor follow-ups reuse the first request's filter/sort — pass ONLY the cursor
-    queryDataItems(COLLECTION, { cursor, limit: 24 }).then(({ items: more, nextCursor }) => {
-      setItems((prev) => [...prev, ...more]);
-      setCursor(nextCursor);
-    });
-
-  if (total === 0) return <p>{/* empty state — no items yet; point the user to the dashboard */}</p>;
   return (
-    <div /* restyle */>
-      {items.map((item) => (
-        <article key={item._id} /* restyle */>
-          <h3>{item.title}</h3>
-          {/* item.ingredients is an array of referenced `data` payloads ONLY because of includeReferences */}
-          <ul>{(item.ingredients || []).map((ref) => <li key={ref._id}>{ref.name}</li>)}</ul>
-        </article>
-      ))}
-      {cursor && <button onClick={loadMore}>Load more</button>}
-    </div>
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger here
+        : <div style={{ display: "flex", gap: 24 }}><Link to="/browse">Browse</Link></div>}
+    </nav>
   );
 }
+
+export function Featured() {                                // on your home page
+  const { items } = useCollection({ limit: 6 });            // hook returns { items, total, loadMore, hasMore }
+  return <ItemGrid items={items || []} empty="Content coming soon." />;
+}
+```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
+
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
+
+## Using the client (data shapes that are load-bearing)
+The shipped hooks own the common paths; when you call the helpers directly (a filtered strip, a
+search box, a form), keep this wiring — it's the bug-prone part:
+
+```jsx
+import { queryDataItems, getDataItem, getDataItemBy, countDataItems, insertDataItem } from "@/rest/wix-cms";
+
+// LIST — queryDataItems resolves to { items, nextCursor } (NOT a bare array). Each item is the flat
+// `data` payload and always carries `_id`. Pass nextCursor back as `cursor` for the next page;
+// define filter/sort on the FIRST request only (cursor follow-ups reuse them — pass only the cursor).
+const { items, nextCursor } = await queryDataItems("Recipes", {
+  sort: [{ fieldName: "publishDate", order: "DESC" }],        // array of { fieldName, order } — NOT { field: -1 }
+  filter: { publishDate: { $lte: { "$date": new Date().toISOString() } } }, // date wrapped { "$date": ISO }
+  limit: 24,
+});
+
+// DETAIL — route by the item's `_id` (getDataItem) or a slug field (getDataItemBy); null on miss →
+// show a not-found state, never invent an item. (useItemDetail already does this off collection.config.)
+const one = await getDataItemBy("Recipes", "slug", slugFromUrl);
+
+// FILTER & SEARCH — operators: $eq $ne $gt $gte $lt $lte $in $nin $startsWith $exists $hasSome $hasAll,
+// combined with $and/$or/$not. Simple text search: { title: { $startsWith: term } }.
+
+// MULTI_REFERENCE fields are NOT inline — without asking, item.<field> isn't populated. Pass
+// includeReferences: [{ field: "ingredients", limit: 10 }] to queryDataItems, THEN .map item.<field>.
+
+// PUBLIC FORM — insertDataItem("Reviews", { name, email, message }); needs Insert = "Anyone".
+// Resolves to the flat inserted `data` payload (with _id); throws on failure — never fake success.
 ```
 
-**Image fields need conversion — don't put the field straight into `<img src>`.** A
-merchant-uploaded image field comes back as a Wix media URI like
-`wix:image://v1/<id>~mv2.jpg/<filename>#originWidth=…&originHeight=…`, which a browser
-**cannot** render directly. Only images written by your own seed step tend to be plain
-`https://static.wixstatic.com/...` URLs, which do work in `<img src>`. So branch on it:
-a value starting with `https://` (or `//`) is usable as-is; a `wix:image://` value must be
-converted to a static URL first. **Neither helper in this skill converts media URIs** — look
-up the current Wix Media image-URL conversion in the Wix docs (search "Wix Media" / "image
-URL" in the API reference under "Beyond the snippets") and use that; never hand-assemble the
-`static.wixstatic.com` URL by guessing the transform.
+**Images are handled by the shipped `lib/wixImage.js`.** A merchant-uploaded image field comes back
+as a `wix:image://…` media URI the browser can't render; `wixImage()` converts it (and passes
+`https://` / `//` URLs through). The shipped `ItemCard`/`ItemDetail` already run every image through
+it — if you render an image yourself, do the same: `import { wixImage } from "@/lib/wixImage"`.
 
-## Hard rules (do not violate)
-- ✅ Read/write ONLY through the helpers in `wix-cms.js` (which call the official Wix Data
-  `/wix-data/v2/items` endpoints).
-- ❌ Never hand-build Wix Data URLs or invent endpoint paths.
-- ❌ Never mock data — render live Wix Data items or the empty state.
-- ❌ Never invent fields, reviews, ratings, or content not present in the collection.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Use the item's `_id` as the route key and as `itemId` for get/update/remove.
-- ✅ `queryDataItems` resolves to `{ items, nextCursor }` (not a bare array) — destructure and
-  iterate `.items`; each item is a flat `data` payload with `_id`. `insert`/`update` also
-  resolve to the flat `data` payload (with `_id`), not a `{ dataItem: { … } }` wrapper.
-- ✅ `sort` is `[{ fieldName, order: "ASC"|"DESC" }]` (not Mongo `{ field: -1 }`); date filter
-  comparands are wrapped `{ "$date": "ISO" }` (not a bare string).
-- ✅ A `MULTI_REFERENCE` field is not inline — pass `includeReferences: [{ field, limit }]` and
-  only then `.map` over `item.<field>`; without it the field isn't populated.
-- ✅ Convert `wix:image://` media URIs before using them in `<img src>` (a plain `https://` /
-  `//` URL is fine as-is); look up the conversion in the Wix docs — no helper here does it.
-- ✅ The owner field is `_owner` (Wix Data v2), not `_ownerId`.
-- ✅ `updateDataItem` REPLACES the whole item — fetch with `getDataItem`, merge your
-  changes, then pass the full object, or use Patch Data Item (see below) for partial edits.
-- ✅ Treat permission errors (HTTP 403) as a configuration step, not a code bug: tell the
-  user which permission to grant in the dashboard. Writes throw on failure — don't swallow
-  the error and show a fake success.
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Point at your collection + map `FIELDS` in `collection.config.js` (STEP 2) — using your seed plan's
+  field keys, not guesses.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+  `Collection`/`ItemDetail` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
+  `Header` is plain in-flow markup (not `position:fixed`).
+- Read/write ONLY through the `wix-cms.js` helpers (they call the official Wix Data endpoints) — never
+  hand-build a Wix Data URL.
+- `queryDataItems` resolves to `{ items, nextCursor }` (destructure, iterate `.items`); `sort` is
+  `[{ fieldName, order }]` (not Mongo `{ field: -1 }`); date comparands wrap as `{ "$date": ISO }`.
+- Convert `wix:image://` URIs (via `lib/wixImage.js`) before `<img src>` — never render one raw.
+- The owner field is `_owner` (Wix Data v2), not `_ownerId`. A "my items" view is
+  `queryDataItems(collectionId, { filter: { _owner: memberId } })`.
+- `updateDataItem` REPLACES the whole item — fetch + merge first (or use Patch Data Item).
+- Render live Wix data or the shipped empty state — never mock items; never invent fields not in the
+  collection.
+- Treat a 403 as a permissions setup step (tell the user which permission to grant), not a code bug.
 
-## Beyond the snippets
-The snippets cover the common CMS paths (list, detail, filter, count, insert, update,
-remove). If you hit a use case they don't cover, make the call yourself with
-`wixApiRequest` — but look up the exact endpoint, HTTP method, and request body in the
-**official Wix API reference** first; never guess:
+## Fallback only — beyond the shipped client
+When you hit an error or need something the shipped client doesn't cover, make the call yourself with
+`wixApiRequest` — but look up the exact endpoint, method, and body in the **official Wix API
+reference** first; never guess. Or read the relevant shipped file under `src/`, or use the
+**`wix-docs`** skill.
 - CMS / Data Items API reference: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
-- Data Items sample flows: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/sample-flows.md
-- **Partial update** (change some fields, keep the rest): Patch Data Item —
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/patch-data-item.md
-- **Upsert** (insert or update by id): Save Data Item —
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/save-data-item.md
-- **Bulk** insert/update/save/remove (many items in one call):
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
-- **Free-text / fuzzy search** across fields: Search Data Items —
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/search-data-items.md
-- **Aggregations** (counts/averages grouped by a field): Aggregate Data Items —
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/aggregate-data-items.md
-- **Distinct values** (e.g. all categories for a filter menu): Query Distinct Values —
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-distinct-values.md
-- **Referenced items** (expand a reference field beyond the inline limit): Query Referenced
-  Data Items — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-referenced-data-items.md
-- **Collection schema / field keys & types**: Get Data Collection —
-  https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/get-data-collection.md
-- **Member-gated & user-generated content** → the **members** vertical
-  (`references/members/INSTRUCTIONS.md`). A collection whose permissions are `read: Anyone`,
-  `insert: Site Member`, `update/remove: Site Member Author` gives you the classic pattern: anyone
-  reads, only logged-in members write, and each member edits only their own. Sign the member in with
-  custom login (on your own UI), then `insertDataItem` runs as the member and Wix stamps the item's
-  `_owner` automatically — so a **"my items"** view is just
-  `queryDataItems(collectionId, { filter: { _owner: <memberId> } })`, and author-only
-  `updateDataItem`/`removeDataItem` are enforced server-side. (This skill never provisions the
-  collection — the owner creates it with those permissions in the dashboard.)
-  **Prefer Wix for member-generated content, and keep one feature's data and identity together.**
-  Content that belongs to the Wix site (likes, reviews, submissions) is best kept in a Wix collection
-  via these helpers, keyed on the Wix member's server-stamped `_owner`. What breaks is a *split*
-  feature — the row stored in one place while the member is identified from the Wix session elsewhere
-  (or filtered by some other `created_by`/user id): the two ids won't match, so ownership filters
-  miss. Keep them on one side; for Wix-backed rows that's `_owner`.
-
-Keep the snippets as the default for everything they already do; reach for the API
-reference only for the gap.
+- **Partial update**: Patch Data Item — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/patch-data-item.md
+- **Upsert by id**: Save Data Item — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/save-data-item.md
+- **Bulk** insert/update/save/remove: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
+- **Free-text / fuzzy search**: Search Data Items — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/search-data-items.md
+- **Aggregations**: Aggregate Data Items — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/aggregate-data-items.md
+- **Distinct values** (e.g. a filter menu): Query Distinct Values — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-distinct-values.md
+- **Referenced items** (beyond the inline limit): Query Referenced Data Items — https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/query-referenced-data-items.md
+- **Collection schema / field keys**: Get Data Collection — https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/get-data-collection.md
+- **Member-gated & user-generated content** → the **members** vertical (`references/members/INSTRUCTIONS.md`).
+  Keep a feature's data and identity together on one side: for Wix-backed member content, store the row
+  in a Wix collection and key it on the server-stamped `_owner`.
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the CMS content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For CMS data those pages are:
-- **Collections & items** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-cms` (`Dashboard → CMS`) → **Create Collection**, then open a collection to add items.
-- **Permissions** — no separate deep link; in the same CMS area, open the collection → **More Actions → Permissions & Privacy**. For the headless app to work anonymously, set **Show content** to *Everyone* (visitor reads) and, for a public form, **Collect content** to *Everyone* (visitor inserts). Update/Delete stay admin-only.
+Provide deep links so the owner can edit content (substitute the site's `metaSiteId`, from the handoff
+/ `ListWixSites`):
+- **Collections & items** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-cms` (`Dashboard → CMS`)
+  → **Create Collection**, then open a collection to add items.
+- **Permissions** — same CMS area → open the collection → **More Actions → Permissions & Privacy**. For
+  the headless app to read anonymously, set **Show content** to *Everyone*; for a public form, set
+  **Collect content** to *Everyone*. Update/Delete stay admin-only.
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed the collection per `seed/SEED.md` (the build-time seed module) — separate from this client build;
+run in parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (same anonymous visitor, no re-mint per load)
-- [ ] `queryDataItems` returns live items (destructured from `{ items, nextCursor }`);
-      pagination via `nextCursor` loads more
-- [ ] `sort` uses `[{ fieldName, order }]` and date filters wrap comparands in `{ "$date": ISO }`
-- [ ] Multi-reference fields fetched with `includeReferences` before being mapped
-- [ ] Image fields: `wix:image://` URIs converted before `<img src>`, not rendered raw
-- [ ] Detail page uses the item's `_id` (or a slug field via `getDataItemBy`) and shows a
-      not-found state on miss — no invented item
-- [ ] Filter/sort produce the expected subset (operators match the field types)
-- [ ] Public form `insertDataItem` succeeds only when Insert is "Anyone"; on a 403 the user
-      is told to grant the permission — no fake success
-- [ ] Update is treated as a full replace (fetch + merge), so no fields are silently dropped
-- [ ] Empty state shown when `countDataItems` is 0
-- [ ] No mock data anywhere; no hand-built Wix Data URLs
-- [ ] Told the user at least once that they can continue setting up their content in the dashboard and provided deep links.
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `collection.config.js`: `COLLECTION_ID` set to the collection name; `FIELDS` mapped to your
+      real field keys (from the seed plan); unused roles set to `null`.
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all
+      routes; shipped `Collection`/`ItemDetail` untouched; content clears the fixed chrome.
+- [ ] `useCollection` returns live items (destructured from `{ items, nextCursor }`); Load-more paginates.
+- [ ] Detail page resolves by slug (or `_id`) and shows a not-found state on miss — no invented item.
+- [ ] Image fields render (via `lib/wixImage.js`) — `wix:image://` URIs converted, not shown raw.
+- [ ] Empty collection shows the shipped empty state; no mock items anywhere.
+- [ ] Any 403 surfaced to the user as a permissions step; told the user they can keep editing content
+      in the dashboard, with deep links.

--- a/skills/wix-vibe-headless/references/cms/app/collection.config.js
+++ b/skills/wix-vibe-headless/references/cms/app/collection.config.js
@@ -1,0 +1,31 @@
+// collection.config.js — THE data surface. This is where you point the shipped list + detail at
+// YOUR Wix CMS collection and map its field keys to the roles the UI renders. Edit this file; do
+// NOT edit the components. It is the CMS equivalent of theme.css: one place, and the whole client
+// follows.
+//
+// The item shape is USER-DEFINED — the field keys below are the ones from your own seed / design
+// plan for this collection. Carry that plan forward as the canonical list; don't guess keys or
+// reverse-engineer them from a single fetched row.
+
+// The collection NAME from your Wix dashboard (CMS → Content Manager), e.g. "Recipes", "Posts".
+// NOT a GUID — the name is the id in Wix Data.
+export const COLLECTION_ID = "<YOUR-COLLECTION>";
+
+// Map your collection's field keys → the roles the shipped UI renders. Any role you set to null is
+// skipped (the UI just omits it). `title` is the only required role.
+export const FIELDS = {
+  title:   "title",         // required — card heading + detail heading
+  image:   "image",         // media field (wix:image:// or https URL) — null if the collection has none
+  summary: "description",   // short text shown on the card
+  body:    "content",       // long HTML body shown on the detail page (rendered as HTML)
+  date:    "publishDate",   // ISO date field shown as meta + used for the default sort
+  slug:    "slug",          // human-readable field for detail URLs; null → routes fall back to _id
+};
+
+// Default list sort — an array of { fieldName, order: "ASC"|"DESC" } (Wix syntax, NOT Mongo
+// { field: -1 }). null → collection/insertion order. Uses FIELDS.date when set.
+export const SORT = FIELDS.date ? [{ fieldName: FIELDS.date, order: "DESC" }] : null;
+
+// Route key for an item: the slug value when a slug field is mapped, else the item's `_id`.
+// Both the card link and the detail route read this — one definition, so they can't drift.
+export const itemKey = (item) => (FIELDS.slug && item?.[FIELDS.slug]) || item?._id;

--- a/skills/wix-vibe-headless/references/cms/app/components/ItemCard.jsx
+++ b/skills/wix-vibe-headless/references/cms/app/components/ItemCard.jsx
@@ -1,0 +1,38 @@
+// List tile for one CMS item. Pure UI: which fields to show comes from collection.config (FIELDS),
+// styling comes entirely from theme.css tokens (var(--...)) — re-skin via those, not this JSX. The
+// image conversion (wixImage) and the slug-or-_id route key (itemKey) are load-bearing.
+import { Link } from "react-router-dom";
+import { FIELDS, itemKey } from "@/collection.config";
+import { wixImage } from "@/lib/wixImage";
+
+export default function ItemCard({ item }) {
+  const image = FIELDS.image ? wixImage(item[FIELDS.image]) : null;
+  const title = item[FIELDS.title];
+  const summary = FIELDS.summary ? item[FIELDS.summary] : null;
+  const date = FIELDS.date && item[FIELDS.date]
+    ? new Date(item[FIELDS.date]).toLocaleDateString()
+    : null;
+
+  return (
+    <Link to={`/item/${itemKey(item)}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      <div style={{ aspectRatio: "16 / 10", background: "var(--color-bg)" }}>
+        {image
+          ? <img src={image} alt={title || ""} loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          : <div style={{ width: "100%", height: "100%" }} />}
+      </div>
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 6 }}>
+        {date && <span style={{ color: "var(--color-muted)", fontSize: 12 }}>{date}</span>}
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 16, fontWeight: 600 }}>{title}</h3>
+        {summary && (
+          <p style={{ margin: 0, color: "var(--color-muted)", fontSize: 14, lineHeight: 1.5 }}>{summary}</p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/cms/app/components/ItemGrid.jsx
+++ b/skills/wix-vibe-headless/references/cms/app/components/ItemGrid.jsx
@@ -1,0 +1,20 @@
+// Responsive grid of ItemCards + empty state. Token-styled; re-skin via theme.css. Keyed on the
+// item's `_id` (always present on a CMS item).
+import ItemCard from "./ItemCard";
+
+export default function ItemGrid({ items, empty = "No items yet." }) {
+  if (!items?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+      gap: "var(--space)",
+    }}>
+      {items.map((item) => <ItemCard key={item._id} item={item} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/cms/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/cms/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/cms/app/hooks/useCollection.js
+++ b/skills/wix-vibe-headless/references/cms/app/hooks/useCollection.js
@@ -1,0 +1,34 @@
+// useCollection — all list-page data logic, no markup: count for the empty state, load the first
+// page (with the configured sort + optional filter), and paginate by cursor. The wiring here is the
+// load-bearing part — queryDataItems resolves to { items, nextCursor }, cursor follow-ups reuse the
+// first request's filter/sort (pass ONLY the cursor) — keep it verbatim; the page just renders what
+// this returns.
+import { useState, useEffect, useCallback } from "react";
+import { queryDataItems, countDataItems } from "@/rest/wix-cms";
+import { COLLECTION_ID, SORT } from "@/collection.config";
+
+export function useCollection({ filter, limit = 24 } = {}) {
+  const [items, setItems] = useState(null);   // null = loading, [] = empty
+  const [cursor, setCursor] = useState(null);
+  const [total, setTotal] = useState(null);
+
+  useEffect(() => {
+    countDataItems(COLLECTION_ID).then(setTotal);
+    queryDataItems(COLLECTION_ID, {
+      ...(SORT ? { sort: SORT } : {}),
+      ...(filter ? { filter } : {}),
+      limit,
+    }).then(({ items, nextCursor }) => { setItems(items); setCursor(nextCursor); });
+  }, [limit]);   // filter changes are rare; re-mount the page to refetch
+
+  const loadMore = useCallback(() => {
+    if (!cursor) return;
+    // cursor follow-ups reuse the first request's filter/sort — pass ONLY the cursor
+    queryDataItems(COLLECTION_ID, { cursor, limit }).then(({ items: more, nextCursor }) => {
+      setItems((prev) => [...(prev || []), ...more]);
+      setCursor(nextCursor);
+    });
+  }, [cursor, limit]);
+
+  return { items, total, loadMore, hasMore: Boolean(cursor) };
+}

--- a/skills/wix-vibe-headless/references/cms/app/hooks/useItemDetail.js
+++ b/skills/wix-vibe-headless/references/cms/app/hooks/useItemDetail.js
@@ -1,0 +1,24 @@
+// useItemDetail — detail-page data logic, no markup: resolve one item from the route key. When a
+// slug field is mapped it routes by that (getDataItemBy); otherwise by the item's `_id`
+// (getDataItem). A miss sets notFound so the page shows a not-found state — it never invents an
+// item. The detail page only renders what this returns.
+import { useState, useEffect } from "react";
+import { getDataItem, getDataItemBy } from "@/rest/wix-cms";
+import { COLLECTION_ID, FIELDS } from "@/collection.config";
+
+export function useItemDetail(key) {
+  const [item, setItem] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!key) return;
+    setItem(null);
+    setNotFound(false);
+    const load = FIELDS.slug
+      ? getDataItemBy(COLLECTION_ID, FIELDS.slug, key)
+      : getDataItem(COLLECTION_ID, key);
+    load.then((it) => (it ? setItem(it) : setNotFound(true)));
+  }, [key]);
+
+  return { item, notFound };
+}

--- a/skills/wix-vibe-headless/references/cms/app/lib/wixImage.js
+++ b/skills/wix-vibe-headless/references/cms/app/lib/wixImage.js
@@ -1,0 +1,18 @@
+// wixImage — turn a Wix CMS image field value into a URL a browser can render.
+// CMS media fields come back in two shapes and only ONE renders directly in <img src>:
+//   • a plain `https://static.wixstatic.com/...` (or protocol-relative `//...`) URL → usable as-is
+//   • a Wix media URI `wix:image://v1/<mediaId>/<filename>#originWidth=…&originHeight=…` → NOT
+//     renderable by the browser; the `<mediaId>` segment maps to a static.wixstatic.com/media/ URL.
+// Merchant-uploaded images (via the dashboard) are the `wix:image://` form; images your seed step
+// wrote are usually already `https://`. This converts both so the shipped UI never shows a broken
+// image. Returns null for an empty/unknown value (the UI shows a token surface instead).
+export function wixImage(value) {
+  if (!value || typeof value !== "string") return null;
+  if (value.startsWith("//")) return `https:${value}`;
+  if (value.startsWith("http")) return value;
+  if (value.startsWith("wix:image://")) {
+    const mediaId = value.slice("wix:image://v1/".length).split("/")[0];
+    return mediaId ? `https://static.wixstatic.com/media/${mediaId}` : null;
+  }
+  return null;
+}

--- a/skills/wix-vibe-headless/references/cms/app/pages/Collection.jsx
+++ b/skills/wix-vibe-headless/references/cms/app/pages/Collection.jsx
@@ -1,0 +1,30 @@
+// Collection / list page — lists items from the configured collection, with a Load-more button and
+// an empty state when the collection is empty. Thin view over useCollection (all logic in the hook).
+// Route this at whatever path fits your content (e.g. /posts, /recipes); the card links to /item/:key.
+import { useCollection } from "@/hooks/useCollection";
+import ItemGrid from "@/components/ItemGrid";
+
+export default function Collection() {
+  const { items, total, loadMore, hasMore } = useCollection({ limit: 24 });
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      {items === null && total === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : (
+          <>
+            <ItemGrid items={items} empty="No items yet — add some from your Wix dashboard." />
+            {hasMore && (
+              <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 1.5)" }}>
+                <button onClick={loadMore} style={{
+                  padding: "10px 24px", cursor: "pointer",
+                  background: "var(--color-primary)", color: "var(--color-on-primary)",
+                  border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+                }}>Load more</button>
+              </div>
+            )}
+          </>
+        )}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/cms/app/pages/ItemDetail.jsx
+++ b/skills/wix-vibe-headless/references/cms/app/pages/ItemDetail.jsx
@@ -1,0 +1,49 @@
+// Item detail page — thin view over useItemDetail (all logic in the hook). Renders the mapped
+// fields: image, date, title, and the long body. The body is treated as HTML (CMS rich-text fields
+// come back as HTML); it renders via dangerouslySetInnerHTML only when it's a string. Token-styled;
+// re-skin via theme.css.
+import { useParams } from "react-router-dom";
+import { useItemDetail } from "@/hooks/useItemDetail";
+import { FIELDS } from "@/collection.config";
+import { wixImage } from "@/lib/wixImage";
+
+export default function ItemDetail() {
+  const { key } = useParams();
+  const { item, notFound } = useItemDetail(key);
+
+  if (notFound) return <Centered>Not found.</Centered>;
+  if (!item) return <Centered>Loading…</Centered>;
+
+  const image = FIELDS.image ? wixImage(item[FIELDS.image]) : null;
+  const title = item[FIELDS.title];
+  const date = FIELDS.date && item[FIELDS.date]
+    ? new Date(item[FIELDS.date]).toLocaleDateString()
+    : null;
+  const body = FIELDS.body ? item[FIELDS.body] : null;
+  const summary = FIELDS.summary ? item[FIELDS.summary] : null;
+
+  return (
+    <main style={{ maxWidth: 760, margin: "0 auto", padding: "calc(var(--space) * 1.5) var(--space)" }}>
+      {date && <p style={{ color: "var(--color-muted)", fontSize: 13, margin: "0 0 8px" }}>{date}</p>}
+      <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 var(--space)" }}>{title}</h1>
+
+      {image && (
+        <div style={{
+          aspectRatio: "16 / 9", background: "var(--color-surface)",
+          borderRadius: "var(--radius)", overflow: "hidden", marginBottom: "calc(var(--space) * 1.5)",
+        }}>
+          <img src={image} alt={title || ""} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+        </div>
+      )}
+
+      {typeof body === "string"
+        ? <div style={{ color: "var(--color-text)", lineHeight: 1.7 }}
+            dangerouslySetInnerHTML={{ __html: body }} />
+        : summary && <p style={{ color: "var(--color-text)", lineHeight: 1.7 }}>{summary}</p>}
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/cms/app/theme.css
+++ b/skills/wix-vibe-headless/references/cms/app/theme.css
@@ -1,0 +1,36 @@
+/* theme.css — THE styling surface. Theme the whole content site by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every template component reads these variables, so
+   changing them here re-skins the entire site. Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, wells */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text, dates, meta */
+  --color-border:    #e5e7eb;   /* hairlines, dividers */
+  --color-primary:   #111827;   /* buttons, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* highlights, tags, badges */
+  --color-danger:    #dc2626;   /* errors */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1100px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **cms** to the storefront-as-files model: generic collection list + detail; collection.config.js field mapping + wixImage helper.

- `references/cms/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (11 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)