### PR TITLE
docs(seed): uniform seed API surface across verticals — inline image in the one setup<V> call

### DIFF
--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -30,7 +30,9 @@ const result = await seed.setupBlog(ctx, {
         { type: "paragraph", text: "Every batch starts with beans from a single estate." },
         { type: "quote", text: "Great coffee is grown, not made." },
       ],
-      // optional — import an image, then pass the WixMedia file id here
+      // cover is optional and attached IN this one call. Import the FINAL https://media.base44.com/...
+      // url from the COMPLETED generate_image (it runs in the background while you build — wait for it)
+      // into Wix Media to get the fileId; never import a /__generating__/<id>.png placeholder.
       coverImageUrl: fileIds[0],
     },
   ],

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -41,6 +41,9 @@ const result = await seed.setupBlog(ctx, {
 // check each posts[].success (bulk returns 200 even on partial failure).
 ```
 
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add.
+
 ## Escape hatch — individual functions
 
 Call the steps yourself when you need finer control (custom ordering, reusing existing ids):

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -22,7 +22,11 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // are local "YYYY-MM-DDThh:mm:ss".
 const result = await seed.setupBookings(ctx, {
   services: [
-    { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…", price: 75, duration: 60, category: "Our Services" },
+    // `image` per service is optional and attached IN this one call. Use the FINAL
+    // https://media.base44.com/... url from the COMPLETED generate_image (it runs in the background
+    // while you build — wait for it), never a still-generating /__generating__/<id>.png placeholder
+    // (Wix can't fetch it); import it into Wix Media for the { id, url, width, height } shape.
+    { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…", price: 75, duration: 60, category: "Our Services", image: { id, url, width, height } },
     { type: "CLASS", name: "Morning Yoga", description: "…", price: 20, capacity: 20, category: "Our Services",
       sessions: [{ start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00" }] },
   ],
@@ -30,7 +34,7 @@ const result = await seed.setupBookings(ctx, {
 });
 // result: { services:[...], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
 
-// optional — generate an image, then patch each service (revision-checked):
+// fallback (finer control / re-attach): attachServiceImage patches one service's image after the fact.
 // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
 ```
 

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -38,7 +38,9 @@ const summary = await seed.setupCms(ctx, {
           typeMetadata: { multiReference: { referencedCollectionId: "categories" } } },
       ],
       items: [
-        // image ON only: fileUrl generated per IMAGE_GENERATION.md; drop `image` to leave the item text-only
+        // image is optional and attached IN this one call; drop it to leave the item text-only. The url
+        // must be the FINAL https://media.base44.com/... url from the COMPLETED generate_image (it runs in
+        // the background while you build — wait for it), never a still-generating /__generating__/<id>.png.
         { _key: "recipe-cake", title: "Chocolate Cake", image: { fieldKey: "photo", url: fileUrl } },
       ] },
   ],

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -53,6 +53,9 @@ const summary = await seed.setupCms(ctx, {
 // summary = { collections, itemIdsByCollection, referencesInserted, imagesAttached }
 ```
 
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add.
+
 ## Escape hatch — individual steps
 
 Call the low-level fns directly when `setupCms` doesn't fit (e.g. verifying persistence mid-flow, or a

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -44,6 +44,9 @@ const summary = await seed.setupEvents(ctx, {
 // summary -> { events: [{ id, slug, ticketCount, category }], categories: [{ id, name }], imagesAttached }
 ```
 
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add.
+
 ### Escape hatch — individual steps
 
 Call the step functions directly only when `setupEvents` doesn't fit (e.g. re-running a single step,

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -35,6 +35,9 @@ const summary = await seed.setupEvents(ctx, {
     location: { name: "The Echo Lot", type: "VENUE", address: { addressLine: "120 Harbor St", city: "Seattle", subdivision: "US-WA", postalCode: "98101", country: "US" } },
     ticketTiers: [{ name: "General Admission", price: "65.00", initialLimit: 200 }],
     category: "Talks",
+    // image is optional and attached IN this one call. Use the FINAL https://media.base44.com/... url
+    // from the COMPLETED generate_image (it runs in the background while you build — wait for it), never a
+    // still-generating /__generating__/<id>.png placeholder; import it into Wix Media for { id, url, … }.
     image: { id: file.id, url: file.url, height: 1024, width: 1024 }, // altText defaults to the event slug
   }],
 });

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -32,7 +32,9 @@ const summary = await seed.setupPortfolio(ctx, {
     { title: "Northwind Rebrand", description: "Full identity refresh for a logistics firm.",
       collection: "Brand Identity",                    // resolved to that collection's id
       details: [{ label: "Year", text: "2025" }],
-      // optional — generate + import per IMAGE_GENERATION.md, then pass ids/dims:
+      // cover/items are optional and attached IN this one call. Import the FINAL https://media.base44.com/...
+      // url from the COMPLETED generate_image (it runs in the background while you build — wait for it) to
+      // get each imageId; never import a still-generating /__generating__/<id>.png placeholder.
       cover: { imageId: ids[0], height: 2880, width: 1920 },
       items: [{ sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }] },
   ],

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -34,6 +34,9 @@ const { plans, coverageAttached, benefitsCreated } = await seed.setupPricingPlan
 // A plans-only run (no bookings) just omits coveredServiceIds — STEP 2 is skipped automatically.
 ```
 
+**Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
+"sample" data, don't reset. Just add.
+
 ## Escape hatch — individual functions
 Call the steps yourself when you need finer control than the one-call path:
 

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -30,7 +30,10 @@ const result = await seed.setupRestaurants(ctx, {
     name: "Dinner", description: "Evening menu",
     sections: [
       { name: "Antipasti", description: "To start", items: [
-        { name: "Bruschetta al Pomodoro", description: "Grilled sourdough, San Marzano tomatoes, basil.", price: 9.50, imageUrl: "https://…" },
+        // imageUrl per item is optional and attached IN this one call. It must be the FINAL
+        // https://media.base44.com/... url from the COMPLETED generate_image (it runs in the background
+        // while you build — wait for it), never a still-generating /__generating__/<id>.png placeholder.
+        { name: "Bruschetta al Pomodoro", description: "Grilled sourdough, San Marzano tomatoes, basil.", price: 9.50, imageUrl: "https://media.base44.com/…" },
       ] },
     ],
   },


### PR DESCRIPTION
## What
The karate/bookings build split seed→attach and showed placeholder images. Root cause was **docs, not code**: the seed API is already uniform — every `setup<V>` takes images **inline** and attaches them in the one call, with the granular `attach*` fns as exported extras (verified in every module). But the docs diverged:
- **bookings** never showed the inline `image` in its `setupBookings` snippet, so the agent reached for the separate `attachServiceImage`;
- the others under-showed the FINAL-url rule storefront has.

## Fix (docs only, all 6 non-storefront SEED.md)
- Show the inline image field in the `setup<V>` snippet as the **primary** path — added it to bookings (which was missing it).
- Add the final-url note at that field: *use the FINAL `https://media.base44.com/...` url from the COMPLETED `generate_image` (background — wait for it), never a `/__generating__/` placeholder* (import-to-Wix-Media wording for bookings/blog/portfolio/events; direct url for restaurants/cms).
- Demote the granular `attach*` helper to a labeled **"finer control / re-attach" fallback**.

Now every vertical reads like storefront: **one big `setup<V>` that takes everything incl. images; granular calls allowed but not encouraged.** No module changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)