### PR TITLE
docs(wix-vibe-headless): make generic.md a cross-platform lens over the skill

### DIFF
--- a/skills/wix-vibe-headless/platforms/README.md
+++ b/skills/wix-vibe-headless/platforms/README.md
@@ -4,10 +4,14 @@ One file per AI-builder platform (Base44, Lovable, Bolt, v0, Manus, …). Each f
 **handoff prompt** the Wix Headless funnel hands to that platform after it creates the site +
 OAuth app: build the client, then seed/manage the business.
 
-`generic.md` is the **platform-agnostic** version — same flow (install skills → build client →
-seed/manage → wrap up) with no assumptions about a specific platform's tooling. Use it as the
-default/fallback for platforms without their own tuned file; `base44.md` is the Base44-specific
-one (its exec tool, secret store, pre-configured connector, etc.).
+`generic.md` is the **platform-agnostic** version and the default/fallback for any platform without
+its own tuned file. It is also a **lens over the skill**: the skill's `SKILL.md` + per-vertical
+`INSTRUCTIONS.md` are written for Base44's stack (Vite + react-router + `.jsx`, files pre-copied into
+`src/`), so `generic.md` tells a non-Base44 agent what the skill's three real assets are (the `rest/`
+client layer, the field-shape/route-pattern data contract, the `seed/` functions), which Base44-isms
+to ignore/translate, and the hard rule to **generate into the existing stack — never convert the
+framework**. `base44.md` is the Base44-specific one (its exec tool, secret store, pre-configured
+connector, `deploy.cjs` copy path, etc.).
 
 These are hosted (served at `https://www.wix.com/skills/vibe-headless/platforms/<platform>.md`)
 so the funnel loader can pass a short pointer to the prompt instead of inlining the whole

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -1,40 +1,81 @@
-# Wix Managed Headless — build instructions
+# Wix Managed Headless — build instructions (any stack)
 
 You are building a **Wix Managed** headless site. The business to build, and your Wix client id
-and metasite id, are given in your initial prompt. Follow the steps below:
+and metasite id, are given in your initial prompt. Read **"What this skill is"** and **"Hard
+rules"** first — they change how you read everything else — then follow the steps.
 
