### PR TITLE
feat(members): ship the client as files (storefront-as-files)

### DIFF
--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -1,213 +1,283 @@
+# Wix Members — ready-made custom-login client
 
-# Wix Members — custom login (client-only REST)
+The members client is **shipped as real files**, not snippets to regenerate. It's a complete
+**custom login** — email+password sign-up/sign-in, "Continue with Google/Facebook" (and custom SSO),
+a member session, an account area, and route gating — styled entirely from `theme.css` tokens. Copy
+it into the app, theme the tokens, wire the routes — you generate almost none of the auth code (the
+OAuth state machine, PKCE, the hidden-iframe token exchange, and the social `/callback` all ship and
+are correct).
 
-> **Source files (in this skill):** the shared transport `references/shared/wix-client.js`, the shared
-> config `references/shared/wix-config.js`, and this vertical's `references/members/wix-members-auth.js`.
-> Copy **all three** into your app's `src/rest/` side by side — `wix-client.js` does
-> `import { WIX_CLIENT_ID } from "./wix-config.js"` and the helper does `import { … } from "./wix-client.js"`,
-> so they must land in the same folder.
-
-Adds real **member accounts** to a client-only headless front end: sign up, log in, log out, and
-member-gated surfaces — all from the browser over the public `WIX_CLIENT_ID`, no SDK, no backend.
-
-**This is *custom* login: the front owns its login UI.** The member types credentials in **your own
-form on your own page** (or clicks your own social button) — they are **never redirected to a
-Wix-hosted login page**. This is the REST equivalent of the SDK `OAuthStrategy` recipe; the older
-"redirect the user to a Wix login page" flow is deliberately **not** used here.
-
-## When to use
-- User wants members to **sign up / log in** on a page they built (email+password, "Continue with
-  Google/Facebook", or custom SSO), with the login UI living in their own app.
-- User wants **member-gated** content, an **account / profile** page, or a "my orders / my bookings /
-  my plans" view (those reads need a logged-in member).
-- **Pricing-plans is present.** Buying/reading a member's plans is members-only — pair this vertical
-  with `pricing-plans` so the member can log in *before* the subscribe / "my subscription" surface.
-
-## Two mechanisms — pick by the brief (a page may use both)
-
-| | **(A) Direct-credential** | **(B) Social / SSO** |
-| :-- | :-- | :-- |
-| **Use when** | your own email+password form, or custom sign-up fields | "Sign in with Google / Facebook", or enterprise SSO |
-| **User leaves your page?** | **No** — silent iframe token exchange | **Yes** — full-page redirect to the provider, back to your `/callback` |
-| **Kick-off** | `register()` / `login()` | `startSocialLogin(idp, callbackUri)` |
-| **Finish** | automatic on `SUCCESS` | `completeSocialLogin()` on the `/callback` page |
-| **Custom sign-up fields?** | Yes (`register`'s `profile`) | No — the provider owns the identity |
-| **Needs an allow-listed origin/URI?** | **Yes** — your app **origin** (postMessage target) | **Yes** — your `/callback` **URL** |
-
-Both converge on the **same end state**: member tokens written onto the shared client, so **every
-later `wixApiRequest` runs as the member** (login just swaps the token set on the client you already
-have). Don't blend their exchange calls — the helper handles each internally.
+**Custom login only.** The member types credentials in **your own form on your own page** (or clicks
+your own social button) — they are **never redirected to a Wix-hosted login page**. Talks to Wix
+directly over the public `WIX_CLIENT_ID`; login swaps the token set on the one shared client, so
+**every later `wixApiRequest` runs as the member** (their cart, orders, plans, "my …" reads). Never
+mock a logged-in member; never mint a second client after login.
 
 ## Prerequisites
-1. A Wix site with the **Members Area app installed** if you need member *profile* data (name, photo,
-   roles) or custom field definitions. Pure "logged-in vs. not" gating needs no app — see the
-   identity-vs-profile split below.
-2. The site's public headless **`WIX_CLIENT_ID`** (from the handoff prompt), set in
-   `src/rest/wix-config.js`. Public, buyer-facing credential — safe to hardcode/commit.
-3. **OAuth-app allow-listing — the #1 gotcha. Two *different* fields gate the two mechanisms:**
+- The site's **Wix OAuth app** (headless) is the auth target — members **self-register**, so there is
+  **nothing to seed** (see **Seeding** below); the client renders the shipped logged-out state until a
+  member signs in.
+- The **Members Area app** installed *only if* you need member **profile** data (name, photo, roles,
+  custom fields). Pure "logged-in vs. not" gating needs no app — see **Identity vs. profile** below.
+- The public headless **`WIX_CLIENT_ID`** from your prompt (buyer-facing, safe to hardcode/commit).
+- **OAuth-app allow-listing — the #1 gotcha, a manual owner-only step you can't do from client code.**
+  Two *different* fields gate the two mechanisms:
 
-   | Mechanism | What must be allow-listed | OAuth-app field | On `localhost:4321`? |
-   | :-- | :-- | :-- | :-- |
-   | **(A) direct-credential** | your app **origin** (the hidden iframe `postMessage`s the code back to it) | `allowedRedirectDomains` | ✅ allowed by default |
-   | **(B) social / SSO** | the **exact `/callback` URL** (full-page redirect target) | `allowedRedirectUris` | ❌ **must be added** |
+  | Mechanism | What must be allow-listed | OAuth-app field | On `localhost:4321`? |
+  | :-- | :-- | :-- | :-- |
+  | **credential** (your form) | your app **origin** (the hidden iframe `postMessage`s the code back) | `allowedRedirectDomains` | ✅ allowed by default |
+  | **social / SSO** | the **exact `/callback` URL** (full-page redirect target) | `allowedRedirectUris` | ❌ **must be added** |
 
-   - `localhost:4321` is Wix's default-allowed dev **origin**, so **credential login works there with zero
-     setup**. But social **still fails on `localhost:4321`** until you add `http://localhost:4321/callback`
-     to `allowedRedirectUris` — the default covers the origin, not the callback URI. (These are genuinely
-     two separate fields; matching Oz's SDK `wix-headless` `managed/DEPLOYMENT.md`.)
-   - **Any non-default origin** — your deployed domain, a different localhost port —
-     must be registered too: the origin (for A) and the `<origin>/callback` (for B).
-   - **Symptoms:** (A) unregistered origin → login hangs, then `MemberAuthError('timeout')` + a console
-     *"Failed to execute 'postMessage'… target origin … does not match"*. (B) unregistered callback →
-     the Wix authorize page shows *"Invalid redirect URI. Please add an allowed URI to your OAuth App"*
-     **before** returning — so the client can't catch it; you must register it up front.
-   - Google & Facebook are enabled by default; **custom SSO** also needs an IDP connection created in
-     the Business Manager, whose **connection id** you pass as `idp` (see "Custom SSO" below).
+  `localhost:4321` is Wix's default-allowed dev **origin**, so **credential login works there with zero
+  setup**; social **still fails** until you add `http://localhost:4321/callback` to `allowedRedirectUris`.
+  Any non-default origin (deployed domain, other port) needs both the origin and `<origin>/callback`.
+  **Symptoms:** unregistered origin → credential login hangs then throws `MemberAuthError('timeout')`
+  (+ a console *"postMessage… target origin does not match"*); unregistered callback → the Wix
+  authorize page shows *"Invalid redirect URI"* before returning, so the client can't catch it.
 
-   > **⚠️ AGENT: this is a manual, owner-only step you cannot do from client-only code — surface it
-   > proactively.** As soon as a run uses social/SSO (or deploys credential login to a non-`4321`
-   > origin), **tell the user** the exact URIs to add and where, and note that **social login stays
-   > dead until they do it** (a client-only front has no account token to register it via the API).
-   > See "Point the user to their dashboard" below for the deep link and the exact values.
+  > **⚠️ AGENT: surface this proactively.** As soon as a run uses social/SSO (or deploys credential
+  > login to a non-`4321` origin), **tell the user the exact URIs to add and where** (deep link under
+  > **Point the user to their dashboard**), and note that **social login stays dead until they do it**.
 
-## The API (copy as-is; do not re-derive it)
-Copy `wix-client.js`, `wix-config.js`, and `wix-members-auth.js` into `src/rest/` and set
-`WIX_CLIENT_ID` in `wix-config.js`. Exports of `wix-members-auth.js`:
-- **Direct-credential:** `register(email, password, profile?)`, `login(email, password)`,
-  `verifyEmail(code, stateToken)`, `sendPasswordResetEmail(email, redirectUri)`
-- **Social / SSO:** `startSocialLogin(idp, callbackUri, returnTo?)`, `completeSocialLogin()`, `IDP`
-- **Session:** `isLoggedIn()`, `getCurrentMember()`, `logout(returnTo?)`
-- **Errors:** `MemberAuthError` (`.code` + `.message`)
+## STEP 1 — The client is already in `src/`
+The install step (base44.md STEP 1) deployed the whole members UI client + REST scaffolds into
+`src/` (imports use the `@/` alias → `src/`). Here's every file and what it is — **this is your map,
+so you don't need to open them:**
 
-The full state-machine, `profile`, and error semantics are documented as JSDoc at the top of
-`wix-members-auth.js`. **Read it before wiring the UI.**
+| file | what it is |
+|---|---|
+| `theme.css` | design tokens — the **only** file you edit to re-skin (STEP 3) |
+| `context/MemberContext.jsx` | `useMember()` provider: current member, `loggedIn`, `refresh()`, `logout()` |
+| `hooks/useLoginForm.js` | credential state machine (login/register/verify, error mapping) — logic only |
+| `components/LoginForm.jsx` | email+password form UI (sign-in/sign-up tabs, verify-code + pending phases) |
+| `components/SocialButtons.jsx` | "Continue with Google/Facebook" buttons (kick off the redirect) |
+| `components/MemberMenu.jsx` | header account control — "Log in" vs. member name + log-out (like a cart button) |
+| `components/RequireAuth.jsx` | route gate: renders children for a member, else redirects to `/login` |
+| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `pages/Login.jsx`, `pages/Account.jsx` | the shipped login + account routes (`/login`, `/account`) |
+| `pages/Callback.jsx` | social/SSO return route — mount at **exactly** `/callback` |
+| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-client.js` + `rest/wix-members-auth.js` | REST transport + the auth helper (copy verbatim) |
 
-> **⚠️ Copy `wix-members-auth.js` verbatim — do NOT rewrite its internals.** Wire the UI to the
-> exported functions, but leave the helper's bodies alone. The OAuth request shapes are **exact and
-> unforgiving** — the `createRedirectSession` body in particular needs the `auth.authRequest` wrapper,
-> flat PKCE fields, and `responseType`/`scope`; "simplifying" it into a spread of the input object
-> returns **400 Bad Request** and login dies. Extend by *calling* the exports, not by editing them.
+They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
+`read_file` the shipped page/component/hook source to inspect it** — the table says what each is and
+every shape you need is in the snippets below. Read a shipped file's source **only** on a real
+fallback — a runtime error, or a field the snippets don't cover (see "Fallback only" at the end).
+(Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
+`references/members/app/` → `src/`.)
 
-## How to wire it (UI is the project's choice — the skill ships the REST layer only)
+> **⚠️ Copy `wix-members-auth.js` verbatim — do NOT rewrite its internals.** The OAuth wire shapes are
+> exact and unforgiving: the `createRedirectSession` body needs the `auth.authRequest` wrapper, flat
+> PKCE fields, and `responseType`/`scope` — "simplifying" it returns **400** and login dies. Extend by
+> *calling* the exports, never by editing them. Its full JSDoc (state machine, `profile`, errors) is at
+> the top of the file — read that, not the whole body, if you need the contract.
 
-### (A) Credential form + the state machine — handle every branch (not just SUCCESS)
-`register()` / `login()` / `verifyEmail()` resolve to `{ state, member?, stateToken? }`:
-- **`"SUCCESS"`** → logged in; `member` is populated (or `null` if the Members Area app isn't
-  installed). Render the account UI / navigate.
-- **`"REQUIRE_EMAIL_VERIFICATION"`** → a 6-digit code was emailed. Collect it and call
-  `verifyEmail(code, stateToken)`. (Fires when a new registrant's email already exists as a contact,
-  or when email verification is enabled in Member Settings.)
-- **`"REQUIRE_OWNER_APPROVAL"`** → show a "pending approval" notice; not an error.
+## STEP 2 — Credentials
+Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
+one place both ids live.
 
-Hard failures **throw** a `MemberAuthError` — catch it and show `err.message` (`.code` is stable:
-`invalidCredentials`, `emailAlreadyExists`, …). `emailAlreadyExists` on register → route to log in.
+## STEP 3 — Theme (the styling step — do ONLY this to the shipped components)
+Edit `src/theme.css` tokens to the brand: palette, `--font-display`/`--font-body`, `--radius`,
+spacing, `--form-maxw` (the login card width). Every shipped component reads these vars, so this
+re-skins the whole auth surface. **Do not restyle the shipped components' JSX** — that's what keeps
+this a copy, not a regeneration. Style the home page / header you build (STEP 4) from the same tokens
+so it matches. Dark brand → activate the dark tokens with `document.documentElement.dataset.theme = "dark"`.
 
-```js
-import { login, register, verifyEmail, isLoggedIn, getCurrentMember, logout, MemberAuthError } from "./rest/wix-members-auth.js";
-try {
-  const res = await login(email, password);
-  if (res.state === "SUCCESS") showAccount(res.member);
-  else if (res.state === "REQUIRE_EMAIL_VERIFICATION") promptForCode(res.stateToken);
-  else if (res.state === "REQUIRE_OWNER_APPROVAL") showPending();
-} catch (e) {
-  if (e instanceof MemberAuthError) showError(e.message); else throw e;
+## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+`App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`, the **Base44 builder
+account**) — edit it in, don't replace it. The Wix member session is separate and ships under its own
+name, **`MemberProvider`/`useMember`**, so the two never collide (do NOT rename it to `useAuth`).
+- `import "@/theme.css";` once at the app entry.
+- Wrap the routed tree in `<MemberProvider>` (from `@/context/MemberContext`).
+- Put your **header + footer in a `Layout`** that renders `<Outlet/>` between them, and nest every
+  route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
+  — including the shipped `Login`/`Account`/`Callback` — so you **never edit the shipped pages to add
+  a header/footer** (they render inside `<Outlet/>` as-is).
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+  your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
+  markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
+  the content by the region's measured height so it clears the chrome and self-corrects when the
+  banner is dismissed.
+- Routes under the Layout: `/login` → `Login`, `/callback` → `Callback` (both shipped, as-is), and
+  `/account` → `Account` **wrapped in `<RequireAuth>`** so a visitor is bounced to `/login`. **You add
+  `/` → your own Home** page. Gate your own member-only routes ("my orders", "my plans") the same way.
+
+```jsx
+import "@/theme.css";
+import { useRef, useState, useEffect } from "react";
+import { Routes, Route, Outlet } from "react-router-dom";
+import { MemberProvider } from "@/context/MemberContext";
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only
+import RequireAuth from "@/components/RequireAuth";           // shipped route gate
+import Login from "@/pages/Login";
+import Account from "@/pages/Account";
+import Callback from "@/pages/Callback";
+import Home from "@/pages/Home";       // YOU build
+import Header from "@/components/Header";   // YOU build — plain in-flow markup, NOT position:fixed
+import Footer from "@/components/Footer";   // YOU build
+
+function Layout() {
+  const topRef = useRef(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {                                  // measure the fixed region → pad content below it
+    const ro = new ResizeObserver(() => setOffset(topRef.current?.offsetHeight ?? 0));
+    if (topRef.current) ro.observe(topRef.current);
+    return () => ro.disconnect();
+  }, []);
+  return (<>
+    <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
+      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <Header />                             {/* your brand header, in-flow inside this fixed block */}
+    </div>
+    <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}
+      <Outlet />                             {/* shipped Login/Account/Callback render here, untouched */}
+      <Footer />
+    </div>
+  </>);
+}
+
+<MemberProvider>
+  <Routes>
+    <Route element={<Layout />}>                                          {/* chrome wraps all */}
+      <Route path="/" element={<Home />} />                               {/* yours */}
+      <Route path="/login" element={<Login />} />                         {/* shipped, as-is */}
+      <Route path="/callback" element={<Callback />} />                   {/* shipped — must be /callback */}
+      <Route path="/account" element={<RequireAuth><Account /></RequireAuth>} />  {/* gated, shipped */}
+    </Route>
+  </Routes>
+</MemberProvider>
+```
+
+## What you build (not shipped)
+The **home / landing page**, the **`Header`** (mount `<MemberMenu/>` in it) and a **`Footer`** — the
+two you drop into the `Layout` (STEP 4) so they wrap every route — plus the overall brand story,
+styled from the same `theme.css` tokens. The nav's account control is a `<MemberMenu/>` (shows
+"Log in" for a visitor, the member's name + log-out once signed in — render it as-is, don't wrap it in
+your own auth text button):
+
+```jsx
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import MemberMenu from "@/components/MemberMenu";
+
+// Responsive header: choose ONE branch with a state flag, so <MemberMenu/> mounts once.
+// Do NOT render a desktop nav AND a mobile nav toggled by `hidden md:flex` / `md:hidden`:
+// these navs are inline-styled, and an inline `display` beats a Tailwind class, so `hidden`
+// never applies — BOTH branches render and you get two menus. One branch = one menu.
+export function Header() {
+  const [mobile, setMobile] = useState(() => window.innerWidth < 768);
+  useEffect(() => {
+    const onResize = () => setMobile(window.innerWidth < 768);
+    window.addEventListener("resize", onResize);            // keep it reactive to viewport changes
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return (
+    <nav style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+      {/* brand/logo */}
+      {mobile
+        ? <YourMenu />                                       // your hamburger + <MemberMenu/> here
+        : <div style={{ display: "flex", gap: 24 }}><Link to="/">Home</Link><MemberMenu /></div>}
+    </nav>
+  );
 }
 ```
+Everything visual reads `theme.css` tokens, so your home/nav match the shipped pages automatically.
 
-Custom sign-up fields go in `register`'s `profile` (`{ firstName, lastName, nickname, addresses, … }`).
-Standard fields work as-is; arbitrary `customFields` keys must first be defined in the Members Area
-app or they're silently dropped.
+**Editing a component and the change doesn't show? It's the preview, not your code.** The dev preview
+can serve a stale module after a write. Before diagnosing a visual bug you just "fixed", do a fresh
+full navigate/reload of the preview and re-check — don't keep rewriting correct code against a stale
+render.
 
-### (B) Social / SSO — your button + a `/callback` route
-```js
-// on your login page:
-import { startSocialLogin, IDP } from "./rest/wix-members-auth.js";
-const callbackUri = new URL("/callback", window.location.origin).href; // must be allow-listed
-onGoogleClick   = () => startSocialLogin(IDP.GOOGLE,   callbackUri, window.location.pathname);
-onFacebookClick = () => startSocialLogin(IDP.FACEBOOK, callbackUri, window.location.pathname);
+## Using the client from your own UI (session, gating, "my …" reads)
 
-// on the /callback page (a route/page at exactly that path):
-import { completeSocialLogin } from "./rest/wix-members-auth.js";
-const { member, returnTo } = await completeSocialLogin();
-window.location.replace(returnTo || "/");
+```jsx
+import { useMember } from "@/context/MemberContext";
+
+// useMember() gives:
+// { member, loggedIn, loading, refresh(), logout(returnTo?) }
+// - member is null for a visitor OR when the Members Area app isn't installed (loggedIn still true).
+// - login/register happen in the shipped LoginForm; call refresh() after your own login call.
+
+function Greeting() {
+  const { loggedIn, member, loading } = useMember();
+  if (loading) return null;
+  return loggedIn ? <span>Hi, {member?.profile?.nickname || "member"}</span> : <a href="/login">Log in</a>;
+}
+
+// A member-only read runs as the member on the SAME shared client — no extra auth, no `elevate`:
+import { wixApiRequest } from "@/rest/wix-client";
+const { orders } = await wixApiRequest("/ecom/v1/orders/query", { body: { query: {} } }); // member's own
 ```
-**Custom SSO:** identical call — pass your connection id as `idp` instead of `IDP.GOOGLE`:
-`startSocialLogin("<connectionId>", callbackUri)`. The connection id comes from an IDP connection you
-create in the Business Manager (dashboard link below).
 
-### Session, account area, logout
-- **Gate UI** on `isLoggedIn()`. Read the member with `await getCurrentMember()` (name / photo / roles
-  / custom fields) — returns `null` for a visitor or when the Members Area app isn't installed.
-- **Logout:** `await logout()` — clears local tokens and redirects through the Wix logout URL; the
-  client is a clean anonymous visitor afterward.
-- **Persistence is automatic.** Member tokens live in the same `localStorage` the visitor token used,
-  so a reload stays logged in and tokens auto-refresh via `wix-client.js` — do **not** add your own.
+## Extending the client — the auth helper's exports (copy as-is, do NOT re-derive)
+Building auth UI beyond the shipped pages? Call these exports (from `@/rest/wix-members-auth`) — the
+same ones the shipped hook/pages use:
+
+```js
+// (A) Credential — handle EVERY branch, not just SUCCESS. register/login/verifyEmail → { state, ... }:
+import { login, register, verifyEmail, MemberAuthError } from "@/rest/wix-members-auth";
+try {
+  const res = await login(email, password);
+  if (res.state === "SUCCESS") { /* logged in; res.member (or null w/o Members Area app) */ }
+  else if (res.state === "REQUIRE_EMAIL_VERIFICATION") { /* 6-digit code emailed; verifyEmail(code, res.stateToken) */ }
+  else if (res.state === "REQUIRE_OWNER_APPROVAL") { /* show a pending notice — not an error */ }
+} catch (e) {
+  if (e instanceof MemberAuthError) show(e.message); else throw e;   // .code: invalidCredentials, emailAlreadyExists, …
+}
+// Custom sign-up fields → register's 3rd arg `profile` ({ firstName, lastName, nickname, addresses, … }).
+// Arbitrary customFields keys must be defined in the Members Area app first, or they're silently dropped.
+
+// (B) Social / SSO — button + the shipped /callback page:
+import { startSocialLogin, IDP } from "@/rest/wix-members-auth";
+const callbackUri = new URL("/callback", window.location.origin).href;   // must be allow-listed
+startSocialLogin(IDP.GOOGLE, callbackUri, window.location.pathname);      // custom SSO: pass a connectionId as idp
+```
 
 ## Identity vs. profile — don't conflate them
 - **Identity / auth** — sign up, log in, log out, "is this caller a member?". Native to the headless
   OAuth app. **No app install needed** — every login mechanism here runs on this layer alone.
-- **Member profile / Members Area** — name / photo / roles, an account page, and custom-field
-  definitions. Served by the **Members Area app**, which must be installed. If `getCurrentMember()`
-  returns `null` while `isLoggedIn()` is `true`, suspect the app isn't installed — not a code bug.
+- **Member profile / Members Area** — name / photo / roles, an account page, custom-field definitions.
+  Served by the **Members Area app**, which must be installed. If `getCurrentMember()`/`useMember().member`
+  is `null` while `loggedIn` is `true`, suspect the app isn't installed — **not a code bug**.
 
-## Hard rules (do not violate)
-- ✅ **Custom login only.** The member logs in on **your** UI; never redirect them to a Wix-hosted
-  login page, and never use a Wix login-page redirect for member auth.
-- ✅ **One shared client.** Member login swaps the token set on `wix-client.js` — reuse the same
-  transport for everything so the member identity (and their cart) carries across the app. Never mint
-  a second client or re-mint anonymously after login (it drops the member).
-- ✅ **For a Wix-backed feature, use the Wix member as the identity — keep it consistent.** When the
-  feature is about **Wix members** (the user gave you a `WIX_CLIENT_ID`), log in and gate on the
-  **Wix member** (`getCurrentMember()` / the Wix member token), and key member-owned Wix rows on
-  `_owner` (see the `cms` vertical). Don't identify one feature's user from two different sessions —
-  the ids won't match.
-- ❌ **Don't blend the two exchanges.** Credential login finishes via the hidden iframe; social
-  finishes via `/callback`. The helper keeps them separate — don't cross-wire.
-- ❌ **Never fake a member.** No mock "logged-in" state, no invented profile, roles, or member counts.
-  Render the real member or the logged-out state.
-- ✅ **Fail loudly.** The helper throws `MemberAuthError` on bad credentials, state mismatch, timeout,
-  and token-exchange failure — surface them; don't swallow.
-- ⛔ **No `elevate` / admin scope.** A member reading their **own** data (profile, own orders /
-  bookings / plans) is authorized by the member token alone. There is no admin elevation on a
-  client-only front, and own-data reads don't need it.
-- ⛔ **MFA / TOTP is not available headless.** The security layers are password + email verification +
-  reCAPTCHA, all **dashboard-governed** — document them as host-configurable, don't set them from code.
+Fallback only — when you hit an error or need something not shown here (password reset, custom SSO
+connection ids, a profile field these snippets don't have): read the relevant shipped file under
+`src/rest/`, or look it up via the **`wix-docs`** skill.
 
-## Beyond the snippets
-The helper covers sign-up / login / social / SSO / logout / current-member. For a genuine gap, extend
-with `wixApiRequest` — but confirm the endpoint, method, and body in the API reference first (or via
-the co-installed **`wix-docs`** skill). Never guess.
-- Custom login (JS SDK, concepts mirror the REST calls): https://dev.wix.com/docs/go-headless/self-managed-headless/authentication/members/custom-login-page/custom-login/custom-login-using-the-js-sdk.md
-- External / social login (REST): https://dev.wix.com/docs/rest/business-management/headless-authentication/redirects/create-redirect-session
-- Retrieve Tokens (REST): https://dev.wix.com/docs/rest/business-management/headless-authentication/authentication/retrieve-tokens
-- Members API (read/update profile, query members): https://dev.wix.com/docs/api-reference/members/members/members-v1/introduction
+## Hard rules
+- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
+- Theme via `theme.css` tokens, never by rewriting the shipped components.
+- **Custom login only** — the member logs in on **your** UI; never redirect them to a Wix-hosted login page.
+- **One shared client** — login swaps the token set on `wix-client.js`; reuse it for everything so the
+  member identity carries across the app. Never mint a second client or re-mint anonymously after login.
+- Copy `wix-members-auth.js` verbatim; extend by *calling* its exports, never by editing them.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Login`/`Account`/`Callback` to add chrome; the fixed top region owns positioning (`<WixManageBanner/>` above a plain in-flow `<Header/>`).
+- **Never fake a member** — no mock logged-in state, invented profile, or roles. Render the real member or the real logged-out state.
+- **Fail loudly** — the helper throws `MemberAuthError`; surface `.message`, don't swallow it.
+- No `elevate` / admin scope, and no headless MFA/TOTP — those security layers are dashboard-governed.
 
 ## Point the user to their dashboard
-Some setup only happens in the Wix dashboard — always give the user the deep links:
-- **Members Area app** (for profile data + custom fields) — `https://manage.wix.com/dashboard/{metaSiteId}/member-permissions`
-- **Signup security** (email verification, owner approval, reCAPTCHA) — `Dashboard → Settings → Login & Security` / member signup settings
-- **Allowed authorization redirect URIs** — the OAuth-app / **Headless Settings** for the project:
-  `https://manage.wix.com/dashboard/{metaSiteId}/oauth-apps-settings`. Add:
-  - the **app origin** (e.g. `https://myapp.example.com`) — needed for direct-credential login from a
-    non-default origin (`localhost:4321` is pre-allowed);
-  - the **exact `/callback` URL** (e.g. `https://myapp.example.com/callback`) — required for social/SSO;
-  - also add password-reset / logout return URLs if you use them.
-  Tell the user these exact values; the callback URL must match your `startSocialLogin` `callbackUri`
-  character-for-character.
-- **Custom SSO connection** (to obtain a `connectionId`) — created under the project's IAM / SSO
-  settings in the Business Manager.
+Some setup only happens in the Wix dashboard — always give the user the deep links (substitute the
+site's `metaSiteId` from the handoff / `ListWixSites`):
+- **Allowed authorization redirect URIs** (the #1 gotcha) — `https://manage.wix.com/dashboard/{metaSiteId}/oauth-apps-settings`.
+  Add the **app origin** (for credential login off `localhost:4321`) and the **exact `/callback` URL**
+  (for social/SSO) — character-for-character matching your `startSocialLogin` `callbackUri`.
+- **Members Area app** (profile data + custom fields) — `https://manage.wix.com/dashboard/{metaSiteId}/member-permissions`
+- **Signup security** (email verification, owner approval, reCAPTCHA) — `Dashboard → Settings → Login & Security`
+- **Custom SSO connection** (to obtain a `connectionId`) — the project's IAM / SSO settings in the Business Manager.
 
-Substitute the site's `metaSiteId` (from the handoff / `ListWixSites`).
+## Seeding
+**Nothing to seed** — members self-register; there is no build-time member to create. See
+`seed/SEED.md` (separate from this client build; the members work is entirely frontend wiring).
 
-## Verification checklist (before declaring done)
-- [ ] `WIX_CLIENT_ID` set to the prompt's value (not the `<YOUR-CLIENT-ID>` placeholder)
-- [ ] Sign-up: `register()` returns `SUCCESS` (or `REQUIRE_EMAIL_VERIFICATION` handled via `verifyEmail`)
-- [ ] Log-in: `login()` reaches `SUCCESS`; wrong password shows `invalidCredentials`, not a crash
-- [ ] After login `isLoggedIn()` is `true` and `getCurrentMember()` returns the member (or `null` with
-      the Members Area app not installed — documented, not a bug)
-- [ ] A member-scoped read (e.g. pricing-plans "my plans") now returns the member's data via the same client
-- [ ] Social: the button redirects to the provider and `/callback` logs the member in (callback URL
-      allow-listed); custom SSO works with its `connectionId` (or is flagged as pending host setup)
-- [ ] Logout clears the session and the next load is a clean anonymous visitor
-- [ ] No mocked member state, profile, or roles anywhere
-- [ ] Told the user about any required dashboard setup (Members Area app, allowed redirect URIs) with deep links
+## Verify (before declaring done)
+- [ ] Client files copied into `src/`; `WIX_CLIENT_ID` set (not the placeholder).
+- [ ] `theme.css` themed to the brand; shipped components/pages not restyled or rewritten.
+- [ ] `Layout` (fixed `<WixManageBanner/>` + `<Header/>` region, then `<Outlet/>` + Footer) wraps all routes; shipped `Login`/`Account`/`Callback` untouched; content clears the fixed chrome; `<MemberProvider>` wraps the tree; `<MemberMenu/>` in the header.
+- [ ] Sign-up: `register()` reaches `SUCCESS` (or `REQUIRE_EMAIL_VERIFICATION` handled via the code entry).
+- [ ] Log-in: `login()` reaches `SUCCESS`; wrong password shows `invalidCredentials`, not a crash.
+- [ ] After login `useMember().loggedIn` is `true`; `/account` renders the member (or the identity-only fallback with the Members Area app not installed — documented, not a bug). `/account` bounces a visitor to `/login`.
+- [ ] Session survives reload (same client); logout clears it and the next load is a clean anonymous visitor.
+- [ ] Social: the button redirects to the provider and `/callback` logs the member in (callback URL allow-listed), or is flagged as pending host setup.
+- [ ] No mocked member state, profile, or roles anywhere.
+- [ ] Told the user about any required dashboard setup (allowed redirect URIs, Members Area app) with deep links.

--- a/skills/wix-vibe-headless/references/members/app/components/LoginForm.jsx
+++ b/skills/wix-vibe-headless/references/members/app/components/LoginForm.jsx
@@ -1,0 +1,111 @@
+// Credential login/sign-up form — a thin view over useLoginForm (all logic lives in the hook).
+// Token-styled; re-skin via theme.css, don't rewrite this JSX. Renders one of three phases the hook
+// drives: the email/password form, the 6-digit verification-code entry, or a pending-approval notice.
+import { useLoginForm } from "@/hooks/useLoginForm";
+
+const inputStyle = {
+  width: "100%", padding: "11px 12px", boxSizing: "border-box", fontSize: 15,
+  border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+  background: "var(--color-bg)", color: "var(--color-text)",
+};
+const labelStyle = { display: "block", fontSize: 13, color: "var(--color-muted)", marginBottom: 6 };
+
+export default function LoginForm({ onSuccess }) {
+  const f = useLoginForm({ onSuccess });
+
+  if (f.phase === "pending") {
+    return <Notice>Your account is awaiting owner approval. You'll be able to sign in once it's approved.</Notice>;
+  }
+
+  if (f.phase === "verify") {
+    return (
+      <form onSubmit={f.submitCode} style={formStyle}>
+        <p style={{ color: "var(--color-muted)", margin: 0, lineHeight: 1.5 }}>
+          We emailed you a 6-digit code. Enter it to finish.
+        </p>
+        <div>
+          <label style={labelStyle} htmlFor="mf-code">Verification code</label>
+          <input id="mf-code" style={inputStyle} inputMode="numeric" autoComplete="one-time-code"
+            value={f.code} onChange={(e) => f.setCode(e.target.value)} />
+        </div>
+        {f.error && <ErrorText>{f.error}</ErrorText>}
+        <SubmitButton busy={f.busy}>Verify</SubmitButton>
+      </form>
+    );
+  }
+
+  return (
+    <form onSubmit={f.submit} style={formStyle}>
+      <div style={{ display: "flex", gap: 8 }}>
+        <ModeTab active={f.mode === "login"} onClick={() => f.switchMode("login")}>Sign in</ModeTab>
+        <ModeTab active={f.mode === "register"} onClick={() => f.switchMode("register")}>Sign up</ModeTab>
+      </div>
+
+      {f.mode === "register" && (
+        <div style={{ display: "flex", gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <label style={labelStyle} htmlFor="mf-first">First name</label>
+            <input id="mf-first" style={inputStyle} value={f.fields.firstName}
+              onChange={(e) => f.setField("firstName", e.target.value)} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <label style={labelStyle} htmlFor="mf-last">Last name</label>
+            <input id="mf-last" style={inputStyle} value={f.fields.lastName}
+              onChange={(e) => f.setField("lastName", e.target.value)} />
+          </div>
+        </div>
+      )}
+
+      <div>
+        <label style={labelStyle} htmlFor="mf-email">Email</label>
+        <input id="mf-email" type="email" autoComplete="email" required style={inputStyle}
+          value={f.fields.email} onChange={(e) => f.setField("email", e.target.value)} />
+      </div>
+      <div>
+        <label style={labelStyle} htmlFor="mf-pass">Password</label>
+        <input id="mf-pass" type="password" required style={inputStyle}
+          autoComplete={f.mode === "register" ? "new-password" : "current-password"}
+          value={f.fields.password} onChange={(e) => f.setField("password", e.target.value)} />
+      </div>
+
+      {f.error && <ErrorText>{f.error}</ErrorText>}
+      <SubmitButton busy={f.busy}>{f.mode === "register" ? "Create account" : "Sign in"}</SubmitButton>
+    </form>
+  );
+}
+
+const formStyle = { display: "flex", flexDirection: "column", gap: "var(--space)" };
+
+function ModeTab({ active, onClick, children }) {
+  return (
+    <button type="button" onClick={onClick} style={{
+      flex: 1, padding: "8px 0", cursor: "pointer", fontSize: 14, fontWeight: 600,
+      background: active ? "var(--color-surface)" : "transparent",
+      color: active ? "var(--color-text)" : "var(--color-muted)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+    }}>{children}</button>
+  );
+}
+
+function SubmitButton({ busy, children }) {
+  return (
+    <button type="submit" disabled={busy} style={{
+      padding: "12px 24px", cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
+      background: "var(--color-primary)", color: "var(--color-on-primary)",
+      border: "none", borderRadius: "var(--radius-sm)", fontSize: 15, fontWeight: 600,
+    }}>{busy ? "…" : children}</button>
+  );
+}
+
+function ErrorText({ children }) {
+  return <p role="alert" style={{ color: "var(--color-danger)", margin: 0, fontSize: 14 }}>{children}</p>;
+}
+
+function Notice({ children }) {
+  return (
+    <p style={{
+      padding: "var(--space)", background: "var(--color-surface)", color: "var(--color-text)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius)", lineHeight: 1.5, margin: 0,
+    }}>{children}</p>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/components/MemberMenu.jsx
+++ b/skills/wix-vibe-headless/references/members/app/components/MemberMenu.jsx
@@ -1,0 +1,36 @@
+// Header account control — the members analog of a cart button. Reads useMember() and renders the
+// session state: a "Log in" link for a visitor, or the member's name + a log-out button once signed
+// in. Drop it into the Header you build (STEP 4), same as the storefront's CartButton. Pure UI reading
+// useMember + theme.css tokens — render it as-is; don't wrap it in your own auth logic.
+import { Link } from "react-router-dom";
+import { useMember } from "@/context/MemberContext";
+
+export default function MemberMenu() {
+  const { loggedIn, member, loading, logout } = useMember();
+
+  if (loading) return <span style={{ color: "var(--color-muted)", fontSize: 14 }}>…</span>;
+
+  if (!loggedIn) {
+    return (
+      <Link to="/login" style={{
+        color: "var(--color-primary)", textDecoration: "none", fontSize: 14, fontWeight: 600,
+      }}>Log in</Link>
+    );
+  }
+
+  // member may be null when logged in but the Members Area app isn't installed — fall back to a
+  // generic label rather than assuming a profile (see INSTRUCTIONS → identity vs. profile).
+  const name = member?.profile?.nickname || member?.contact?.firstName || member?.loginEmail || "Account";
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <Link to="/account" style={{ color: "var(--color-text)", textDecoration: "none", fontSize: 14, fontWeight: 600 }}>
+        {name}
+      </Link>
+      <button type="button" onClick={() => logout()} style={{
+        background: "none", border: "1px solid var(--color-border)", borderRadius: 999,
+        padding: "4px 12px", fontSize: 13, cursor: "pointer", color: "var(--color-muted)",
+      }}>Log out</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/components/RequireAuth.jsx
+++ b/skills/wix-vibe-headless/references/members/app/components/RequireAuth.jsx
@@ -1,0 +1,21 @@
+// Route gate for member-only surfaces. Wrap any protected element in <RequireAuth> — it renders the
+// children only for a logged-in member, otherwise redirects to /login (carrying the attempted path so
+// login can return there). This is the gate the shipped Account page uses; reuse it for your own
+// member-only routes ("my orders", "my plans", …). Reads useMember; no styling of its own.
+import { Navigate, useLocation } from "react-router-dom";
+import { useMember } from "@/context/MemberContext";
+
+export default function RequireAuth({ children, fallback = "/login" }) {
+  const { loggedIn, loading } = useMember();
+  const location = useLocation();
+
+  // Wait for the initial session read before deciding — otherwise a logged-in member gets bounced to
+  // /login on first paint while the token check is still resolving.
+  if (loading) {
+    return <div style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>Loading…</div>;
+  }
+  if (!loggedIn) {
+    return <Navigate to={fallback} replace state={{ from: location.pathname }} />;
+  }
+  return children;
+}

--- a/skills/wix-vibe-headless/references/members/app/components/SocialButtons.jsx
+++ b/skills/wix-vibe-headless/references/members/app/components/SocialButtons.jsx
@@ -1,0 +1,31 @@
+// "Continue with Google / Facebook" buttons. Social/SSO is a FULL-PAGE redirect: this kicks it off
+// with startSocialLogin, which sends the browser to the provider and returns to your /callback route
+// (mount Callback there). callbackUri MUST be allow-listed on the OAuth app or Wix rejects it before
+// returning — see INSTRUCTIONS (allowedRedirectUris). Token-styled; re-skin via theme.css.
+import { startSocialLogin, IDP } from "@/rest/wix-members-auth";
+
+// The exact /callback URL that must be registered as an allowed redirect URI. `returnTo` is where
+// the member lands after login — carry the current path so they resume where they started.
+function go(idp) {
+  const callbackUri = new URL("/callback", window.location.origin).href;
+  startSocialLogin(idp, callbackUri, window.location.pathname);
+}
+
+export default function SocialButtons() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <ProviderButton onClick={() => go(IDP.GOOGLE)}>Continue with Google</ProviderButton>
+      <ProviderButton onClick={() => go(IDP.FACEBOOK)}>Continue with Facebook</ProviderButton>
+    </div>
+  );
+}
+
+function ProviderButton({ onClick, children }) {
+  return (
+    <button type="button" onClick={onClick} style={{
+      width: "100%", padding: "11px 16px", cursor: "pointer", fontSize: 15, fontWeight: 600,
+      background: "var(--color-bg)", color: "var(--color-text)",
+      border: "1px solid var(--color-border)", borderRadius: "var(--radius-sm)",
+    }}>{children}</button>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/members/app/components/WixManageBanner.jsx
@@ -1,0 +1,44 @@
+// Dev-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
+import { useState } from "react";
+import { WIX_METASITE_ID } from "@/rest/wix-config";
+
+const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
+const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
+const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+export default function WixManageBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
+  });
+  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
+  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore disabled storage */ }
+  };
+
+  return (
+    <div style={{
+      position: "relative", display: "flex", alignItems: "center", justifyContent: "center", gap: 14,
+      width: "100%", padding: "12px 48px", boxSizing: "border-box",
+      background: "#fff", color: "#131720", fontSize: 15,
+      fontFamily: "system-ui,-apple-system,sans-serif", borderBottom: "1px solid #e2e2ea",
+    }}>
+      <span>
+        Manage your business behind this site in Wix{" "}
+        <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{ color: "inherit", textDecoration: "underline" }}>business manager</a>
+      </span>
+      <a href={DASHBOARD_URL} target="_blank" rel="noopener" style={{
+        background: "#131720", color: "#fff", borderRadius: 999, padding: "8px 18px", fontSize: 14, textDecoration: "none",
+      }}>Open</a>
+      <button type="button" aria-label="Dismiss banner" onClick={dismiss} style={{
+        position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)",
+        background: "none", border: "none", color: "#868aa5", fontSize: 16, lineHeight: 1, cursor: "pointer", padding: 6,
+      }}>✕</button>
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/context/MemberContext.jsx
+++ b/skills/wix-vibe-headless/references/members/app/context/MemberContext.jsx
@@ -1,0 +1,54 @@
+// Member auth state — mirrors the Wix SESSION on the shared client (never a local guess). Wrap the
+// app in <MemberProvider>; every component reads useMember(). Login mechanisms (credential/social)
+// write member tokens onto @/rest/wix-client via the auth helper; this provider reads that session
+// and exposes the current member + logout. Data wiring is correct as-is — do not re-derive it.
+//
+// NAMED useMember (not useAuth) ON PURPOSE: the Base44 App.jsx already ships a platform
+// AuthProvider/useAuth for the builder account — a second `useAuth` would shadow it. This is the
+// WIX member session, kept under its own name so the two never collide.
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import { isLoggedIn, getCurrentMember, logout as apiLogout } from "@/rest/wix-members-auth";
+
+const MemberContext = createContext(null);
+
+export function MemberProvider({ children }) {
+  const [member, setMember] = useState(null);
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // Re-read the session from the shared client. Call after a successful login so the header/account
+  // update without a reload. `member` stays null (with loggedIn true) when the Members Area app
+  // isn't installed — that's setup, not a bug (see INSTRUCTIONS → identity vs. profile).
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const active = isLoggedIn();
+      setLoggedIn(active);
+      setMember(active ? await getCurrentMember() : null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  // logout() clears local tokens then redirects through the Wix logout URL, so it navigates away;
+  // we still reset local state first for the instant before the redirect lands.
+  const logout = useCallback(async (returnTo) => {
+    setMember(null);
+    setLoggedIn(false);
+    await apiLogout(returnTo);
+  }, []);
+
+  return (
+    <MemberContext.Provider value={{ member, loggedIn, loading, refresh, logout }}>
+      {children}
+    </MemberContext.Provider>
+  );
+}
+
+export function useMember() {
+  const ctx = useContext(MemberContext);
+  if (!ctx) throw new Error("useMember must be used within <MemberProvider>");
+  return ctx;
+}

--- a/skills/wix-vibe-headless/references/members/app/hooks/useLoginForm.js
+++ b/skills/wix-vibe-headless/references/members/app/hooks/useLoginForm.js
@@ -1,0 +1,77 @@
+// useLoginForm — all credential-auth logic, no markup: hold the form fields, run login/register,
+// and DRIVE THE STATE MACHINE. register()/login()/verifyEmail() resolve to { state, member?,
+// stateToken? }; SUCCESS is only one of the branches. Handling every branch (email verification,
+// owner approval) and mapping MemberAuthError to a message is the bug-prone part — keep it verbatim;
+// the LoginForm component only renders what this returns. Social/SSO does NOT go through here (it's
+// a full-page redirect — see SocialButtons + the /callback page).
+import { useState } from "react";
+import { login, register, verifyEmail, MemberAuthError } from "@/rest/wix-members-auth";
+import { useMember } from "@/context/MemberContext";
+
+export function useLoginForm({ onSuccess } = {}) {
+  const { refresh } = useMember();
+  const [mode, setMode] = useState("login");        // "login" | "register"
+  const [fields, setFields] = useState({ email: "", password: "", firstName: "", lastName: "" });
+  // phase drives which UI shows: the form, the 6-digit code entry, or a pending-approval notice.
+  const [phase, setPhase] = useState("form");        // "form" | "verify" | "pending"
+  const [stateToken, setStateToken] = useState(null);
+  const [code, setCode] = useState("");
+  const [error, setError] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  const setField = (name, value) => setFields((f) => ({ ...f, [name]: value }));
+
+  // Route a resolved { state } to the right phase. On SUCCESS refresh the member session (so the
+  // header/account update) and hand control back to the caller (navigate away).
+  async function applyResult(res) {
+    if (res.state === "SUCCESS") {
+      await refresh();
+      onSuccess?.(res.member);
+    } else if (res.state === "REQUIRE_EMAIL_VERIFICATION") {
+      setStateToken(res.stateToken);
+      setPhase("verify");
+    } else if (res.state === "REQUIRE_OWNER_APPROVAL") {
+      setPhase("pending");
+    }
+  }
+
+  // Wrap a helper call: clear the error, flip busy, map MemberAuthError to a shown message.
+  // emailAlreadyExists on register → bounce the user to the login tab instead of erroring out.
+  async function run(fn) {
+    setError(null);
+    setBusy(true);
+    try {
+      await applyResult(await fn());
+    } catch (e) {
+      if (e instanceof MemberAuthError) {
+        if (e.code === "emailAlreadyExists") { setMode("login"); setError(e.message); }
+        else setError(e.message);
+      } else throw e;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const submit = (e) => {
+    e?.preventDefault?.();
+    const { email, password, firstName, lastName } = fields;
+    if (mode === "register") {
+      const profile = (firstName || lastName) ? { firstName, lastName } : undefined;
+      return run(() => register(email, password, profile));
+    }
+    return run(() => login(email, password));
+  };
+
+  const submitCode = (e) => {
+    e?.preventDefault?.();
+    return run(() => verifyEmail(code, stateToken));
+  };
+
+  const switchMode = (next) => { setMode(next); setError(null); };
+
+  return {
+    mode, switchMode, fields, setField,
+    phase, code, setCode,
+    error, busy, submit, submitCode,
+  };
+}

--- a/skills/wix-vibe-headless/references/members/app/pages/Account.jsx
+++ b/skills/wix-vibe-headless/references/members/app/pages/Account.jsx
@@ -1,0 +1,45 @@
+// Account page (`/account`) — the member's own profile + log out. Gate it with <RequireAuth> in the
+// router (STEP 4) so a visitor is bounced to /login. Reads the member from useMember(); shows the
+// identity-only fallback when the Members Area app isn't installed (member is null but loggedIn is
+// true — that's setup, not a bug). Token-styled; re-skin via theme.css.
+import { useMember } from "@/context/MemberContext";
+
+export default function Account() {
+  const { member, logout } = useMember();
+
+  const name = member?.profile?.nickname
+    || [member?.contact?.firstName, member?.contact?.lastName].filter(Boolean).join(" ")
+    || member?.loginEmail
+    || "Member";
+  const email = member?.loginEmail;
+  const photo = member?.profile?.photo?.url;
+
+  return (
+    <main style={{ maxWidth: "var(--form-maxw)", margin: "0 auto", padding: "calc(var(--space) * 2) var(--space)" }}>
+      <div style={{
+        display: "flex", flexDirection: "column", alignItems: "center", gap: 12, textAlign: "center",
+        padding: "calc(var(--space) * 1.5)", background: "var(--color-surface)",
+        border: "1px solid var(--color-border)", borderRadius: "var(--radius)", boxShadow: "var(--shadow)",
+      }}>
+        <div style={{
+          width: 72, height: 72, borderRadius: "50%", overflow: "hidden",
+          background: "var(--color-bg)", border: "1px solid var(--color-border)",
+        }}>
+          {photo && <img src={photo.startsWith("//") ? `https:${photo}` : photo} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />}
+        </div>
+        <h1 style={{ fontFamily: "var(--font-display)", margin: 0, fontSize: 22 }}>{name}</h1>
+        {email && <p style={{ color: "var(--color-muted)", margin: 0 }}>{email}</p>}
+        {!member && (
+          <p style={{ color: "var(--color-muted)", margin: 0, fontSize: 13, lineHeight: 1.5 }}>
+            You're signed in. Install the Wix Members Area app to show profile details here.
+          </p>
+        )}
+        <button type="button" onClick={() => logout()} style={{
+          marginTop: 8, padding: "10px 24px", cursor: "pointer", fontSize: 14, fontWeight: 600,
+          background: "var(--color-primary)", color: "var(--color-on-primary)",
+          border: "none", borderRadius: "var(--radius-sm)",
+        }}>Log out</button>
+      </div>
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/pages/Callback.jsx
+++ b/skills/wix-vibe-headless/references/members/app/pages/Callback.jsx
@@ -1,0 +1,32 @@
+// Social/SSO callback page — mount at EXACTLY `/callback` (the URL you allow-list on the OAuth app;
+// it must match SocialButtons' callbackUri character-for-character). The provider redirects the whole
+// page back here with `#code`/`#state` in the hash; completeSocialLogin() verifies state, exchanges
+// the code for member tokens, and logs the member in on the shared client. Then refresh the session
+// and send them to `returnTo`. Token-styled; re-skin via theme.css.
+import { useEffect, useState } from "react";
+import { completeSocialLogin } from "@/rest/wix-members-auth";
+import { useMember } from "@/context/MemberContext";
+
+export default function Callback() {
+  const { refresh } = useMember();
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    completeSocialLogin()
+      .then(async ({ returnTo }) => {
+        await refresh();
+        if (!cancelled) window.location.replace(returnTo || "/");
+      })
+      .catch((e) => { if (!cancelled) setError(e.message || "Login failed."); });
+    return () => { cancelled = true; };
+  }, [refresh]);
+
+  return (
+    <main style={{ padding: "calc(var(--space) * 3)", textAlign: "center", color: "var(--color-muted)" }}>
+      {error
+        ? <p style={{ color: "var(--color-danger)" }} role="alert">{error} <a href="/login" style={{ color: "var(--color-primary)" }}>Try again</a></p>
+        : <p>Signing you in…</p>}
+    </main>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/pages/Login.jsx
+++ b/skills/wix-vibe-headless/references/members/app/pages/Login.jsx
@@ -1,0 +1,38 @@
+// Login page (`/login`) — composes the shipped LoginForm (credential state machine) with
+// SocialButtons (Google/Facebook redirect). On credential SUCCESS it returns the member to where
+// they came from (RequireAuth stashes it in location.state.from) or home. Social login returns via
+// /callback instead. Token-styled; re-skin via theme.css — don't rewrite this page to add chrome
+// (the Header/Footer live in the Layout).
+import { useNavigate, useLocation } from "react-router-dom";
+import LoginForm from "@/components/LoginForm";
+import SocialButtons from "@/components/SocialButtons";
+
+export default function Login() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from || "/";
+
+  return (
+    <main style={{
+      maxWidth: "var(--form-maxw)", margin: "0 auto", padding: "calc(var(--space) * 2) var(--space)",
+      display: "flex", flexDirection: "column", gap: "calc(var(--space) * 1.25)",
+    }}>
+      <h1 style={{ fontFamily: "var(--font-display)", textAlign: "center", margin: 0 }}>Welcome</h1>
+
+      <LoginForm onSuccess={() => navigate(from, { replace: true })} />
+
+      <Divider>or</Divider>
+      <SocialButtons />
+    </main>
+  );
+}
+
+function Divider({ children }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, color: "var(--color-muted)", fontSize: 13 }}>
+      <span style={{ flex: 1, height: 1, background: "var(--color-border)" }} />
+      {children}
+      <span style={{ flex: 1, height: 1, background: "var(--color-border)" }} />
+    </div>
+  );
+}

--- a/skills/wix-vibe-headless/references/members/app/theme.css
+++ b/skills/wix-vibe-headless/references/members/app/theme.css
@@ -1,0 +1,38 @@
+/* theme.css — THE styling surface. Theme the whole auth client by editing these tokens to the
+   brand; do NOT restyle the components' JSX. Every shipped component (login form, account area,
+   member menu) reads these variables, so changing them here re-skins every auth surface. Import
+   this once at the app entry.
+
+   Set the palette/typography/shape to the brand, then you're done styling. Add tokens if a brand
+   needs them, but keep components reading `var(--...)` — never hardcode a color in a component. */
+
+:root {
+  /* ---- color (set these to the brand) ---- */
+  --color-bg:        #ffffff;   /* page background */
+  --color-surface:   #f6f6f7;   /* cards, form wells, member menu */
+  --color-text:      #16181d;   /* primary text */
+  --color-muted:     #6b7280;   /* secondary text, labels, helper text */
+  --color-border:    #e5e7eb;   /* input borders, hairlines, dividers */
+  --color-primary:   #111827;   /* submit button, links, active */
+  --color-on-primary:#ffffff;   /* text/icon on primary */
+  --color-accent:    #d97757;   /* highlights, focus ring, badges */
+  --color-danger:    #dc2626;   /* auth errors, invalid fields */
+
+  /* ---- typography ---- */
+  --font-body:    system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-display: var(--font-body);  /* set a display face for headings if the brand has one */
+
+  /* ---- shape & rhythm ---- */
+  --radius:      12px;
+  --radius-sm:   8px;
+  --space:       16px;          /* base spacing unit */
+  --maxw:        1200px;        /* content max width */
+  --form-maxw:   420px;         /* auth cards / login form width */
+  --shadow:      0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* Optional dark theme: the agent may map these if the brand is dark. Components need no change. */
+:root[data-theme="dark"] {
+  --color-bg:#0b0f17; --color-surface:#131a26; --color-text:#e5e7eb; --color-muted:#94a3b8;
+  --color-border:#232b3a; --color-primary:#e5e7eb; --color-on-primary:#0b0f17;
+}


### PR DESCRIPTION
Converts **members** to the storefront-as-files model: login/account/callback; MemberProvider/useMember (avoids platform useAuth), RequireAuth.

- `references/members/app/` — theme.css + components + pages + hooks/context + `WixManageBanner.jsx` (verbatim), deployed to `src/` by deploy.cjs.
- `INSTRUCTIONS.md` rewritten to the storefront model: file-manifest table + don't-`read_file`-the-source, STEP 2 `wix-config.js`, STEP 3 theme tokens, STEP 4 the fixed-region Layout (`<WixManageBanner/>` above an in-flow `<Header/>`, ResizeObserver-measured content padding, shipped pages in `<Outlet/>` untouched).

Verified: all `.jsx` parse clean (ts), `.js` node --check clean, all `@/` imports resolve, banner verbatim. Part of the all-vertical fan-out (12 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)