### PR TITLE
feat(events): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -1,309 +1,235 @@
+# Wix Events — ready-made client
 
-# Wix Events Skill
+The events client is **shipped as real files**, not snippets to regenerate. It's a complete events
+listing + detail page + RSVP + ticketing (reserve → hosted checkout, plus in-app free-ticket
+checkout), styled entirely from `theme.css` tokens. Copy it into the app, theme the tokens, wire the
+routes — you generate almost none of the events code (offset paging, category filtering, the RSVP
+`WAITLIST` case, the ticket reservation/checkout shapes all ship and are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared config `references/shared/wix-config.js`, and the helper file(s) you need from `references/events/`. `wix-client.js` imports from `"./wix-config.js"` and the helpers import from `"./wix-client.js"`, so copy them into the same folder (e.g. `src/rest/`).
->
-> | Need | Copy |
-> |---|---|
-> | Event listing + detail (always) | `wix-events-browse.js` |
-> | RSVP, ticketing, registration | `wix-events-registration.js` |
-
-Builds a real, client-only Wix Events site. The browser talks to Wix directly over a
-public `WIX_CLIENT_ID`. Never mock events; never hand-build registration or payment URLs —
-register via the RSVP/ticketing APIs, and complete paid tickets on the official Wix-hosted
-ticket form.
-
-## When to use
-- User wants an events site over Wix Events & Tickets, or asks to "connect Wix Events".
-- Replacing placeholder/mock events with live Wix data.
-- Adding event listings, an event detail page, RSVP, or ticket purchase over existing,
-  published Wix events.
+Talks to Wix directly over the public `WIX_CLIENT_ID` (anonymous visitor tokens). Never mock events;
+never hand-build a registration/ticket/checkout URL — RSVP completes client-side and paid tickets go
+through the Wix-hosted ticket form via the shipped reserve → redirect path.
 
 ## Prerequisites
-1. A Wix site with **Wix Events & Tickets installed and events already published** (this skill
-   does NOT create events — it's read-only over them). Selling **paid** tickets also needs a
-   Wix premium plan + a configured payment method; **free** events and RSVP events work without.
-2. The site's public headless **`WIX_CLIENT_ID`**, provided in the handoff prompt (the Wix
-   Business Manager surfaces a copyable prompt with the id filled in — see the router `SKILL.md`). Set it
-   in `src/rest/wix-config.js` in place of the placeholder. It is a visitor-facing
-   credential (it only mints anonymous visitor tokens), **not** a secret, so hardcoding/
-   committing it is fine.
-3. For paid tickets the buyer completes payment on the **Wix-hosted ticket form** (the redirect
-   target of `getTicketCheckoutUrl`). The deployed app domain may need to be allow-listed on the
-   OAuth client for that page to return cleanly — a **separate Wix setup the user completes
-   later**, out of this skill's scope. If the return fails before that's done, that's expected;
-   flag it and continue.
+- The site's **Wix Events & Tickets** app is the read/registration target. It's installed and seeded separately (see **Seeding** below), in parallel with this build — so it may have no events at build time; the client renders the shipped empty state until events are published. This client is read-only over events (it does not create them).
+- The public headless **`WIX_CLIENT_ID`** from your prompt (visitor-facing, safe to hardcode/commit).
+- Selling **paid** tickets also needs a Wix premium plan + a configured payment method on the site; **free** events and RSVP events work without. For paid tickets the buyer completes payment on the Wix-hosted ticket form; the deployed app domain may need to be allow-listed on the OAuth client for the return to land cleanly — a separate Wix setup the user completes later, out of scope here.
 
-## The API (copy as-is; do not re-derive it)
-This skill ships only the REST layer — no UI components. Build the events UI however the
-project wants; wire it to these two snippets. Copy them into the app (e.g. `src/api/`) and only
-adjust import paths:
-- `src/rest/wix-client.js` — visitor-token mint/refresh + transport. Reads `WIX_CLIENT_ID` from
-  `wix-config.js`. The visitor refresh token is persisted to localStorage and IS the identity of
-  the visitor's ticket reservation/cart — do not re-mint anonymously per load.
-- `src/rest/wix-config.js` — set `WIX_CLIENT_ID` (and `WIX_METASITE_ID`) from the prompt.
-- `src/rest/wix-events-browse.js` — **Browse & discovery:**
-  `queryEvents`, `getEventBySlug`, `countUpcomingEvents`, `queryEventCategories`, `listEventsByCategory`
-- `src/rest/wix-events-registration.js` — **RSVP & ticketing:**
-  `createRsvp`, `queryTicketDefinitions`, `reserveTickets`, `getTicketCheckoutUrl`, `checkoutTickets`
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole events UI client + REST scaffolds into `src/`
+(imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map, so you
+don't need to open them:**
 
-The `Event`, `TicketDefinition`, and `RSVP`/`Order` shapes are documented as JSDoc comments at
-the top of each helper file. Read the relevant file(s) before building the UI — they describe
-the key fields and link to the full API reference for anything not shown. The **Reference
-components** section below shows correct usage of the browse + registration helpers (grid,
-category menu, load-more, detail page, free-ticket checkout) — adapt the logic, restyle freely.
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `hooks/useEventsList.js` | listing logic — categories, active filter, offset "load more", empty count |
+| `hooks/useEventDetail.js` | detail data for a slug — event + derived `type`/`open` registration state |
+| `hooks/useRsvpForm.js` | RSVP submit logic (`YES`/`NO`, additional guests, `WAITLIST` result) |
+| `hooks/useTicketing.js` | ticket selection + reserve → paid redirect / free in-app checkout |
+| `components/EventCard.jsx`, `EventGrid.jsx` | event listing UI (grid + card, with empty state) |
+| `components/CategoryFilter.jsx` | category menu (renders `label` + `assignedEventsCount`) |
+| `components/EventRegistration.jsx` | branches on `registration.type` (RSVP / TICKETING / EXTERNAL / NONE) |
+| `components/RsvpForm.jsx` | RSVP form UI over `useRsvpForm` |
+| `components/TicketPicker.jsx` | ticket list + quantity + checkout UI over `useTicketing` |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Events.jsx`, `pages/EventDetail.jsx` | the two shipped routes (`/events`, `/events/:slug`) |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` | visitor-token mint/refresh + REST transport (reads `wix-config.js`) |
+| `rest/wix-events-browse.js` | browse/discovery helpers (`queryEvents`, `getEventBySlug`, categories, count) |
+| `rest/wix-events-registration.js` | RSVP + ticketing helpers (`createRsvp`, `reserveTickets`, `getTicketCheckoutUrl`, `checkoutTickets`) |
 
-## How to wire it (UI is the project's choice)
-- **Event grid** — `queryEvents()` lists live (UPCOMING/STARTED) events, soonest first. Render
-  `title`, `mainImage.url`, `dateAndTimeSettings.formatted.dateAndTime`, `location.name`, and
-  `shortDescription`. Use `offset`/`nextOffset` from the result to page. Link each card by `slug`.
-- **Event detail** — `getEventBySlug(slug)`; returns null on miss — show a not-found state, never
-  invent an event.
-  - **Description fields:** `event.shortDescription` is a **plain string** (safe teaser). The full
-    `event.description` is **Ricos rich content** — an object shaped `{ nodes: [...] }`, **not a string**.
-    Render it with a Ricos viewer (`@wix/ricos`) or walk `nodes` to extract text; **never** call string
-    methods (`.split`/`.slice`/`.substring`) on it — that crashes the page. When you only need text, use
-    `shortDescription`.
-  - Branch the registration UI on `event.registration.type`:
-  - `"RSVP"` → render the RSVP form (fields from `event.form.controls`).
-  - `"TICKETING"` → render the ticket picker.
-  - `"EXTERNAL"` → link out to `event.registration.external.url`.
-  - `"NONE"` → details only, no registration.
-  Only `registration.status` values starting `OPEN_` accept new registrations; otherwise show the
-  closed state.
-- **Categories (optional)** — `queryEventCategories()` for a filter menu (`counts.assignedEventsCount`
-  per category); `listEventsByCategory(categoryId)` to list a category's events (same card fields
-  and paging as `queryEvents`).
-- **RSVP** — `createRsvp(eventId, { firstName, lastName, email, status, additionalGuestNames?, extraFields? })`.
-  `status` defaults to `"YES"`; only offer `"NO"` when `registration.rsvp.responseType` is
-  `"YES_AND_NO"`. If the event is full with a waitlist enabled, the returned RSVP comes back with
-  status `"WAITLIST"` — tell the guest. Completes fully client-side; no redirect.
-- **Ticketing** — show tickets, reserve, then complete on the hosted form:
-  1. `queryTicketDefinitions(eventId)` → render each ticket's `name`, price (`pricing.fixedPrice.amount`
-     + `currency` for standard tickets; `free` boolean for free tickets; `pricing.minPrice` for
-     donation/"pay what you want"; `pricing.pricingOptions.options` for tiered), and filter on
-     `saleStatus === "SALE_STARTED"`. The endpoint already returns only non-hidden, available tickets.
-  2. `reserveTickets([{ ticketDefinitionId, quantity, guestPrice?, pricingOptionId? }])` → holds the
-     tickets; returns `{ id, expirationDate }`. Show a countdown to `expirationDate` if you like.
-  3. `window.location.href = getTicketCheckoutUrl(event, reservation.id)` → the Wix-hosted ticket
-     form collects guest details + payment and returns the buyer to the event. This is the path for
-     **all paid tickets**.
-  - **Free tickets only:** you may instead call `checkoutTickets(eventId, { reservationId, buyer, guests })`
-    to finish in-app — it returns an order with status `"FREE"`, a `ticketsPdf`, and `tickets[]`. It
-    throws for paid orders (status `INITIATED`), telling you to use the hosted form.
-- **Empty state** — if `countUpcomingEvents()` is 0, show an empty state telling the user to publish
-  events in their Wix dashboard. Never invent events.
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table above says what each is
+and every field shape you need is in the snippets below. Read a shipped file's source **only** on a
+real fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the
+end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/events/app/` → `src/`.)
 
-## Hard rules (do not violate)
-- ✅ Complete paid ticket purchases ONLY via `reserveTickets()` → `getTicketCheckoutUrl()` redirect
-  (the official Wix-hosted ticket form). 
-- ❌ Never hand-build registration, ticket, payment, or checkout URLs — derive the hosted form URL
-  from `event.eventPageUrl` via `getTicketCheckoutUrl`.
-- ❌ Never mock events, tickets, or guest counts — render live Wix data or the empty/closed state.
-- ❌ Never invent reviews, ratings, attendee names, or "X spots left" numbers not returned by the API.
-- ✅ Set `WIX_CLIENT_ID` from the prompt's value (public visitor-facing client id — safe to hardcode).
-- ✅ Branch registration UI on `event.registration.type`; respect `registration.status` (only `OPEN_*`
-  accepts registrations) and ticket `saleStatus`/`salesDetails.soldOut`.
-- ✅ Pass `guestPrice` for donation/"pay what you want" tickets and `pricingOptionId` for tiered tickets
-  to `reserveTickets`.
-- The helpers fail loudly on purpose: `reserveTickets` throws when tickets aren't actually held,
-  `createRsvp` throws on closed/full registration, `checkoutTickets` throws when payment is still owed.
-  A green path means it really worked — don't swallow these.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live. The visitor refresh token minted from this id is persisted to localStorage
+and **is** the identity of the visitor's ticket reservation — don't re-mint anonymously per load.
 
-## Beyond the snippets
-The snippets cover the common RSVP + ticketing paths. If you hit a use case they don't cover
-(coupons/`discount` at checkout, members/auth, schedule/agenda, seating maps, canceling a
-reservation, a field not in the typedefs), make the call yourself with `wixApiRequest` — but look
-up the exact endpoint, HTTP method, and request body in the **official Wix Events API reference**
-first; never guess:
-- Events API reference: https://dev.wix.com/docs/api-reference/business-solutions/events.md
-- Registration (RSVP + ticketing) overview: https://dev.wix.com/docs/api-reference/business-solutions/events/registration/introduction.md
-- Member login + a "my registrations" account view → the **members** vertical (`references/members/INSTRUCTIONS.md`).
-- Ticketing flow (reservations → orders → tickets): https://dev.wix.com/docs/api-reference/business-solutions/events/registration/ticketing/introduction.md
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing. Every shipped component reads these vars, so this re-skins the whole events site. **Do not
+restyle the shipped components' JSX** — that's what keeps this a copy, not a regeneration. Style the
+home page / header you build (STEP 4) from the same tokens so it matches. Dark brand → activate the
+dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
-Keep the snippets as the default for everything they already do; reach for the API reference only
-for the gap.
-
-## Reference components (headless — adapt the logic, restyle freely)
-
-These are the recurring events pieces, written **headless**: the data wiring (Wix field paths,
-the offset load-more math, the ticketing Money object, the free-ticket checkout shape) is correct
-and complete — the markup is deliberately plain. **Copy the logic exactly; restyle the JSX to the
-brand.** Don't re-derive the data shapes from scratch (that's where the bugs are — the category
-`label`, the `lowestPrice` Money object, and the `{ events, nextOffset }` paging especially). They
-consume the `src/rest/` helpers; you don't need to read those helpers' source.
-
-**`components/EventCard.jsx`** — grid tile. Note the date/location/teaser field paths and the
-TICKETING "from" price, read off `registration.tickets.lowestPrice` — a **Money object**
-`{ value, currency, formattedValue }`. Render `formattedValue`, **never** the raw object (React
-"objects are not valid as a child" crash). This is a different shape from the ticket-definition
-price path `pricing.fixedPrice.amount` (a plain number) used inside the ticket picker.
+## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
+replace it. (Events needs no cross-page provider — there's no cart; the RSVP/ticketing state is local
+to the detail page.)
+- `import "@/theme.css";` once at the app entry.
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Events` / `EventDetail` — so you **never edit the shipped pages to add a
+  header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's **ResizeObserver-measured** height so it clears the chrome and
+  self-corrects when the banner is dismissed.
+- Routes under the Layout: `/events` → `Events`, `/events/:slug` → `EventDetail` (both shipped, as-is).
+  **You add `/` → your own Home** page.
 
 ```jsx
-import { Link } from "react-router-dom";
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import Events from "@/pages/Events";
+import EventDetail from "@/pages/EventDetail";
+import Home from "@/pages/Home";       // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
 
-export default function EventCard({ event }) {
-  const when = event.dateAndTimeSettings?.formatted?.dateAndTime;
-  const where = event.location?.name;
-  const isTicketing = event.registration?.type === "TICKETING";
-  // lowestPrice is a Money object { value, currency, formattedValue } — render formattedValue,
-  // NEVER the raw object (React child crash). Ticket-definition prices use pricing.fixedPrice.amount.
-  const fromPrice = event.registration?.tickets?.lowestPrice?.formattedValue;
-  const soldOut = event.registration?.tickets?.soldOut;
-  return (
-    <Link to={`/events/${event.slug}`} /* restyle */>
-      {event.mainImage?.url
-        ? <img src={event.mainImage.url} alt={event.title} loading="lazy" />
-        : <div>{/* placeholder */}</div>}
-      <h3>{event.title}</h3>
-      {when && <span>{when}</span>}
-      {where && <span>{where}</span>}
-      {event.shortDescription && <p>{event.shortDescription}</p>}
-      {isTicketing && (soldOut ? <span>Sold out</span> : fromPrice && <span>From {fromPrice}</span>)}
-    </Link>
-  );
-}
-```
-
-**`pages/Events.jsx`** — the listing (grid + category menu + empty state + load-more). Both
-`queryEvents` and `listEventsByCategory` return an **object** `{ events, total, offset, nextOffset }`,
-not a bare array — destructure `events` first; `nextOffset` is `null` when there are no more pages.
-`queryEventCategories()` returns `{ categories, total }`; render `category.label` (**not** `name` —
-the display field is `label`), key/filter by `category.id`, and show `counts.assignedEventsCount`.
-
-```jsx
-import { useState, useEffect } from "react";
-import { queryEvents, listEventsByCategory, queryEventCategories, countUpcomingEvents } from "@/rest/wix-events-browse";
-import EventCard from "@/components/EventCard";
-
-export default function Events() {
-  const [events, setEvents] = useState([]);
-  const [nextOffset, setNextOffset] = useState(null); // offset for the next page; null when no more
-  const [menu, setMenu] = useState([]);               // category menu
-  const [active, setActive] = useState(null);         // selected category id, or null for "all"
-  const [total, setTotal] = useState(null);
-
-  useEffect(() => {
-    countUpcomingEvents().then(setTotal);
-    // queryEventCategories returns { categories, total } — destructure the array first.
-    queryEventCategories().then(({ categories }) => setMenu(categories));
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
   }, []);
-
-  useEffect(() => {
-    const load = active
-      ? listEventsByCategory(active, { limit: 24 })
-      : queryEvents({ limit: 24 });
-    // Both return an OBJECT { events, total, offset, nextOffset } — not a bare array.
-    load.then(({ events, nextOffset }) => { setEvents(events); setNextOffset(nextOffset); });
-  }, [active]);
-
-  const loadMore = () => {
-    const load = active
-      ? listEventsByCategory(active, { limit: 24, offset: nextOffset })
-      : queryEvents({ limit: 24, offset: nextOffset });
-    load.then(({ events: more, nextOffset: next }) => { setEvents((e) => [...e, ...more]); setNextOffset(next); });
-  };
-
-  if (total === 0) return <p>{/* empty state — no events published yet */}</p>;
-  return (
-    <div /* restyle */>
-      <nav>
-        <button onClick={() => setActive(null)} aria-pressed={active === null}>All</button>
-        {menu.map((c) => (
-          // display field is `label`, NOT `name`; key/filter by `category.id`.
-          <button key={c.id} onClick={() => setActive(c.id)} aria-pressed={active === c.id}>
-            {c.label} ({c.counts?.assignedEventsCount ?? 0})
-          </button>
-        ))}
-      </nav>
-      <div /* grid */>{events.map((e) => <EventCard key={e.id} event={e} />)}</div>
-      {nextOffset !== null && <button onClick={loadMore}>Load more</button>}
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
-  );
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Events/EventDetail render here, untouched */}
+      <Footer />
+    </div>
+  </>);
 }
+
+<Routes>
+  <Route element={<Layout />}>                                {/* chrome wraps all */}
+    <Route path="/" element={<Home />} />                     {/* yours */}
+    <Route path="/events" element={<Events />} />             {/* shipped, as-is */}
+    <Route path="/events/:slug" element={<EventDetail />} />  {/* shipped, as-is */}
+  </Route>
+</Routes>
 ```
 
