### PR TITLE
feat(portfolio): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -1,256 +1,234 @@
+# Wix Portfolio — ready-made client
 
-# Wix Portfolio Skill
+The portfolio client is **shipped as real files**, not snippets to regenerate. It's a complete
+collections gallery + collection page + project detail (media gallery + `details[]` rows), styled
+entirely from `theme.css` tokens. The install step copied it into `src/`; you theme the tokens and
+wire the routes — you generate almost none of the read/render code (return-object destructuring,
+`item.type` media branching, the `details[]` link shape all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and this vertical's `references/portfolio/wix-portfolio.js`. Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { wixApiRequest } from "./wix-client.js"`, so they must land in the same folder.
-
-Builds a real, client-only Wix portfolio showcase. The browser talks to Wix directly over a
-public `WIX_CLIENT_ID`. Portfolio is **read-only**: never mock projects, never invent media,
-and always render live Wix data (or an honest empty state). The content tree is
-**Collection → Project → Project Item (image/video)**.
-
-## When to use
-- User wants a Wix portfolio / showcase site or asks to "connect Wix Portfolio".
-- Replacing placeholder/mock galleries with live Wix Portfolio data.
-- Adding a collections gallery, project grids, or a project detail page (media gallery +
-  details/links) over an existing Wix Portfolio.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Portfolio is
+**read-only**: never mock projects, never invent media — render live Wix data or the shipped empty
+state. The content tree is **Collection → Project → Project Item (image/video)**.
 
 ## Prerequisites
-1. A Wix site with **Wix Portfolio installed and content already added** — at least one
-   collection with projects, and projects with items (this skill does NOT provision; it is
-   read-only over the content).
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`).
-   Set it in `src/rest/wix-config.js` in place of the placeholder. It is a visitor-facing
-   credential (it only mints anonymous visitor tokens), **not** a secret, so
-   hardcoding/committing it is fine.
-3. If the read calls return `403`/`428` before content is published, the Portfolio app or its
-   content may not be live yet. That is a **Wix dashboard setup step the owner completes** —
-   out of this skill's scope. Flag it and continue; don't fall back to mock data.
+- The site's **Wix Portfolio** is the read target. It's installed and seeded separately (see
+  **Seeding** below), in parallel with this build — so it may be empty at build time; the client
+  renders the shipped empty state until collections and projects land.
+- The public headless **`WIX_CLIENT_ID`** from your prompt (visitor-facing, safe to hardcode/commit).
+- If the read calls return `403`/`428` before content is published, the Portfolio app or its content
+  may not be live yet — a **Wix dashboard step the owner completes**, out of scope here. Flag it and
+  continue; don't fall back to mock data.
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the portfolio's UI however the
-project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
-adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
-  `wix-config.js`. The visitor refresh token is persisted to localStorage; do not re-mint
-  anonymously per load.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-portfolio.js` — exports:
-  - **Collections:** `queryCollections`, `getCollectionBySlug`, `countCollections`
-  - **Projects:** `queryProjects`, `queryProjectsByCollection`, `getProjectBySlug`, `getProject`
-  - **Project items (media):** `listProjectItems`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole portfolio UI client + REST scaffolds into
+`src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map,
+so you don't need to open them:**
 
-The Collection, Project, and Project Item shapes are documented as JSDoc comments at the top of
-`wix-portfolio.js`. Read them before building the UI — they describe the key fields (cover
-image/video, media resolutions, details rows) and link to the full API reference.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `hooks/usePortfolioGallery.js` | collections gallery data — first page + count + cursor paging |
+| `hooks/useCollectionProjects.js` | one collection's header + its projects (paged), by slug |
+| `hooks/useProjectDetail.js` | project + its media gallery, by slug (null → not-found) |
+| `components/CollectionCard.jsx`, `CollectionGrid.jsx` | collections listing UI (grid + card, with empty state) |
+| `components/ProjectCard.jsx`, `ProjectGrid.jsx` | projects listing UI (grid + card, with empty state) |
+| `components/ProjectMedia.jsx` | one gallery item — branches on `item.type` (IMAGE / VIDEO) |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Portfolio.jsx` | collections gallery route (`/portfolio`) |
+| `pages/CollectionPage.jsx` | collection page route (`/collection/:slug`) |
+| `pages/ProjectDetail.jsx` | project detail route (`/project/:slug`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` + `rest/wix-portfolio.js` | REST transport + portfolio read helpers |
 
-## How to wire it (UI is the project's choice)
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each
+is and every field shape you need is in the snippets below. Read a shipped file's source **only** on
+a real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/portfolio/app/` → `src/`.)
 
-**Every list helper returns an object, not a bare array** — destructure the named key first, or
-`.map`/`.filter` on the result throws `… is not a function` (the #1 portfolio-listing bug):
-`queryCollections()` → `{ collections, nextCursor }`; `queryProjects()` /
-`queryProjectsByCollection(id)` → `{ projects, nextCursor }`; `listProjectItems(id)` →
-`{ items, total }`. Single fetches (`getCollectionBySlug`, `getProjectBySlug`, `getProject`)
-return the object or `null`; `countCollections()` returns a number.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
-- **Collections gallery (home)** — `const { collections, nextCursor } = await queryCollections()`
-  for the listing (visible collections only, in dashboard order); pass `nextCursor` back as
-  `cursor` to load the next page. Render `collection.title`, `collection.description`, and
-  `collection.coverImage.imageInfo.url`. Link each card to a collection page keyed on
-  `collection.slug`.
-- **Collection page** — `getCollectionBySlug(slug)` for the header (returns null on miss — show
-  a not-found state, never invent one). Then
-  `const { projects, nextCursor } = await queryProjectsByCollection(collection.id, { limit?, cursor? })`
-  for its project grid; paginate exactly like `queryCollections`.
-- **All-work gallery (optional)** —
-  `const { projects, nextCursor } = await queryProjects()` to list every visible project across
-  collections (newest-first); paginate the same way.
-- **Project grid card** — render `project.title` and the cover: use `project.coverImage.imageInfo.url`
-  when present, else the `project.coverVideo.videoInfo.posters[0]` / first
-  `coverVideo.videoInfo.resolutions[]` entry. Link each card to a project page keyed on `project.slug`.
-- **Project detail page** — `getProjectBySlug(slug)` for the header (title, description, and the
-  `details[]` rows: each has a `label` plus either `text` or `link: { text, url, target }`).
-  Then `const { items, total } = await listProjectItems(project.id)` for the media gallery —
-  `items` is the array (the helper returns `{ items, total }`, **not** a bare array; iterate
-  `items`). Branch on **`item.type`**, which is `"IMAGE" | "VIDEO" | "UNDEFINED"`: render IMAGE
-  items from `item.image.imageInfo.url` and VIDEO items from the first
-  `item.video.videoInfo.resolutions[]` entry's `url` (with `item.video.videoInfo.posters[0]` as
-  the poster). Honor each item's optional `item.link: { text, url, target }` (same link shape as
-  the `details[]` rows above).
-  - If you already hold a project id (not a slug), use `getProject(projectId)` instead.
-- **Empty state** — if `countCollections()` is 0, show an empty state telling the user to add
-  collections and projects in their Wix dashboard. Never invent projects or media.
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole portfolio. **Do not
+restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
+home page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the
+dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
-## Worked snippets (headless — adapt the logic, restyle freely)
+## STEP 4 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it. Portfolio is read-only with no cross-page state, so there's **no provider to wrap** (no
+cart equivalent) — just the Layout and the routes.
+- `import "@/theme.css";` once at the app entry.
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Portfolio` / `CollectionPage` / `ProjectDetail` — so you **never edit the
+  shipped pages to add a header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's measured height so it clears the chrome and self-corrects when the
+  banner is dismissed.
+- Routes under the Layout: `/portfolio` → `Portfolio`, `/collection/:slug` → `CollectionPage`,
+  `/project/:slug` → `ProjectDetail` (all shipped, as-is). **You add `/` → your own Home** page.
 
-Portfolio ships no UI components; these are illustrative wiring, not files to copy verbatim.
-The data paths (return-object destructuring, field paths, `item.type` branching, `details[]`
-link shape) are the load-bearing part — keep those exactly and restyle the markup to the brand.
+```jsx
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Portfolio from "@/pages/Portfolio";
+import CollectionPage from "@/pages/CollectionPage";
+import ProjectDetail from "@/pages/ProjectDetail";
+import Home from "@/pages/Home";        // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
 
