### PR TITLE
fix(wix-vibe-headless): align verticals — self-install their app + drop all cleanup cruft

### DIFF
--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -83,8 +83,8 @@ await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fi
 
 `content` blocks: `{type:"heading",text,level?}` · `{type:"paragraph",text}` · `{type:"quote",text}` ·
 `{type:"bulleted"|"ordered",items:[…]}`. For node types the recipe doesn't cover (code, images),
-pass a pre-built Ricos `richContent` on the post instead. No Blog-app install helper — the recipe
-assumes Blog is already installed on the site.
+pass a pre-built Ricos `richContent` on the post instead. `setupBlog` **installs the Wix Blog app
+first** (`installBlogApp`, idempotent), so seeding works even if the site doesn't have it yet.
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
+++ b/skills/wix-vibe-headless/references/blog/seed/seed-blog.js
@@ -27,6 +27,7 @@
 // wix-headless/references/inline-recipes/setup-blog.md.
 
 const API = "https://www.wixapis.com";
+const BLOG_APP_ID = "14bcded7-0066-7c35-14d7-466cb3f09103"; // installBlogApp installs this before seeding
 
 async function req(ctx, path, { method = "POST", body } = {}) {
   const res = await fetch(API + path, {
@@ -202,7 +203,17 @@ async function attachPostCovers(ctx, covers) {
  *   url — imported to Wix Media here — and a cover is attached only for posts that provide one.
  * @returns { posts:[{id,index,success}], categories:[{id,name}], tags:[{id,name}], coversAttached }
  */
+// Install the Wix Blog app before seeding — base44 sites aren't guaranteed to have it (no separate
+// Setup step here, unlike the wix-headless recipe). Idempotent: re-installing returns 200.
+async function installBlogApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: BLOG_APP_ID, enabled: true },
+  } });
+}
+
 async function setupBlog(ctx, { posts = [], categories = [], tags = [] } = {}) {
+  await installBlogApp(ctx);
   const memberId = await getAuthorMemberId(ctx);
   const catNames = [...new Set([...categories, ...posts.flatMap((p) => [].concat(p.category ?? [], p.categories ?? []))])];
   const tagNames = [...new Set([...tags, ...posts.flatMap((p) => [].concat(p.tags ?? []))])];
@@ -233,6 +244,6 @@ async function setupBlog(ctx, { posts = [], categories = [], tags = [] } = {}) {
 }
 
 module.exports = {
-  setupBlog,
+  setupBlog, installBlogApp,
   getAuthorMemberId, createPosts, createCategories, createTags, importImage, attachPostCovers,
 };

--- a/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
+++ b/skills/wix-vibe-headless/references/bookings/seed/seed-bookings.js
@@ -13,11 +13,6 @@
 //
 //   await seed.installBookingsApp(ctx);                          // if the site doesn't have Wix Bookings yet
 //
-//   // Clean is a JUDGMENT call — never auto-delete. Only remove obvious install samples on a
-//   // fresh install; if what's there could be the owner's real services, ask first (additive).
-//   const existing = await seed.listServices(ctx);
-//   // await seed.deleteServices(ctx, existing.filter(isObviousSample).map(s => s.id));
-//
 //   // ORDER MATTERS: resolve a staff resource (STEP 1) and a category (STEP 2) BEFORE services (STEP 3).
 //   const staff = await seed.queryStaffWithRetry(ctx);           // polls: fresh install provisions the owner async
 //   const resourceId = staff[0].resourceId;                      // NB: resourceId, NOT staff id
@@ -105,17 +100,10 @@ async function installBookingsApp(ctx) {
   } });
 }
 
-// Clean is JUDGMENT — never auto-delete. Agent lists, decides which are obvious install samples,
-// deletes only those. The default "Business Owner" is a RESOURCE, not a service — it won't appear here.
+// The default "Business Owner" is a RESOURCE, not a service — it won't appear here.
 async function listServices(ctx) {
   const r = await req(ctx, "/bookings/v2/services/query", { body: { query: { paging: { limit: 100 } } } });
   return (r.services ?? []).map((s) => ({ id: s.id, name: s.name }));
-}
-async function deleteServices(ctx, ids) {
-  if (!ids || !ids.length) return;
-  for (const id of ids) {
-    await req(ctx, `/bookings/v2/services/${id}`, { method: "DELETE" });
-  }
 }
 
 // STEP 1: resolve staff resources. Returns [{ resourceId, id, name }].
