### PR TITLE
fix(wix-vibe-headless): import generated images to Wix Media before binding

### DIFF
--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -9,7 +9,8 @@ seed operation. `require` it and call the functions with plain data.
 
 **DEFAULT — one call.** `setupBlog(ctx, plan)` runs the whole flow (memberId → categories/tags →
 posts → covers), keeping every id in memory. Pass category/tag **names** and it resolves them to
-ids internally; covers attach only for posts that carry a WixMedia file id.
+ids internally; a post's `coverImageUrl` is a plain image url that the module imports into Wix Media
+for you (Blog binds the cover by the Wix Media file id, not a url).
 
 ```js
 // build-time exec_tool
@@ -30,10 +31,11 @@ const result = await seed.setupBlog(ctx, {
         { type: "paragraph", text: "Every batch starts with beans from a single estate." },
         { type: "quote", text: "Great coffee is grown, not made." },
       ],
-      // cover is optional and attached IN this one call. Import the FINAL https://media.base44.com/...
-      // url from the COMPLETED generate_image (it runs in the background while you build — wait for it)
-      // into Wix Media to get the fileId; never import a /__generating__/<id>.png placeholder.
-      coverImageUrl: fileIds[0],
+      // cover is optional and attached IN this one call. Pass a plain url — the module imports it to
+      // Wix Media for you (Blog binds the cover by file id). Use the FINAL https://media.base44.com/...
+      // url from the COMPLETED generate_image (it runs in the background while you build — wait for
+      // it), never a still-generating /__generating__/<id>.png placeholder.
+      coverImageUrl: "https://media.base44.com/…",
     },
   ],
 });
@@ -63,8 +65,9 @@ const posts = await seed.createPosts(ctx, [
   ] },
 ]);   // → [{ id, index, success }] — check each .success (bulk returns 200 even on partial failure)
 
-// optional — import images, then attach covers (PATCH + re-publish)
-await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fileIds[i] })));
+// optional — import each url to Wix Media (blog binds by file id), then attach covers (PATCH + re-publish)
+const files = await Promise.all(imageUrls.map((u) => seed.importImage(ctx, u)));   // → [{ id, url }]
+await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: files[i].id })));
 ```
 
 ## Functions
@@ -75,7 +78,8 @@ await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fi
 | `createPosts(ctx, posts, { memberId })` | STEP 2 — auto single-vs-bulk create, published → `[{id,index,success}]` |
 | `createCategories(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.categoryIds`) |
 | `createTags(ctx, names)` | STEP 3 — sequential creates → `[{id,name}]` (feed into `post.tagIds`) |
-| `attachPostCovers(ctx, [{postId,fileId}])` | optional — PATCH cover (`displayed+custom+wixMedia.image.id`) + re-publish |
+| `importImage(ctx, url)` | import an external url into Wix Media → `{id,url}` (file id + wixstatic url); blog binds the cover by this file id |
+| `attachPostCovers(ctx, [{postId,fileId}])` | optional — PATCH cover (`displayed+custom+wixMedia.image.id`) + re-publish; `fileId` MUST be a Wix Media file id from `importImage` |
 
 `content` blocks: `{type:"heading",text,level?}` · `{type:"paragraph",text}` · `{type:"quote",text}` ·
 `{type:"bulleted"|"ordered",items:[…]}`. For node types the recipe doesn't cover (code, images),

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -17,8 +17,9 @@
 //       { type: "quote", text: "Great coffee is grown, not made." },
 //     ] },
 //   ], { memberId });
-//   // optional — import images, then attach covers + re-publish
-//   await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fileIds[i] })));
+//   // optional — import each image url to Wix Media (blog binds by file id), then attach covers + re-publish
+//   const files = await Promise.all(imageUrls.map((u) => seed.importImage(ctx, u)));   // → [{ id, url }]
+//   await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: files[i].id })));
 //
 // **NOT yet live-verified — transcribed from setup-blog.md.** If any call fails with a shape the
 // caller didn't expect, fall back to the wix-docs skill (search + read the live Wix Blog API
@@ -158,8 +159,18 @@ async function createTags(ctx, names) {
   return out;
 }
 
+// Import an external image URL into Wix Media → { id, url }. Blog binds the cover by the Wix Media
+// file **id**, NOT a url — an external url (e.g. a base44 generate_image result) MUST be imported
+// first; the raw url renders nothing. id = wixstatic file id, url = the permanent wixstatic url.
+async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
 // Attach images step (optional). covers: [{ postId, fileId }] where fileId is the WixMedia
-// file.id from IMAGE_GENERATION.md import (Blog binds the cover by id, not url). Per post:
+// file.id from importImage (Blog binds the cover by id, not url). Per post:
 //   PATCH /blog/v3/draft-posts/{id}  (NOT POST …/{id}/update — that 404s for a single post),
 // setting media.displayed:true + media.custom:true + wixMedia.image.id (id ALONE is a silent no-op),
 // then re-publish (the PATCH sets hasUnpublishedChanges, so the live post stays cover-less until republish).
