### PR TITLE
fix(deploy): non-destructive re-run (fill missing, never overwrite edits)

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -4,7 +4,8 @@
 // wix-config.js) is copied always; then ONLY the chosen vertical's app/ (its UI + app/rest/ helpers).
 // Deploying a single vertical is deliberate: every vertical's app/ has files at the SAME paths
 // (theme.css, components/…), so copying all of them into one src/ would clobber and pile up. Two
-// copies (not one) only because shared stays DRY. paths are the Base44 sandbox's /app. Idempotent.
+// copies (not one) only because shared stays DRY. paths are the Base44 sandbox's /app. Re-running is
+// non-destructive: it fills in only missing files, never overwriting the agent's edits (see COPY).
 // No vertical arg -> deploys just the shared transport; re-run with the vertical once known.
 // NOTE: .cjs on purpose — the app is an ESM package ("type":"module"); a .js here would load as ESM
 // and require()/module.exports would throw.
@@ -15,12 +16,17 @@ const VERTICALS = ['storefront', 'bookings', 'blog', 'cms', 'portfolio', 'pricin
 const vertical = process.argv[2];
 const deployed = { vertical: null };
 
+// force:false + errorOnExist:false — fill in only files that AREN'T there yet; never overwrite.
+// A re-run (e.g. the "files missing? re-run" fallback) then restores what's missing without
+// clobbering the agent's edits (themed theme.css, wired components) from the first deploy.
+const COPY = { recursive: true, force: false, errorOnExist: false };
+
 // Shared transport — always (app/rest/wix-client.js, wix-config.js -> src/rest/).
-if (existsSync(`${REF}/shared/app`)) cpSync(`${REF}/shared/app`, '/app/src', { recursive: true });
+if (existsSync(`${REF}/shared/app`)) cpSync(`${REF}/shared/app`, '/app/src', COPY);
 
 // The chosen vertical ONLY — its app/ (UI + app/rest/ helpers) -> src/.
 if (vertical && VERTICALS.includes(vertical) && existsSync(`${REF}/${vertical}/app`)) {
-  cpSync(`${REF}/${vertical}/app`, '/app/src', { recursive: true });
+  cpSync(`${REF}/${vertical}/app`, '/app/src', COPY);
   deployed.vertical = vertical;
 } else if (vertical) {
   deployed.error = `unknown vertical "${vertical}" — expected one of: ${VERTICALS.join(', ')}`;


### PR DESCRIPTION
## What
`deploy.cjs` used `cpSync(app, src, { recursive: true })`. Node's `force` defaults to **true**, so a **re-run overwrites existing files** — meaning the INSTRUCTIONS "files missing? re-run" fallback would silently **clobber the agent's edits** (themed `theme.css`, wired/tweaked components) with the pristine skill copies.

## Fix
`{ recursive: true, force: false, errorOnExist: false }` on both `cpSync`s → a re-run **copies only files that aren't there yet**, never overwriting. First deploy still lays everything down; a re-run just fills gaps and preserves edits. Header comment corrected (was "copies overwrite … idempotent", which framed a destructive behavior as safe).

## Verified
Simulated: deploy → edit `theme.css` + delete a component → **re-run** → the `theme.css` edit is **preserved** and the deleted component is **restored**. `node --check` clean.

Follow-up to #901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)