### PR TITLE
fix(wix-vibe-headless): events — site-currency tickets + render category name (fix '(1)')

### DIFF
--- a/skills/wix-vibe-headless/references/events/app/components/CategoryFilter.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/CategoryFilter.jsx
@@ -1,5 +1,5 @@
 // Category filter menu for the events listing. Pure UI — the active id + setter come from
-// useEventsList. Display field is `label` (NOT `name`); key/filter by `category.id`; the per-category
+// useEventsList. Display field is `name`; key/filter by `category.id`; the per-category
 // count is `counts.assignedEventsCount`. Styled with base44 design tokens (shadcn Tailwind classes).
 
 const chipBase = "py-1.5 px-3.5 cursor-pointer text-sm font-body border rounded-full";
@@ -15,7 +15,7 @@ export default function CategoryFilter({ categories, active, onSelect }) {
       {categories.map((c) => (
         <button key={c.id} onClick={() => onSelect(c.id)} aria-pressed={active === c.id}
           className={`${chipBase} ${active === c.id ? chipActive : chipIdle}`}>
-          {c.label} ({c.counts?.assignedEventsCount ?? 0})
+          {c.name} ({c.counts?.assignedEventsCount ?? 0})
         </button>
       ))}
     </nav>

--- a/skills/wix-vibe-headless/references/events/app/hooks/useEventsList.js
+++ b/skills/wix-vibe-headless/references/events/app/hooks/useEventsList.js
@@ -3,7 +3,7 @@
 // the bug-prone part — keep them verbatim; the Events page only renders what this returns.
 //   • queryEvents / listEventsByCategory return { events, total, offset, nextOffset } — an OBJECT,
 //     not a bare array; nextOffset is null when there are no more pages.
-//   • queryEventCategories returns { categories, total }; render category.label (NOT name),
+//   • queryEventCategories returns { categories, total }; render category.name,
 //     key/filter by category.id, count = counts.assignedEventsCount.
 //   • total === 0 → the whole catalog is empty; show the "publish events" empty state.
 import { useState, useEffect } from "react";

--- a/skills/wix-vibe-headless/references/events/app/rest/wix-events-browse.js
+++ b/skills/wix-vibe-headless/references/events/app/rest/wix-events-browse.js
@@ -31,7 +31,7 @@ import { wixApiRequest } from "./wix-client.js";
  *   form {object} — registration form controls (FORM fieldset),
  *   calendarUrls {object} — { google, ics } (DETAILS fieldset)
  *
- * Category: { id, label, slug, counts.assignedEventsCount }
+ * Category: { id, name, counts.assignedEventsCount }
  * Full model: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/categories
  */
 

--- a/skills/wix-vibe-headless/references/events/seed/seed-events.js
+++ b/skills/wix-vibe-headless/references/events/seed/seed-events.js
@@ -63,7 +63,7 @@ function buildRegistration(ev) {
       initialType: "TICKETING",
       tickets: {
         ticketLimitPerOrder: ev.ticketLimitPerOrder ?? 8, // per recipe (example value)
-        currency: ev.currency ?? "USD", // per recipe (example value)
+        currency: ev.currency ?? "USD", // setupEvents threads the site currency; USD only as last-resort fallback
         reservationDurationInMinutes: ev.reservationDurationInMinutes ?? 20, // per recipe (example value)
       },
     };
@@ -121,7 +121,7 @@ async function createTicketTiers(ctx, eventId, tiers) {
         name: t.name,
         description: t.description,
         ...(t.initialLimit != null ? { initialLimit: t.initialLimit } : {}), // omit => unlimited
-        pricingMethod: { fixedPrice: { value: String(t.price), currency: t.currency ?? "USD" } }, // value MUST be a decimal string
+        pricingMethod: { fixedPrice: { value: String(t.price), currency: t.currency ?? "USD" } }, // value = decimal string; currency = site currency (threaded by setupEvents), USD only as fallback
         feeType: t.feeType ?? "FEE_INCLUDED", // per recipe (default)
       },
       fields: ["SALES_DETAILS"],
@@ -199,12 +199,26 @@ async function installEventsApp(ctx) {
   } });
 }
 
+// Ticket prices are in the SITE's currency. The ticket-definitions API REQUIRES `currency` and does
+// not infer it (omitting it 400s), and it does NOT fall back to the site currency — whatever you pass
+// is used verbatim. So resolve the site's payment currency once and thread it through, instead of a
+// hardcoded default that would mis-price tickets on a non-USD site (e.g. USD tickets on a EUR/ILS site).
+async function getSiteCurrency(ctx) {
+  try {
+    const r = await req(ctx, "/site-properties/v4/properties", { method: "GET" });
+    return r?.properties?.paymentCurrency || "USD";
+  } catch { return "USD"; }
+}
+
 async function setupEvents(ctx, { events = [] } = {}) {
   await installEventsApp(ctx);
+  const siteCurrency = await getSiteCurrency(ctx);
   const created = [];
   for (const ev of events) {
-    const e = await createEvent(ctx, ev);
-    const tiers = ev.ticketTiers?.length ? await createTicketTiers(ctx, e.id, ev.ticketTiers) : [];
+    const e = await createEvent(ctx, { ...ev, currency: ev.currency ?? siteCurrency });
+    const tiers = ev.ticketTiers?.length
+      ? await createTicketTiers(ctx, e.id, ev.ticketTiers.map((t) => ({ ...t, currency: t.currency ?? siteCurrency })))
+      : [];
     await publishEvent(ctx, e.id);
     created.push({ ...e, category: ev.category, imageUrl: ev.imageUrl, ticketCount: tiers.length });
   }
@@ -233,5 +247,5 @@ async function setupEvents(ctx, { events = [] } = {}) {
 module.exports = {
   setupEvents,
   createEvent, createTicketTiers, publishEvent,
-  installEventsApp, createEventCategories, assignEventsToCategory, importImage, setEventMainImage,
+  installEventsApp, getSiteCurrency, createEventCategories, assignEventsToCategory, importImage, setEventMainImage,
 };


### PR DESCRIPTION
Two events bugs from a live build (Indian Music Events, Ireland/EUR), both fixed and verified.

## 1. Tickets seeded in USD instead of the site currency
`buildRegistration` and `createTicketTiers` defaulted `currency` to `"USD"`. The ticket-definitions API **requires** `currency`, **does not infer** it from the site, and uses what you pass **verbatim** — so tickets were mis-priced in USD on non-USD sites.

Fix: resolve the site currency once — `getSiteCurrency` → `GET /site-properties/v4/properties` → `paymentCurrency` — and thread it through `setupEvents` into the event registration and every ticket tier.

**Verified live** (owner token, on a site whose currency is ILS): before → ticket `currency: "USD"`; after → `currency: "ILS"`. Omitting currency returns `400 "currency is not present"`, confirming it must be passed.

## 2. CategoryFilter shows "(1)" instead of category names
The component read `category.label`, but the Wix Events **Category object has no `label` field** — the display name is **`category.name`** (confirmed against the [Category Object docs](https://dev.wix.com/docs/rest/business-solutions/events/event-management/categories/category-object)). Empty `label` rendered as just the count → "(1) (1) (1)…". Fixed `CategoryFilter`, `useEventsList`, and the `wix-events-browse` doc-comment to use `name`.

Note: the ticket-definitions `403 PERMISSION_DENIED` in that build is a **separate** issue — the connector OAuth app's granted Wix permission set (the "mega scope") lacks `WIX_EVENTS.READ_DRAFT_EVENTS`; under investigation. This PR makes the seed correct so it works once the connector scope is granted (and it already works with a site-owner token, as verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)