@@ -183,12 +194,12 @@ async function attachPostCovers(ctx, covers) {
  * category/tag names → ids internally and keeps every id in memory, so nothing is hand-threaded
  * across exec calls. Order: memberId → categories/tags → posts (with resolved ids) → covers.
  * @param plan {
- *   posts: [{ title, content?|richContent?, category?|categories?(name|names), tags?(names), coverImageUrl?|cover?(WixMedia fileId) }],
+ *   posts: [{ title, content?|richContent?, category?|categories?(name|names), tags?(names), coverImageUrl? }],
  *   categories?: [name],  // pre-create categories even if no post references them
  *   tags?: [name],
  * }
- *   category/categories/tags are display NAMES (resolved to ids here); cover/coverImageUrl is the
- *   WixMedia file id — a cover is attached only for posts that provide one.
+ *   category/categories/tags are display NAMES (resolved to ids here); coverImageUrl is a plain image
+ *   url — imported to Wix Media here — and a cover is attached only for posts that provide one.
  * @returns { posts:[{id,index,success}], categories:[{id,name}], tags:[{id,name}], coversAttached }
  */
 async function setupBlog(ctx, { posts = [], categories = [], tags = [] } = {}) {
@@ -208,14 +219,20 @@ async function setupBlog(ctx, { posts = [], categories = [], tags = [] } = {}) {
       ...(tn.length ? { tagIds: tn.map((n) => tagId.get(n)).filter(Boolean) } : {}),
     };
   }), { memberId });
