### PR TITLE
docs(wix-vibe-headless): slim generic.md to a what-you-got + 4-step lens

### DIFF
--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -6,26 +6,47 @@ id are in your prompt. This skill is **client-only REST** over the public `WIX_C
 
 ## What you've got in the skill
 
-Its docs (`SKILL.md`, each `references/<vertical>/INSTRUCTIONS.md`) were authored for **one host
-stack** (Vite + react-router, `.jsx`, files pre-copied into `src/`). You may be on another — so take
-the **three assets** and adapt them; don't copy the host's setup:
+The docs were authored for **one host stack** (Vite + react-router, `.jsx`, files pre-copied into
+`src/`) — you may be on another, so **adapt these assets to your stack; don't copy the host's setup.**
+Everything is under `.agents/skills/wix-vibe-headless/references/`.
 
-1. **`rest/` layer** — `shared/app/rest/wix-client.js` + `<vertical>/app/rest/wix-*.js`: the transport
-   + data layer, and the source of truth for every request/response **shape**, the token lifecycle,
-   fieldsets, and paging. **Use ~verbatim** (plain `fetch`, already SSR-guarded; TS → rename `.js →
-   .ts` + add types) — don't change the shapes.
-2. **UI + data contract** — `<vertical>/app/{components,pages,hooks}` + the field snippets in
-   `INSTRUCTIONS.md`: a **reference** UI. **Regenerate it in your framework** (your router, `.tsx`,
-   your design tokens); keep the field shapes and route patterns (e.g. `/product/:slug`).
-3. **seed functions** — `<vertical>/seed/seed-*.js`: **reuse them** to create content (step 3).
+**Shared transport — both files, used by every vertical (`shared/app/rest/`):**
+
+| file | what's in it |
+|---|---|
+| `wix-client.js` | The transport. Exchanges `WIX_CLIENT_ID` for an anonymous **visitor token**, persists + refreshes it (that token *is* the cart/session identity), and exposes `wixApiRequest(path, {method, body, query})`. Also the member-session swap — `setSessionTokens` / `clearSession` / `isMember`. Plain `fetch`; already SSR-guards `window`/`localStorage`; maps 402 + error bodies. **Use ~verbatim.** |
+| `wix-config.js` | The one place you set `WIX_CLIENT_ID` + `WIX_METASITE_ID`. |
+
+**Every `references/<vertical>/` holds the same four things:**
+
+- `app/rest/wix-*.js` — the vertical's **data layer**: named calls carrying the exact request/response
+  **shapes**, fieldsets, and paging. **Use ~verbatim** (TS → rename `.js → .ts` + add types); never
+  change the shapes.
+- `app/{components,pages,hooks,context}/…` — a **reference UI** (+ hooks/providers). **Regenerate it
+  in your framework** (your router, `.tsx`, your design tokens); keep the field shapes and route
+  patterns (e.g. `/product/:slug`).
+- `seed/seed-*.js` — build-time **seeding functions**; **reuse them** to create content (step 3).
+- `INSTRUCTIONS.md` (build guide + field-shape snippets) and `seed/SEED.md` (how to run the seed module).
+
+**The nine verticals — data layer (`app/rest/`) + seed module (`seed/`):**
+
+| vertical | `app/rest/` data layer | seed module |
+|---|---|---|
+| storefront | `wix-store-catalog.js`, `wix-store-cart.js` — products & variants; server cart + checkout redirect | `seed-store.js` |
+| bookings | `wix-bookings-services.js`, `wix-bookings-checkout.js` — services/categories/slots; booking + checkout | `seed-bookings.js` |
+| blog | `wix-blog.js` — posts (list + by-slug), categories, tags | `seed-blog.js` |
+| events | `wix-events-browse.js`, `wix-events-registration.js` — events & categories; RSVP / ticketing + checkout | `seed-events.js` |
+| portfolio | `wix-portfolio.js` — collections, projects, galleries | `seed-portfolio.js` |
+| restaurants | `wix-restaurants-menu.js`, `-ordering.js`, `-reservations.js` — menu; online ordering; table reservations | `seed-restaurants.js` |
+| cms | `wix-cms.js` — Wix Data collections: list / detail / filter + form CRUD | `seed-cms.js` |
+| pricing-plans | `wix-pricing-plans.js` — plans list + subscribe/checkout | `seed-pricing-plans.js` |
+| members | `wix-members-auth.js` — custom login/signup (email+password, social, SSO), session, account | *(none — members sign up at runtime; nothing to seed)* |
 
 Anything in the docs about the **host's own setup** — copying files into `src/`, its `@/` alias, its
 `import.meta.env` flags, a theming file, its build/exec/connector tooling — is that host's, not a
-rule: adapt it to your stack or ignore it. The **"shared model"** in `SKILL.md` (public-client-id
+rule: **adapt it to your stack or ignore it.** The `SKILL.md` **"shared model"** (public-client-id
 auth, money = objects → render `formattedValue`, visitor token = cart identity, member login swaps
 the token set) is **universal — follow it as-is**.
-
-(All paths are under `.agents/skills/wix-vibe-headless/references/`.)
 
 ## The flow — install → build client → seed → done
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -17,7 +17,7 @@ the **three assets** and adapt them; don't copy the host's setup:
 2. **UI + data contract** — `<vertical>/app/{components,pages,hooks}` + the field snippets in
    `INSTRUCTIONS.md`: a **reference** UI. **Regenerate it in your framework** (your router, `.tsx`,
    your design tokens); keep the field shapes and route patterns (e.g. `/product/:slug`).
-3. **seed functions** — `<vertical>/seed/seed-*.js`: **reuse them** to create content (step 4).
+3. **seed functions** — `<vertical>/seed/seed-*.js`: **reuse them** to create content (step 3).
 
 Anything in the docs about the **host's own setup** — copying files into `src/`, its `@/` alias, its
 `import.meta.env` flags, a theming file, its build/exec/connector tooling — is that host's, not a
@@ -40,7 +40,7 @@ the token set) is **universal — follow it as-is**.
 
 ## The flow — install → build client → seed → done
 
-Run **build client** (step 3) and **seed** (step 4) in parallel; parallelize independent work within each.
+Run **build the client** (step 2) and **seed** (step 3) in parallel; parallelize independent work within each.
 
 ### 1 · Install the skills
 
@@ -60,42 +60,25 @@ for s in vibe-headless docs; do
 done
 ```
 