-**`pages/EventDetail.jsx`** — the detail page. `getEventBySlug(slug)` returns **null** on miss —
-show a not-found state, never invent an event. Branch the registration UI on `registration.type`
-and only accept registrations while `registration.status` starts with `OPEN_`. `shortDescription`
-is a plain string (safe); the full `event.description` is **Ricos rich content** `{ nodes: [...] }`
-— render it with `@wix/ricos` or walk `nodes`; **never** call string methods on it (that crashes
-the page).
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
+(STEP 4) so they wrap every route — plus the overall brand story, styled from the same `theme.css`
+tokens. **Compose the shipped pieces** — a "featured events" strip is just `queryEvents` + the shipped
+`EventGrid`; the nav is a link to `/events`:
 
 ```jsx
 import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import { getEventBySlug } from "@/rest/wix-events-browse";
+import { Link } from "react-router-dom";
+import { queryEvents } from "@/rest/wix-events-browse";
+import EventGrid from "@/components/EventGrid";
 
-export default function EventDetail() {
-  const { slug } = useParams();
-  const [event, setEvent] = useState(null);
-  const [notFound, setNotFound] = useState(false);
-
+// Responsive header: choose ONE branch with a state flag (copy this pattern). Do NOT render a
+// desktop nav AND a mobile nav toggled by Tailwind `hidden md:*` — these navs are inline-styled and
+// an inline `display` beats a Tailwind class, so `hidden` never applies and BOTH branches render.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
   useEffect(() => {
-    getEventBySlug(slug).then((e) => (e ? setEvent(e) : setNotFound(true))); // null on miss
-  }, [slug]);
-
-  if (notFound) return <div>Event not found.</div>;
-  if (!event) return <div>Loading…</div>;
-
-  const reg = event.registration ?? {};
-  const open = typeof reg.status === "string" && reg.status.startsWith("OPEN_"); // only OPEN_* takes registrations
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);             // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
   return (
-    <div /* restyle */>
-      {event.mainImage?.url && <img src={event.mainImage.url} alt={event.title} />}
-      <h1>{event.title}</h1>
-      <p>{event.dateAndTimeSettings?.formatted?.dateAndTime}</p>
-      {/* shortDescription is a plain string (safe to render). event.description is Ricos rich
-          content { nodes: [...] } — render with @wix/ricos or walk nodes; NEVER call string
-          methods (.slice/.substring) on it — that crashes the page. */}
-      {event.shortDescription && <p>{event.shortDescription}</p>}
-
-      {reg.type === "RSVP" && (open ? <div>{/* RSVP form — fields from event.form.controls */}</div> : <p>Registration is closed.</p>)}
-      {reg.type === "TICKETING" && (open ? <div>{/* ticket picker — see the free-ticket checkout snippet */}</div> : <p>Ticket sales are closed.</p>)}
-      {reg.type === "EXTERNAL" && <a href={reg.external?.url}>Register</a>}
-      {reg.type === "NONE" && null}
-    </div>
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile ? <YourMenu /> : <Link to="/events">Events</Link>}
+    </nav>
   );
 }
-```
 