-**`pages/Portfolio.jsx`** — collections gallery (grid + empty state + paging). `queryCollections`
-returns `{ collections, nextCursor }` — an object, not an array. Keep the destructuring.
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped pages render here, untouched */}
+      <Footer />
+    </div>
+  </>);
+}
+
+<Routes>
+  <Route element={<Layout />}>                                     {/* chrome wraps all */}
+    <Route path="/" element={<Home />} />                          {/* yours */}
+    <Route path="/portfolio" element={<Portfolio />} />            {/* shipped, as-is */}
+    <Route path="/collection/:slug" element={<CollectionPage />} />{/* shipped, as-is */}
+    <Route path="/project/:slug" element={<ProjectDetail />} />    {/* shipped, as-is */}
+  </Route>
+</Routes>
+```
+
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
+(STEP 4) so they wrap every route — plus the overall brand story, styled from the same `theme.css`
+tokens. **Compose the shipped pieces** — a featured strip is just `queryCollections` (or
+`queryProjects`) + the shipped `CollectionGrid` / `ProjectGrid`; the nav is a link to `/portfolio`:
 
 ```jsx
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { queryCollections, countCollections } from "@/rest/wix-portfolio";
+import { queryCollections } from "@/rest/wix-portfolio";
+import CollectionGrid from "@/components/CollectionGrid";
 