-1. **Install the Wix skills locally**
-2. **(optional) Brief doesn't say what to build? Ask, or read the site**
-3. **Build the client**
-4. **Seed and manage the business** (run in parallel with 3)
-5. **When done** (required: mount the dev-only manage banner + point the user to the Wix dashboard)
+## What this skill is (read this first)
+
+`wix-vibe-headless` is a **client-only REST connector** to a live Wix site over the public
+`WIX_CLIENT_ID` (a visitor-facing credential, safe in the browser) — **no `@wix/sdk`, no backend,
+no build step**. Its docs (`SKILL.md` and each `references/<vertical>/INSTRUCTIONS.md`) are written
+for **one specific host — Base44** (Vite + react-router, `.jsx`, shadcn tokens in `index.css`, files
+pre-copied into `src/` by a `deploy.cjs`). **You are almost certainly on a different stack** (Next.js,
+TanStack Start, Remix, plain Vite, …), so don't read those docs literally — read them for the **three
+real assets** and translate the Base44-isms (table below):
+
+1. **`references/shared/app/rest/wix-client.js` + `references/<vertical>/app/rest/wix-*.js`** — the
+   REST transport + per-vertical data layer. **Copy these ~verbatim** (rule 2). They are the source
+   of truth for every request/response **shape**, the token lifecycle, fieldsets, and paging.
+2. **`references/<vertical>/app/{components,pages,hooks}` + the field snippets in `INSTRUCTIONS.md`** —
+   a **reference UI + the data contract**. **Regenerate the UI in your framework**; what you actually
+   take from here is the **field shapes** and the **route patterns** (e.g. `/product/:slug`).
+3. **`references/<vertical>/seed/seed-*.js`** — build-time seeding **functions**. **Reuse the
+   functions**; wrap them in *your* platform's exec/connector (STEP 4).
+
+## Hard rules (do not skip)
+
+1. **Never convert the project's framework, bundler, dev server, or ports.** If the template is
+   Next.js, build Next.js (App Router: `app/<route>/page.tsx`); if TanStack Start, add `src/routes/*`;
+   if Vite + react-router, use that. **Generate the Wix files *into* the existing stack — do NOT
+   migrate the project to Vite.** (Converting the framework is the single biggest source of wasted
+   time here: orphaned dev servers, port whack-a-mole, broken previews.)
+2. **Copy the `rest/` layer ~verbatim.** It's plain `fetch`, framework-agnostic, and already guards
+   `window`/`localStorage` for SSR. If your project is TypeScript, rename `.js → .ts` and add types —
+   but **do not change the request/response shapes, endpoints, or token logic**. That's the hard-won
+   part.
+3. **Everything else you GENERATE in your stack's idiom** — your router, your file extensions
+   (`.tsx`), your design tokens. Any browser-only code (cart provider, the manage banner, anything
+   reading `localStorage`/`window`) must be **SSR-safe**: gate it with a client-only / hydration
+   guard so it doesn't run during server render or static prerender. For the dev-only manage banner,
+   use a **portable dev check** — `import.meta.env?.DEV` is Vite-only; fall back to
+   `process.env.NODE_ENV !== "production"`.
+4. **Read-only over the owner's content.** Render live Wix data or an honest empty state — never
+   mock, invent, or provision content on the client.
+
+## How to read `SKILL.md` + `INSTRUCTIONS.md` — translate the Base44-isms
+
+| The doc says… | For you it means… |
+|---|---|
+| "the client is already deployed into `src/`" / run `deploy.cjs` | there is **no copy step** — you **generate** these files into your project |
+| "don't `read_file` the shipped source" | **do** read the `rest/` files — they are your source of truth for shapes |
+| "shipped as real files, copy-as-is `.jsx`" | **regenerate** as your framework's components (`.tsx`, your router) |
+| `@/` import alias, `import.meta.env.DEV` | use **your** stack's import paths + a **portable** dev check |
+| theme via base44 `src/index.css` / shadcn tokens | map the same intent to **your** design system's tokens |
+| react-router routes like `/product/:slug` | keep the **route pattern**; implement it in **your** router |
+| `preview_screenshot` / `exec_tool` / base44 connector | use **your** platform's equivalents (STEP 4 for seeding) |
+
+Everything in `SKILL.md`'s **"shared model"** (auth = one public client id, money fields are objects →
+render `formattedValue`, visitor token = cart identity, member login swaps the token set) **is
+universal — follow it as-is.**
 
 ## STEP 1 — Install the Wix skills locally
 
-Install three skills — they land under `.agents/skills/` as:
-- **`wix-vibe-headless`** — the client build guide: how to build the frontend against the Wix
-  APIs. This is your main source of truth (STEP 3).
-- **`wix-headless`** — a broad skill for building full Wix apps with the Wix SDK packages, **most
-  of which does not apply to how you build here**. Use it **only** as a seeding/admin recipe
-  reference — its `references/SEED.md` and `references/inline-recipes/`, for STEP 4. **Ignore
-  everything else in it** — in particular do **not** follow its authentication / `@wix/cli` /
-  "managed project" setup (e.g. anything under `references/managed/`, such as `AUTHENTICATION.md`).
-  That is **not** how auth works here — auth is handled per STEP 4 below.
-- **`wix-docs`** — a **fallback**: how to search and read the Wix API reference docs, for anything
-  the seeding recipes above don't cover.
+Install three skills — they land under `.agents/skills/`:
+- **`wix-vibe-headless`** — the client build guide (STEP 3), read through the lens above.
+- **`wix-headless`** — use it **only** as a seeding/admin recipe reference (`references/SEED.md`,
+  `references/inline-recipes/`, for STEP 4). **Ignore everything else** — in particular its
+  `@wix/cli` / "managed project" auth (`references/managed/`). That is **not** how auth works here.
+- **`wix-docs`** — a **fallback**: how to search + read the Wix API reference for anything the
+  seeding recipes don't cover.
 