-**Free-ticket checkout** — for **free** tickets you may finish in-app instead of redirecting:
-reserve, then call `checkoutTickets(eventId, { reservationId, buyer, guests })` with the guest
-sub-shape `guests: [{ firstName, lastName, email }]`. It throws for paid orders (telling you to use
-`getTicketCheckoutUrl`), so a green path is a real, confirmed order.
-
-```jsx
-import { reserveTickets, checkoutTickets, getTicketCheckoutUrl } from "@/rest/wix-events-registration";
-
-// FREE tickets only: reserve, then finish in-app with checkoutTickets — no redirect.
-// For ANY paid ticket, redirect instead: window.location.href = getTicketCheckoutUrl(event, reservation.id).
-async function claimFreeTicket(event, ticketDefinitionId, buyer /* { firstName, lastName, email } */) {
-  const reservation = await reserveTickets([{ ticketDefinitionId, quantity: 1 }]); // { id, expirationDate }
-  const order = await checkoutTickets(event.id, {
-    reservationId: reservation.id,
-    buyer,
-    guests: [{ firstName: buyer.firstName, lastName: buyer.lastName, email: buyer.email }],
-  });
-  return order; // status "FREE"; carries order.ticketsPdf and order.tickets[]. Throws if payment is owed.
+export function Featured() {                                 // on your home page
+  const [events, setEvents] = useState([]);
+  // NB: queryEvents returns { events, total, offset, nextOffset } — destructure the array.
+  useEffect(() => { queryEvents({ limit: 6 }).then(({ events }) => setEvents(events)); }, []);
+  return <EventGrid events={events} empty="Events coming soon." />;
 }
 ```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
