### PR TITLE
fix(wix-vibe-headless): graceful no-image card placeholder across verticals

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
@@ -23,7 +23,7 @@ export default function ServiceCard({ service }) {
       <div className="relative aspect-[4/3] bg-background">
         {image
           ? <img src={image} alt={service.name} loading="lazy" className="w-full h-full object-cover" />
-          : <div className="w-full h-full" />}
+          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
       </div>
       <div className="p-3 flex flex-col gap-1">
         <h3 className="m-0 font-display text-[15px] font-semibold">{service.name}</h3>

--- a/skills/wix-vibe-headless/references/cms/app/components/ItemCard.jsx
+++ b/skills/wix-vibe-headless/references/cms/app/components/ItemCard.jsx
@@ -19,7 +19,7 @@ export default function ItemCard({ item }) {
       <div className="aspect-[16/10] bg-background">
         {image
           ? <img src={image} alt={title || ""} loading="lazy" className="w-full h-full object-cover" />
-          : <div className="w-full h-full" />}
+          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
       </div>
       <div className="p-3 flex flex-col gap-1.5">
         {date && <span className="text-muted-foreground text-[12px]">{date}</span>}

--- a/skills/wix-vibe-headless/references/events/app/components/EventCard.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/EventCard.jsx
@@ -20,7 +20,7 @@ export default function EventCard({ event }) {
       <div className="relative aspect-[3/2] bg-background">
         {image
           ? <img src={image} alt={event.title} loading="lazy" className="w-full h-full object-cover" />
-          : <div className="w-full h-full" />}
+          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
         {isTicketing && soldOut && (
           <span className="absolute top-2 left-2 py-0.5 px-2 text-xs bg-destructive text-white rounded-sm">Sold out</span>
         )}

--- a/skills/wix-vibe-headless/references/portfolio/app/components/CollectionCard.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/CollectionCard.jsx
@@ -18,7 +18,7 @@ export default function CollectionCard({ collection }) {
         {image
           ? <img src={image} alt={collection.title} loading="lazy"
               className="w-full h-full object-cover" />
-          : <div className="w-full h-full" />}
+          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
       </div>
       <div className="p-3 flex flex-col gap-1">
         <h3 className="m-0 font-display text-base font-semibold">{collection.title}</h3>

--- a/skills/wix-vibe-headless/references/portfolio/app/components/ProjectCard.jsx
+++ b/skills/wix-vibe-headless/references/portfolio/app/components/ProjectCard.jsx
@@ -26,7 +26,7 @@ export default function ProjectCard({ project }) {
         {image
           ? <img src={image} alt={project.title} loading="lazy"
               className="w-full h-full object-cover" />
-          : <div className="w-full h-full" />}
+          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
       </div>
       <div className="p-3 flex flex-col gap-1">
         <h3 className="m-0 font-display text-[15px] font-semibold">{project.title}</h3>

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
@@ -20,7 +20,7 @@ export default function ProductCard({ product }) {
       <div className="relative aspect-square bg-background">
         {image
           ? <img src={image} alt={product.name} loading="lazy" className="w-full h-full object-cover" />
-          : <div className="w-full h-full" />}
+          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
         {soldOut && (
           <span className="absolute top-2 left-2 px-2 py-0.5 text-xs bg-destructive text-white rounded-sm">Sold out</span>
         )}


### PR DESCRIPTION
## Problem
When a seeded item has no image, the image-structural cards rendered an **empty `<div>`** in a fixed aspect box → a **blank panel** in the grid (the kung-fu "Trial Session", climbing "Private Coaching" cards). Builds routinely image only some items — the generated-image budget gets spread across hero/sections + a few flagship items — so imageless cards are common.

## Fix
Replace the empty fallback with a **branded placeholder** — `bg-muted` + a faint centered image glyph (`text-muted-foreground/40`) — in the 6 cards with a structural image slot:
- bookings `ServiceCard`, storefront `ProductCard`, cms `ItemCard`, events `EventCard`, portfolio `ProjectCard` + `CollectionCard`.

An imageless item now reads as intentional and keeps uniform card height in the grid.

**Left as-is:** blog `PostCard` and restaurants `MenuItemCard` already degrade by omitting the image block (text-first) — a gray box there would be worse. pricing-plans / members have no image cards.

## Verify
- 6 cards parse clean (esbuild); no `: <div className="w-full h-full" />` blank fallbacks remain; placeholder present in each.

Styling only — no logic/props/media-read changes. (Seeding-coverage nudge deferred per discussion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)