@@ -287,7 +275,6 @@ async function attachServiceImage(ctx, it) {
  *                imageUrl? }],                             // a plain image url; imported to Wix Media here, optional
  *   staffResourceId?: string,   // defaults to the fresh install's owner (queryStaff()[0].resourceId)
  * }}
- * Cleanup is intentionally NOT here — deleting existing services is a judgment call.
  * @returns { services:[...createServices], categories:[{id,name}], resourceId, sessionsScheduled, imagesAttached }
  */
 async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
@@ -340,7 +327,7 @@ async function setupBookings(ctx, { services = [], staffResourceId } = {}) {
 
 module.exports = {
   setupBookings,
-  installBookingsApp, listServices, deleteServices,
+  installBookingsApp, listServices,
   queryStaff, queryStaffWithRetry, createStaff, queryCategories, createCategories,
   createServices, scheduleClassSessions, getService, importImage, attachServiceImage,
 };

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -9,7 +9,7 @@ seed operation. `require` it and call the functions with plain data.
 
 Two one-way constraints fix the order: `registration.initialType` (`TICKETING`/`RSVP`) is **immutable**
 after create, and **publishing is one-way**. So per event: create DRAFT → (ticketed) add tiers → publish.
-Wix Events is **pre-installed** by setup — never reinstall (a 403 means fail loudly). There is no
+`setupEvents` **installs the Wix Events app first** (idempotent — a re-install returns 200), so seeding works even if the site doesn't have it yet. There is no
 clean-up step (a fresh install ships no sample events).
 
 ```js

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -9,8 +9,7 @@ seed operation. `require` it and call the functions with plain data.
 
 Two one-way constraints fix the order: `registration.initialType` (`TICKETING`/`RSVP`) is **immutable**
 after create, and **publishing is one-way**. So per event: create DRAFT → (ticketed) add tiers → publish.
-`setupEvents` **installs the Wix Events app first** (idempotent — a re-install returns 200), so seeding works even if the site doesn't have it yet. There is no
-clean-up step (a fresh install ships no sample events).
+`setupEvents` **installs the Wix Events app first** (idempotent — a re-install returns 200), so seeding works even if the site doesn't have it yet.
 
 ```js
 // build-time exec_tool

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -12,7 +12,6 @@
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
 //   // setupEvents installs the Wix Events app first (installEventsApp) — base44 sites may not have it.
-//   // No clean-up: a fresh Events install ships no sample events, so nothing to delete first.
 //
 //   // STEP 1: create each event as a DRAFT (TICKETING = paid tiers | RSVP = free built-in form)
 //   const ev = await seed.createEvent(ctx, {
@@ -189,7 +188,6 @@ async function setEventMainImage(ctx, item) {
  *   category?: string,                                     // category NAME; resolved to id + assigned
  *   imageUrl?: string                                      // a plain image url; imported to Wix Media here, optional
  * }] }}
- * Cleanup is intentionally NOT here — deleting existing content is a judgment call.
  */
 // Install the Wix Events app so seeding self-provisions — base44 sites aren't guaranteed to have it
 // (there's no separate Setup step here, unlike the wix-headless recipe this was ported from). Idempotent:

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -11,7 +11,7 @@
 //   const seed = require("/app/.agents/skills/wix-vibe-headless/references/events/seed/seed-events.js");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
-//   // Wix Events is PRE-INSTALLED by setup — do NOT reinstall. A 403/app-not-installed means fail loudly.
+//   // setupEvents installs the Wix Events app first (installEventsApp) — base44 sites may not have it.
 //   // No clean-up: a fresh Events install ships no sample events, so nothing to delete first.
 //
 //   // STEP 1: create each event as a DRAFT (TICKETING = paid tiers | RSVP = free built-in form)