+
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
+
+## Using the client from your own UI
+
+```jsx
+// Every browse list helper returns an OBJECT { events, total, offset, nextOffset } — not a bare
+// array. Destructure `events`; nextOffset is null when there are no more pages.
+import { queryEvents, getEventBySlug, queryEventCategories, listEventsByCategory, countUpcomingEvents } from "@/rest/wix-events-browse";
+
+const { events, nextOffset } = await queryEvents({ limit: 24 });          // live UPCOMING/STARTED, soonest first
+const { categories } = await queryEventCategories();                       // render category.label (NOT name)
+const { events: inCat } = await listEventsByCategory(categories[0].id);    // same shape + paging as queryEvents
+const total = await countUpcomingEvents();                                 // 0 → shipped empty state
+
+// Detail by slug — returns null on miss (the shipped EventDetail shows a not-found state):
+const event = await getEventBySlug(slug);
+
+// Image urls live at event.mainImage.url. shortDescription is a PLAIN string (safe to render).
+// event.description is Ricos rich content { nodes: [...] } — NOT a string; render with @wix/ricos or
+// walk nodes; NEVER call string methods (.slice/.split) on it — that crashes the page.
+```
+
+The registration flows are already wired in the shipped `EventRegistration` (branches on
+`registration.type`, respects `registration.status` — only `OPEN_*` accepts registrations), so your
+pages just render `<EventRegistration .../>` as the shipped `EventDetail` does. Doing a flow yourself:
+
+```jsx
+import { createRsvp, reserveTickets, getTicketCheckoutUrl, checkoutTickets } from "@/rest/wix-events-registration";
+
+// RSVP (client-side): status "NO" only when registration.rsvp.responseType === "YES_AND_NO".
+const rsvp = await createRsvp(event.id, { firstName, lastName, email });   // rsvp.status may be "WAITLIST"
+
+// PAID tickets: reserve, then redirect to the Wix-hosted ticket form — NEVER a hand-built URL.
+const reservation = await reserveTickets([{ ticketDefinitionId, quantity: 1 }]);
+window.location.href = getTicketCheckoutUrl(event, reservation.id);
+
+// FREE tickets only: finish in-app instead of redirecting (throws if payment is owed).
+const order = await checkoutTickets(event.id, { reservationId: reservation.id, buyer, guests: [buyer] });
+```
+
+## Extending the client
+Building something beyond the shipped pages (a "my registrations" account view, coupons, seating
+maps, a schedule/agenda, canceling a reservation)? The helpers cover the common RSVP + ticketing
+paths; for a gap, make the call with `wixApiRequest` — but look up the exact endpoint/body in the
+official Wix Events API reference first, never guess:
+- Events API reference: https://dev.wix.com/docs/api-reference/business-solutions/events.md
+- Registration (RSVP + ticketing): https://dev.wix.com/docs/api-reference/business-solutions/events/registration/introduction.md
+- Member login + "my registrations" → the **members** vertical (`references/members/INSTRUCTIONS.md`).
+
+Fallback only — when you hit an error or need something not shown here: read the relevant shipped file
+under `src/`, or look it up via the **`wix-docs`** skill.
+
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Events`/`EventDetail` to add chrome.
+- The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
+- Paid ticket checkout goes through the shipped reserve → `getTicketCheckoutUrl` redirect (the Wix-hosted ticket form) — never a hand-built registration/ticket/payment URL.
+- Render live Wix data or the shipped empty/closed/not-found state — never mock events, tickets, guest counts, or "X spots left".
 
 ## Point the user to their dashboard
-In some cases, users need to access the Wix dashboard in order to edit the events content for their site. To facilitate this, provide the user with deep links directly to the relevant dashboard pages. For events data those pages are:
+Provide deep links so the owner can edit content (substitute the site's `metaSiteId`):
 - **Events** — `https://manage.wix.com/dashboard/{metaSiteId}/events` (`Dashboard → Events` → **+ Add Event**; create the event, then set it up as **Ticketed** or **RSVP**; only published events appear in the app)
 
