### PR TITLE
fix(wix-vibe-headless): read service image from mainMedia, not media.items

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
@@ -13,7 +13,7 @@ function servicePrice(service) {
 }
 
 export default function ServiceCard({ service }) {
-  const image = mediaUrl(service.media?.items?.[0]?.image);
+  const image = mediaUrl(service.media?.mainMedia?.image ?? service.media?.items?.[0]?.image ?? service.media?.coverMedia?.image);
   const price = servicePrice(service);
 
   return (

--- a/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
@@ -13,7 +13,7 @@ export default function ServiceDetail() {
   if (d.notFound) return <Centered>Service not found.</Centered>;
   if (!d.service) return <Centered>Loading…</Centered>;
 
-  const image = mediaUrl(d.service.media?.items?.[0]?.image);
+  const image = mediaUrl(d.service.media?.mainMedia?.image ?? d.service.media?.items?.[0]?.image ?? d.service.media?.coverMedia?.image);
   const locations = (d.service.locations || []).map((l) => l.name || l.formattedAddress).filter(Boolean);
 
   return (

--- a/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-services.js
@@ -9,8 +9,10 @@ import { wixApiRequest } from "./wix-client.js";
  *
  *   id {string}, type "APPOINTMENT"|"CLASS"|"COURSE", name {string}, tagLine {string},
  *   description {string}, hidden {boolean},
- *   media.items {array} — [{ image: { id, url, width, height, altText } }]
- *     (url may be a bare Wix media handle — pass through mediaUrl() before rendering),
+ *   media.mainMedia.image { id, url, width, height, altText } — the PRIMARY service image (what the
+ *     seed sets and the card shows); media.items {array} is the gallery, media.coverMedia the cover.
+ *     Read mainMedia first, fall back to items[0]/coverMedia. url may be a bare Wix media handle —
+ *     pass through mediaUrl() before rendering,
  *   payment.rateType "FIXED"|"CUSTOM"|"VARIED"|"NO_FEE"|"SUBSCRIPTION",
  *   payment.fixed.price { value, currency, formattedValue } — value + currency are always
  *     present; formattedValue is optional (may be missing), so format the price from


### PR DESCRIPTION
## Problem

Bookings builds seed service images successfully (`imagesAttached: 5`) but the storefront shows none. Root cause is an inconsistency **inside our own skill**:

| | field |
|---|---|
| Seed (`attachServiceImage`) writes | `media.mainMedia.image` + `media.coverMedia.image` ✅ |
| Frontend (`ServiceCard.jsx`, `ServiceDetail.jsx`) reads | `media.items[0].image` — `items` is `[]` → nothing renders |

The seed is canonical (Wix's primary-image slot is `mainMedia`; their own UI primitive is `ServiceMainMedia`/`ServicePrimitive.MainMedia`, and `items[]` is the gallery). The **read** was wrong.

## Fix

Read `mainMedia` first, fall back to gallery then cover:
```js
mediaUrl(service.media?.mainMedia?.image ?? service.media?.items?.[0]?.image ?? service.media?.coverMedia?.image)
```
Applied in `ServiceCard.jsx`, `ServiceDetail.jsx`, and corrected the `mediaUrl` JSDoc model in `wix-bookings-services.js` (it wrongly said the image lives in `media.items`). Seed is unchanged.

## Verification

Against a live seeded service:
- `media.items` = `[]`, `media.mainMedia.image` populated.
- `mediaUrl(mainMedia.image)` → `https://static.wixstatic.com/media/…~mv2.png` → **HTTP 200, image/png**.

Diagnosed by downloading the affected app's source (Krav Maga dojo, commit `a37451…`) and tracing the services-page image chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)