@@ -37,7 +37,7 @@
 // wix-headless/references/inline-recipes/setup-events.md.
 
 const API = "https://www.wixapis.com";
-// Wix Events app id — for reference only. The app is pre-installed by setup; never reinstall here.
+// Wix Events app id — installEventsApp installs it before seeding (base44 sites may not have it).
 const EVENTS_APP_ID = "140603ad-af8d-84a5-2c80-a0f60cb47351";
 
 async function req(ctx, path, { method = "POST", body } = {}) {
@@ -191,7 +191,18 @@ async function setEventMainImage(ctx, item) {
  * }] }}
  * Cleanup is intentionally NOT here — deleting existing content is a judgment call.
  */
+// Install the Wix Events app so seeding self-provisions — base44 sites aren't guaranteed to have it
+// (there's no separate Setup step here, unlike the wix-headless recipe this was ported from). Idempotent:
+// re-installing an already-installed app returns 200 (verified), so it's safe to call unconditionally.
+async function installEventsApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: EVENTS_APP_ID, enabled: true },
+  } });
+}
+
 async function setupEvents(ctx, { events = [] } = {}) {
+  await installEventsApp(ctx);
   const created = [];
   for (const ev of events) {
     const e = await createEvent(ctx, ev);
@@ -224,5 +235,5 @@ async function setupEvents(ctx, { events = [] } = {}) {
 module.exports = {
   setupEvents,
   createEvent, createTicketTiers, publishEvent,
-  createEventCategories, assignEventsToCategory, importImage, setEventMainImage,
+  installEventsApp, createEventCategories, assignEventsToCategory, importImage, setEventMainImage,
 };

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -75,7 +75,7 @@ await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, t
 | `createProjectItems(ctx, [{projectId,sortOrder,title,imageId,height,width}])` | one POST per gallery image (optional) |
 
 `hidden` defaults to `false` (shown) — omit it for visible entities; send `hidden: true` only to
-hide. On `428` / `APP_NOT_INSTALLED`, the Setup step was skipped — fail loudly, don't self-install.
+hide. `setupPortfolio` **installs the Wix Portfolio app first** (`installPortfolioApp`, idempotent), so seeding works even if the site doesn't have it yet.
 
 ## Fallback
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -9,13 +9,6 @@
 //   const seed = require("/app/.agents/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js");
 //   const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 //
-//   // Clean is JUDGMENT — never auto-delete. Only obvious install samples on a fresh install;
-//   // projects BEFORE collections. If it could be the owner's real content, ask first.
-//   const projs = await seed.listProjects(ctx);
-//   // await seed.deleteProjects(ctx, projs.filter(isObviousSample).map(p => p.id));
-//   const cols = await seed.listCollections(ctx);
-//   // await seed.deleteCollections(ctx, cols.filter(isObviousSample).map(c => c.id));
-//
 //   const collections = await seed.createCollections(ctx, [{ title, description }]);        // STEP 1
 //   const projects = await seed.createProjects(ctx, [                                        // STEP 2
 //     { title, description, collectionIds: [collections[0].id], details: [{ label, text }] },
@@ -50,25 +43,14 @@ async function req(ctx, path, { method = "POST", body } = {}) {
 
 // ---- exported operations ----
 
-// STEP 0 clean helpers. Clean is JUDGMENT — never auto-delete. Delete children before parents:
-// projects first, then collections (deleting a collection does not clean up its projects).
+// Read-only listing helpers.
 async function listProjects(ctx) {
   const r = await req(ctx, "/portfolio/v1/projects", { method: "GET" });
   return (r.projects ?? []).map((p) => ({ id: p.id, title: p.title }));
 }
-// No bulk-delete for projects — one DELETE call per id (each returns 200).
-async function deleteProjects(ctx, ids) {
-  if (!ids || !ids.length) return;
-  for (const id of ids) await req(ctx, `/portfolio/v1/projects/${id}`, { method: "DELETE" });
-}
 async function listCollections(ctx) {
   const r = await req(ctx, "/portfolio/v1/collections", { method: "GET" });
   return (r.collections ?? []).map((c) => ({ id: c.id, title: c.title }));
-}
-// No bulk-delete for collections — one DELETE call per id (each returns 200).
-async function deleteCollections(ctx, ids) {
-  if (!ids || !ids.length) return;
-  for (const id of ids) await req(ctx, `/portfolio/v1/collections/${id}`, { method: "DELETE" });
 }
 
 /**
@@ -248,7 +230,7 @@ async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
 
 module.exports = {
   setupPortfolio, installPortfolioApp,
-  listProjects, deleteProjects, listCollections, deleteCollections,
+  listProjects, listCollections,
   createCollections, createProjects, importImage,
   attachProjectCovers, attachCollectionCovers, createProjectItems,
 };

--- a/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
+++ b/skills/wix-vibe-headless/references/portfolio/seed/seed-portfolio.js
@@ -31,6 +31,7 @@
 // wix-headless/references/inline-recipes/setup-portfolio.md.
 
 const API = "https://www.wixapis.com";
+const PORTFOLIO_APP_ID = "d90652a2-f5a1-4c7c-84c4-d4cdcc41f130"; // installPortfolioApp installs this before seeding
 
 async function req(ctx, path, { method = "POST", body } = {}) {
   const res = await fetch(API + path, {
@@ -175,7 +176,17 @@ async function createProjectItems(ctx, items) {
  *   are optional — a project/collection without one skips it.
  * @returns { collections:[{id,slug,revision}], projects:[{id,slug,revision}], itemsCreated, coversAttached }
  */
+// Install the Wix Portfolio app before seeding — base44 sites aren't guaranteed to have it (no
+// separate Setup step here, unlike the wix-headless recipe). Idempotent: re-installing returns 200.
+async function installPortfolioApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: PORTFOLIO_APP_ID, enabled: true },
+  } });
+}
+
 async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