-  const covers = created
-    .map((post, i) => ({ postId: post.id, fileId: posts[i]?.coverImageUrl ?? posts[i]?.cover }))
-    .filter((c) => c.postId && c.fileId);
+  const covers = [];
+  for (let i = 0; i < created.length; i++) {
+    const url = posts[i]?.coverImageUrl;
+    if (!created[i]?.id || !url) continue;
+    try {
+      const file = await importImage(ctx, url, `post-${i}.png`);   // → Wix Media file id
+      covers.push({ postId: created[i].id, fileId: file.id });
+    } catch { /* never block on image failure — leave the post cover-less */ }
+  }
   if (covers.length) await attachPostCovers(ctx, covers);
   return { posts: created, categories: cats, tags: tgs, coversAttached: covers.length };
 }
 
 module.exports = {
   setupBlog,
-  getAuthorMemberId, createPosts, createCategories, createTags, attachPostCovers,
+  getAuthorMemberId, createPosts, createCategories, createTags, importImage, attachPostCovers,
 };

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -22,11 +22,11 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // are local "YYYY-MM-DDThh:mm:ss".
 const result = await seed.setupBookings(ctx, {
   services: [
-    // `image` per service is optional and attached IN this one call. Use the FINAL
-    // https://media.base44.com/... url from the COMPLETED generate_image (it runs in the background
-    // while you build — wait for it), never a still-generating /__generating__/<id>.png placeholder
-    // (Wix can't fetch it); import it into Wix Media for the { id, url, width, height } shape.
-    { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…", price: 75, duration: 60, category: "Our Services", image: { id, url, width, height } },
+    // `imageUrl` per service is optional and attached IN this one call. Pass a plain url — the module
+    // imports it into Wix Media for you (bookings binds a service image by the Wix Media file id, not a
+    // url). Use the FINAL https://media.base44.com/... url from the COMPLETED generate_image (it runs in
+    // the background while you build — wait for it), never a still-generating /__generating__/<id>.png.
+    { type: "APPOINTMENT", name: "Consultation", description: "…", tagLine: "…", price: 75, duration: 60, category: "Our Services", imageUrl: "https://media.base44.com/…" },
     { type: "CLASS", name: "Morning Yoga", description: "…", price: 20, capacity: 20, category: "Our Services",
       sessions: [{ start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00" }] },
   ],
@@ -34,8 +34,9 @@ const result = await seed.setupBookings(ctx, {
 });
 // result: { services:[...], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
 
-// fallback (finer control / re-attach): attachServiceImage patches one service's image after the fact.
-// await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
+// fallback (finer control / re-attach): import the url to Wix Media, then patch one service after the fact.
+// const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
+// await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
 ```
 
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
@@ -57,8 +58,10 @@ const services = await seed.createServices(ctx, [                   // → [{id,
 await seed.scheduleClassSessions(ctx, [
   { scheduleId: services[1].scheduleId, resourceId: staff[0].resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20 },
 ]);
-// images (optional): use the FINAL https://media.base44.com/... url only (never a /__generating__/ placeholder)
-await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: services[0].revision, image: { id, url, width, height } });
+// images (optional): import the url to Wix Media first (bookings binds by file id), then attach.
+// Use the FINAL https://media.base44.com/... url only (never a /__generating__/ placeholder).
+const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
+await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: services[0].revision, image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
 ```
 
 ## Functions
@@ -73,7 +76,8 @@ await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: servic
 | `createServices(ctx, services)` | STEP 3 — one bulk create (APPOINTMENT/CLASS mixed) → `[{id,slug,revision,type,scheduleId,success,error}]` |
 | `scheduleClassSessions(ctx, sessions)` | STEP 4 (CLASS only) — one bulk Calendar-Events-V3 create → `[{id,success,error}]` |
 | `getService(ctx, serviceId)` | fetch a service (current `revision`; confirm an image landed) |
-| `attachServiceImage(ctx, {serviceId,revision,image})` | optional — patch `media.mainMedia`/`coverMedia` (revision-checked) |
+| `importImage(ctx, url)` | import an external url into Wix Media → `{id,url}` (file id + wixstatic url); bookings binds by this file id |
+| `attachServiceImage(ctx, {serviceId,revision,image})` | optional — patch `media.mainMedia`/`coverMedia` (revision-checked); `image.id` MUST be a Wix Media file id from `importImage` |
 
 Both bulk calls report per-item `success`/`error` — retry only the failed items **once** with the
 same body; don't loop and don't re-create the ones that already succeeded.

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -32,8 +32,9 @@
 //   await seed.scheduleClassSessions(ctx, services.filter(s => s.type === "CLASS").map(s => ({
 //     scheduleId: s.scheduleId, resourceId, start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", capacity: 20,
 //   })));
-//   // optional — generate an image, then patch each service (revision-checked).
-//   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id, url, width, height } });
+//   // optional — import the image url to Wix Media first (bookings binds by file id), then patch (revision-checked).
+//   // const file = await seed.importImage(ctx, imageUrl); // → { id, url } (Wix Media file id + wixstatic url)
+//   // await seed.attachServiceImage(ctx, { serviceId: s.id, revision: s.revision, image: { id: file.id, url: file.url, width: 1024, height: 1024 } });
 //
 // If any call fails with a shape the caller didn't expect, or you need an operation this module
 // doesn't cover, fall back to the wix-docs skill (search + read the live Wix API reference) —
@@ -217,8 +218,22 @@ async function getService(ctx, serviceId) {
 }
 
 /**
- * Attach images (optional). Writes under media.mainMedia + media.coverMedia; revision-checked.
- * @param it { serviceId, revision, image: { id, url, width, height } }  (image.id is the binding field)
+ * Import an external image URL into Wix Media → { id, url }. Bookings binds a service image by the
+ * Wix Media file **id** (`mainMedia.image.id`), NOT a url — so an external url (e.g. a base44
+ * generate_image result) MUST be imported first; the raw url as the id stores (200) but renders
+ * nothing. `id` is the wixstatic file id (`<hash>~mv2.png`), `url` the permanent wixstatic url.
+ */
+async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
+/**
+ * Attach an image (optional). Writes under media.mainMedia + media.coverMedia; revision-checked.
+ * @param it { serviceId, revision, image: { id, url, width, height } } — `image.id` MUST be a Wix
+ *   Media file id (from importImage), never a raw external url.
  * ⚠️ Writing under media.image (not mainMedia/coverMedia) returns 200 but SILENTLY drops the image — a 200
  * is not proof; confirm with getService and check media.mainMedia is populated. Never block on failure.
  */
@@ -244,7 +259,7 @@ async function attachServiceImage(ctx, it) {
  *   services: [{ type:"APPOINTMENT"|"CLASS", name, description, tagLine?, price?, free?, duration?,
  *                capacity?, category?(name), staffMemberIds?,
  *                sessions?: [{ start, end, capacity? }],  // CLASS only; local "YYYY-MM-DDThh:mm:ss"
- *                image? }],                                // {id,url,width,height} to attach, optional
+ *                imageUrl? }],                             // a plain image url; imported to Wix Media here, optional
  *   staffResourceId?: string,   // defaults to the fresh install's owner (queryStaff()[0].resourceId)
  * }}
  * Cleanup is intentionally NOT here — deleting existing services is a judgment call.
@@ -283,11 +298,16 @@ async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
 
   let imagesAttached = 0;
   for (let i = 0; i < created.length; i++) {
-    const img = services[i]?.image;
-    if (img && created[i]?.id) {
-      await attachServiceImage(ctx, { serviceId: created[i].id, revision: created[i].revision, image: img });
+    const url = services[i]?.imageUrl;         // a plain image url (e.g. base44 generate_image) — imported here
+    if (!url || !created[i]?.id) continue;
+    try {
+      const file = await importImage(ctx, url, `${created[i].slug || "service"}.png`);   // → Wix Media file id
+      await attachServiceImage(ctx, {
+        serviceId: created[i].id, revision: created[i].revision,
+        image: { id: file.id, url: file.url, width: 1024, height: 1024 },
+      });
       imagesAttached++;
-    }
+    } catch { /* never block on image failure — leave the service text-only */ }
   }
 
   return { services: created, categories: cats, resourceId, sessionsScheduled: scheduled.length, imagesAttached };
@@ -297,5 +317,5 @@ module.exports = {
   setupBookings,
   installBookingsApp, listServices, deleteServices,
   queryStaff, createStaff, queryCategories, createCategories,
-  createServices, scheduleClassSessions, getService, attachServiceImage,
+  createServices, scheduleClassSessions, getService, importImage, attachServiceImage,
 };

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -26,7 +26,7 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 // category NAMES → ids + assigns and attaches main images. Ids are kept in memory; nothing is
 // hand-threaded across exec calls. Dates MUST be in the future (ISO-8601 UTC); default ~60–90 days
 // out and note it if the request gives none. price is a decimal STRING; ticket name <= 30 chars;
-// omit ticketTiers for RSVP/free, omit image if you have none. height/width REQUIRED or it won't render.
+// omit ticketTiers for RSVP/free, omit imageUrl if you have none.
 const summary = await seed.setupEvents(ctx, {
   events: [{
     title: "Summer Synth Festival", shortDescription: "One night of analog sound.",
@@ -35,10 +35,11 @@ const summary = await seed.setupEvents(ctx, {
     location: { name: "The Echo Lot", type: "VENUE", address: { addressLine: "120 Harbor St", city: "Seattle", subdivision: "US-WA", postalCode: "98101", country: "US" } },
     ticketTiers: [{ name: "General Admission", price: "65.00", initialLimit: 200 }],
     category: "Talks",
-    // image is optional and attached IN this one call. Use the FINAL https://media.base44.com/... url
-    // from the COMPLETED generate_image (it runs in the background while you build — wait for it), never a
-    // still-generating /__generating__/<id>.png placeholder; import it into Wix Media for { id, url, … }.
-    image: { id: file.id, url: file.url, height: 1024, width: 1024 }, // altText defaults to the event slug
+    // imageUrl is optional and attached IN this one call. Pass a plain url — the module imports it to
+    // Wix Media for you (events binds the main image by file id). Use the FINAL https://media.base44.com/...
+    // url from the COMPLETED generate_image (it runs in the background while you build — wait for it),
+    // never a still-generating /__generating__/<id>.png placeholder. altText defaults to the event slug.
+    imageUrl: "https://media.base44.com/…",
   }],
 });
 // summary -> { events: [{ id, slug, ticketCount, category }], categories: [{ id, name }], imagesAttached }
@@ -70,7 +71,8 @@ await seed.publishEvent(ctx, ev.id);
 const cats = await seed.createEventCategories(ctx, ["Talks"]);
 await seed.assignEventsToCategory(ctx, cats[0].id, [ev.id]);
 
-// Attach images (optional): generate per IMAGE_GENERATION.md, then set mainImage. height/width REQUIRED or it won't render.
+// Attach images (optional): import the url to Wix Media (events binds by file id), then set mainImage.
+const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
 await seed.setEventMainImage(ctx, { eventId: ev.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: ev.slug });
 ```
 
@@ -88,7 +90,8 @@ Free/RSVP events need neither.
 | `publishEvent(ctx, eventId)` | STEP 3 — publish (one-way) |
 | `createEventCategories(ctx, names)` | STEP 4 (opt) — v1 Categories, one call each → `[{id,name}]` |
 | `assignEventsToCategory(ctx, categoryId, eventIds)` | STEP 4 (opt) — path `/{categoryId}/events`, body `{eventId:[…]}` |
-| `setEventMainImage(ctx, {eventId,id,url,height,width,altText})` | optional — PATCH `mainImage` (no revision) |
+| `importImage(ctx, url)` | import an external url into Wix Media → `{id,url}` (file id + wixstatic url); the main image binds by this file id |
+| `setEventMainImage(ctx, {eventId,id,url,height,width,altText})` | optional — PATCH `mainImage` (no revision); `id` = a Wix Media file id from `importImage` |
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -28,8 +28,9 @@
 //   // STEP 4 (optional): group by format/track
 //   const cats = await seed.createEventCategories(ctx, ["Talks"]);
 //   await seed.assignEventsToCategory(ctx, cats[0].id, [ev.id]);
-//   // Attach images (optional): height/width REQUIRED or it won't render
-//   await seed.setEventMainImage(ctx, { eventId: ev.id, id: fileId, url: fileUrl, height: 1024, width: 1024, altText: ev.slug });
+//   // Attach images (optional): import the url to Wix Media first (events binds by file id), then patch.
+//   const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
+//   await seed.setEventMainImage(ctx, { eventId: ev.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: ev.slug });
 //
 // If any call fails with a shape the caller didn't expect, fall back to the wix-docs skill
 // (search + read the live Wix API reference) — never guess. Source recipe (authoritative):
@@ -151,9 +152,20 @@ async function assignEventsToCategory(ctx, categoryId, eventIds) {
   return req(ctx, `/events/v1/categories/${categoryId}/events`, { body: { eventId: eventIds } });
 }
 
+// Import an external image URL into Wix Media → { id, url }. Events binds mainImage by the Wix Media
+// file **id**, NOT a url — an external url (e.g. a base44 generate_image result) MUST be imported
+// first; the raw url as the id stores (200) but renders nothing. id = wixstatic file id, url = the
+// permanent wixstatic url.
+async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
 // Attach images (optional). mainImage is an Image OBJECT; height/width are REQUIRED or it won't
 // render. Events V3 uses NO revision — partial PATCH keyed by event.id. Works before OR after publish.
-// item: { eventId, id, url, height, width, altText }  (id = the WixMedia image id)
+// item: { eventId, id, url, height, width, altText }  (id = the WixMedia image id, from importImage)
 async function setEventMainImage(ctx, item) {
   return req(ctx, `/events/v3/events/${item.eventId}`, {
     method: "PATCH",
@@ -175,7 +187,7 @@ async function setEventMainImage(ctx, item) {
  *   ...createEvent fields (title, shortDescription?, type, startDate, endDate, timeZoneId, location, …),
  *   ticketTiers?: [{ name, price, initialLimit?, … }],   // TICKETING only; omit to skip
  *   category?: string,                                     // category NAME; resolved to id + assigned
- *   image?: { id, url, height, width, altText? }           // optional; omit to skip
+ *   imageUrl?: string                                      // a plain image url; imported to Wix Media here, optional
  * }] }}
  * Cleanup is intentionally NOT here — deleting existing content is a judgment call.
  */
@@ -185,7 +197,7 @@ async function setupEvents(ctx, { events = [] } = {}) {
     const e = await createEvent(ctx, ev);
     const tiers = ev.ticketTiers?.length ? await createTicketTiers(ctx, e.id, ev.ticketTiers) : [];
     await publishEvent(ctx, e.id);
-    created.push({ ...e, category: ev.category, image: ev.image, ticketCount: tiers.length });
+    created.push({ ...e, category: ev.category, imageUrl: ev.imageUrl, ticketCount: tiers.length });
   }
   const names = [...new Set(created.map((e) => e.category).filter(Boolean))];
   const cats = names.length ? await createEventCategories(ctx, names) : [];
@@ -195,9 +207,12 @@ async function setupEvents(ctx, { events = [] } = {}) {
   }
   let imagesAttached = 0;
   for (const e of created) {
-    if (!e.image?.url) continue;
-    await setEventMainImage(ctx, { eventId: e.id, altText: e.slug, ...e.image });
-    imagesAttached++;
+    if (!e.imageUrl) continue;
+    try {
+      const file = await importImage(ctx, e.imageUrl, `${e.slug || "event"}.png`);   // → Wix Media file id
+      await setEventMainImage(ctx, { eventId: e.id, id: file.id, url: file.url, height: 1024, width: 1024, altText: e.slug });
+      imagesAttached++;
+    } catch { /* never block on image failure — leave the event image-less */ }
   }
   return {
     events: created.map((e) => ({ id: e.id, slug: e.slug, ticketCount: e.ticketCount, category: e.category ?? null })),
@@ -209,5 +224,5 @@ async function setupEvents(ctx, { events = [] } = {}) {
 module.exports = {
   setupEvents,
   createEvent, createTicketTiers, publishEvent,
-  createEventCategories, assignEventsToCategory, setEventMainImage,
+  createEventCategories, assignEventsToCategory, importImage, setEventMainImage,
 };

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -32,11 +32,12 @@ const summary = await seed.setupPortfolio(ctx, {
     { title: "Northwind Rebrand", description: "Full identity refresh for a logistics firm.",
       collection: "Brand Identity",                    // resolved to that collection's id
       details: [{ label: "Year", text: "2025" }],
-      // cover/items are optional and attached IN this one call. Import the FINAL https://media.base44.com/...
-      // url from the COMPLETED generate_image (it runs in the background while you build — wait for it) to
-      // get each imageId; never import a still-generating /__generating__/<id>.png placeholder.
-      cover: { imageId: ids[0], height: 2880, width: 1920 },
-      items: [{ sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }] },
+      // cover/items are optional and attached IN this one call. Pass plain urls — the module imports
+      // them to Wix Media for you (portfolio binds by file id). Use the FINAL https://media.base44.com/...
+      // url from the COMPLETED generate_image (it runs in the background while you build — wait for it),
+      // never a still-generating /__generating__/<id>.png placeholder.
+      coverImageUrl: "https://media.base44.com/…",
+      items: [{ sortOrder: 1, title: "Hero", imageUrl: "https://media.base44.com/…" }] },
   ],
 });
 // summary => { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
@@ -55,10 +56,11 @@ const projects = await seed.createProjects(ctx, [                               
     collectionIds: [collections[0].id], details: [{ label: "Year", text: "2025" }] },
 ]);
 
-// optional — generate + import images, then attach
-await seed.attachProjectCovers(ctx, projects.map((p, i) => ({ id: p.id, revision: p.revision, imageId: ids[i], height: 2880, width: 1920 })));
-await seed.attachCollectionCovers(ctx, collections.map((c, i) => ({ id: c.id, revision: c.revision, imageId: cids[i], height: 2880, width: 1920 })));
-await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title: "Hero", imageId: ids[0], height: 896, width: 1200 }]);
+// optional — import each url to Wix Media first (portfolio binds by file id), then attach
+const files = await Promise.all(imageUrls.map((u) => seed.importImage(ctx, u)));   // → [{ id, url }]
+await seed.attachProjectCovers(ctx, projects.map((p, i) => ({ id: p.id, revision: p.revision, imageId: files[i].id, height: 1024, width: 1024 })));
+await seed.attachCollectionCovers(ctx, collections.map((c, i) => ({ id: c.id, revision: c.revision, imageId: files[i].id, height: 1024, width: 1024 })));
+await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title: "Hero", imageId: files[0].id, height: 1024, width: 1024 }]);
 ```
 
 ## Functions
@@ -67,7 +69,8 @@ await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, t
 | `setupPortfolio(ctx, plan)` | **DEFAULT** — one call: collections → projects → items → covers; returns `{collections,projects,itemsCreated,coversAttached}` |
 | `createCollections(ctx, collections)` | STEP 1 — `[{title,description?,hidden?}]` → `[{id,slug,revision}]` |
 | `createProjects(ctx, projects)` | STEP 2 — `[{title,description?,collectionIds,details?,hidden?}]` → `[{id,slug,revision}]` |
-| `attachProjectCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each project's cover (optional) |
+| `importImage(ctx, url)` | import an external url into Wix Media → `{id,url}` (file id + wixstatic url); covers + items bind by this file id |
+| `attachProjectCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each project's cover (optional); `imageId` = a Wix Media file id from `importImage` |
 | `attachCollectionCovers(ctx, [{id,revision,imageId,height,width}])` | PATCH each collection's cover (optional) |
 | `createProjectItems(ctx, [{projectId,sortOrder,title,imageId,height,width}])` | one POST per gallery image (optional) |
 

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -20,9 +20,10 @@
 //   const projects = await seed.createProjects(ctx, [                                        // STEP 2
 //     { title, description, collectionIds: [collections[0].id], details: [{ label, text }] },
 //   ]);
-//   // optional —
-//   await seed.attachProjectCovers(ctx, projects.map((p,i) => ({ id:p.id, revision:p.revision, imageId:ids[i], height:2880, width:1920 })));
-//   await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title, imageId, height:896, width:1200 }]);
+//   // optional — import each image url to Wix Media first (portfolio binds by file id), then attach.
+//   const files = await Promise.all(imageUrls.map((u) => seed.importImage(ctx, u)));   // → [{ id, url }]
+//   await seed.attachProjectCovers(ctx, projects.map((p,i) => ({ id:p.id, revision:p.revision, imageId:files[i].id, height:1024, width:1024 })));
+//   await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, title, imageId: files[0].id, height:1024, width:1024 }]);
 //
 // **NOT yet live-verified — transcribed from setup-portfolio.md.** If any call fails with a
 // shape the caller didn't expect, fall back to the wix-docs skill (search + read the live Wix
@@ -115,9 +116,19 @@ async function createProjects(ctx, projects) {
   return out;
 }
 
+// Import an external image URL into Wix Media → { id, url }. Portfolio binds covers + gallery items
+// by the Wix Media file **id**, NOT a url — an external url (e.g. a base44 generate_image result)
+// MUST be imported first; the raw url renders nothing. id = wixstatic file id, url = wixstatic url.
+async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
 // Optional — pass a cover/items to attach, omit to skip. Cover = the listing-card thumbnail. PATCH per entity,
 // echoing the current revision (a missing/stale revision fails). height + width are required
-// alongside the imported WixMedia image id. items: [{ id, revision, imageId, height, width }].
+// alongside the imported WixMedia image id (from importImage). items: [{ id, revision, imageId, height, width }].
 async function attachProjectCovers(ctx, items) {
   for (const it of items) {
     await req(ctx, `/portfolio/v1/projects/${it.id}`, {
@@ -154,13 +165,14 @@ async function createProjectItems(ctx, items) {
  * collections→projects→items→covers are wired without hand-threading ids. Order matches SEED.md:
  * createCollections → createProjects (into collections) → createProjectItems → attach*Covers.
  * @param plan {
- *   collections: [{ title, description?, hidden?, cover?: { imageId, height, width } }],
+ *   collections: [{ title, description?, hidden?, coverImageUrl? }],
  *   projects:    [{ title, description?, details?, hidden?,
  *                   collection?: "<collection title>",   // resolved to that collection's id
- *                   items?: [{ sortOrder, title, imageId, height, width }],
- *                   cover?: { imageId, height, width } }],
+ *                   items?: [{ sortOrder, title, imageUrl }],
+ *                   coverImageUrl? }],
  * }
- *   Covers/items are optional — a project/collection without a `cover`/`items` skips it.
+ *   coverImageUrl / items[].imageUrl are plain image urls — imported to Wix Media here. Covers/items
+ *   are optional — a project/collection without one skips it.
  * @returns { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
  */
 async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
@@ -175,19 +187,44 @@ async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
     })),
   );
 
-  const itemsFlat = projects.flatMap((p, i) =>
-    (p.items ?? []).map((it) => ({ ...it, projectId: projs[i].id })),
-  );
+  // resolve a plain image url → { imageId, height, width } by importing to Wix Media (binds by file id)
+  const toImage = async (url, name) => {
+    const file = await importImage(ctx, url, name);
+    return { imageId: file.id, height: 1024, width: 1024 };
+  };
+
+  // STEP 3 — project media-gallery items (import each image; a failed import skips that item)
+  const itemsFlat = [];
+  for (let i = 0; i < projects.length; i++) {
+    for (const it of projects[i].items ?? []) {
+      if (!it.imageUrl) continue;
+      try {
+        const img = await toImage(it.imageUrl, `${it.title || "item"}.png`);
+        itemsFlat.push({ projectId: projs[i].id, sortOrder: it.sortOrder, title: it.title, ...img });
+      } catch { /* skip this item's image */ }
+    }
+  }
   const items = itemsFlat.length ? await createProjectItems(ctx, itemsFlat) : [];
 
-  const projCovers = projects
-    .map((p, i) => (p.cover ? { id: projs[i].id, revision: projs[i].revision, ...p.cover } : null))
-    .filter(Boolean);
+  // STEP 4 — covers (import each; a failed import skips that cover)
+  const projCovers = [];
+  for (let i = 0; i < projects.length; i++) {
+    if (!projects[i].coverImageUrl) continue;
+    try {
+      const img = await toImage(projects[i].coverImageUrl, `${projects[i].title || "project"}-cover.png`);
+      projCovers.push({ id: projs[i].id, revision: projs[i].revision, ...img });
+    } catch { /* skip */ }
+  }
   if (projCovers.length) await attachProjectCovers(ctx, projCovers);
 
-  const colCovers = collections
-    .map((c, i) => (c.cover ? { id: cols[i].id, revision: cols[i].revision, ...c.cover } : null))
-    .filter(Boolean);
+  const colCovers = [];
+  for (let i = 0; i < collections.length; i++) {
+    if (!collections[i].coverImageUrl) continue;
+    try {
+      const img = await toImage(collections[i].coverImageUrl, `${collections[i].title || "collection"}-cover.png`);
+      colCovers.push({ id: cols[i].id, revision: cols[i].revision, ...img });
+    } catch { /* skip */ }
+  }
   if (colCovers.length) await attachCollectionCovers(ctx, colCovers);
 
   return {
@@ -201,6 +238,6 @@ async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
 module.exports = {
   setupPortfolio,
   listProjects, deleteProjects, listCollections, deleteCollections,
-  createCollections, createProjects,
+  createCollections, createProjects, importImage,
   attachProjectCovers, attachCollectionCovers, createProjectItems,
 };

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -64,8 +64,9 @@ const menu = await seed.createMenu(ctx, {           // builds items → sections
   ],
 });                                                 // → { menuId, sectionIds, itemIds }
 
-// optional — generate an image, then attach (full-replace — echo revision + price)
-// await seed.attachItemImages(ctx, [{ id, revision, price, image: { id, url, height, width } }]);
+// optional — import the url to Wix Media (restaurants binds by file id), then attach (full-replace — echo revision + price)
+// const file = await seed.importImage(ctx, imageUrl);   // → { id, url } (Wix Media file id + wixstatic url)
+// await seed.attachItemImages(ctx, [{ id, revision, price, image: { id: file.id, url: file.url, height: 1024, width: 1024 } }]);
 
 // ── ONLINE ORDERING (add-on, on demand; MENU-FIRST) ──────────────────────────────────────────────
 await seed.installOrdersApp(ctx);                   // auto-provisions a working ordering setup
@@ -94,7 +95,8 @@ await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Expe
 |---|---|
 | `installMenusApp(ctx)` | install the Wix Restaurants Menus app |
 | `createMenu(ctx, {name,description?,sections})` | items → sections → menu bottom-up → `{menuId,sectionIds,itemIds}` |
-| `attachItemImages(ctx, [{id,revision,price,image}])` | image pass — full-replace PATCH (echo revision + priceInfo) |
+| `importImage(ctx, url)` | import an external url into Wix Media → `{id,url}` (file id + wixstatic url); menu items bind by this file id |
+| `attachItemImages(ctx, [{id,revision,price,image}])` | image pass — full-replace PATCH (echo revision + priceInfo); `image.id` = a Wix Media file id from `importImage` |
 
 **Shared** (ordering + reservations STEP 0)
 | fn | does |

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -184,10 +184,21 @@ async function createMenu(ctx, menu) {
   return { menuId: menuRes.menu?.id, sectionIds, itemIds: createdItems.map((it) => it?.id) };
 }
 
+// Import an external image URL into Wix Media → { id, url }. Restaurants binds a menu-item image by
+// the Wix Media file **id**, NOT a url — an external url (e.g. a base44 generate_image result) MUST
+// be imported first; the raw url as the id stores (200) but renders nothing. id = wixstatic file id,
+// url = the permanent wixstatic url.
+async function importImage(ctx, url, displayName = "image.png") {
+  const r = await req(ctx, "/site-media/v1/files/import", { body: { url, mimeType: "image/png", displayName } });
+  const f = r.file || r;
+  if (!f?.id) throw new Error(`import-file returned no file id: ${JSON.stringify(r).slice(0, 200)}`);
+  return { id: f.id, url: f.url };
+}
+
 // Optional (pass-2). The ITEM is the image-bearing entity. Update Item is a FULL-ENTITY REPLACE
 // with NO field mask — you MUST echo each item's current `revision` AND `priceInfo`, or it fails
 // `428 MISSING_ITEM_PRICING` and the image does NOT apply. `image` is an OBJECT { id, url, height, width }
-// (never a bare string); the binding field is the Wix Media file `id`. Never block on image failure.
+// (never a bare string); the binding field is the Wix Media file `id` (from importImage). Never block on image failure.
 // items: [{ id, revision, price, image: { id, url, height, width } }]
 async function attachItemImages(ctx, items) {
   return req(ctx, "/restaurants/menus/v1/bulk/items/update", {
@@ -368,7 +379,7 @@ async function createExperiences(ctx, reservationLocationId, experiences) {
  *
  * @param plan {
  *   menu: { name, description?, sections: [{ name, description?,
- *           items: [{ name, description?, price, imageUrl?|image? }] }] },
+ *           items: [{ name, description?, price, imageUrl? }] }] },   // imageUrl = a plain url; imported to Wix Media here
  *   ordering?:     boolean | { address? },
  *   reservations?: boolean | { address?, configuration? },
  * }
@@ -383,15 +394,17 @@ async function setupRestaurants(ctx, plan) {
   const flatItems = plan.menu.sections.flatMap((s) => s.items || []);
   const itemNameToId = new Map(flatItems.map((it, i) => [it.name, itemIds[i]]));
 
-  // image pass — map each plan item that carries an image to its created id (revision "1", fresh).
-  const imageItems = flatItems
-    .filter((it) => it.image || it.imageUrl)
-    .map((it) => ({
-      id: itemNameToId.get(it.name),
-      revision: "1",
-      price: it.price,
-      image: it.image || { url: it.imageUrl },
-    }));
+  // image pass — import each item's url to Wix Media (restaurants binds by file id), then full-replace
+  // update its created id (revision "1", fresh + priceInfo). A failed import just skips that image.
+  const imageItems = [];
+  for (const it of flatItems) {
+    if (!it.imageUrl) continue;
+    try {
+      const file = await importImage(ctx, it.imageUrl, `${it.name || "item"}.png`);
+      imageItems.push({ id: itemNameToId.get(it.name), revision: "1", price: it.price,
+        image: { id: file.id, url: file.url, height: 1024, width: 1024 } });
+    } catch { /* skip this item's image */ }
+  }
   let imagesAttached = 0;
   if (imageItems.length) {
     try { await attachItemImages(ctx, imageItems); imagesAttached = imageItems.length; }
@@ -440,7 +453,7 @@ module.exports = {
   installMenusApp, installOrdersApp, installTableReservationsApp,
   // menu
   listMenuItems, deleteMenuItems, listMenuSections, deleteMenuSections, listMenus, deleteMenu,
-  createMenu, attachItemImages,
+  createMenu, importImage, attachItemImages,
   // shared business location (ordering + reservations STEP 0)
   setBusinessLocation,
   // ordering add-on


### PR DESCRIPTION
## Problem

For **id-binding** verticals — bookings, blog, portfolio, events, restaurants — Wix binds an image by the **Wix Media file id**, not a url. The seed modules were passing the raw `generate_image` url (`https://media.base44.com/...`) straight into the binding id field. Wix accepted the write (200) but rendered **nothing** — the exact "I don't see images for the services" symptom.

Missing step: import the url into Wix Media first (`POST /site-media/v1/files/import`) → use the returned `file.id`.

## Fix

- Add `importImage(ctx, url)` to each id-binding module → `{ id, url }` (wixstatic file id + permanent url).
- Rewire each `setup<V>` one-call path to accept a **plain `imageUrl`/`coverImageUrl`** and import it internally before attaching the file id. Import failures never block the seed (item just stays image-less).
- SEED.md: inline fields become plain urls with the import noted; escape-hatch snippets show the `importImage` step; functions tables list it.
- **Stores + CMS unchanged** — they bind by url (Stores re-hosts server-side, CMS IMAGE fields store the url string).

## Verification

Ran the **actual bookings module** against a live site:

```
importImage      -> { id: "e6a89e_…~mv2.png", url: "https://static.wixstatic.com/media/…~mv2.png" }
attachServiceImage -> 200
getService       -> mainMedia.image.id === the imported file id  → PASS ✅ (renders from Wix Media)
```

`node --check` passes on all five modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)