-export default function Portfolio() {
-  const [collections, setCollections] = useState([]);
-  const [cursor, setCursor] = useState(null);
-  const [total, setTotal] = useState(null);
-
+// Responsive header: choose ONE branch with a state flag — do NOT render a desktop nav AND a mobile
+// nav toggled by `hidden md:flex` / `md:hidden`. These navs are inline-styled, and an inline
+// `display` beats a Tailwind class, so `hidden` never applies — BOTH branches render. One branch.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
   useEffect(() => {
-    countCollections().then(setTotal);                       // number → 0 means empty state
-    // NB: destructure — queryCollections returns { collections, nextCursor }, not an array.
-    queryCollections({ limit: 24 }).then(({ collections, nextCursor }) => {
-      setCollections(collections);
-      setCursor(nextCursor);
-    });
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
   }, []);
-
-  const loadMore = () =>
-    queryCollections({ limit: 24, cursor }).then(({ collections: more, nextCursor }) => {
-      setCollections((c) => [...c, ...more]);
-      setCursor(nextCursor);
-    });
-
-  if (total === 0) return <p>{/* empty state — add collections in the Wix dashboard */}</p>;
   return (
-    <div /* restyle */>
-      <div /* grid */>
-        {collections.map((c) => (
-          <Link key={c.id} to={`/collection/${c.slug}`} /* restyle */>
-            {c.coverImage?.imageInfo?.url && (
-              <img src={c.coverImage.imageInfo.url} alt={c.title} loading="lazy" />
-            )}
-            <h3>{c.title}</h3>
-            {c.description && <p>{c.description}</p>}
-          </Link>
-        ))}
-      </div>
-      {cursor && <button onClick={loadMore}>Load more</button>}
-    </div>
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger + a link to /portfolio
+        : <div style={{ display: "flex", gap: 24 }}><Link to="/portfolio">Work</Link></div>}
+    </nav>
   );
 }
+export function Featured() {                                // on your home page
+  const [collections, setCollections] = useState([]);
+  // NB: queryCollections returns { collections, nextCursor } — destructure the array.
+  useEffect(() => { queryCollections({ limit: 6 }).then(({ collections }) => setCollections(collections)); }, []);
+  return <CollectionGrid collections={collections} empty="Collections coming soon." />;
+}
 ```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
 
-**`pages/ProjectDetail.jsx`** — project header + `details[]` rows + media gallery. Two shapes to
-keep: `listProjectItems` returns `{ items, total }` (iterate `items`), and each item branches on
-`item.type`. Videos render from `resolutions[].url` (the confirmed field).
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
+
+## Using the client from your own UI (hand-built lists, images)
+
+**Every list helper returns an OBJECT, not a bare array** — destructure the named key first, or
+`.map`/`.filter` on the result throws `… is not a function` (the #1 portfolio-listing bug):
 
 ```jsx
-import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import { getProjectBySlug, listProjectItems } from "@/rest/wix-portfolio";
+// listings — destructure the named array + the cursor:
+const { collections, nextCursor } = await queryCollections({ limit: 24 });   // visible, dashboard order
+const { projects } = await queryProjects({ limit: 24 });                     // all work, newest-first
+const { projects: inCollection } = await queryProjectsByCollection(collectionId, { limit: 24 });
+const { items, total } = await listProjectItems(projectId);                  // gallery — iterate `items`
 
-// media item: branch on item.type ("IMAGE" | "VIDEO" | "UNDEFINED")
-function ProjectMedia({ item }) {
-  if (item.type === "IMAGE")
-    return <img src={item.image?.imageInfo?.url} alt={item.title || ""} loading="lazy" />;
-  if (item.type === "VIDEO") {
-    const src = item.video?.videoInfo?.resolutions?.[0]?.url; // resolutions[].url is the confirmed field
-    // poster: item.video.videoInfo.posters[0] — poster-entry sub-shape isn't in the helper
-    // JSDoc; if you need the poster image URL, confirm the field in wix-docs before using it.
-    return <video src={src} controls playsInline />;
-  }
-  return null; // UNDEFINED — nothing renderable
-}
+// single fetches return the object or null (render a not-found/empty state, never invent one):
+const collection = await getCollectionBySlug(slug);
+const project = await getProjectBySlug(slug);   // or getProject(id) when you hold a GUID
+const n = await countCollections();             // number → 0 means the empty state
 
