### PR TITLE
docs(seed): standardize the Escape-hatch section across all verticals

### DIFF
--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -45,8 +45,8 @@ const result = await seed.setupBlog(ctx, {
 "sample" data, don't reset. Just add.
 
 ## Escape hatch — individual functions
-
-Call the steps yourself when you need finer control (custom ordering, reusing existing ids):
+Reach for the functions below only when the one-call `setupBlog` doesn't fit (custom ordering,
+reusing existing ids). `setupBlog` is built from them, in this order:
 
 ```js
 const memberId = await seed.getAuthorMemberId(ctx);   // STEP 1 — required for every post create

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -42,8 +42,8 @@ const result = await seed.setupBookings(ctx, {
 "sample" data, don't reset. Just add.
 
 ## Escape hatch — individual functions
-Reach for the individual functions below only when the one-call `setupBookings` doesn't fit (partial
-re-seed, custom ordering). `setupBookings` is built from them, in this order.
+Reach for the functions below only when the one-call `setupBookings` doesn't fit (partial re-seed,
+custom staff/ordering). `setupBookings` is built from them, in this order:
 
 ```js
 await seed.installBookingsApp(ctx);

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -39,8 +39,11 @@ const result = await seed.setupBookings(ctx, {
 ```
 
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
-"sample" data, don't reset. Just add. Need finer control than `setupBookings`? The individual
-functions below still exist (setupBookings is built from them, in the order shown).
+"sample" data, don't reset. Just add.
+
+## Escape hatch — individual functions
+Reach for the individual functions below only when the one-call `setupBookings` doesn't fit (partial
+re-seed, custom ordering). `setupBookings` is built from them, in the order shown.
 
 ## Functions
 | fn | does |

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -43,7 +43,23 @@ const result = await seed.setupBookings(ctx, {
 
 ## Escape hatch — individual functions
 Reach for the individual functions below only when the one-call `setupBookings` doesn't fit (partial
-re-seed, custom ordering). `setupBookings` is built from them, in the order shown.
+re-seed, custom ordering). `setupBookings` is built from them, in this order.
+
+```js
+await seed.installBookingsApp(ctx);
+const staff = await seed.queryStaff(ctx);                            // → [{resourceId,id,name}]; use resourceId, NOT id
+const cats = await seed.createCategories(ctx, ["Our Services"]);    // → [{id,name}]; every service needs a categoryId
+const services = await seed.createServices(ctx, [                   // → [{id,slug,revision,type,scheduleId}]
+  { type: "APPOINTMENT", name: "Consultation", price: 75, duration: 60, categoryId: cats[0].id, staffMemberIds: [staff[0].resourceId] },
+  { type: "CLASS", name: "Morning Yoga", price: 20, capacity: 20, categoryId: cats[0].id },
+]);
+// CLASS only: schedule sessions with each class's returned scheduleId (local wall-clock times)
+await seed.scheduleClassSessions(ctx, [
+  { scheduleId: services[1].scheduleId, resourceId: staff[0].resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20 },
+]);
+// images (optional): use the FINAL https://media.base44.com/... url only (never a /__generating__/ placeholder)
+await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: services[0].revision, image: { id, url, width, height } });
+```
 
 ## Functions
 | fn | does |

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -56,11 +56,9 @@ const summary = await seed.setupCms(ctx, {
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.
 
-## Escape hatch — individual steps
-
-Call the low-level fns directly when `setupCms` doesn't fit (e.g. verifying persistence mid-flow, or a
-shape the plan can't express). Order: install → createCollection → bulkInsertItems → queryItems (verify)
-→ insertReferences (cross-collection) → attachItemImage.
+## Escape hatch — individual functions
+Reach for the functions below only when the one-call `setupCms` doesn't fit (verifying persistence
+mid-flow, a shape the plan can't express). `setupCms` is built from them, in this order:
 
 ```js
 await seed.installCmsApp(ctx);                          // if a data call returns WDE0110 (app not installed)

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -47,10 +47,9 @@ const summary = await seed.setupEvents(ctx, {
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.
 
-### Escape hatch — individual steps
-
-Call the step functions directly only when `setupEvents` doesn't fit (e.g. re-running a single step,
-or a shape it doesn't model). Same order applies: create DRAFT → (ticketed) tiers → publish → categories → image.
+## Escape hatch — individual functions
+Reach for the functions below only when the one-call `setupEvents` doesn't fit (re-running a single
+step, a shape it doesn't model). `setupEvents` is built from them, in this order:
 
 ```js
 // STEP 1 — create each event as a DRAFT. TICKETING = paid tiers; RSVP = free built-in form (no fields to seed).

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -42,8 +42,9 @@ const summary = await seed.setupPortfolio(ctx, {
 // summary => { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
 ```
 
-### Escape hatch — individual functions
-Use these directly when you need step-by-step control. Same order applies.
+## Escape hatch — individual functions
+Reach for the functions below only when the one-call `setupPortfolio` doesn't fit (step-by-step
+control, partial re-seed). `setupPortfolio` is built from them, in this order:
 
 ```js
 const collections = await seed.createCollections(ctx, [                                 // STEP 1

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -38,7 +38,8 @@ const { plans, coverageAttached, benefitsCreated } = await seed.setupPricingPlan
 "sample" data, don't reset. Just add.
 
 ## Escape hatch — individual functions
-Call the steps yourself when you need finer control than the one-call path:
+Reach for the functions below only when the one-call `setupPricingPlans` doesn't fit (custom coverage,
+step-by-step control). `setupPricingPlans` is built from them, in this order:
 
 ```js
 const plans = await seed.createPlans(ctx, [

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -43,15 +43,13 @@ const result = await seed.setupRestaurants(ctx, {
 // → { menuId, sectionIds, itemIds, orderingEnabled, reservationsEnabled, imagesAttached }
 ```
 
-## Escape hatch: the individual fns
-
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.
 
-Reach for these only when the one-call path doesn't fit (partial re-seed, custom
-fulfillment methods, experiences). The **items → sections → menu** ordering below is the rule
-`setupRestaurants`/`createMenu` bake in — a section is created with its `itemIds`, a menu with its
-`sectionIds`, so each child must exist before its parent.
+## Escape hatch — individual functions
+Reach for the functions below only when the one-call `setupRestaurants` doesn't fit (partial re-seed,
+custom fulfillment methods, experiences). `setupRestaurants` is built from them, in this order
+(items → sections → menu — each child before its parent):
 
 ```js
 // ── MENU (always; the seedable core) ────────────────────────────────────────────────────────────

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -31,8 +31,11 @@ const result = await seed.setupStore(ctx, {
 ```
 
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
-"sample" data, don't reset. Just add. Need finer control than `setupStore`? The individual functions
-below still exist (setupStore is built from them).
+"sample" data, don't reset. Just add.
+
+## Escape hatch — individual functions
+Reach for the individual functions below only when the one-call `setupStore` doesn't fit (partial
+re-seed, custom ordering, verifying persistence mid-flow). `setupStore` is built from them.
 
 ## Functions
 | fn | does |

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -34,8 +34,8 @@ const result = await seed.setupStore(ctx, {
 "sample" data, don't reset. Just add.
 
 ## Escape hatch — individual functions
-Reach for the individual functions below only when the one-call `setupStore` doesn't fit (partial
-re-seed, custom ordering, verifying persistence mid-flow). `setupStore` is built from them, in this order.
+Reach for the functions below only when the one-call `setupStore` doesn't fit (partial re-seed, custom
+ordering, mid-flow checks). `setupStore` is built from them, in this order:
 
 ```js
 await seed.installStoresApp(ctx);                                     // install + wait for the V3 catalog

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -35,7 +35,18 @@ const result = await seed.setupStore(ctx, {
 
 ## Escape hatch — individual functions
 Reach for the individual functions below only when the one-call `setupStore` doesn't fit (partial
-re-seed, custom ordering, verifying persistence mid-flow). `setupStore` is built from them.
+re-seed, custom ordering, verifying persistence mid-flow). `setupStore` is built from them, in this order.
+
+```js
+await seed.installStoresApp(ctx);                                     // install + wait for the V3 catalog
+const products = await seed.bulkCreateProducts(ctx, [                 // → [{id,slug,revision}], in stock by `quantity`
+  { name: "The Glam Rocker", description: "…", price: 49.99, quantity: 12 },
+]);
+const cats = await seed.createCategories(ctx, ["Legends"]);           // sequential → [{id,name}]
+await seed.addProductsToCategories(ctx, { [cats[0].id]: [products[0].id] });
+// images: use the FINAL https://media.base44.com/... url only (never a /__generating__/ placeholder)
+await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: imageUrls[i], altText: p.slug })));
+```
 
 ## Functions
 | fn | does |


### PR DESCRIPTION
storefront and bookings were the only two SEED.md without an `## Escape hatch — individual functions` heading + intro paragraph — they folded a one-liner into the additive note and went straight to the Functions table. Added the section to both so all 8 seeding SEED.md share the same structure (additive note → Escape-hatch intro → Functions table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)