+  await installPortfolioApp(ctx);
   const cols = await createCollections(ctx, collections);               // STEP 1
   const idByName = new Map(collections.map((c, i) => [c.title, cols[i].id]));
 
@@ -236,7 +247,7 @@ async function setupPortfolio(ctx, { collections = [], projects = [] } = {}) {
 }
 
 module.exports = {
-  setupPortfolio,
+  setupPortfolio, installPortfolioApp,
   listProjects, deleteProjects, listCollections, deleteCollections,
   createCollections, createProjects, importImage,
   attachProjectCovers, attachCollectionCovers, createProjectItems,

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -17,7 +17,8 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-// There is NO clean-up step — a fresh Pricing Plans install ships no sample plans.
+// setupPricingPlans installs the Wix Pricing Plans app first (idempotent) — base44 sites may not
+// have it. There is NO clean-up step — a fresh Pricing Plans install ships no sample plans.
 
 // DEFAULT: one call. Creates the plan(s), keeps their ids in memory, and (per plan) wires bookings
 // coverage when provided — createPlans then attachBookingsCoverage (2a→2b→2c), in order.

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -17,8 +17,7 @@ const seed = (() => { const m = { exports: {} };
   return m.exports; })();
 const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
-// setupPricingPlans installs the Wix Pricing Plans app first (idempotent) — base44 sites may not
-// have it. There is NO clean-up step — a fresh Pricing Plans install ships no sample plans.
+// setupPricingPlans installs the Wix Pricing Plans app first (idempotent) — base44 sites may not have it.
 
 // DEFAULT: one call. Creates the plan(s), keeps their ids in memory, and (per plan) wires bookings
 // coverage when provided — createPlans then attachBookingsCoverage (2a→2b→2c), in order.

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/seed-pricing-plans.js
@@ -28,6 +28,7 @@ const { randomUUID } = require("crypto");
 
 const API = "https://www.wixapis.com";
 const BOOKINGS_APP_ID = "13d21c63-b5ec-5912-8397-c3a5ddb27a97"; // per recipe: providerAppId for coverage
+const PRICING_PLANS_APP_ID = "1522827f-c56c-a5c9-2ac9-00f9e6ae12d3"; // installPricingPlansApp installs this before seeding
 const PP_NAMESPACE = "@wix/pricing-plans"; // per recipe: literal, with @ and slash, in every 2a–2c call
 
 async function req(ctx, path, { method = "POST", body } = {}) {
@@ -218,7 +219,17 @@ async function attachBookingsCoverage(ctx, planId, serviceIds, { creditAmount } 
  *   bookingsCoverage?: { serviceIds?, creditAmount? } }] } // richer coverage; creditAmount = limited pack
  * @returns { plans: [{id,name,coveredServiceIds}], coverageAttached: [{planId,itemSetId,serviceIds}], benefitsCreated }
  */
