### PR TITLE
fix(wix-vibe-headless): poll for staff after Bookings install; dedupe categories

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -48,7 +48,7 @@ custom staff/ordering). `setupBookings` is built from them, in this order:
 
 ```js
 await seed.installBookingsApp(ctx);
-const staff = await seed.queryStaff(ctx);                            // → [{resourceId,id,name}]; use resourceId, NOT id
+const staff = await seed.queryStaffWithRetry(ctx);                   // → [{resourceId,id,name}]; polls (fresh install provisions the owner async); use resourceId, NOT id
 const cats = await seed.createCategories(ctx, ["Our Services"]);    // → [{id,name}]; every service needs a categoryId
 const services = await seed.createServices(ctx, [                   // → [{id,slug,revision,type,scheduleId}]
   { type: "APPOINTMENT", name: "Consultation", price: 75, duration: 60, categoryId: cats[0].id, staffMemberIds: [staff[0].resourceId] },
@@ -69,10 +69,11 @@ await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: servic
 |---|---|
 | `setupBookings(ctx, {services, staffResourceId?})` | **one-call**: install → staff → categories → services → CLASS sessions → images |
 | `installBookingsApp(ctx)` | install the Wix Bookings app on the site |
-| `queryStaff(ctx)` | `[{resourceId,id,name}]` — STEP 1; use `resourceId`, not `id` |
+| `queryStaff(ctx)` | `[{resourceId,id,name}]` — one shot; use `resourceId`, not `id` |
+| `queryStaffWithRetry(ctx)` | STEP 1 — same, but polls until the default owner provisions after a fresh install (avoids `MISSING_APPOINTMENT_RESOURCES`) |
 | `createStaff(ctx, [{name,description}])` | create named staff → `[{resourceId,id,name}]` (omit email/phone) |
 | `queryCategories(ctx)` | `[{id,name}]` — reuse a category created earlier this run |
-| `createCategories(ctx, names)` | STEP 2 — every service needs a `category.id` or it's invisible → `[{id,name}]` |
+| `createCategories(ctx, names)` | STEP 2 — every service needs a `category.id` or it's invisible → `[{id,name}]`; reuses an existing same-named category (idempotent, no dupes on re-run) |
 | `createServices(ctx, services)` | STEP 3 — one bulk create (APPOINTMENT/CLASS mixed) → `[{id,slug,revision,type,scheduleId,success,error}]` |
 | `scheduleClassSessions(ctx, sessions)` | STEP 4 (CLASS only) — one bulk Calendar-Events-V3 create → `[{id,success,error}]` |
 | `getService(ctx, serviceId)` | fetch a service (current `revision`; confirm an image landed) |

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -19,7 +19,7 @@
 //   // await seed.deleteServices(ctx, existing.filter(isObviousSample).map(s => s.id));
 //
 //   // ORDER MATTERS: resolve a staff resource (STEP 1) and a category (STEP 2) BEFORE services (STEP 3).
-//   const staff = await seed.queryStaff(ctx);                    // fresh install has a default "Business Owner"
+//   const staff = await seed.queryStaffWithRetry(ctx);           // polls: fresh install provisions the owner async
 //   const resourceId = staff[0].resourceId;                      // NB: resourceId, NOT staff id
 //   const cats = await seed.createCategories(ctx, ["Our Services"]);
 //   const services = await seed.createServices(ctx, [
@@ -127,6 +127,22 @@ async function queryStaff(ctx) {
   return (r.staffMembers ?? []).map((m) => ({ resourceId: m.resourceId, id: m.id, name: m.name }));
 }
 
+// installBookingsApp → provisioning is async (Wix signals completion via the App-Instance-Installed
+// webhook, which an exec script can't receive). The default "Business Owner" resource isn't queryable
+// in the same tick, so queryStaff returns [] (or throws "Business schedule not found") until it lands.
+// Poll so the one-call path resolves the owner instead of failing APPOINTMENT services with
+// MISSING_APPOINTMENT_RESOURCES. Already-provisioned sites return on the first try (no added latency).
+async function queryStaffWithRetry(ctx, { tries = 10, delayMs = 2000 } = {}) {
+  let lastErr;
+  for (let i = 0; i < tries; i++) {
+    try { const s = await queryStaff(ctx); if (s.length) return s; }
+    catch (e) { lastErr = e; }
+    if (i < tries - 1) await new Promise((r) => setTimeout(r, delayMs));
+  }
+  if (lastErr) throw lastErr; // never provisioned → surface the real error rather than a silent []
+  return [];
+}
+
 // STEP 1 (optional): create named staff when the request names stylists/providers. staff: [{ name, description }].
 // ⚠️ Omit email/phone unless you have a real value — V1 rejects empty strings. Returns [{ resourceId, id, name }].
 async function createStaff(ctx, staff) {
@@ -148,10 +164,19 @@ async function queryCategories(ctx) {
 // STEP 2: create categories — every service needs a category.id or it's invisible on the live site.
 // Independent (no shared revision, unlike Stores categories); looped here one call per category.
 async function createCategories(ctx, names) {
+  // Reuse an existing same-named category instead of creating a duplicate. Bookings categories aren't
+  // unique-by-name, so a re-run (or a partial-failure retry — categories are created before services)
+  // would otherwise pile up dupes. Keeps the seed additive-but-idempotent.
+  const byName = new Map((await queryCategories(ctx)).map((c) => [c.name, c]));
   const out = [];
   for (const name of names) {
-    const r = await req(ctx, "/bookings/v2/categories", { body: { category: { name } } });
-    out.push({ id: r.category?.id, name });
+    let cat = byName.get(name);
+    if (!cat) {
+      const r = await req(ctx, "/bookings/v2/categories", { body: { category: { name } } });
+      cat = { id: r.category?.id, name };
+      byName.set(name, cat);
+    }
+    out.push(cat);
   }
   return out;
 }
@@ -270,8 +295,8 @@ async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
 
   let resourceId = staffResourceId;
   if (!resourceId) {
-    const staff = await queryStaff(ctx);
-    resourceId = staff[0]?.resourceId; // fresh install ships a default owner
+    const staff = await queryStaffWithRetry(ctx); // fresh install provisions the default owner async — poll
+    resourceId = staff[0]?.resourceId;
   }
 
   const catNames = [...new Set(services.map((s) => s.category).filter(Boolean))];
@@ -316,6 +341,6 @@ async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
 module.exports = {
   setupBookings,
   installBookingsApp, listServices, deleteServices,
-  queryStaff, createStaff, queryCategories, createCategories,
+  queryStaff, queryStaffWithRetry, createStaff, queryCategories, createCategories,
   createServices, scheduleClassSessions, getService, importImage, attachServiceImage,
 };


### PR DESCRIPTION
## Problem (observed in a live build)

A Krav Maga bookings build failed its first seed with:
```
400 MISSING_APPOINTMENT_RESOURCES
"service of type appointment requires at least one staff member or service resource"
```
`setupBookings` installs the Bookings app and then, to resolve the default owner `resourceId` for APPOINTMENT services, calls `queryStaff` **in the same tick**. App install → provisioning is **asynchronous** (Wix signals completion via the *App-Instance-Installed* webhook, which an `exec_tool` script can't receive), so `queryStaff` returned `[]`, appointments got no staff, and the seed 400'd. The agent had to detour: manual `installBookingsApp` → `queryStaff` → re-seed with an explicit `staffResourceId` (~94s / ~22% of the build).

### Grounding
- **`wix-headless` recipe** (`setup-bookings.md`) never hits this — it's scoped to a site where Bookings is *already installed/provisioned* and only queries staff ("a fresh install always has a default Business Owner resource"). Our module **added** the inline install, so it must tolerate async provisioning.
- **Live docs** confirm install is a first-class async, webhook-signalled event (`app-instance-installed`), and that APPOINTMENT needs `staffMemberIds` = staff `resourceId`.

## Fixes

1. **`queryStaffWithRetry`** — poll `queryStaff` after install until the default owner provisions (up to ~20s), tolerating both `[]` and a thrown "Business schedule not found". `setupBookings`' fallback uses it. Already-provisioned sites return on the first try (no added latency). Escape-hatch docs updated to prefer it.
2. **`createCategories` dedupe** — reuse an existing same-named category instead of creating a duplicate. Categories are created before services, so any partial-failure retry (or re-run) previously piled up dupes.

## Verification (live, provisioned site)
- `queryStaffWithRetry` → 1 staff in ~1.1s (single query, no wasted retries).
- `createCategories` twice with the same name → same id, **+1** net row (not +2).
- `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)