-Install them so you can read them from files as you go (fetching skill docs over the web
-truncates or summarises large files).
-
-**Run the Skills CLI** — this is the install path to use:
 ```bash
 CI=1 npx skills@latest add wix/skills/skills/wix-headless --yes
 CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
 CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 ```
 
-**Only if the CLI above actually errors** (not on a guess), fall back to curl + gzip — download
-each bundle and extract it into `.agents/skills/wix-<name>/`:
+**Only if the CLI actually errors** (not on a guess), fall back to curl + gzip:
 ```bash
 for s in headless vibe-headless docs; do
   mkdir -p ".agents/skills/wix-$s"
@@ -42,13 +83,14 @@ for s in headless vibe-headless docs; do
 done
 ```
 
+Read the skills from these files as you go (fetching skill docs over the web truncates large files).
+
 ## STEP 2 (optional) — Brief doesn't say what to build? Ask, or read the site
 
-Only needed when the business description in your prompt is vague or missing — otherwise skip
-to STEP 3. Don't guess which Wix Business Solution to build (stores, bookings, blog, events,
-portfolio, restaurants, CMS, pricing plans, members, etc..): **ask the user** one short
-question (what do they offer?), or — with an admin-grade Wix credential (connector token or
-API key, per STEP 4; the public `WIX_CLIENT_ID` is not enough) — **read the site in one call**:
+Only when the business description is vague or missing. Don't guess which Wix Business Solution to
+build (stores, bookings, blog, events, portfolio, restaurants, CMS, pricing plans, members):
+**ask the user** one short question, or — with an admin-grade Wix credential (connector token or API
+key, per STEP 4; the public `WIX_CLIENT_ID` is not enough) — **read the site** in one call:
 
 ```bash
 curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
@@ -56,67 +98,67 @@ curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-contex
   -d '{"siteId": "<metasite id from your prompt>"}'
 ```
 
-It returns a markdown report of the site — installed apps (by name), status, URL, locale, and
-CMS collections
+It returns the installed apps (by name), status, URL, locale, and CMS collections
 ([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md);
-with an API key send it raw as the `Authorization` value, no `Bearer`). Build for the solutions
-whose apps are installed (several → prioritize by the user's words and by which holds real,
-non-sample content); the same set drives STEP 4's seeding — never seed guessed ones.
+with an API key send it raw as the `Authorization` value, no `Bearer`). Build for the solutions whose
+apps are installed; the same set drives STEP 4's seeding — never seed guessed ones.
 
-## STEP 3 — Build the client
+## STEP 3 — Build the client (generate into your stack)
 
-Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **exactly** — it is the single
-source of truth for how the client app is built against the Wix APIs (over the public
-`WIX_CLIENT_ID`, which is a buyer/visitor-facing credential, safe in the frontend).
+Read `.agents/skills/wix-vibe-headless/SKILL.md` and each target vertical's
+`references/<vertical>/INSTRUCTIONS.md` **through the lens above**: copy the `rest/` layer verbatim,
+regenerate the UI in your framework from the field snippets + route patterns, and ignore the
+"already in `src/` / don't read the source / `index.css` / `@/` / `deploy.cjs`" framing (that's
+Base44's copy path — you generate instead). Set `WIX_CLIENT_ID` + `WIX_METASITE_ID` in `wix-config`.
 
-## STEP 4 — Seed and manage the business
+**Per-stack cheatsheet** (map the reference UI to your stack; never convert the project):
+
+| stack (example platform) | routes go in | dev-gate | SSR / verify notes |
+|---|---|---|---|
+| **Next.js** (v0) | `app/<route>/page.tsx`; `"use client"` on the cart provider + banner | `process.env.NODE_ENV !== "production"` | keep the dev server on **:3000** (don't spawn Vite). If the in-tool browser rewrites `localhost` to a sandbox host, verify by curling the served module URLs + checking for transform errors instead of a screenshot. |
+| **TanStack Start** (Lovable) | `src/routes/*.tsx` (e.g. `shop.tsx`, `product.$slug.tsx`) | `import.meta.env.DEV` | wrap client-only bits in a `ClientOnly` / `useHydrated` guard; if copying the `.js` `rest/` files into a TS project, set `allowJs` + `jsx` in `tsconfig.json` (or rename to `.ts`). |
+| **Vite + react-router** (Base44-like) | `src/pages/*` wired in `<Routes>` | `import.meta.env.DEV` | closest to the shipped reference; the `rest/` files drop in directly. |
+
+## STEP 4 — Seed and manage the business (run in parallel with STEP 3)
 
 **⛔ Never delete or clean up anything on the user's site — seeding is additive only.** Ignore any
-cleanup/reset step in the `wix-headless` seed recipes: it's a live user-owned business, so never
-delete or overwrite existing content, even apparent sample data. If a cleanup truly seems needed,
-ask the user first.
+cleanup/reset step in the `wix-headless` seed recipes: it's a live user-owned business. If a cleanup
+truly seems needed, ask the user first.
 
-Seed the site with real content by following the `wix-headless` skill's `references/SEED.md`
-(`.agents/skills/wix-headless/references/SEED.md`). Where its seed recipes don't cover what you
-need, fall back to the `wix-docs` skill to search and read the relevant Wix API docs.
+Seed real content by **reusing the functions** in `references/<vertical>/seed/seed-*.js` (they encode
+the correct Wix API sequences, incl. app-install + provisioning-race handling), following the
+`wix-headless` skill's `references/SEED.md` for anything they don't cover, and `wix-docs` beyond that.
 
-These management/admin calls need **elevated Wix credentials** — the public client id is not
-enough. If you don't already have a way to authenticate them, either **connect your platform's
-Wix connector** (if it has one) or **ask the user for a Wix API key / token** and store it in your
-platform's built-in **connector / secrets (env) manager** — never hardcode or commit it. **Once
-the connector is connected (or the API key is in place), you can make Wix REST admin calls
-directly** — authenticate each call with that credential (the `wix-docs` skill covers Wix API-key
-auth). Or, if the user prefers, tell them they can add this content themselves in the Wix
-dashboard instead.
+**Auth for admin/seed calls** — the public client id is **not** enough. Get an elevated credential
+one of these ways, and store it in your platform's **connector / secrets (env) manager** — never
+hardcode or commit it:
+- **Your platform has a Wix connector** → connect it and call through its gateway. *(Lovable, e.g.:
+  gateway `https://connector-gateway.lovable.dev/wix`, with `LOVABLE_API_KEY` + `X-Connection-Api-Key`.)*
+- **Base44** → the connector is pre-wired; run seed modules via its exec tool.
+- **Otherwise** → ask the user for a **Wix API key** and authenticate each REST call with it (the
+  `wix-docs` skill covers Wix API-key auth — send it raw as `Authorization`, no `Bearer`).
 
-Authenticate admin calls with **only** that connector/API key. Do **not** install or run the Wix
-CLI (`@wix/cli`), do a device-login, or follow `wix-headless`'s `references/managed/AUTHENTICATION.md`
-— that managed-project auth flow does not apply here.
+Do **not** install/run the Wix CLI (`@wix/cli`), device-login, or follow `wix-headless`'s
+`references/managed/AUTHENTICATION.md` — that managed-project flow does not apply here.
 
-Management/admin operations (seeding, `wix-headless`, `wix-docs`) are **separate from the
-client** — the client is built solely per the `wix-vibe-headless` skill.
+**Notes:** the client's product/content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is
+installed + seeded — that's expected and resolves once STEP 4 lands (the seed modules install the app
+first). **Image seeding** is two Wix Media calls — `generate-upload-url` then a `PUT` of the bytes —
+before you attach the returned file to a product/post/etc.
 
-If possible, run STEP 3 and STEP 4 in parallel — building the client and seeding the business
-are independent. Within each, also parallelize independent work (API calls, seeding multiple
-entities) to finish faster.
+Run STEP 3 and STEP 4 in parallel where possible, and parallelize independent work within each.
 
 ## Later admin requests
 
-For any later admin/management request, work the same way as STEP 4: check the `wix-headless`
-skill's inline recipes first (`.agents/skills/wix-headless/references/inline-recipes/`) and fall
-back to the `wix-docs` skill where the operation isn't documented there.
+Work the same way as STEP 4: check `wix-headless`'s inline recipes
+(`.agents/skills/wix-headless/references/inline-recipes/`) first, fall back to `wix-docs`.
 
-## When done
+## STEP 5 — When done
 
-After the site is built and seeded:
-
-1. **Add the dev-only manage banner** (required) (links the app to its Wix back office): the shipped
-   `<WixManageBanner/>` component (in the vertical's `app/components/`) — set `WIX_METASITE_ID` in
-   `wix-config.js`, then render it in your Layout's fixed top region above the header (see the
-   vertical's INSTRUCTIONS STEP 4). It self-gates to dev builds (via `import.meta.env.DEV`) — use it
-   as-is; you own the guarantee that a production build never shows it (no dev flag → no banner).
-2. **Ask the user to open** this URL to complete the setup in Wix (required; substitute the
-   metasite id you were given): `https://manage.wix.com/dashboard/{metaSiteId}` — and, since
-   the banner from step 1 is mounted, also tell them: *in dev builds the site shows a slim
-   banner at the top linking straight to this Wix dashboard (dismissible; never shown in
-   production).*
+1. **Add the dev-only manage banner** (required): regenerate `WixManageBanner` for your stack from the
+   reference (`references/<vertical>/app/components/WixManageBanner.jsx`) — set `WIX_METASITE_ID`, mount
+   it in your Layout's fixed top region above the header, gate it to dev with a **portable** check
+   (see rule 3), and guard its `localStorage` read for SSR. It must **never** render in production.
+2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (substitute the metasite id
+   from your prompt) to finish setup in Wix — connect a payment provider, manage content, etc. Mention
+   the dev builds show a slim dismissible banner linking to that same dashboard (never in production).


### PR DESCRIPTION
## Problem
The skill's `SKILL.md` + per-vertical `INSTRUCTIONS.md` are written for **Base44's stack** (Vite + react-router + `.jsx`, files pre-copied into `src/` via `deploy.cjs`, shadcn tokens in `index.css`). Other platforms fight it:
- **Lovable (TanStack Start)** retrofitted the router, SSR guards, and tsconfig by hand.
- **v0 (Next.js)** *converted the whole project to Vite* → orphaned dev servers, port whack-a-mole, a broken preview.

## Approach
Rather than de-Base44-ify SKILL.md + 9 INSTRUCTIONS (churn + regression risk to the working Base44 path), concentrate the cross-platform story in **`generic.md`** — the doc the funnel already hands non-Base44 platforms, read *before* SKILL.md. It becomes a **lens**:
- **What the skill actually is** + its 3 real assets: `rest/` client layer (copy verbatim), components/pages (regenerate from the field-shape + route-pattern contract), `seed/` functions (reuse).
- **Hard rules:** never convert the framework/bundler/dev-server/ports — *generate into the existing stack*; SSR-safe browser code; portable dev-gate; copy `rest/` verbatim.
- **Ignore/translate table** for the Base44-isms in SKILL.md/INSTRUCTIONS ("already in src/", "don't read the source", `@/`, `import.meta.env.DEV`, `index.css` theming, `deploy.cjs`).
- **Per-stack cheatsheet** (Next.js / TanStack Start / Vite: where routes go, dev-gate, SSR/verify) folding in the Lovable + v0 specifics (connector gateway + keys, keep :3000, curl-verify caveat when the browser preview can't reach localhost).

## What did NOT change
`SKILL.md`, the 9 `INSTRUCTIONS.md`, the `rest/` request/response shapes, and the `seed/` functions are untouched — **Base44's path is exactly as before**. The shipped banner + `wix-client.js` are already SSR-crash-safe (try/catch + `typeof window` guards), so no code edits were needed — it genuinely all lives in `generic.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)