-### 2 · (optional) Not sure what to build?
-
-Only if the brief is vague. **Ask** one short question, or — with an admin credential (step 4) —
-**read the site**:
-
-```bash
-curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
-  -H 'Authorization: Bearer <admin token>' -H 'Content-Type: application/json' \
-  -d '{"siteId": "<metasite id from your prompt>"}'
-```
-
-Returns the installed apps, status, locale, CMS collections
-([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md);
-API key → send it raw, no `Bearer`). Build for the **installed** apps — never guessed ones.
-
-### 3 · Build the client
+### 2 · Build the client
 
 Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**
 above). Use the `rest/` layer as-is, regenerate the UI for your framework, and set `WIX_CLIENT_ID` +
-`WIX_METASITE_ID` in `wix-config`.
+`WIX_METASITE_ID` in `wix-config`. If the brief doesn't say which Wix solution(s) to build, **ask the
+user** one short question (what do they offer?), or let step 3's site read settle it.
 
-### 4 · Seed the content
+### 3 · Seed the content
 
 **⛔ NO CLEANUP — EVER.** Strictly **additive**: never delete, reset, or overwrite anything on the
 user's live site — not even apparent sample/demo content. If something looks wrong, leave it and tell
 the user.
 
-Reuse the functions in `references/<vertical>/seed/seed-*.js` (they encode the Wix API sequences,
-incl. app-install + provisioning-race handling); use `wix-docs` for anything they don't cover.
-
 **Auth** (the public client id won't do): if your platform has a **built-in Wix connector**, use it
 (it holds the credential). Otherwise take a **Wix API key** into your secrets manager (never hardcode
 or commit) — create one at **[account API keys → Add key](https://manage.wix.com/account/api-keys/addkey)**
 ([how-to](https://dev.wix.com/docs/api-reference/articles/authentication/api-keys/generate-an-api-key)) —
-and send it **raw as `Authorization` (no `Bearer`)** with a **`wix-site-id`** header
-(`wix-account-id` only for account-level APIs — one, not both):
+and send it **raw as `Authorization` (no `Bearer`)** with a **`wix-site-id`** header (`wix-account-id`
+only for account-level APIs — one, not both):
 
 ```bash
 curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
@@ -103,11 +86,22 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
   -H 'Content-Type: application/json' -d '{"query":{"cursorPaging":{"limit":10}}}'
 ```
 
-Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is installed + seeded (expected; the
-seed modules install it first). Image seeding = two Wix Media calls (`generate-upload-url` → `PUT` the
-bytes) before attaching.
+**Once you have that admin credential**, you can read the site to see which apps are actually
+installed — build and seed only those, never guessed ones:
 
-### 5 · Done
+```bash
+curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H 'Authorization: <admin token or raw API key>' -H 'Content-Type: application/json' \
+  -d '{"siteId": "<metasite id from your prompt>"}'
+```
+
+Then seed by reusing the functions in `references/<vertical>/seed/seed-*.js` (they encode the Wix API
+sequences, incl. app-install + provisioning-race handling); use `wix-docs` for anything they don't
+cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is installed + seeded
+(expected; the seed modules install it first). Image seeding = two Wix Media calls
+(`generate-upload-url` → `PUT` the bytes) before attaching.
+
+### 4 · Done
 
 Mount the dev-only manage banner (regenerate `WixManageBanner` for your stack — set `WIX_METASITE_ID`,
 above the header, SSR-safe, portable dev-gate, **never in production**), then tell the user to open

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -66,8 +66,7 @@ CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 
 Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**
 above). Read and use the `rest/` layer, regenerate the UI for your framework, and set `WIX_CLIENT_ID`
-+ `WIX_METASITE_ID` in `wix-config`. If the brief doesn't say which Wix solution(s) to build, **ask the
-user** one short question (what do they offer?).
++ `WIX_METASITE_ID` in `wix-config`.
 
 ### 3 · Seed the content
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -52,14 +52,6 @@ CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
 CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 ```
 
-Only if the CLI errors (not on a guess), fall back to curl + gzip:
-```bash
-for s in vibe-headless docs; do
-  mkdir -p ".agents/skills/wix-$s"
-  curl -s "https://www.wix.com/skills/$s.tgz" | tar xz -C ".agents/skills/wix-$s" --strip-components=1
-done
-```
-
 ### 2 · Build the client
 
 Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -65,8 +65,8 @@ CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 ### 2 · Build the client
 
 Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**
-above). Use the `rest/` layer as-is, regenerate the UI for your framework, and set `WIX_CLIENT_ID` +
-`WIX_METASITE_ID` in `wix-config`. If the brief doesn't say which Wix solution(s) to build, **ask the
+above). Read and use the `rest/` layer, regenerate the UI for your framework, and set `WIX_CLIENT_ID`
++ `WIX_METASITE_ID` in `wix-config`. If the brief doesn't say which Wix solution(s) to build, **ask the
 user** one short question (what do they offer?).
 
 ### 3 · Seed the content

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -1,74 +1,58 @@
 # Wix Managed Headless — build instructions (any stack)
 
 You are building a **Wix Managed** headless site — the business, your `WIX_CLIENT_ID`, and metasite
-id are in your prompt. Read **"What this skill is"** + **"Hard rules"** first (they change how you
-read everything else), then the steps.
+id are in your prompt. This skill is **client-only REST** over the public `WIX_CLIENT_ID`
+(visitor-facing, safe in the browser) — no `@wix/sdk`, no backend, no build step.
 
-## What this skill is (read first)
+## What you've got in the skill
 
-`wix-vibe-headless` is a **client-only REST connector** to a live Wix site over the public
-`WIX_CLIENT_ID` (visitor-facing, safe in the browser) — **no `@wix/sdk`, no backend, no build step**.
-Its docs (`SKILL.md`, each `references/<vertical>/INSTRUCTIONS.md`) are written for **one specific
-host stack** — Vite + react-router, `.jsx`, shadcn tokens in `index.css`, files pre-copied into
-`src/` by a `deploy.cjs`. **You may well be on a different stack**, so don't read them literally —
-read them for the **three real assets**, and translate the host-stack assumptions (table below):
+Its docs (`SKILL.md`, each `references/<vertical>/INSTRUCTIONS.md`) were authored for **one host
+stack** (Vite + react-router, `.jsx`, files pre-copied into `src/`). You may be on another — so take
+the **three assets** and adapt them; don't copy the host's setup:
 
-1. **`shared/app/rest/wix-client.js` + `<vertical>/app/rest/wix-*.js`** — REST transport + data layer.
-   **Copy ~verbatim** (rule 2); the source of truth for every request/response **shape**, the token
-   lifecycle, fieldsets, and paging.
-2. **`<vertical>/app/{components,pages,hooks}` + the field snippets in `INSTRUCTIONS.md`** — a
-   reference UI + data contract. **Regenerate the UI in your framework**; what you take is the **field
-   shapes** and **route patterns** (e.g. `/product/:slug`).
-3. **`<vertical>/seed/seed-*.js`** — build-time seeding **functions**. **Reuse them**; wrap in your
-   platform's exec/connector (STEP 4).
+1. **`rest/` layer** — `shared/app/rest/wix-client.js` + `<vertical>/app/rest/wix-*.js`: the transport
+   + data layer, and the source of truth for every request/response **shape**, the token lifecycle,
+   fieldsets, and paging. **Use ~verbatim** (plain `fetch`, already SSR-guarded; TS → rename `.js →
+   .ts` + add types) — don't change the shapes.
+2. **UI + data contract** — `<vertical>/app/{components,pages,hooks}` + the field snippets in
+   `INSTRUCTIONS.md`: a **reference** UI. **Regenerate it in your framework** (your router, `.tsx`,
+   your design tokens); keep the field shapes and route patterns (e.g. `/product/:slug`).
+3. **seed functions** — `<vertical>/seed/seed-*.js`: **reuse them** to create content (step 4).
+
+Anything in the docs about the **host's own setup** — copying files into `src/`, its `@/` alias, its
+`import.meta.env` flags, a theming file, its build/exec/connector tooling — is that host's, not a
+rule: adapt it to your stack or ignore it. The **"shared model"** in `SKILL.md` (public-client-id
+auth, money = objects → render `formattedValue`, visitor token = cart identity, member login swaps
+the token set) is **universal — follow it as-is**.
 
 (All paths are under `.agents/skills/wix-vibe-headless/references/`.)
 
-## Hard rules (do not skip)
+## Hard rules
 
 1. **Never convert the project's framework, bundler, dev server, or ports** — generate the Wix files
-   *into* the existing stack (Next.js → `app/<route>/page.tsx`; a file-based SSR router →
-   `src/routes/*`; Vite + react-router → as-is). Switching the project to a different bundler is the
-   #1 time-sink here: orphaned dev servers, port whack-a-mole, broken previews.
-2. **Copy the `rest/` layer ~verbatim** — plain `fetch`, framework-agnostic, already SSR-guards
-   `window`/`localStorage`. TypeScript project? rename `.js → .ts` + add types — but **never change
-   the shapes, endpoints, or token logic** (the hard-won part).
-3. **Generate everything else in your idiom** — your router, `.tsx`, your design tokens. Browser-only
-   code (cart provider, manage banner, anything touching `localStorage`/`window`) must be **SSR-safe**
-   (client-only / hydration guard). Dev-gate the banner portably: `import.meta.env?.DEV` is Vite-only
-   → fall back to `process.env.NODE_ENV !== "production"`.
-4. **Read-only over the owner's content** — live Wix data or an honest empty state; never mock,
-   invent, or provision on the client.
+   *into* the existing stack. Switching the project to another bundler is the #1 time-sink here:
+   orphaned dev servers, port whack-a-mole, broken previews.
+2. **`rest/` layer ~verbatim; regenerate everything else in your idiom.** Browser-only code (cart,
+   manage banner, anything using `localStorage`/`window`) must be **SSR-safe**; dev-gate the banner
+   portably (`import.meta.env?.DEV` is Vite-only → fall back to `process.env.NODE_ENV !== "production"`).
+3. **Read-only over the owner's content** — render live Wix data or an honest empty state; never
+   mock, invent, or provision.
 
-## How to read `SKILL.md` + `INSTRUCTIONS.md` — translate the host-stack assumptions
+## The flow — install → build client → seed → done
 
-| The doc says… | For you it means… |
-|---|---|
-| "already deployed into `src/`" / run `deploy.cjs` | there is **no copy step** — you **generate** these files |
-| "don't `read_file` the shipped source" | **do** read the `rest/` files — your source of truth for shapes |
-| "copy-as-is `.jsx`" | **regenerate** as your framework's components (`.tsx`, your router) |
-| `@/` alias, `import.meta.env.DEV` | use **your** import paths + a **portable** dev check |
-| theme via the host's `index.css` / shadcn tokens | map the intent to **your** design tokens |
-| react-router `/product/:slug` | keep the **route pattern**; implement it in **your** router |
-| host-specific tools (screenshot / exec / a pre-wired connector) | use **your** platform's equivalents (STEP 4) |
+Run **build client** (step 3) and **seed** (step 4) in parallel; parallelize independent work within each.
 
-`SKILL.md`'s **"shared model"** (public-client-id auth, money = objects → render `formattedValue`,
-visitor token = cart identity, member login swaps the token set) is **universal — follow as-is.**
+### 1 · Install the skills
 
-## STEP 1 — Install the Wix skills locally
-
-Install two (land under `.agents/skills/`):
-- **`wix-vibe-headless`** — the client build guide (STEP 3) **and** the seeding modules (STEP 4),
-  read via the lens above. **This skill is self-contained — everything you need is here.**
-- **`wix-docs`** — **fallback** to search/read the Wix API reference for anything the seed modules
-  don't cover.
+Two skills, into `.agents/skills/`: **`wix-vibe-headless`** (this build guide + the seed modules —
+self-contained) and **`wix-docs`** (fallback to search/read the Wix API reference).
 
 ```bash
 CI=1 npx skills@latest add wix/skills/skills/wix-vibe-headless --yes
 CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 ```
 
-**Only if the CLI errors** (not on a guess), fall back to curl + gzip:
+Only if the CLI errors (not on a guess), fall back to curl + gzip:
 ```bash
 for s in vibe-headless docs; do
   mkdir -p ".agents/skills/wix-$s"
@@ -76,13 +60,10 @@ for s in vibe-headless docs; do
 done
 ```
 
-Read them from files as you go (web fetches truncate large docs).
+### 2 · (optional) Not sure what to build?
 
-## STEP 2 (optional) — Brief vague? Ask, or read the site
-
-Only when the business description is missing/unclear. Don't guess the Wix Business Solution (stores,
-bookings, blog, events, portfolio, restaurants, CMS, pricing plans, members): **ask** one short
-question, or — with an admin credential (STEP 4; the public client id won't do) — **read the site**:
+Only if the brief is vague. **Ask** one short question, or — with an admin credential (step 4) —
+**read the site**:
 
 ```bash
 curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
@@ -90,69 +71,44 @@ curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-contex
   -d '{"siteId": "<metasite id from your prompt>"}'
 ```
 
-Returns installed apps (by name), status, URL, locale, CMS collections
+Returns the installed apps, status, locale, CMS collections
 ([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md);
-with an API key send it raw, no `Bearer`). Build for the **installed** apps — never guessed ones; the
-same set drives STEP 4's seeding.
+API key → send it raw, no `Bearer`). Build for the **installed** apps — never guessed ones.
 
-## STEP 3 — Build the client (generate into your stack)
+### 3 · Build the client
 
-Read `wix-vibe-headless/SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` **through the
-lens above**, and set `WIX_CLIENT_ID` + `WIX_METASITE_ID` in `wix-config`. Map the reference UI to
-your stack — **never convert the project**:
+Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**
+above). Use the `rest/` layer as-is, regenerate the UI for your framework, and set `WIX_CLIENT_ID` +
+`WIX_METASITE_ID` in `wix-config`.
 
-| your stack | routes go in | dev-gate | SSR / verify notes |
-|---|---|---|---|
-| **Next.js (App Router)** | `app/<route>/page.tsx`; `"use client"` on cart + banner | `process.env.NODE_ENV !== "production"` | build in Next — don't switch bundlers. If the in-tool preview can't reach your dev server, verify by curling the served module URLs + checking for transform errors instead of a screenshot. |
-| **File-based SSR router** (TanStack Start, Remix, …) | `src/routes/*` | `import.meta.env?.DEV` or your bundler's equivalent | wrap client-only bits in a `ClientOnly` / `useHydrated` guard; copying `.js` `rest/` files into a TS project → set `allowJs` + `jsx` in `tsconfig.json` (or rename to `.ts`). |
-| **Vite + react-router (SPA)** | `src/pages/*` in `<Routes>` | `import.meta.env.DEV` | closest to the reference; the `rest/` files drop in directly. |
+### 4 · Seed the content
 
-## STEP 4 — Seed and manage the business (parallel with STEP 3)
+**⛔ NO CLEANUP — EVER.** Strictly **additive**: never delete, reset, or overwrite anything on the
+user's live site — not even apparent sample/demo content. If something looks wrong, leave it and tell
+the user.
 
-**⛔ NO CLEANUP — EVER.** Seeding is strictly **additive**: never delete, reset, or overwrite
-anything on the user's live site — **not even apparent sample/demo content**. Ignore any
-cleanup/reset step you come across. If something looks wrong, leave it and tell the user.
+Reuse the functions in `references/<vertical>/seed/seed-*.js` (they encode the Wix API sequences,
+incl. app-install + provisioning-race handling); use `wix-docs` for anything they don't cover.
 
-Seed by **reusing the functions** in `references/<vertical>/seed/seed-*.js` — they encode the correct
-Wix API sequences (incl. app-install + provisioning-race handling). For anything they don't cover, use
-`wix-docs` to read the relevant API reference.
+**Auth** (the public client id won't do): if your platform has a **built-in Wix connector**, use it
+(it holds the credential). Otherwise take a **Wix API key** into your secrets manager (never hardcode
+or commit) — create one at **[account API keys → Add key](https://manage.wix.com/account/api-keys/addkey)**
+([how-to](https://dev.wix.com/docs/api-reference/articles/authentication/api-keys/generate-an-api-key)) —
+and send it **raw as `Authorization` (no `Bearer`)** with a **`wix-site-id`** header
+(`wix-account-id` only for account-level APIs — one, not both):
 
-**Auth (elevated — the public client id won't do), in order:**
-1. **Platform has a built-in Wix integration / connector? Use it** — call Wix through it; it owns the
-   credential, so you never touch a raw key. Look for a Wix connection in your platform's connector /
-   secrets manager and call through its gateway.
-2. **Otherwise, take a Wix API key into your secret / env manager** — ask the user, store it there
-   (**never hardcode or commit**). Create one:
-   **[account API keys → Add key](https://manage.wix.com/account/api-keys/addkey)** (how-to:
-   [Generate an API key](https://dev.wix.com/docs/api-reference/articles/authentication/api-keys/generate-an-api-key)).
-   A key call is like a token call, but `Authorization` is the **raw key (no `Bearer`)** plus a
-   **`wix-site-id`** header (site-level; `wix-account-id` only for account-level APIs — one, not both;
-   site-level keys must be made from the **site owner's** account):
-   ```bash
-   curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
-     -H 'Authorization: <API_KEY>' -H 'wix-site-id: <METASITE_ID>' \
-     -H 'Content-Type: application/json' -d '{"query":{"cursorPaging":{"limit":10}}}'
-   ```
-   The seed modules take a token via `ctx`; to run them with a key, swap their
-   `Authorization: Bearer <token>` for the raw-key + `wix-site-id` shape above.
+```bash
+curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
+  -H 'Authorization: <API_KEY>' -H 'wix-site-id: <METASITE_ID>' \
+  -H 'Content-Type: application/json' -d '{"query":{"cursorPaging":{"limit":10}}}'
+```
 
-Do **not** reach for the Wix CLI (`@wix/cli`) or a device-login — auth is the connector or the API key.
+Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is installed + seeded (expected; the
+seed modules install it first). Image seeding = two Wix Media calls (`generate-upload-url` → `PUT` the
+bytes) before attaching.
 
-**Notes:** client content queries return `REQUIRED_APP_NOT_INSTALLED` until STEP 4 installs + seeds
-the app (expected; the seed modules install it first). Image seeding = two Wix Media calls
-(`generate-upload-url` → `PUT` the bytes) before you attach the file to a product/post/etc.
+### 5 · Done
 
-## Later admin requests
-
-Same as STEP 4: reuse the skill's `references/<vertical>/seed/` modules and patterns; fall back to
-`wix-docs` for anything they don't cover.
-
-## STEP 5 — When done
-
-1. **Add the dev-only manage banner** (required): regenerate `WixManageBanner` for your stack
-   (reference: `references/<vertical>/app/components/WixManageBanner.jsx`) — set `WIX_METASITE_ID`,
-   mount it in the Layout's fixed top region above the header, dev-gate it **portably** (rule 3), and
-   guard its `localStorage` read for SSR. **Never** render it in production.
-2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` to finish setup in Wix
-   (payments, content). Mention dev builds show a slim dismissible banner to that same dashboard
-   (never in production).
+Mount the dev-only manage banner (regenerate `WixManageBanner` for your stack — set `WIX_METASITE_ID`,
+above the header, SSR-safe, portable dev-gate, **never in production**), then tell the user to open
+`https://manage.wix.com/dashboard/{metaSiteId}` to finish setup in Wix (payments, content).

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -27,17 +27,6 @@ the token set) is **universal — follow it as-is**.
 
 (All paths are under `.agents/skills/wix-vibe-headless/references/`.)
 
-## Hard rules
-
-1. **Never convert the project's framework, bundler, dev server, or ports** — generate the Wix files
-   *into* the existing stack. Switching the project to another bundler is the #1 time-sink here:
-   orphaned dev servers, port whack-a-mole, broken previews.
-2. **`rest/` layer ~verbatim; regenerate everything else in your idiom.** Browser-only code (cart,
-   manage banner, anything using `localStorage`/`window`) must be **SSR-safe**; dev-gate the banner
-   portably (`import.meta.env?.DEV` is Vite-only → fall back to `process.env.NODE_ENV !== "production"`).
-3. **Read-only over the owner's content** — render live Wix data or an honest empty state; never
-   mock, invent, or provision.
-
 ## The flow — install → build client → seed → done
 
 Run **build the client** (step 2) and **seed** (step 3) in parallel; parallelize independent work within each.

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -14,19 +14,18 @@ Everything is under `.agents/skills/wix-vibe-headless/references/`.
 
 | file | what's in it |
 |---|---|
-| `wix-client.js` | The transport. Exchanges `WIX_CLIENT_ID` for an anonymous **visitor token**, persists + refreshes it (that token *is* the cart/session identity), and exposes `wixApiRequest(path, {method, body, query})`. Also the member-session swap — `setSessionTokens` / `clearSession` / `isMember`. Plain `fetch`; already SSR-guards `window`/`localStorage`; maps 402 + error bodies. **Use ~verbatim.** |
-| `wix-config.js` | The one place you set `WIX_CLIENT_ID` + `WIX_METASITE_ID`. |
+| `wix-client.js` | The transport: exchanges `WIX_CLIENT_ID` for an anonymous **visitor token**, persists + refreshes it (that token *is* the cart/session identity), and exposes `wixApiRequest(path, {method, body, query})` — plus the member-session swap (`setSessionTokens` / `clearSession` / `isMember`). Plain `fetch`; SSR-guards `window`/`localStorage`; maps 402 + error bodies. |
+| `wix-config.js` | Holds `WIX_CLIENT_ID` + `WIX_METASITE_ID` — the only values to fill in. |
 
 **Every `references/<vertical>/` holds the same four things:**
 
 - `app/rest/wix-*.js` — the vertical's **data layer**: named calls carrying the exact request/response
-  **shapes**, fieldsets, and paging. **Use ~verbatim** (TS → rename `.js → .ts` + add types); never
-  change the shapes.
-- `app/{components,pages,hooks,context}/…` — a **reference UI** (+ hooks/providers). **Regenerate it
-  in your framework** (your router, `.tsx`, your design tokens); keep the field shapes and route
-  patterns (e.g. `/product/:slug`).
-- `seed/seed-*.js` — build-time **seeding functions**; **reuse them** to create content (step 3).
-- `INSTRUCTIONS.md` (build guide + field-shape snippets) and `seed/SEED.md` (how to run the seed module).
+  **shapes**, fieldsets, and paging.
+- `app/{components,pages,hooks,context}/…` — a **reference UI** (+ hooks/providers) built on that data
+  layer; the field shapes and route patterns it uses (e.g. `/product/:slug`) are the data contract.
+- `seed/seed-*.js` — build-time **seeding functions** that create content.
+- `INSTRUCTIONS.md` — the vertical's build guide + field-shape snippets; `seed/SEED.md` — how the seed
+  module is run.
 
 **The nine verticals — data layer (`app/rest/`) + seed module (`seed/`):**
 

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -105,6 +105,8 @@ cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is inst
 
 ### 4 · Done
 
-Mount the dev-only manage banner (regenerate `WixManageBanner` for your stack — set `WIX_METASITE_ID`,
-above the header, SSR-safe, portable dev-gate, **never in production**), then tell the user to open
-`https://manage.wix.com/dashboard/{metaSiteId}` to finish setup in Wix (payments, content).
+Mount the dev-only manage banner (regenerate `WixManageBanner` for your stack — it reads
+`WIX_METASITE_ID` from `wix-config`, already set in step 2, and self-hides while it's still the
+placeholder; mount above the header, SSR-safe, portable dev-gate, **never in production**), then tell
+the user to open `https://manage.wix.com/dashboard/{metaSiteId}` to finish setup in Wix (payments,
+content).

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -67,7 +67,7 @@ CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**
 above). Use the `rest/` layer as-is, regenerate the UI for your framework, and set `WIX_CLIENT_ID` +
 `WIX_METASITE_ID` in `wix-config`. If the brief doesn't say which Wix solution(s) to build, **ask the
-user** one short question (what do they offer?), or let step 3's site read settle it.
+user** one short question (what do they offer?).
 
 ### 3 · Seed the content
 
@@ -88,16 +88,7 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
   -H 'Content-Type: application/json' -d '{"query":{"cursorPaging":{"limit":10}}}'
 ```
 
-**Once you have that admin credential**, you can read the site to see which apps are actually
-installed — build and seed only those, never guessed ones:
-
-```bash
-curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
-  -H 'Authorization: <admin token or raw API key>' -H 'Content-Type: application/json' \
-  -d '{"siteId": "<metasite id from your prompt>"}'
-```
-
-Then seed by reusing the functions in `references/<vertical>/seed/seed-*.js` (they encode the Wix API
+Seed by reusing the functions in `references/<vertical>/seed/seed-*.js` (they encode the Wix API
 sequences, incl. app-install + provisioning-race handling); use `wix-docs` for anything they don't
 cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is installed + seeded
 (expected; the seed modules install it first). Image seeding = two Wix Media calls


### PR DESCRIPTION
Reframes `generic.md` per the intended philosophy: **tell the agent what it has in the skill and facilitate the four steps (install → build client → seed → done)** — don't teach it how to translate each host-specific tool.

- **Removed** the granular ignore/translate table + per-stack cheatsheet. They were too prescriptive (mapping `screenshot`/`exec_tool`/connector/`@/`/theming one-by-one), and `screenshot` isn't even referenced anywhere in the skill.
- **Replaced** with: (1) *What you've got* — the 3 assets (`rest/` layer used ~verbatim; UI + data contract to regenerate in your framework; seed functions to reuse) + one line that anything about the *host's own setup* is adapt-or-ignore; (2) 3 hard rules; (3) the coarse flow.
- Fully platform-agnostic (no v0 / Lovable / Base44); API-key seed example kept.
- **9,986 → 6,123 chars.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)