### PR TITLE
docs(wix-vibe-headless): ground the "don't chase images" note in the resolution mechanism

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -141,10 +141,13 @@ Once the site is built and seeded:
    metasite id) to complete setup in Wix (required), and mention that dev builds show a dismissible
    top banner linking to this same dashboard.
 
-**Preview briefly, don't chase images.** A quick preview to confirm the app renders is enough.
-Generated images — the hero in your own code and the seeded product images alike — can still be
-resolving right after the build; that's normal. Don't debug, re-seed, re-attach, or swap a generated
-image's url in your code; leave them and finish.
+**Preview briefly, don't chase images.** A quick render check is enough. Generated images show as
+alt-text/broken in this preview because `generate_image` returns a `/__generating__/…` placeholder —
+the platform swaps every placeholder for the final url **automatically at the end of the turn**
+(failed ones get a stock fallback), in your own components and the seeded data alike. So a broken
+image in the preview is expected and already handled: **do NOT swap, re-seed, re-attach, or debug
+image urls.** Hand-editing a placeholder `src` is wasted work and just risks find_replace errors on
+urls that are about to be replaced anyway. Leave them and finish.
 
 ## Later admin requests
 


### PR DESCRIPTION
## Problem
Builds keep wasting time hand-swapping `/__generating__/` placeholder URLs → final `media.base44` URLs in their **own** components after previewing. One pottery-studio build did **9 `find_replace`s across two turns** to do it, and they were fiddly ("they're inside the array and have different surrounding context since the earlier replacements shifted things").

The STEP-5 note already said *"don't … swap a generated image's url … leave them and finish"* — but with no reason. So the agent, seeing broken alt-text in its **mid-turn** preview, rationalized fixing it.

## Verified in base44 source
`backend/app/user_apps/builder/image_generation/resolution.py :: resolve_pending_images` — called from the builder loop at `builder/chat/add_message.py:2600` / `:3091` — awaits the pending generations at the **end of the turn** and **replaces every `/__generating__/` placeholder with the final storage URL across all app source files and entity records**, with a **stock fallback** for failures. So the manual swap is provably wasted, and the mid-turn broken preview is just because resolution runs *after* the turn.

## Change
Reword the note to state that mechanism plainly (placeholder → final URL swapped automatically at end of turn; failures get a fallback; applies to the agent's own components *and* seeded data), so a broken image in the preview reads as **expected-and-handled** and the agent has no reason to intervene. Positive framing, per the "remove the reason, don't just say don't" approach.

Single DRY edit in `base44.md` (platform-level behavior) — no per-vertical mirror. Stays within the fetched-file budget (9077 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)