+// Install the Wix Pricing Plans app before seeding — base44 sites aren't guaranteed to have it (no
+// separate Setup step here, unlike the wix-headless recipe). Idempotent: re-installing returns 200.
+async function installPricingPlansApp(ctx) {
+  return req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+    tenant: { tenantType: "SITE", id: ctx.siteId },
+    appInstance: { appDefId: PRICING_PLANS_APP_ID, enabled: true },
+  } });
+}
+
 async function setupPricingPlans(ctx, { plans = [] } = {}) {
+  await installPricingPlansApp(ctx);
   const created = await createPlans(ctx, plans); // ids kept in memory
   const coverageAttached = [];
   for (let i = 0; i < created.length; i++) {
@@ -233,7 +244,7 @@ async function setupPricingPlans(ctx, { plans = [] } = {}) {
 }
 
 module.exports = {
-  setupPricingPlans,
+  setupPricingPlans, installPricingPlansApp,
   createPlans,
   attachBookingsCoverage,
   getProgramDefinition, createPoolDefinition, createBenefitItems,

--- a/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
+++ b/skills/wix-vibe-headless/references/restaurants/seed/seed-restaurants.js
@@ -93,32 +93,17 @@ async function installTableReservationsApp(ctx) { return installApp(ctx, TABLE_R
 // Everything is the Restaurants Menus V1 API on /restaurants/menus/v1/... — one service.
 // REST flattens the protobuf wrappers: send plain values (`"visible": true`), never `{"value": …}`.
 
-// STEP 0 — clean the install's default sample "Dinner Menu". JUDGMENT call: only delete when it's
-// obviously the install's own sample; if it could be the owner's real menu, ask first (seeding is
-// additive). Children before parents: items → sections → menus.
 async function listMenuItems(ctx) {
   const r = await req(ctx, "/restaurants/menus/v1/items", { method: "GET" });
   return (r.items ?? []).map((it) => ({ id: it.id, name: it.name }));
-}
-async function deleteMenuItems(ctx, ids) {
-  if (!ids || !ids.length) return;
-  return req(ctx, "/restaurants/menus/v1/bulk/items/delete", { method: "DELETE", body: { ids } });
 }
 async function listMenuSections(ctx) {
   const r = await req(ctx, "/restaurants/menus/v1/sections", { method: "GET" });
   return (r.sections ?? []).map((s) => ({ id: s.id, name: s.name }));
 }
-async function deleteMenuSections(ctx, ids) {
-  if (!ids || !ids.length) return;
-  return req(ctx, "/restaurants/menus/v1/bulk/sections/delete", { method: "DELETE", body: { ids } });
-}
 async function listMenus(ctx) {
   const r = await req(ctx, "/restaurants/menus/v1/menus", { method: "GET" });
   return (r.menus ?? []).map((m) => ({ id: m.id, name: m.name }));
-}
-// No bulk-delete endpoint for menus — one DELETE per menu; single delete takes only the path id (no revision).
-async function deleteMenu(ctx, menuId) {
-  return req(ctx, `/restaurants/menus/v1/menus/${menuId}`, { method: "DELETE" });
 }
 
 /**
@@ -452,7 +437,7 @@ module.exports = {
   // app install
   installMenusApp, installOrdersApp, installTableReservationsApp,
   // menu
-  listMenuItems, deleteMenuItems, listMenuSections, deleteMenuSections, listMenus, deleteMenu,
+  listMenuItems, listMenuSections, listMenus,
   createMenu, importImage, attachItemImages,
   // shared business location (ordering + reservations STEP 0)
   setBusinessLocation,

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -123,15 +123,9 @@ async function installStoresApp(ctx) {
   await waitForCatalogV3(ctx);
 }
 
-// Clean is JUDGMENT — never auto-delete. Agent lists, decides which are obvious install samples,
-// deletes only those (SEED.md: seeding is additive; deleting real content needs the owner's OK).
 async function listProducts(ctx) {
   const r = await req(ctx, "/stores/v3/products/query", { body: { query: { paging: { limit: 50 } } } });
   return (r.products ?? []).map((p) => ({ id: p.id, name: p.name }));
-}
-async function deleteProducts(ctx, ids) {
-  if (!ids || !ids.length) return;
-  return req(ctx, "/stores/v3/bulk/products/delete", { body: { productIds: ids } });
 }
 
 /**
@@ -245,8 +239,6 @@ async function attachProductImages(ctx, items) {
  *   products: [{ name, description, price, compareAtPrice?, quantity, options?, imageUrl?, altText? }],
  *   categories?: { [categoryName]: string[] },   // map of category name -> product NAMES in it
  * }}
- * Cleanup is intentionally NOT here — deleting existing content is a judgment call; do it explicitly
- * with listProducts/deleteProducts first if (and only if) the site holds obvious install samples.
  * @returns { products: [{id,slug,revision,name}], categories: [{id,name}], imagesAttached: number }
  */
 async function setupStore(ctx, { products = [], categories = {} } = {}) {
@@ -277,6 +269,6 @@ async function setupStore(ctx, { products = [], categories = {} } = {}) {
 
 module.exports = {
   setupStore,
-  installStoresApp, listProducts, deleteProducts,
+  installStoresApp, listProducts,
   bulkCreateProducts, createCategories, addProductsToCategories, attachProductImages,
 };


### PR DESCRIPTION
Two seed-module alignment fixes, both surfaced this session.

## 1. Self-install the Wix app (the `428` bug)
An events build failed with `428 WIX_EVENTS_APP_NOT_INSTALLED` and shipped an empty site. **events/pricing-plans/blog/portfolio** assumed their app was pre-installed and refused to install it, while **bookings/stores/cms/restaurants** self-install. Root cause: the wix-headless recipes install apps in a separate `SETUP.md` step that base44 has no equivalent for.

Fix: add `installEventsApp` / `installPricingPlansApp` / `installBlogApp` / `installPortfolioApp` (same `/apps-installer-service/v1/app-instance/install` endpoint) and call it first in each `setup<V>`; drop the "never install / fail loudly on 428" guidance.

App def ids from **`wix-headless/references/SETUP.md`** (authoritative, not guessed): events `140603ad…`, pricing-plans `1522827f…`, blog `14bcded7…`, portfolio `d90652a2…`.

Verified live: re-installing an already-installed app → **HTTP 200** (idempotent). On the actual failing site: install → 200, re-install → 200, and the events query that `428`'d now returns 200 (empty).

## 2. Remove all cleanup cruft (additive-only)
Seeding is additive — we never delete. Removed every `delete*` helper (`deleteServices/Products/Projects/Collections/MenuItems/MenuSections/Menu`) + their exports, all "STEP 0 clean the sample X / never auto-delete / judgment call" guidance, and the pointless "no clean-up step / ships no sample / nothing to delete" notes. Each SEED.md keeps exactly one policy line: *"Seeding is additive — never delete or overwrite… don't clean up… just add."* Read-only `list*` helpers kept.

## Verification
- All 6 touched seed modules **load without a dangling-export error** (`node -e require`), no `delete*` remains, no cleanup notes remain, additive principle intact in all 8 SEED.md.
- `node --check` clean on all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)