### PR TITLE
fix(wix-vibe-headless): group SlotPicker slots by day (times-only chips)

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
@@ -1,35 +1,57 @@
 // Bookable-slot picker — pure UI. Slots, paging cursor, and the pick handler come from
-// useServiceDetail (all the slot data wiring lives in that hook). Each slot's key must combine the
+// useServiceDetail (all the slot data wiring lives in that hook). Slots are grouped by day — the
+// date shown once as a heading, then time-only chips — so a long availability list reads like a
+// calendar instead of a flat wall of repeated "Mon, Aug 10, 1:30 PM". Each chip's key combines the
 // start time with its schedule/event id so appointment and class slots stay distinct. Styled with
-// base44 design tokens (shadcn Tailwind classes) — e.g. group `slots` by day for a fuller calendar.
-const chipCls =
-  "px-3 py-2 cursor-pointer text-sm font-body border rounded-sm";
+// base44 design tokens (shadcn Tailwind classes).
+const chipCls = "px-3 py-2 cursor-pointer text-sm font-body border rounded-sm";
 const chipIdle = "border-border bg-card text-foreground";
 const chipActiveCls = "border-primary bg-primary text-primary-foreground";
+
+// Group slots by their local day, preserving order. localStartDate is "YYYY-MM-DDThh:mm:ss" (no zone),
+// so the first 10 chars are the day key.
+function groupByDay(slots) {
+  const days = new Map();
+  for (const slot of slots) {
+    const key = slot.localStartDate.slice(0, 10);
+    if (!days.has(key)) days.set(key, []);
+    days.get(key).push(slot);
+  }
+  return [...days.values()];
+}
 
 export default function SlotPicker({ slots, cursor, onLoadMore, selectedSlot, onPick }) {
   if (!slots?.length) {
     return <p className="text-muted-foreground">No available times in this range — try later.</p>;
   }
   return (
-    <div>
-      <div className="flex flex-wrap gap-2">
-        {slots.map((slot) => {
-          const active = selectedSlot?.localStartDate === slot.localStartDate;
-          return (
-            <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
-              aria-pressed={active} onClick={() => onPick(slot)}
-              className={`${chipCls} ${active ? chipActiveCls : chipIdle}`}>
-              {new Date(slot.localStartDate).toLocaleString(undefined, {
-                weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
-              })}
-            </button>
-          );
-        })}
-      </div>
+    <div className="flex flex-col gap-6">
+      {groupByDay(slots).map((daySlots) => (
+        <div key={daySlots[0].localStartDate.slice(0, 10)}>
+          <h3 className="text-sm font-semibold text-muted-foreground mb-2">
+            {new Date(daySlots[0].localStartDate).toLocaleDateString(undefined, {
+              weekday: "short", month: "short", day: "numeric",
+            })}
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {daySlots.map((slot) => {
+              const active = selectedSlot?.localStartDate === slot.localStartDate;
+              return (
+                <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
+                  aria-pressed={active} onClick={() => onPick(slot)}
+                  className={`${chipCls} ${active ? chipActiveCls : chipIdle}`}>
+                  {new Date(slot.localStartDate).toLocaleTimeString(undefined, {
+                    hour: "numeric", minute: "2-digit",
+                  })}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
       {cursor && (
         <button onClick={onLoadMore}
-          className="mt-4 px-4 py-2 cursor-pointer bg-card text-foreground border border-border rounded-sm">
+          className="px-4 py-2 cursor-pointer bg-card text-foreground border border-border rounded-sm">
           Load more times
         </button>
       )}


### PR DESCRIPTION
## Problem
The bookings `SlotPicker` rendered every 30-min slot as a flat wrapped list with the **full date on every chip** (`Mon, Aug 10, 1:30 PM` ×N). For a service with wide availability it becomes a long, repetitive wall — date repeats on each chip, chips are long (2 per row), and the whole thing sprawls into a big scroll that reads like a data dump, not a time picker.

## Fix
Group slots by their local **day**: the date shows once as a heading, then **time-only** chips (`1:30 PM`) beneath it.

**Before**
```
[ Mon, Aug 10, 1:30 PM ] [ Mon, Aug 10, 2:00 PM ]
[ Mon, Aug 10, 2:30 PM ] [ Mon, Aug 10, 3:00 PM ]
…40 more rows…
```
**After**
```
Mon, Aug 10
[1:30] [2:00] [2:30] [3:00] [3:30] [4:00] [4:30] [5:00] [5:30] [6:00]

Tue, Aug 11
[12:00] [12:30] [1:00] [1:30] [2:00] [6:00]
```
Short chips pack 5–6 per row and the list collapses to a fraction of the height, scanning like a calendar.

Pure UI: same `slots`, same selected/idle chip styles, same `onPick` and "Load more times" — only the layout changed. `localStartDate` is `"YYYY-MM-DDThh:mm:ss"`, so the first 10 chars are the day key. Parses clean (esbuild); grouping logic unit-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)