### PR TITLE
fix(wix-manage): send each variant complete on a Catalog V3 update

### DIFF
--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -332,7 +332,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 - To update `variantsInfo.variants`, also pass `options`, and vice versa. Variants and options are mutually dependent and must stay aligned.
 - When converting a simple product to an optioned product, rebuild the variants list so every variant has `choices`; do not keep an existing choice-less default variant unchanged.
 - Always include `choicesSettings` with the complete list of choices when updating a product with options.
-- Use `optionChoiceNames` rather than `optionChoiceIds` in variants for more reliable updates.
+- Use `optionChoiceNames` rather than `optionChoiceIds` in variants for more reliable updates. Reading them back is not symmetric: Get Product returns each variant's `choices` with `optionChoiceIds` only, and fills in `optionChoiceNames` just when the request's `fields` array includes `"VARIANT_OPTION_CHOICE_NAMES"`. So to find the variant for a named choice such as `Large`, either pass that field and match on the name, or take the choice GUID from `options[].choicesSettings.choices[].choiceId` and match it against `variants[].choices[].optionChoiceIds.choiceId`. Matching on a name the response never carried raises nothing — it just selects no variant.
 - Include the `renderType` in `optionChoiceNames`.
 
 ## Error Message Reference

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -216,7 +216,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
   }'
 ```
 
-When updating existing variants, include each existing variant `id`. If no GUID is passed, a variant is created with a new GUID.
+When updating existing variants, include each existing variant `id`. If no GUID is passed, a variant is created with a new GUID. Each variant object is replaced whole rather than merged, so carry over the fields you are not changing: rebuilding a variant from just its `id` plus the field you want to set drops everything else and is rejected on the first required field it lost (`price must not be empty`). Start from the variant as returned by Get Product and override only what the user asked to change.
 
 ### Convert a Simple Product to Color Variants
 
@@ -344,7 +344,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 | `Expected an object` for `description` | Sent `description` as a string | Use `plainDescription` for HTML strings, or send `description` as Rich Content |
 | `choicesSettings must not be empty` | Missing choices array | Include full `choicesSettings.choices` array |
 | `Missing product option choices` | Variant references non-existent option | Use `optionChoiceNames` with exact option and choice names |
-| `price must not be empty` | A variant was created or replaced without a price | Include `price.actualPrice.amount` on every new variant |
+| `price must not be empty` | A variant was sent without a price — including an existing variant rebuilt from only its `id` and the field being changed | Carry `price.actualPrice.amount` on every variant you send, not just new ones; copy it from the Get Product response for variants you are not repricing |
 | `variantsInfo is invalid: variants has size 0, expected 1 or more` | Variants were read from a Search or Query Products response, which does not return them | Re-read the product with Get Product and send its `variantsInfo.variants` |
 | `Missing option choices` or `INVALID_DEFAULT_VARIANT` | Product has options but at least one variant has no matching choices | Rebuild `variantsInfo.variants` so every variant includes choices for all product options |
 | `DIGITAL_PRODUCT_CANNOT_BE_VISIBLE_IN_POS` | Sent `visibleInPos: true` on a digital product | Digital products can't be visible in POS; leave `visibleInPos` out of the body |

--- a/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
+++ b/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
@@ -1,0 +1,86 @@
+name: stores/update-product-sku-full-variant
+description: >
+  A store owner asks to set an existing Catalog V3 product's SKU. Verifies the agent loads the
+  Update Product with Options (Catalog V3) recipe and sends each variant complete in the Update
+  Product PATCH. `variantsInfo.variants` replaces both the array and each variant object, so a
+  variant rebuilt from only its `id` plus the changed field loses the fields it did not carry and
+  the request is rejected with `price must not be empty`.
+triggerPrompt: >
+  Set the SKU of my Eval Gate Mug to MUG-001.
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3
+  - type: llm_judge          # correctness — the user's outcome
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Set the SKU of my Eval Gate Mug to MUG-001."
+
+      The site is a Catalog V3 store seeded with a physical product named "Eval Gate Mug" priced
+      at $12.00, with a single variant and no product options. The template also ships other demo
+      products; those are irrelevant and must not affect the score.
+
+      Score 9-10: the agent located the existing "Eval Gate Mug" and set its variant SKU to
+      "MUG-001" with a successful (2xx) Catalog V3 Update Product PATCH, and confirmed it back to
+      the user.
+
+      Score 7-8: the SKU is "MUG-001" on the existing product after a successful update, but the
+      confirmation to the user is vague or omits the SKU.
+
+      Score 4-6: the SKU ends up correct but the variant lost data in the process — for example
+      its price is no longer $12.00, or the variant was replaced and carries a new id.
+
+      Score 1-3: the agent created a NEW product instead of updating the existing one; OR set the
+      SKU on a different product, or to a value other than "MUG-001"; OR the final update call
+      errored (non-2xx); OR it only described how to do it without doing it.
+
+      Do not deduct for merely reading or listing the other demo products.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the tool-call path (gates, per docs/eval-scenarios.md)
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
+      trace, including the request bodies and any error bodies.
+
+      Score 9-10: a direct path — the product was located, re-read with Get Product, and updated
+      in one successful PATCH whose variant carried its existing fields alongside the new SKU. No
+      non-2xx responses, no retried request bodies.
+
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
+      a probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant
+      read.
+
+      Score 1-3: any Update Product call was REJECTED and then retried. In particular, score here
+      when a variant was rebuilt from only its `id` plus the changed field and the PATCH came back
+      with `price must not be empty` (or any other REQUIRED_FIELD violation on
+      `product.variantsInfo.variants[...]` caused by fields the agent did not carry over), even
+      though a later call succeeded. Also score here for a wrong endpoint or wrong catalog version
+      tried first.
+
+      Do not deduct for reading the seeded store's other demo products.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed mug product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Mug
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true

--- a/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
+++ b/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
@@ -57,7 +57,10 @@ assertions:
       Large variant's SKU. No non-2xx responses, no retried request bodies.
 
       Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example a
-      probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant read.
+      probing or repeated API-spec/schema lookup to discover where `sku` lives, a redundant read, or
+      an extra call to work out how a variant identifies its option choice (such as a first attempt
+      that matched the choice by name, selected no variant because the response carried only choice
+      GUIDs, and had to be re-run after inspecting the product's options).
 
       Score 1-3: any Update Product call was REJECTED and then retried. Score here in particular
       when the rejection came from variant state the agent did not carry over — a variant rebuilt

--- a/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
+++ b/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
@@ -1,12 +1,13 @@
 name: stores/update-product-sku-full-variant
 description: >
-  A store owner asks to set an existing Catalog V3 product's SKU. Verifies the agent loads the
-  Update Product with Options (Catalog V3) recipe and sends each variant complete in the Update
-  Product PATCH. `variantsInfo.variants` replaces both the array and each variant object, so a
-  variant rebuilt from only its `id` plus the changed field loses the fields it did not carry and
-  the request is rejected with `price must not be empty`.
+  A store owner asks to set the SKU on one variant of a Catalog V3 product that has two variants.
+  Verifies the agent loads the Update Product with Options (Catalog V3) recipe and sends every
+  variant complete in the Update Product PATCH. `variantsInfo.variants` replaces both the array and
+  each variant object, so sending only the changed variant drops the other one, and rebuilding a
+  variant from just its `id` plus the changed field drops the fields it did not carry — rejected
+  with `price must not be empty`.
 triggerPrompt: >
-  Set the SKU of my Eval Gate Mug to MUG-001.
+  Set the SKU of the Large size of my Eval Gate Mug to MUG-L-001.
 tags: [stores]
 assertions:
   - tool: ReadFullDocsArticle
@@ -16,25 +17,30 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: >
-      The user's request (verbatim): "Set the SKU of my Eval Gate Mug to MUG-001."
+      The user's request (verbatim): "Set the SKU of the Large size of my Eval Gate Mug to
+      MUG-L-001."
 
-      The site is a Catalog V3 store seeded with a physical product named "Eval Gate Mug" priced
-      at $12.00, with a single variant and no product options. The template also ships other demo
-      products; those are irrelevant and must not affect the score.
+      The site is a Catalog V3 store seeded with a physical product "Eval Gate Mug" that has one
+      option, Size, with two choices: Small (price $12.00) and Large (price $16.00). Each size is a
+      separate variant. The template also ships other demo products; those are irrelevant and must
+      not affect the score.
 
-      Score 9-10: the agent located the existing "Eval Gate Mug" and set its variant SKU to
-      "MUG-001" with a successful (2xx) Catalog V3 Update Product PATCH, and confirmed it back to
-      the user.
+      Score 9-10: after a successful (2xx) Update Product PATCH, the Large variant's SKU is
+      "MUG-L-001", AND the product still has both variants, AND the Small variant is untouched
+      (still $12.00), AND the Large variant kept its $16.00 price. The agent confirmed the change.
 
-      Score 7-8: the SKU is "MUG-001" on the existing product after a successful update, but the
-      confirmation to the user is vague or omits the SKU.
+      Score 7-8: the same end state, but the confirmation to the user is vague or omits the SKU.
 
-      Score 4-6: the SKU ends up correct but the variant lost data in the process — for example
-      its price is no longer $12.00, or the variant was replaced and carries a new id.
+      Score 4-6: the SKU is set on the Large variant but the product lost state in the process —
+      the Small variant is missing, either variant's price changed or was cleared, or a variant
+      carries a new id.
 
-      Score 1-3: the agent created a NEW product instead of updating the existing one; OR set the
-      SKU on a different product, or to a value other than "MUG-001"; OR the final update call
-      errored (non-2xx); OR it only described how to do it without doing it.
+      Score 1-3: the SKU was set on the wrong variant or to a different value; OR a NEW product was
+      created instead of updating the existing one; OR the final update call errored (non-2xx); OR
+      the agent only described how to do it without doing it.
+
+      Judge the end state, not the number of attempts — a run that was rejected and then recovered
+      to the correct end state still scores here on correctness.
 
       Do not deduct for merely reading or listing the other demo products.
 
@@ -43,23 +49,24 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: >
-      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
-      trace, including the request bodies and any error bodies.
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call trace,
+      including the request bodies and any error bodies.
 
-      Score 9-10: a direct path — the product was located, re-read with Get Product, and updated
-      in one successful PATCH whose variant carried its existing fields alongside the new SKU. No
-      non-2xx responses, no retried request bodies.
+      Score 9-10: a direct path — the product was located, re-read with Get Product, and updated in
+      one successful PATCH that carried BOTH variants with their existing fields, changing only the
+      Large variant's SKU. No non-2xx responses, no retried request bodies.
 
-      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
-      a probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant
-      read.
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example a
+      probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant read.
 
-      Score 1-3: any Update Product call was REJECTED and then retried. In particular, score here
-      when a variant was rebuilt from only its `id` plus the changed field and the PATCH came back
-      with `price must not be empty` (or any other REQUIRED_FIELD violation on
-      `product.variantsInfo.variants[...]` caused by fields the agent did not carry over), even
-      though a later call succeeded. Also score here for a wrong endpoint or wrong catalog version
-      tried first.
+      Score 1-3: any Update Product call was REJECTED and then retried. Score here in particular
+      when the rejection came from variant state the agent did not carry over — a variant rebuilt
+      from only its `id` plus the changed field returning `price must not be empty` or any other
+      REQUIRED_FIELD violation on `product.variantsInfo.variants[...]`, or only the changed variant
+      being sent so the other one was dropped (`Missing option choices`,
+      `INVALID_DEFAULT_VARIANT`, or a variants array shorter than the product's) — even though a
+      later call succeeded. Also score here for a wrong endpoint or wrong catalog version tried
+      first.
 
       Do not deduct for reading the seeded store's other demo products.
 
@@ -71,7 +78,7 @@ siteSetup:
   templateId: stores-v3-editor
   bootstrap:
     steps:
-      - label: seed mug product
+      - label: seed mug product with two size variants
         method: post
         url: https://www.wixapis.com/stores/v3/products
         body:
@@ -79,8 +86,30 @@ siteSetup:
             name: Eval Gate Mug
             productType: PHYSICAL
             physicalProperties: {}
+            options:
+              - name: Size
+                optionRenderType: TEXT_CHOICES
+                choicesSettings:
+                  choices:
+                    - choiceType: CHOICE_TEXT
+                      name: Small
+                    - choiceType: CHOICE_TEXT
+                      name: Large
             variantsInfo:
               variants:
-                - price: { actualPrice: { amount: "12.00" } }
+                - choices:
+                    - optionChoiceNames:
+                        optionName: Size
+                        choiceName: Small
+                        renderType: TEXT_CHOICES
+                  price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true
+                - choices:
+                    - optionChoiceNames:
+                        optionName: Size
+                        choiceName: Large
+                        renderType: TEXT_CHOICES
+                  price: { actualPrice: { amount: "16.00" } }
                   physicalProperties: {}
                   visible: true


### PR DESCRIPTION
`variantsInfo.variants` replaces the array **and each variant object** — it does not merge them. The recipe already said to pass the entire existing array, and to include each existing variant `id`. An agent can satisfy both of those and still rebuild each variant from only its `id` plus the field it wants to change, which drops every field it did not carry. The update is then rejected on the first required one:

```
HTTP 400 {"message":"product is invalid:
`-- variantsInfo is invalid:
    `-- variants [at index 0] is invalid:
       `-- price must not be empty",
 "details":{"validationError":{"fieldViolations":[
   {"field":"product.variantsInfo.variants[0].price",
    "description":"must not be empty","violatedRule":"REQUIRED_FIELD"}]}}}
```

## How it shows up

Setting a SKU on an existing product. From a recorded run, the agent read the recipe, located the product and re-read it with Get Product — then assembled the PATCH as:

```js
const updatedVariants = currentVariants.map(v => ({ id: v.id, sku: "MUG-001" }));
```

The variant's price went with it, and the write was rejected. The agent recovered by retrying with the variant spread intact, so the user still got the right SKU — one rejected write and an extra round trip later.

The error table made this harder to diagnose than it needed to be: it attributed `price must not be empty` to a variant "created or replaced without a price" and prescribed the fix "on every **new** variant", so an agent updating an existing variant reads that row as not applying to it.

## Changes

Two lines in `update-product-with-options.md`:

- The paragraph on updating existing variants now says each variant object is replaced whole rather than merged, and to start from the variant as returned by Get Product.
- The `price must not be empty` row now names the existing-variant case and says to carry `price` on every variant sent, not just new ones.

No request or response shapes are restated — both edits are about how to assemble a call from what Get Product already returned.

## Coverage

New scenario `yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml`, three assertions with the path judge gating at 7, per this repo's eval-scenario guide. Its 1-3 band is specifically a rejected-then-retried Update Product caused by a `REQUIRED_FIELD` violation on `variantsInfo.variants[...]` from fields the agent did not carry over, so the scenario fails on the behaviour this PR is meant to remove rather than on the outcome, which was already correct.