-Substitute the site's `metaSiteId` to complete the links (you have it from the handoff / `ListWixSites`). Include the in-dashboard navigation as a fallback.
+## Seeding
+Seed events per `seed/SEED.md` (the build-time setup module) — separate from this client build; run in
+parallel.
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Visitor token persists across reload (same visitor identity for reservations)
-- [ ] Event grid renders live events; clicking a card opens the detail page by `slug`
-- [ ] Detail page branches correctly on `registration.type` (RSVP form vs. ticket picker vs. external link)
-- [ ] RSVP submit creates a real RSVP (and surfaces a `WAITLIST` result when the event is full)
-- [ ] Ticket purchase reserves tickets, then redirects via `getTicketCheckoutUrl` (no hand-built URL)
-- [ ] Paid checkout lands on the Wix-hosted ticket form; buyer returns to the event afterward
-- [ ] Closed registration / sold-out tickets show a clear state rather than a dead end
-- [ ] Empty state shown when `countUpcomingEvents()` is 0
-- [ ] No mock events, tickets, or attendee data anywhere
-- [ ] Told the user at least once that they can continue setting up their events in the dashboard and provided deep links.
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Events`/`EventDetail` untouched; content clears the fixed chrome.
+- [ ] Event grid renders live events; clicking a card opens the detail page by `slug`; visitor token persists across reload.
+- [ ] Detail page branches correctly on `registration.type` (RSVP form vs. ticket picker vs. external link vs. none); closed registration / sold-out tickets show a clear state.
+- [ ] RSVP submit creates a real RSVP (and surfaces a `WAITLIST` result when full); paid ticket purchase reserves then redirects via `getTicketCheckoutUrl`.
+- [ ] Empty catalog shows the shipped empty state (`countUpcomingEvents()` is 0); no mock events anywhere.

--- a/skills/wix-vibe-headless/references/events/app/components/CategoryFilter.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/CategoryFilter.jsx
@@ -1,0 +1,26 @@
+// Category filter menu for the events listing. Pure UI — the active id + setter come from
+// useEventsList. Display field is `label` (NOT `name`); key/filter by `category.id`; the per-category
+// count is `counts.assignedEventsCount`. Token-styled; re-skin via theme.css.
+
+const chipBase = {
+  padding: "6px 14px", cursor: "pointer", fontSize: 14, fontFamily: "var(--font-body)",
+  border: "1px solid var(--color-border)", borderRadius: 999,
+  background: "var(--color-surface)", color: "var(--color-text)",
+};
+const chipActive = { background: "var(--color-primary)", color: "var(--color-on-primary)", borderColor: "var(--color-primary)" };
+
+export default function CategoryFilter({ categories, active, onSelect }) {
+  if (!categories?.length) return null;
+  return (
+    <nav style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: "var(--space)" }}>
+      <button onClick={() => onSelect(null)} aria-pressed={active === null}
+        style={{ ...chipBase, ...(active === null ? chipActive : null) }}>All</button>
+      {categories.map((c) => (
+        <button key={c.id} onClick={() => onSelect(c.id)} aria-pressed={active === c.id}
+          style={{ ...chipBase, ...(active === c.id ? chipActive : null) }}>
+          {c.label} ({c.counts?.assignedEventsCount ?? 0})
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/components/EventCard.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/EventCard.jsx
@@ -1,0 +1,50 @@
+// Grid tile for one event. Styled entirely from theme.css tokens (var(--...)) — re-skin via those
+// tokens, not this JSX. The date/location/teaser field paths and the TICKETING "from" price are
+// load-bearing: lowestPrice is a Money object { value, currency, formattedValue } — render
+// formattedValue, NEVER the raw object (React "objects are not valid as a child" crash). This is a
+// different shape from the ticket-definition price (pricing.fixedPrice.amount) used in the picker.
+import { Link } from "react-router-dom";
+
+export default function EventCard({ event }) {
+  const when = event.dateAndTimeSettings?.formatted?.dateAndTime;
+  const where = event.location?.name;
+  const isTicketing = event.registration?.type === "TICKETING";
+  const fromPrice = event.registration?.tickets?.lowestPrice?.formattedValue;
+  const soldOut = event.registration?.tickets?.soldOut;
+  const image = event.mainImage?.url;
+
+  return (
+    <Link to={`/events/${event.slug}`} style={{
+      display: "flex", flexDirection: "column", textDecoration: "none",
+      color: "var(--color-text)", background: "var(--color-surface)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)",
+      overflow: "hidden", boxShadow: "var(--shadow)",
+    }}>
+      <div style={{ position: "relative", aspectRatio: "3 / 2", background: "var(--color-bg)" }}>
+        {image
+          ? <img src={image} alt={event.title} loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+          : <div style={{ width: "100%", height: "100%" }} />}
+        {isTicketing && soldOut && (
+          <span style={{
+            position: "absolute", top: 8, left: 8, padding: "2px 8px", fontSize: 12,
+            background: "var(--color-danger)", color: "#fff", borderRadius: "var(--radius-sm)",
+          }}>Sold out</span>
+        )}
+      </div>
+      <div style={{ padding: "calc(var(--space) * 0.75)", display: "flex", flexDirection: "column", gap: 4 }}>
+        <h3 style={{ margin: 0, fontFamily: "var(--font-display)", fontSize: 16, fontWeight: 600 }}>{event.title}</h3>
+        {when && <span style={{ color: "var(--color-muted)", fontSize: 13 }}>{when}</span>}
+        {where && <span style={{ color: "var(--color-muted)", fontSize: 13 }}>{where}</span>}
+        {event.shortDescription && (
+          <p style={{ margin: "4px 0 0", color: "var(--color-muted)", fontSize: 14, lineHeight: 1.4 }}>
+            {event.shortDescription}
+          </p>
+        )}
+        {isTicketing && !soldOut && fromPrice && (
+          <span style={{ marginTop: 4, fontWeight: 600, color: "var(--color-accent)" }}>From {fromPrice}</span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/components/EventGrid.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/EventGrid.jsx
@@ -1,0 +1,19 @@
+// Responsive event grid + empty state. Token-styled; re-skin via theme.css.
+import EventCard from "./EventCard";
+
+export default function EventGrid({ events, empty = "No events yet." }) {
+  if (!events?.length) {
+    return (
+      <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>{empty}</p>
+    );
+  }
+  return (
+    <div style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+      gap: "var(--space)",
+    }}>
+      {events.map((e) => <EventCard key={e.id} event={e} />)}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/components/EventRegistration.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/EventRegistration.jsx
@@ -1,0 +1,33 @@
+// Registration surface for the detail page — branches on registration.type and respects `open`
+// (only OPEN_* statuses accept new registrations). Pure UI; the RSVP/ticketing logic lives in their
+// own hooks/components. Token-styled; re-skin via theme.css.
+import RsvpForm from "./RsvpForm";
+import TicketPicker from "./TicketPicker";
+
+const closed = { color: "var(--color-danger)", fontWeight: 600 };
+const link = {
+  display: "inline-block", padding: "12px 24px", textDecoration: "none",
+  background: "var(--color-primary)", color: "var(--color-on-primary)",
+  border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+};
+
+export default function EventRegistration({ event, type, open, registration }) {
+  if (type === "EXTERNAL") {
+    return registration.external?.url
+      ? <a href={registration.external.url} target="_blank" rel="noopener" style={link}>Register</a>
+      : null;
+  }
+  if (type === "NONE") return null;
+
+  if (type === "RSVP") {
+    return open
+      ? <RsvpForm eventId={event.id} responseType={registration.rsvp?.responseType} />
+      : <p style={closed}>Registration is closed.</p>;
+  }
+  if (type === "TICKETING") {
+    return open
+      ? <TicketPicker event={event} />
+      : <p style={closed}>Ticket sales are closed.</p>;
+  }
+  return null;
+}

--- a/skills/wix-vibe-headless/references/events/app/components/RsvpForm.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/RsvpForm.jsx
@@ -1,0 +1,66 @@
+// RSVP form for an RSVP-type event. Pure UI over useRsvpForm — no data logic here. Token-styled;
+// re-skin via theme.css. Offers a "NO" reply only when responseType is "YES_AND_NO"; a WAITLIST
+// result (event full) is surfaced distinctly from a confirmed YES.
+import { useRsvpForm } from "@/hooks/useRsvpForm";
+
+const input = {
+  width: "100%", padding: "10px 12px", boxSizing: "border-box", fontFamily: "var(--font-body)",
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-bg)", color: "var(--color-text)",
+};
+const label = { display: "block", marginBottom: 6, fontSize: 13, fontWeight: 600, color: "var(--color-muted)" };
+const field = { marginBottom: "var(--space)" };
+
+export default function RsvpForm({ eventId, responseType }) {
+  const { form, setField, submit, submitting, canSubmit, result, error } = useRsvpForm(eventId);
+
+  if (result) {
+    const waitlisted = result.status === "WAITLIST";
+    return (
+      <div style={{
+        padding: "var(--space)", borderRadius: "var(--radius)",
+        background: "var(--color-surface)", border: "1px solid var(--color-border)", color: "var(--color-text)",
+      }}>
+        {waitlisted
+          ? "This event is full — you've been added to the waitlist. We'll email you if a spot opens."
+          : "You're on the list! A confirmation is on its way to your email."}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); submit(); }} style={{ maxWidth: 440 }}>
+      <div style={field}>
+        <label style={label}>First name</label>
+        <input style={input} value={form.firstName} onChange={(e) => setField("firstName", e.target.value)} required />
+      </div>
+      <div style={field}>
+        <label style={label}>Last name</label>
+        <input style={input} value={form.lastName} onChange={(e) => setField("lastName", e.target.value)} required />
+      </div>
+      <div style={field}>
+        <label style={label}>Email</label>
+        <input style={input} type="email" value={form.email} onChange={(e) => setField("email", e.target.value)} required />
+      </div>
+
+      {responseType === "YES_AND_NO" && (
+        <div style={field}>
+          <label style={label}>Will you attend?</label>
+          <select style={input} value={form.status} onChange={(e) => setField("status", e.target.value)}>
+            <option value="YES">Yes, I'll be there</option>
+            <option value="NO">No, I can't make it</option>
+          </select>
+        </div>
+      )}
+
+      {error && <p style={{ color: "var(--color-danger)", marginBottom: "var(--space)" }}>{error}</p>}
+
+      <button type="submit" disabled={!canSubmit} style={{
+        padding: "12px 24px", cursor: canSubmit ? "pointer" : "not-allowed",
+        background: "var(--color-primary)", color: "var(--color-on-primary)",
+        border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+        opacity: canSubmit ? 1 : 0.5,
+      }}>{submitting ? "Sending…" : "RSVP"}</button>
+    </form>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/components/TicketPicker.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/TicketPicker.jsx
@@ -1,0 +1,95 @@
+// Ticket picker for a TICKETING event. Pure UI over useTicketing — no data logic here. Token-styled;
+// re-skin via theme.css.
+//   • Ticket-definition price is a plain number at pricing.fixedPrice.amount (+ price.currency here).
+//   • FREE-only selection → an in-app buyer form + checkoutTickets (no redirect).
+//   • Any PAID ticket → "Continue to checkout", which reserves then redirects to the Wix-hosted form.
+import { useState } from "react";
+import { useTicketing } from "@/hooks/useTicketing";
+
+const input = {
+  width: "100%", padding: "10px 12px", boxSizing: "border-box", fontFamily: "var(--font-body)",
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-bg)", color: "var(--color-text)",
+};
+
+function ticketPrice(def) {
+  if (def.free) return "Free";
+  const amount = def.price?.amount ?? def.pricing?.fixedPrice?.amount;
+  const currency = def.price?.currency ?? def.pricing?.fixedPrice?.currency ?? "";
+  return amount != null ? `${amount} ${currency}`.trim() : "";
+}
+
+export default function TicketPicker({ event }) {
+  const t = useTicketing(event);
+  const [buyer, setBuyer] = useState({ firstName: "", lastName: "", email: "" });
+  const setBuyerField = (k, v) => setBuyer((b) => ({ ...b, [k]: v }));
+
+  if (t.order) {
+    return (
+      <div style={{
+        padding: "var(--space)", borderRadius: "var(--radius)",
+        background: "var(--color-surface)", border: "1px solid var(--color-border)",
+      }}>
+        Your tickets are confirmed.{" "}
+        {t.order.ticketsPdf && (
+          <a href={t.order.ticketsPdf} target="_blank" rel="noopener"
+            style={{ color: "var(--color-primary)" }}>Download tickets (PDF)</a>
+        )}
+      </div>
+    );
+  }
+
+  if (!t.definitions.length) {
+    return <p style={{ color: "var(--color-muted)" }}>No tickets are currently on sale.</p>;
+  }
+
+  const buyerReady = buyer.firstName && buyer.lastName && buyer.email;
+
+  return (
+    <div>
+      {t.definitions.map((def) => (
+        <div key={def.id} style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space)",
+          padding: "12px 0", borderBottom: "1px solid var(--color-border)",
+        }}>
+          <div>
+            <div style={{ fontWeight: 600 }}>{def.name}</div>
+            {def.description && <div style={{ color: "var(--color-muted)", fontSize: 14 }}>{def.description}</div>}
+            <div style={{ color: "var(--color-accent)", fontWeight: 600, marginTop: 2 }}>{ticketPrice(def)}</div>
+          </div>
+          <input type="number" min={0} value={t.selection[def.id]?.quantity ?? 0}
+            onChange={(e) => t.setQuantity(def.id, Number(e.target.value) || 0)}
+            style={{ ...input, width: 72, textAlign: "center" }} />
+        </div>
+      ))}
+
+      {t.error && <p style={{ color: "var(--color-danger)", marginTop: "var(--space)" }}>{t.error}</p>}
+
+      {t.hasSelection && t.allFree && (
+        <div style={{ marginTop: "var(--space)", display: "grid", gap: 8, maxWidth: 440 }}>
+          <input style={input} placeholder="First name" value={buyer.firstName}
+            onChange={(e) => setBuyerField("firstName", e.target.value)} />
+          <input style={input} placeholder="Last name" value={buyer.lastName}
+            onChange={(e) => setBuyerField("lastName", e.target.value)} />
+          <input style={input} type="email" placeholder="Email" value={buyer.email}
+            onChange={(e) => setBuyerField("email", e.target.value)} />
+        </div>
+      )}
+
+      {t.hasSelection && (
+        <button
+          disabled={t.submitting || (t.allFree && !buyerReady)}
+          onClick={() => (t.allFree ? t.checkoutFree(buyer) : t.checkoutPaid())}
+          style={{
+            marginTop: "var(--space)", padding: "12px 24px",
+            cursor: t.submitting ? "not-allowed" : "pointer",
+            background: "var(--color-primary)", color: "var(--color-on-primary)",
+            border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+            opacity: t.submitting || (t.allFree && !buyerReady) ? 0.5 : 1,
+          }}>
+          {t.submitting ? "Processing…" : t.allFree ? "Get tickets" : "Continue to checkout"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/hooks/useEventDetail.js
+++ b/skills/wix-vibe-headless/references/events/app/hooks/useEventDetail.js
@@ -1,0 +1,27 @@
+// useEventDetail — load one event by slug and derive its registration state. No markup.
+//   • getEventBySlug returns null on miss → notFound (never invent an event).
+//   • registration.type is "RSVP" | "TICKETING" | "EXTERNAL" | "NONE" — the detail page branches on it.
+//   • Only registration.status values starting "OPEN_" accept new registrations; otherwise `open` is
+//     false and the page shows the closed state.
+//   • shortDescription is a plain string (safe to render). event.description is Ricos rich content
+//     { nodes: [...] } — NOT a string; render with @wix/ricos or walk nodes, never call string
+//     methods on it (that crashes the page). This hook does not touch description.
+import { useState, useEffect } from "react";
+import { getEventBySlug } from "@/rest/wix-events-browse";
+
+export function useEventDetail(slug) {
+  const [event, setEvent] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    setEvent(null);
+    setNotFound(false);
+    getEventBySlug(slug).then((e) => (e ? setEvent(e) : setNotFound(true)));
+  }, [slug]);
+
+  const reg = event?.registration ?? {};
+  const type = reg.type ?? "NONE";
+  const open = typeof reg.status === "string" && reg.status.startsWith("OPEN_");
+
+  return { event, notFound, type, open, registration: reg };
+}

--- a/skills/wix-vibe-headless/references/events/app/hooks/useEventsList.js
+++ b/skills/wix-vibe-headless/references/events/app/hooks/useEventsList.js
@@ -1,0 +1,54 @@
+// useEventsList — all listing logic, no markup: load the category menu + upcoming count, list
+// events (all or filtered by category), and page with offset "load more". The data shapes here are
+// the bug-prone part — keep them verbatim; the Events page only renders what this returns.
+//   • queryEvents / listEventsByCategory return { events, total, offset, nextOffset } — an OBJECT,
+//     not a bare array; nextOffset is null when there are no more pages.
+//   • queryEventCategories returns { categories, total }; render category.label (NOT name),
+//     key/filter by category.id, count = counts.assignedEventsCount.
+//   • total === 0 → the whole catalog is empty; show the "publish events" empty state.
+import { useState, useEffect } from "react";
+import {
+  queryEvents, listEventsByCategory, queryEventCategories, countUpcomingEvents,
+} from "@/rest/wix-events-browse";
+
+export function useEventsList({ pageSize = 24 } = {}) {
+  const [events, setEvents] = useState([]);
+  const [nextOffset, setNextOffset] = useState(null); // offset for the next page; null when no more
+  const [categories, setCategories] = useState([]);   // category menu
+  const [active, setActive] = useState(null);          // selected category id, or null for "all"
+  const [total, setTotal] = useState(null);            // upcoming count across the whole catalog
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    countUpcomingEvents().then(setTotal);
+    queryEventCategories().then(({ categories }) => setCategories(categories));
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    const load = active
+      ? listEventsByCategory(active, { limit: pageSize })
+      : queryEvents({ limit: pageSize });
+    load.then(({ events, nextOffset }) => {
+      setEvents(events);
+      setNextOffset(nextOffset);
+      setLoading(false);
+    });
+  }, [active, pageSize]);
+
+  const loadMore = () => {
+    if (nextOffset === null) return;
+    const load = active
+      ? listEventsByCategory(active, { limit: pageSize, offset: nextOffset })
+      : queryEvents({ limit: pageSize, offset: nextOffset });
+    load.then(({ events: more, nextOffset: next }) => {
+      setEvents((e) => [...e, ...more]);
+      setNextOffset(next);
+    });
+  };
+
+  return {
+    events, categories, active, setActive,
+    total, loading, hasMore: nextOffset !== null, loadMore,
+  };
+}

--- a/skills/wix-vibe-headless/references/events/app/hooks/useRsvpForm.js
+++ b/skills/wix-vibe-headless/references/events/app/hooks/useRsvpForm.js
@@ -1,0 +1,40 @@
+// useRsvpForm — RSVP submission logic for an RSVP-type event, no markup.
+//   • createRsvp(eventId, { firstName, lastName, email, status, additionalGuestNames? }) completes
+//     fully client-side (no redirect) and throws on closed/full registration, guest-limit, duplicate
+//     email, or invalid form — surface the message, don't swallow it.
+//   • Only offer status "NO" when registration.rsvp.responseType === "YES_AND_NO".
+//   • A full-with-waitlist event returns the RSVP with status "WAITLIST" — tell the guest.
+import { useState } from "react";
+import { createRsvp } from "@/rest/wix-events-registration";
+
+export function useRsvpForm(eventId) {
+  const [form, setForm] = useState({ firstName: "", lastName: "", email: "", status: "YES" });
+  const [guests, setGuests] = useState([]); // additional guest names (strings)
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState(null); // the created RSVP (carries .status) on success
+  const [error, setError] = useState(null);
+
+  const setField = (name, value) => setForm((f) => ({ ...f, [name]: value }));
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const rsvp = await createRsvp(eventId, {
+        firstName: form.firstName,
+        lastName: form.lastName,
+        email: form.email,
+        status: form.status,
+        additionalGuestNames: guests.filter(Boolean),
+      });
+      setResult(rsvp); // rsvp.status is "YES" | "NO" | "WAITLIST"
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const canSubmit = !!(form.firstName && form.lastName && form.email) && !submitting;
+  return { form, setField, guests, setGuests, submit, submitting, canSubmit, result, error };
+}

--- a/skills/wix-vibe-headless/references/events/app/hooks/useTicketing.js
+++ b/skills/wix-vibe-headless/references/events/app/hooks/useTicketing.js
@@ -1,0 +1,81 @@
+// useTicketing — ticket selection + checkout logic for a TICKETING event, no markup.
+//   • queryTicketDefinitions(eventId) already returns only non-hidden, buyable (SALE_STARTED) tickets.
+//   • Ticket-definition price is a PLAIN number at pricing.fixedPrice.amount (+ currency) — a different
+//     shape from the card's registration.tickets.lowestPrice Money object.
+//   • reserveTickets([...]) holds the tickets (status PENDING) and throws if they aren't actually held.
+//   • PAID tickets: reserve → window.location = getTicketCheckoutUrl(event, reservationId) (the Wix-
+//     hosted ticket form collects guest details + payment). NEVER hand-build that URL.
+//   • FREE tickets only: reserve → checkoutTickets(eventId, { reservationId, buyer, guests }) finishes
+//     in-app and returns an order with status "FREE"; it throws for paid orders.
+import { useState, useEffect } from "react";
+import {
+  queryTicketDefinitions, reserveTickets, getTicketCheckoutUrl, checkoutTickets,
+} from "@/rest/wix-events-registration";
+
+export function useTicketing(event) {
+  const eventId = event?.id;
+  const [definitions, setDefinitions] = useState([]);
+  const [selection, setSelection] = useState({}); // { [defId]: { quantity, guestPrice?, pricingOptionId? } }
+  const [submitting, setSubmitting] = useState(false);
+  const [order, setOrder] = useState(null); // free-checkout order on success
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!eventId) return;
+    queryTicketDefinitions(eventId).then(setDefinitions);
+  }, [eventId]);
+
+  const setLine = (defId, patch) =>
+    setSelection((s) => ({ ...s, [defId]: { quantity: 0, ...s[defId], ...patch } }));
+  const setQuantity = (defId, quantity) => setLine(defId, { quantity: Math.max(0, quantity) });
+
+  const lines = Object.entries(selection)
+    .filter(([, l]) => l.quantity > 0)
+    .map(([ticketDefinitionId, l]) => ({
+      ticketDefinitionId,
+      quantity: l.quantity,
+      guestPrice: l.guestPrice,
+      pricingOptionId: l.pricingOptionId,
+    }));
+
+  const hasSelection = lines.length > 0;
+  const allFree = hasSelection && lines.every((l) => definitions.find((d) => d.id === l.ticketDefinitionId)?.free);
+
+  // PAID (or mixed): reserve then hand off to the Wix-hosted ticket form.
+  async function checkoutPaid() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const reservation = await reserveTickets(lines);
+      window.location.href = getTicketCheckoutUrl(event, reservation.id);
+    } catch (e) {
+      setError(e.message);
+      setSubmitting(false);
+    }
+  }
+
+  // FREE tickets only: reserve then finish in-app; buyer = { firstName, lastName, email }.
+  async function checkoutFree(buyer) {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const reservation = await reserveTickets(lines);
+      const created = await checkoutTickets(eventId, {
+        reservationId: reservation.id,
+        buyer,
+        guests: [{ firstName: buyer.firstName, lastName: buyer.lastName, email: buyer.email }],
+      });
+      setOrder(created); // status "FREE"; carries ticketsPdf + tickets[]
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return {
+    definitions, selection, setQuantity, setLine,
+    hasSelection, allFree, submitting, order, error,
+    checkoutPaid, checkoutFree,
+  };
+}

--- a/skills/wix-vibe-headless/references/events/app/pages/EventDetail.jsx
+++ b/skills/wix-vibe-headless/references/events/app/pages/EventDetail.jsx
@@ -1,0 +1,54 @@
+// Event detail page — thin view over useEventDetail (all logic lives in the hook). Renders the
+// event summary + the registration surface. Token-styled; re-skin via theme.css.
+//
+// shortDescription is a PLAIN string (safe to render). event.description is Ricos rich content
+// { nodes: [...] } — NOT a string; to show the full body render it with @wix/ricos or walk `nodes`.
+// NEVER call string methods (.slice/.substring/.split) on event.description — that crashes the page.
+import { useParams } from "react-router-dom";
+import { useEventDetail } from "@/hooks/useEventDetail";
+import EventRegistration from "@/components/EventRegistration";
+
+export default function EventDetail() {
+  const { slug } = useParams();
+  const d = useEventDetail(slug);
+
+  if (d.notFound) return <Centered>Event not found.</Centered>;
+  if (!d.event) return <Centered>Loading…</Centered>;
+
+  const { event } = d;
+  const when = event.dateAndTimeSettings?.formatted?.dateAndTime;
+  const where = event.location?.name;
+
+  return (
+    <main style={{
+      maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)",
+      display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: "calc(var(--space) * 2)",
+    }}>
+      <div style={{
+        aspectRatio: "3 / 2", background: "var(--color-surface)",
+        borderRadius: "var(--radius)", overflow: "hidden",
+      }}>
+        {event.mainImage?.url &&
+          <img src={event.mainImage.url} alt={event.title} style={{ width: "100%", height: "100%", objectFit: "cover" }} />}
+      </div>
+
+      <div>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: "0 0 8px" }}>{event.title}</h1>
+        {when && <p style={{ margin: "0 0 4px", color: "var(--color-muted)" }}>{when}</p>}
+        {where && <p style={{ margin: "0 0 var(--space)", color: "var(--color-muted)" }}>{where}</p>}
+
+        {event.shortDescription && (
+          <p style={{ color: "var(--color-text)", lineHeight: 1.6, marginBottom: "calc(var(--space) * 1.5)" }}>
+            {event.shortDescription}
+          </p>
+        )}
+
+        <EventRegistration event={event} type={d.type} open={d.open} registration={d.registration} />
+      </div>
+    </main>
+  );
+}
+
+function Centered({ children }) {
+  return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>{children}</div>;
+}

--- a/skills/wix-vibe-headless/references/events/app/pages/Events.jsx
+++ b/skills/wix-vibe-headless/references/events/app/pages/Events.jsx
@@ -1,0 +1,37 @@
+// Events listing page — category menu + grid + empty state + load more. Thin view over
+// useEventsList (all logic lives in the hook). Token-styled; re-skin via theme.css.
+import { useEventsList } from "@/hooks/useEventsList";
+import CategoryFilter from "@/components/CategoryFilter";
+import EventGrid from "@/components/EventGrid";
+
+export default function Events() {
+  const { events, categories, active, setActive, total, loading, hasMore, loadMore } = useEventsList();
+
+  return (
+    <main style={{ maxWidth: "var(--maxw)", margin: "0 auto", padding: "var(--space)" }}>
+      <h1 style={{ fontFamily: "var(--font-display)", marginBottom: "var(--space)" }}>Events</h1>
+
+      {total === 0 ? (
+        <p style={{ color: "var(--color-muted)", padding: "var(--space)", textAlign: "center" }}>
+          No events published yet — add and publish events from your Wix dashboard.
+        </p>
+      ) : (
+        <>
+          <CategoryFilter categories={categories} active={active} onSelect={setActive} />
+          {loading
+            ? <p style={{ color: "var(--color-muted)" }}>Loading…</p>
+            : <EventGrid events={events} empty="No events in this category yet." />}
+          {hasMore && (
+            <div style={{ textAlign: "center", marginTop: "calc(var(--space) * 1.5)" }}>
+              <button onClick={loadMore} style={{
+                padding: "10px 24px", cursor: "pointer", fontSize: 15, fontWeight: 600,
+                background: "var(--color-surface)", color: "var(--color-text)",
+                border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+              }}>Load more</button>
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/events/app/theme.css
+++ b/skills/wix-vibe-headless/references/events/app/theme.css
@@ -1,0 +1,36 @@
+/* theme.css — THE styling surface. Theme the whole events site by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every template component reads these variables, so
+   changing them here re-skins the entire site. Import this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, wells, forms */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text (date, location, teaser) */
+  --color-border:    #e5e7eb;   /* hairlines, dividers, inputs */
+  --color-primary:   #111827;   /* buttons, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* "From $" price, category counts, highlights */
+  --color-danger:    #dc2626;   /* sold-out, closed, errors */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1200px;        /* content max width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **events** to the storefront-as-files model: events list + detail; RSVP/ticketing branch logic (no provider).

- `references/events/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (15 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)