-export default function ProjectDetail() {
-  const { slug } = useParams();
-  const [project, setProject] = useState(null);
-  const [items, setItems] = useState([]);
-  const [notFound, setNotFound] = useState(false);
+// media item branches on item.type ("IMAGE" | "VIDEO" | "UNDEFINED") — the shipped ProjectMedia
+// already does this: IMAGE → item.image.imageInfo.url; VIDEO → item.video.videoInfo.resolutions[0].url
+// (poster item.video.videoInfo.posters[0]). details[] rows: { label, text? } OR { label, link: { text, url, target } }.
 
-  useEffect(() => {
-    getProjectBySlug(slug).then((p) => {
-      if (!p) return setNotFound(true);                      // null on miss → not-found state
-      setProject(p);
-      // NB: destructure — listProjectItems returns { items, total }, not an array.
-      listProjectItems(p.id).then(({ items }) => setItems(items));
-    });
-  }, [slug]);
-
-  if (notFound) return <div>Project not found.</div>;
-  if (!project) return <div>Loading…</div>;
-  return (
-    <div /* restyle */>
-      <h1>{project.title}</h1>
-      {project.description && <p>{project.description}</p>}
-      {/* details[] row: { label, text? } OR { label, link: { text, url, target } } */}
-      <dl>
-        {(project.details || []).map((d, i) => (
-          <div key={i}>
-            <dt>{d.label}</dt>
-            <dd>
-              {d.link ? (
-                <a href={d.link.url} target={d.link.target}>{d.link.text}</a>
-              ) : (
-                d.text
-              )}
-            </dd>
-          </div>
-        ))}
-      </dl>
-      <div /* gallery grid */>
-        {items.map((item) => (
-          <figure key={item.id}>
-            {item.link ? (
-              <a href={item.link.url} target={item.link.target}><ProjectMedia item={item} /></a>
-            ) : (
-              <ProjectMedia item={item} />
-            )}
-            {item.title && <figcaption>{item.title}</figcaption>}
-          </figure>
-        ))}
-      </div>
-    </div>
-  );
+// An image you render yourself (hero / custom card): make the url https + keep a token bg so a
+// just-generated url that 404s for a second reads as a surface, not a blank block.
+function BrandImage({ url, alt }) {
+  const src = url?.startsWith("//") ? `https:${url}` : url;      // the shipped cards already do this
+  return <div style={{ background: "var(--color-surface)" }}><img src={src} alt={alt} /></div>;
 }
 ```
 
-## Hard rules (do not violate)
-- ✅ Render only live Wix Portfolio data — collections, projects, and items as returned.
-- ❌ Never mock projects, collections, or media — render live data or the empty state.
-- ❌ Never hand-build Wix Media URLs or page permalinks — use the `url`/`imageInfo.url`/
-  `videoInfo.resolutions[].url` fields Wix returns.
-- ❌ Never invent project details, captions, dates, or testimonials. Show only what the API returns.
-- ❌ Never show `hidden: true` collections or projects to visitors (the helpers already filter
-  `hidden` out — don't add them back).
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public client id — safe to hardcode).
-- ✅ Route on `slug` (`getCollectionBySlug` / `getProjectBySlug`); fall back to `getProject(id)`
-  only when you hold a GUID.
-- The helpers fail soft on read: single fetches return `null` on a miss so you render a
-  not-found/empty state rather than a crash — surface that state, don't paper over it with fake data.
+Cover images live at `collection.coverImage.imageInfo.url` and `project.coverImage.imageInfo.url`
+(projects are a one-of: fall back to `coverVideo.videoInfo.posters[0].url` / `resolutions[0].url`).
 
-## Beyond the snippets
-The snippets cover the common portfolio paths. If you hit a use case they don't cover (e.g.
-collection SEO tags, project watermark settings, portfolio-wide settings, or filtering by a
-field not shown), make the call yourself with `wixApiRequest` — but look up the exact endpoint,
-HTTP method, and request body in the **official Wix API reference** first; never guess:
-- Wix Portfolio API reference: https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
-- Portfolio Settings (logo, layout, options): https://dev.wix.com/docs/api-reference/business-solutions/portfolio/portfolio-settings/get-portfolio-settings.md
-- API query language (filters, sort, paging): https://dev.wix.com/docs/rest/articles/getting-started/api-query-language.md
+Fallback only — when you hit an error or need something not shown here (collection SEO, portfolio
+settings, a field these snippets don't have): read the relevant shipped file under `src/`, or look
+it up via the **`wix-docs`** skill / the Portfolio API reference.
 
-Keep the snippets as the default for everything they already do; reach for the API reference
-only for the gap.
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+  `Portfolio`/`CollectionPage`/`ProjectDetail` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
+  `Header` is plain in-flow markup (not `position:fixed`).
+- Route on `slug` (`getCollectionBySlug`/`getProjectBySlug`); use `getProject(id)` only when you hold a GUID.
+- Render live Wix data or the shipped empty state — never mock projects, collections, or media, and
+  never hand-build Wix Media URLs or page permalinks (use the `url`/`imageInfo.url`/`resolutions[].url`
+  fields Wix returns). Hidden collections/projects are already filtered out — don't add them back.
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the portfolio content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For portfolio data those pages are:
-- **Portfolio** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-portfolio/projects` (`Dashboard → Portfolio`). Projects and Collections are tabs on this one page: the **Projects** tab adds projects and their media galleries; the **Collections** tab groups projects into collections.
+Provide the deep link so the owner can edit content (substitute the site's `metaSiteId`):
+- **Portfolio** — `https://manage.wix.com/dashboard/{metaSiteId}/wix-portfolio/projects`
+  (`Dashboard → Portfolio`). Projects and Collections are tabs on this one page: the **Projects** tab
+  adds projects and their media galleries; the **Collections** tab groups projects into collections.
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed collections and projects per `seed/SEED.md` — separate from this client build; run in parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (no re-mint storm; reads stay fast)
-- [ ] Collections gallery renders live collections with cover images, in dashboard order
-- [ ] Clicking a collection lists its projects via `queryProjectsByCollection`
-- [ ] Project page renders the project's media gallery from `listProjectItems` (images AND videos)
-- [ ] Project `details[]` rows render (text rows and link rows both)
-- [ ] Slug routing works; an unknown slug shows a not-found state (no invented project)
-- [ ] Hidden collections/projects never appear
-- [ ] Empty state shown when `countCollections()` is 0
-- [ ] No mock projects, collections, or media anywhere
-- [ ] Told the user at least once that they can continue setting up their portfolio in the dashboard and provided deep links.
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all
+      routes; shipped `Portfolio`/`CollectionPage`/`ProjectDetail` untouched; content clears the fixed chrome.
+- [ ] Visitor token persists across reload (no re-mint storm; reads stay fast).
+- [ ] Collections gallery renders live collections with cover images, in dashboard order.
+- [ ] Clicking a collection lists its projects via `queryProjectsByCollection`.
+- [ ] Project page renders the media gallery from `listProjectItems` (images AND videos) and the
+      `details[]` rows (text rows and link rows both).
+- [ ] Slug routing works; an unknown slug shows the shipped not-found state (no invented content).
+- [ ] Empty catalog shows the shipped empty state (`countCollections()` is 0); no mock content anywhere.
+- [ ] Told the user they can continue setting up their portfolio in the dashboard, with the deep link.

--- a/skills/wix-vibe-headless/references/portfolio/app/components/CollectionCard.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/CollectionCard.jsx
@@ -1,0 +1,35 @@
+// Collection tile → links to /collection/:slug. Styled entirely from theme.css tokens
+// (var(--...)) — re-skin via those tokens, not this JSX. The `//`-protocol image fix and the
+// coverImage.imageInfo.url field path are load-bearing.
+import { Link } from "react-router-dom";
+
+function coverUrl(collection) {
+  const url = collection?.coverImage?.imageInfo?.url;
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+export default function CollectionCard({ collection }) {
+  const image = coverUrl(collection);
+
+  return (
+    <Link to={`/collection/${collection.slug}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      <div style={{ aspectRatio: "4 / 3", background: "var(--color-bg)" }}>
+        {image
+          ? <img src={image} alt={collection.title} loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          : <div style={{ width: "100%", height: "100%" }} />}
+      </div>
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 4 }}>
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 16, fontWeight: 600 }}>{collection.title}</h3>
+        {collection.description && (
+          <p style={{ margin: 0, color: "var(--color-muted)", fontSize: 14, lineHeight: 1.5 }}>{collection.description}</p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/components/CollectionGrid.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/CollectionGrid.jsx
@@ -1,0 +1,19 @@
+// Responsive collections grid + empty state. Token-styled; re-skin via theme.css.
+import CollectionCard from "./CollectionCard";
+
+export default function CollectionGrid({ collections, empty = "No collections yet." }) {
+  if (!collections?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+      gap: "var(--space)",
+    }}>
+      {collections.map((c) => <CollectionCard key={c.id} collection={c} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/components/ProjectCard.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/ProjectCard.jsx
@@ -1,0 +1,42 @@
+// Project tile → links to /project/:slug. Styled entirely from theme.css tokens (var(--...)) —
+// re-skin via those tokens, not this JSX. The cover is a one-of: image when present, else the
+// video's poster / first resolution. The `//`-protocol fix and these field paths are load-bearing.
+import { Link } from "react-router-dom";
+
+function https(url) {
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+// coverImage.imageInfo is ONE-OF with coverVideo.videoInfo — fall back through the video.
+function coverUrl(project) {
+  const image = project?.coverImage?.imageInfo?.url;
+  if (image) return https(image);
+  const vi = project?.coverVideo?.videoInfo;
+  return https(vi?.posters?.[0]?.url || vi?.resolutions?.[0]?.url || null);
+}
+
+export default function ProjectCard({ project }) {
+  const image = coverUrl(project);
+
+  return (
+    <Link to={`/project/${project.slug}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      <div style={{ aspectRatio: "4 / 3", background: "var(--color-bg)" }}>
+        {image
+          ? <img src={image} alt={project.title} loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          : <div style={{ width: "100%", height: "100%" }} />}
+      </div>
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 4 }}>
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 15, fontWeight: 600 }}>{project.title}</h3>
+        {project.description && (
+          <p style={{ margin: 0, color: "var(--color-muted)", fontSize: 14, lineHeight: 1.5 }}>{project.description}</p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/components/ProjectGrid.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/ProjectGrid.jsx
@@ -1,0 +1,19 @@
+// Responsive projects grid + empty state. Token-styled; re-skin via theme.css.
+import ProjectCard from "./ProjectCard";
+
+export default function ProjectGrid({ projects, empty = "No projects yet." }) {
+  if (!projects?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+      gap: "var(--space)",
+    }}>
+      {projects.map((p) => <ProjectCard key={p.id} project={p} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/components/ProjectMedia.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/ProjectMedia.jsx
@@ -1,0 +1,29 @@
+// One gallery media item. Branch on item.type ("IMAGE" | "VIDEO" | "UNDEFINED") — this branching
+// and the field paths (image.imageInfo.url, video.videoInfo.resolutions[0].url) are load-bearing;
+// re-skin via theme.css, don't rewire the paths. Token-styled.
+
+function https(url) {
+  return url ? (url.startsWith("//") ? `https:${url}` : url) : null;
+}
+
+export default function ProjectMedia({ item }) {
+  if (item.type === "IMAGE") {
+    const src = https(item.image?.imageInfo?.url);
+    return src ? (
+      <img src={src} alt={item.title || ""} loading="lazy"
+        style={{ display: "block", width: "100%", height: "auto", borderRadius: "var(--radius-sm)" }} />
+    ) : null;
+  }
+  if (item.type === "VIDEO") {
+    // resolutions[].url is the confirmed field; posters[0] is the poster (sub-shape not in the
+    // helper JSDoc — posters[0].url used here; confirm in wix-docs if a brand needs more).
+    const vi = item.video?.videoInfo;
+    const src = https(vi?.resolutions?.[0]?.url);
+    const poster = https(vi?.posters?.[0]?.url);
+    return src ? (
+      <video src={src} poster={poster || undefined} controls playsInline
+        style={{ display: "block", width: "100%", height: "auto", borderRadius: "var(--radius-sm)", background: "var(--color-surface)" }} />
+    ) : null;
+  }
+  return null; // UNDEFINED — nothing renderable
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/hooks/useCollectionProjects.js
+++ b/skills/wix-vibe-headless/references/portfolio/app/hooks/useCollectionProjects.js
@@ -1,0 +1,35 @@
+// useCollectionProjects — one collection's header + its project grid, no markup. Resolve the
+// collection by slug (null → not-found), then page its projects. getCollectionBySlug returns the
+// object or null; queryProjectsByCollection returns { projects, nextCursor } (an OBJECT) — keep
+// the destructuring, or `.map` on the result throws.
+import { useState, useEffect } from "react";
+import { getCollectionBySlug, queryProjectsByCollection } from "@/rest/wix-portfolio";
+
+export function useCollectionProjects(slug, { limit = 24 } = {}) {
+  const [collection, setCollection] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const [projects, setProjects] = useState(null); // null = loading
+  const [cursor, setCursor] = useState(null);
+
+  useEffect(() => {
+    setNotFound(false);
+    setProjects(null);
+    getCollectionBySlug(slug).then((c) => {
+      if (!c) return setNotFound(true);
+      setCollection(c);
+      queryProjectsByCollection(c.id, { limit }).then(({ projects, nextCursor }) => {
+        setProjects(projects);
+        setCursor(nextCursor);
+      });
+    });
+  }, [slug, limit]);
+
+  const loadMore = () =>
+    collection &&
+    queryProjectsByCollection(collection.id, { limit, cursor }).then(({ projects: more, nextCursor }) => {
+      setProjects((p) => [...(p ?? []), ...more]);
+      setCursor(nextCursor);
+    });
+
+  return { collection, notFound, projects, cursor, loadMore };
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/hooks/usePortfolioGallery.js
+++ b/skills/wix-vibe-headless/references/portfolio/app/hooks/usePortfolioGallery.js
@@ -1,0 +1,27 @@
+// usePortfolioGallery — collections-gallery data, no markup: first page + count for the empty
+// state + cursor paging. queryCollections returns { collections, nextCursor } (an OBJECT, not an
+// array) and countCollections returns a number — those shapes are the bug-prone part; keep them.
+import { useState, useEffect } from "react";
+import { queryCollections, countCollections } from "@/rest/wix-portfolio";
+
+export function usePortfolioGallery({ limit = 24 } = {}) {
+  const [collections, setCollections] = useState(null); // null = loading
+  const [cursor, setCursor] = useState(null);
+  const [total, setTotal] = useState(null);             // 0 → empty state
+
+  useEffect(() => {
+    countCollections().then(setTotal);
+    queryCollections({ limit }).then(({ collections, nextCursor }) => {
+      setCollections(collections);
+      setCursor(nextCursor);
+    });
+  }, [limit]);
+
+  const loadMore = () =>
+    queryCollections({ limit, cursor }).then(({ collections: more, nextCursor }) => {
+      setCollections((c) => [...(c ?? []), ...more]);
+      setCursor(nextCursor);
+    });
+
+  return { collections, total, cursor, loadMore };
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/hooks/useProjectDetail.js
+++ b/skills/wix-vibe-headless/references/portfolio/app/hooks/useProjectDetail.js
@@ -1,0 +1,25 @@
+// useProjectDetail — project-detail data, no markup: load a project by slug (null → not-found),
+// then load its media gallery. listProjectItems returns { items, total } (an OBJECT, not a bare
+// array) — iterate `items`; that shape is the bug-prone part. The PDP page only renders what this
+// returns. details[] rows come through untouched: [{ label, text? OR link: { text, url, target } }].
+import { useState, useEffect } from "react";
+import { getProjectBySlug, listProjectItems } from "@/rest/wix-portfolio";
+
+export function useProjectDetail(slug) {
+  const [project, setProject] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    setNotFound(false);
+    setProject(null);
+    setItems([]);
+    getProjectBySlug(slug).then((p) => {
+      if (!p) return setNotFound(true);
+      setProject(p);
+      listProjectItems(p.id).then(({ items }) => setItems(items));
+    });
+  }, [slug]);
+
+  return { project, notFound, items };
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/pages/CollectionPage.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/pages/CollectionPage.jsx
@@ -1,0 +1,42 @@
+// Collection page — collection header + its project grid (paged). Thin view over
+// useCollectionProjects (all data logic lives in the hook). Token-styled; re-skin via theme.css.
+import { useParams } from "react-router-dom";
+import { useCollectionProjects } from "@/hooks/useCollectionProjects";
+import ProjectGrid from "@/components/ProjectGrid";
+
+export default function CollectionPage() {
+  const { slug } = useParams();
+  const { collection, notFound, projects, cursor, loadMore } = useCollectionProjects(slug, { limit: 24 });
+
+  if (notFound) return <Centered>Collection not found.</Centered>;
+  if (!collection) return <Centered>Loading…</Centered>;
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <header style={{ marginBottom: "calc(var(--space) * 1.5)" }}>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px" }}>{collection.title}</h1>
+        {collection.description && (
+          <p style={{ color: "var(--color-muted)", lineHeight: 1.6, margin: 0 }}>{collection.description}</p>
+        )}
+      </header>
+      {projects === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <ProjectGrid projects={projects} empty="No projects in this collection yet." />}
+      {cursor && (
+        <div style={{ display: "flex", justifyContent: "center", marginTop: "calc(var(--space) * 1.5)" }}>
+          <button onClick={loadMore} style={buttonStyle}>Load more</button>
+        </div>
+      )}
+    </main>
+  );
+}
+
+const buttonStyle = {
+  padding: "10px 24px", cursor: "pointer",
+  background: "var(--color-primary)", color: "var(--color-on-primary)",
+  border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+};
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/pages/Portfolio.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/pages/Portfolio.jsx
@@ -1,0 +1,30 @@
+// Portfolio page — collections gallery (grid + empty state + paging). Thin view over
+// usePortfolioGallery (all data logic lives in the hook). Token-styled; re-skin via theme.css.
+import { usePortfolioGallery } from "@/hooks/usePortfolioGallery";
+import CollectionGrid from "@/components/CollectionGrid";
+
+export default function Portfolio() {
+  const { collections, total, cursor, loadMore } = usePortfolioGallery({ limit: 24 });
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Work</h1>
+      {collections === null
+        ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+        : <CollectionGrid
+            collections={collections}
+            empty={total === 0 ? "No collections yet — add them from your Wix dashboard." : "No collections to show."} />}
+      {cursor && (
+        <div style={{ display: "flex", justifyContent: "center", marginTop: "calc(var(--space) * 1.5)" }}>
+          <button onClick={loadMore} style={buttonStyle}>Load more</button>
+        </div>
+      )}
+    </main>
+  );
+}
+
+const buttonStyle = {
+  padding: "10px 24px", cursor: "pointer",
+  background: "var(--color-primary)", color: "var(--color-on-primary)",
+  border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+};

--- a/skills/wix-vibe-headless/references/portfolio/app/pages/ProjectDetail.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/pages/ProjectDetail.jsx
@@ -1,0 +1,63 @@
+// Project detail — thin view over useProjectDetail (all data logic lives in the hook). Renders the
+// header, the details[] rows (text OR link), and the media gallery (each item via ProjectMedia,
+// which branches on item.type). Token-styled; re-skin via theme.css.
+import { useParams } from "react-router-dom";
+import { useProjectDetail } from "@/hooks/useProjectDetail";
+import ProjectMedia from "@/components/ProjectMedia";
+
+export default function ProjectDetail() {
+  const { slug } = useParams();
+  const { project, notFound, items } = useProjectDetail(slug);
+
+  if (notFound) return <Centered>Project not found.</Centered>;
+  if (!project) return <Centered>Loading…</Centered>;
+
+  const details = project.details || [];
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <header style={{ marginBottom: "calc(var(--space) * 1.5)" }}>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px" }}>{project.title}</h1>
+        {project.description && (
+          <p style={{ color: "var(--color-muted)", lineHeight: 1.6, margin: 0 }}>{project.description}</p>
+        )}
+      </header>
+
+      {/* details[] row: { label, text? } OR { label, link: { text, url, target } } */}
+      {details.length > 0 && (
+        <dl style={{
+          display: "grid", gridTemplateColumns: "auto 1fr", gap: "8px 24px",
+          margin: "0 0 calc(var(--space) * 2)", alignItems: "baseline",
+        }}>
+          {details.map((d, i) => (
+            <div key={i} style={{ display: "contents" }}>
+              <dt style={{ color: "var(--color-muted)", fontSize: 14 }}>{d.label}</dt>
+              <dd style={{ margin: 0 }}>
+                {d.link
+                  ? <a href={d.link.url} target={d.link.target} rel="noopener"
+                      style={{ color: "var(--color-accent)" }}>{d.link.text}</a>
+                  : d.text}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space)" }}>
+        {items.map((item) => (
+          <figure key={item.id} style={{ margin: 0 }}>
+            {item.link
+              ? <a href={item.link.url} target={item.link.target} rel="noopener"><ProjectMedia item={item} /></a>
+              : <ProjectMedia item={item} />}
+            {item.title && (
+              <figcaption style={{ color: "var(--color-muted)", fontSize: 14, marginTop: 6 }}>{item.title}</figcaption>
+            )}
+          </figure>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/portfolio/app/theme.css
+++ b/skills/wix-vibe-headless/references/portfolio/app/theme.css
@@ -1,0 +1,36 @@
+/* theme.css — THE styling surface. Theme the whole portfolio by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every shipped component reads these variables, so
+   changing them here re-skins the entire showcase. Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, media wells, empty states */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text, captions, details labels */
+  --color-border:    #e5e7eb;   /* hairlines, dividers */
+  --color-primary:   #111827;   /* buttons, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* highlights, links, badges */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1200px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change.
+   Activate with document.documentElement.dataset.theme = "dark". */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **portfolio** to the storefront-as-files model: gallery -> collection -> project detail; image/video one-of (no provider).

- `references/portfolio/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (14 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)