### PR TITLE
fix(wix-manage): three Catalog V3 frictions in find-products and update-product

### DIFF
--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -18,12 +18,12 @@ Use **Search Products** for text search and name-based lookup. Use **Query Produ
 | Find products by name or free text | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) | Best for user-provided names, keywords, and broad product lookup. |
 | List all products or page through the catalog | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Supports paging and structured filters on the fields listed below. |
 | Filter by `id`, `slug`, `handle`, dates, or `visible` | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Best for exact structured criteria. |
-| Filter by price — "products under $20", "between $10 and $50" | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) | Query Products has no price filter. Search Products filters on `actualPriceRange.minValue.amount` with `$lt`/`$gt`, which is also where a product's price is read back from. |
+| Filter by price — "products under $20", "between $10 and $50" | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) | Query Products has no price filter, so filter server-side here (STEP 1) instead of paging the catalog and comparing amounts yourself. |
 | Need exact name matching after text lookup | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) + client-side match | Search by the name text, then match the returned `product.name` in your own code. |
 
-### STEP 1: Search products by name or free text
+### STEP 1: Search products by name, free text, or price
 
-Use Search Products when the user gives a product name, keyword, or other text expression:
+Use Search Products when the user gives a product name, keyword, or other text expression, and for price criteria, which Query Products cannot filter on. Free text goes in `search.search`; price and other structured criteria go in `search.filter`. Send only the part you need:
 
 ```bash
 curl -X POST 'https://www.wixapis.com/stores/v3/products/search' \
@@ -31,9 +31,16 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/search' \
 -H 'Authorization: <AUTH>' \
 -d '{
   "search": {
-    "expression": "Blue Shirt"
+    "search": { "expression": "Blue Shirt" },
+    "filter": { "actualPriceRange.minValue.amount": { "$lt": 20 } }
   }
 }'
+```
+
+Both endpoints return their matches in `products`:
+
+```json
+{ "products": [ { "id": "...", "name": "Blue Shirt" } ], "pagingMetadata": { "count": 1 } }
 ```
 
 For exact name matching, search with the user-provided text and then compare the returned `product.name` values in your own code.

--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -37,11 +37,18 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/search' \
 }'
 ```
 
-Both endpoints return their matches in `products`:
+The response puts the matches in `products`:
 
 ```json
-{ "products": [ { "id": "...", "name": "Blue Shirt" } ], "pagingMetadata": { "count": 1 } }
+{
+  "products": [
+    { "id": "...", "name": "Blue Shirt", "slug": "blue-shirt" }
+  ],
+  "pagingMetadata": { "count": 1 }
+}
 ```
+
+Query Products returns the same envelope.
 
 For exact name matching, search with the user-provided text and then compare the returned `product.name` values in your own code.
 

--- a/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
+++ b/skills/wix-manage/references/stores/find-products-query-and-search-catalog-v3.md
@@ -1,6 +1,6 @@
 ---
 name: "Find Products (Query and Search, Catalog V3)"
-description: Find, search, query, and list products from a Wix Store using Catalog V3 Search Products and Query Products endpoints. Explains when to use each endpoint, correct fields enum values, filtering, sorting, and paging.
+description: Find, search, query, and list products from a Wix Store using Catalog V3 Search Products and Query Products endpoints. Explains when to use each endpoint, correct fields enum values, filtering (including by price), sorting, and paging.
 ---
 
 # RECIPE: Business Recipe – Find Products in a Wix Store (Query and Search, Catalog V3)
@@ -18,6 +18,7 @@ Use **Search Products** for text search and name-based lookup. Use **Query Produ
 | Find products by name or free text | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) | Best for user-provided names, keywords, and broad product lookup. |
 | List all products or page through the catalog | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Supports paging and structured filters on the fields listed below. |
 | Filter by `id`, `slug`, `handle`, dates, or `visible` | [Query Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products) | Best for exact structured criteria. |
+| Filter by price — "products under $20", "between $10 and $50" | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) | Query Products has no price filter. Search Products filters on `actualPriceRange.minValue.amount` with `$lt`/`$gt`, which is also where a product's price is read back from. |
 | Need exact name matching after text lookup | [Search Products](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/search-products) + client-side match | Search by the name text, then match the returned `product.name` in your own code. |
 
 ### STEP 1: Search products by name or free text
@@ -80,7 +81,7 @@ The `fields` array requests **additional** fields beyond the defaults. It does *
 | `DESCRIPTION`                      | Rich text description        |
 | `DIRECT_CATEGORIES_INFO`           | Direct category info         |
 | `ALL_CATEGORIES_INFO`              | All category info            |
-| `MIN_VARIANT_PRICE_INFO`           | Minimum variant price        |
+| `MIN_PRICE_VARIANT`                | Lowest-priced visible variant |
 | `INFO_SECTION_DESCRIPTION`         | Info section rich content    |
 | `THUMBNAIL`                        | Thumbnail image              |
 | `DIRECT_CATEGORY_IDS`              | Direct category IDs          |
@@ -106,7 +107,7 @@ The `fields` array requests **additional** fields beyond the defaults. It does *
 
 ### STEP 4: Filtering and sorting with Query Products
 
-`QueryProducts` supports filters only on these fields:
+`QueryProducts` supports filters only on these fields. Price is not among them, so answer a price question with Search Products rather than paging the whole catalog and comparing amounts in your own code:
 
 | Field | Supported Filters | Sortable |
 | ----- | ----------------- | -------- |

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -332,7 +332,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 - To update `variantsInfo.variants`, also pass `options`, and vice versa. Variants and options are mutually dependent and must stay aligned.
 - When converting a simple product to an optioned product, rebuild the variants list so every variant has `choices`; do not keep an existing choice-less default variant unchanged.
 - Always include `choicesSettings` with the complete list of choices when updating a product with options.
-- Use `optionChoiceNames` rather than `optionChoiceIds` in variants for more reliable updates.
+- Use `optionChoiceNames` rather than `optionChoiceIds` in variants for more reliable updates. Reading them back is not symmetric: Get Product returns each variant's `choices` with `optionChoiceIds` only, and fills in `optionChoiceNames` just when the request's `fields` array includes `"VARIANT_OPTION_CHOICE_NAMES"`. So to find the variant for a named choice such as `Large`, either pass that field and match on the name, or take the choice GUID from `options[].choicesSettings.choices[].choiceId` and match it against `variants[].choices[].optionChoiceIds.choiceId`. Matching on a name the response never carried raises nothing — it just selects no variant.
 - Include the `renderType` in `optionChoiceNames`.
 
 ## Error Message Reference

--- a/skills/wix-manage/references/stores/update-product-with-options.md
+++ b/skills/wix-manage/references/stores/update-product-with-options.md
@@ -216,7 +216,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
   }'
 ```
 
-When updating existing variants, include each existing variant `id`. If no GUID is passed, a variant is created with a new GUID.
+When updating existing variants, include each existing variant `id`. If no GUID is passed, a variant is created with a new GUID. Each variant object is replaced whole rather than merged, so carry over the fields you are not changing: rebuilding a variant from just its `id` plus the field you want to set drops everything else and is rejected on the first required field it lost (`price must not be empty`). Start from the variant as returned by Get Product and override only what the user asked to change.
 
 ### Convert a Simple Product to Color Variants
 
@@ -344,7 +344,7 @@ curl -X PATCH "https://www.wixapis.com/stores/v3/products/{productId}" \
 | `Expected an object` for `description` | Sent `description` as a string | Use `plainDescription` for HTML strings, or send `description` as Rich Content |
 | `choicesSettings must not be empty` | Missing choices array | Include full `choicesSettings.choices` array |
 | `Missing product option choices` | Variant references non-existent option | Use `optionChoiceNames` with exact option and choice names |
-| `price must not be empty` | A variant was created or replaced without a price | Include `price.actualPrice.amount` on every new variant |
+| `price must not be empty` | A variant was sent without a price — including an existing variant rebuilt from only its `id` and the field being changed | Carry `price.actualPrice.amount` on every variant you send, not just new ones; copy it from the Get Product response for variants you are not repricing |
 | `variantsInfo is invalid: variants has size 0, expected 1 or more` | Variants were read from a Search or Query Products response, which does not return them | Re-read the product with Get Product and send its `variantsInfo.variants` |
 | `Missing option choices` or `INVALID_DEFAULT_VARIANT` | Product has options but at least one variant has no matching choices | Rebuild `variantsInfo.variants` so every variant includes choices for all product options |
 | `DIGITAL_PRODUCT_CANNOT_BE_VISIBLE_IN_POS` | Sent `visibleInPos: true` on a digital product | Digital products can't be visible in POS; leave `visibleInPos` out of the body |

--- a/yaml/wix-manage-evals/stores/find-products-under-price-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/find-products-under-price-catalog-v3.yml
@@ -1,0 +1,107 @@
+name: stores/find-products-under-price-catalog-v3
+description: >
+  A store owner asks which of their products cost less than a given amount. Verifies the agent
+  loads the Find Products (Query and Search, Catalog V3) recipe and answers with a Search
+  Products price filter, rather than paging the whole catalog through Query Products and
+  comparing amounts in its own code — a path that also invites guessing where the price lives
+  on a Catalog V3 product. The seeded products are the ground truth, and the agent can only
+  know them by reading the catalog.
+triggerPrompt: >
+  Which of my products cost less than $20?
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3
+  - type: llm_judge          # correctness — the user's outcome
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Which of my products cost less than $20?"
+
+      The site is a Catalog V3 store seeded with two products: "Eval Gate Mug" at $12.00 and
+      "Eval Gate Tee" at $25.00. Only the Mug is under $20. The template also ships its own
+      demo catalog.
+
+      Judge the FINAL ANSWER's end state only. How many API calls it took, and whether the
+      agent corrected itself along the way, are judged by a separate assertion — do not
+      deduct for either here.
+
+      Score 9-10: the answer names "Eval Gate Mug" as costing less than $20 and does NOT
+      present "Eval Gate Tee" as under $20, and the products came from a successful (2xx)
+      read of the catalog.
+
+      Score 7-8: the Mug is correctly reported and the Tee is correctly excluded, but the
+      answer is muddled — for example it hedges on the price or buries the result.
+
+      Score 1-3: the answer includes "Eval Gate Tee" among the products under $20; OR omits
+      "Eval Gate Mug"; OR reports that no products are under $20; OR lists products without
+      having read the catalog through any Wix API; OR only describes how to find them
+      without doing it.
+
+      Demo products from the template that genuinely cost less than $20 are NOT an error —
+      do not deduct for naming extra products beyond the Mug.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality of the tool-call path (gates, per docs/eval-scenarios.md)
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
+      trace, including the request bodies and any error bodies.
+
+      Score 9-10: a direct path — the catalog was filtered by price server-side in a single
+      successful read (a Catalog V3 Search Products call carrying a price filter), with no
+      non-2xx responses and no retried request bodies.
+
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for
+      example one probing API-spec or schema lookup beyond what was needed, or a redundant
+      repeat of a read that had already succeeded.
+
+      Score 1-3: any of the following, even though a later call succeeded:
+
+      - the agent fetched products WITHOUT a price filter and compared amounts in its own
+        code — for example a Query Products call followed by a client-side comparison — when
+        a Search Products price filter would have returned the answer directly;
+      - the agent guessed where the price lives on a Catalog V3 product, such as reading
+        `priceData.price` or `price.price`, got `undefined` or an empty result, and then had
+        to re-read a product to discover the real field;
+      - a price filter was sent inside the Query Products `query.filter` and was rejected
+        with `Field '<fieldName>' is not declared as filterable`;
+      - a `fields` value that is not a valid enum constant was sent and rejected;
+      - any other non-2xx response, or a wrong endpoint or catalog version tried first.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed mug product under the threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Mug
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true
+      - label: seed tee product above the threshold
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Tee
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "25.00" } }
+                  physicalProperties: {}
+                  visible: true

--- a/yaml/wix-manage-evals/stores/find-products-under-price-catalog-v3.yml
+++ b/yaml/wix-manage-evals/stores/find-products-under-price-catalog-v3.yml
@@ -68,6 +68,9 @@ assertions:
         to re-read a product to discover the real field;
       - a price filter was sent inside the Query Products `query.filter` and was rejected
         with `Field '<fieldName>' is not declared as filterable`;
+      - the response was parsed with a Catalog V1/V2 shape, such as reading results from
+        `productResults.results` or `catalogItems` rather than `products`, and the call had
+        to be repeated;
       - a `fields` value that is not a valid enum constant was sent and rejected;
       - any other non-2xx response, or a wrong endpoint or catalog version tried first.
 

--- a/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
+++ b/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
@@ -1,0 +1,86 @@
+name: stores/update-product-sku-full-variant
+description: >
+  A store owner asks to set an existing Catalog V3 product's SKU. Verifies the agent loads the
+  Update Product with Options (Catalog V3) recipe and sends each variant complete in the Update
+  Product PATCH. `variantsInfo.variants` replaces both the array and each variant object, so a
+  variant rebuilt from only its `id` plus the changed field loses the fields it did not carry and
+  the request is rejected with `price must not be empty`.
+triggerPrompt: >
+  Set the SKU of my Eval Gate Mug to MUG-001.
+tags: [stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3
+  - type: llm_judge          # correctness — the user's outcome
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Set the SKU of my Eval Gate Mug to MUG-001."
+
+      The site is a Catalog V3 store seeded with a physical product named "Eval Gate Mug" priced
+      at $12.00, with a single variant and no product options. The template also ships other demo
+      products; those are irrelevant and must not affect the score.
+
+      Score 9-10: the agent located the existing "Eval Gate Mug" and set its variant SKU to
+      "MUG-001" with a successful (2xx) Catalog V3 Update Product PATCH, and confirmed it back to
+      the user.
+
+      Score 7-8: the SKU is "MUG-001" on the existing product after a successful update, but the
+      confirmation to the user is vague or omits the SKU.
+
+      Score 4-6: the SKU ends up correct but the variant lost data in the process — for example
+      its price is no longer $12.00, or the variant was replaced and carries a new id.
+
+      Score 1-3: the agent created a NEW product instead of updating the existing one; OR set the
+      SKU on a different product, or to a value other than "MUG-001"; OR the final update call
+      errored (non-2xx); OR it only described how to do it without doing it.
+
+      Do not deduct for merely reading or listing the other demo products.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the tool-call path (gates, per docs/eval-scenarios.md)
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
+      trace, including the request bodies and any error bodies.
+
+      Score 9-10: a direct path — the product was located, re-read with Get Product, and updated
+      in one successful PATCH whose variant carried its existing fields alongside the new SKU. No
+      non-2xx responses, no retried request bodies.
+
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
+      a probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant
+      read.
+
+      Score 1-3: any Update Product call was REJECTED and then retried. In particular, score here
+      when a variant was rebuilt from only its `id` plus the changed field and the PATCH came back
+      with `price must not be empty` (or any other REQUIRED_FIELD violation on
+      `product.variantsInfo.variants[...]` caused by fields the agent did not carry over), even
+      though a later call succeeded. Also score here for a wrong endpoint or wrong catalog version
+      tried first.
+
+      Do not deduct for reading the seeded store's other demo products.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed mug product
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Eval Gate Mug
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true

--- a/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
+++ b/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
@@ -57,7 +57,10 @@ assertions:
       Large variant's SKU. No non-2xx responses, no retried request bodies.
 
       Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example a
-      probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant read.
+      probing or repeated API-spec/schema lookup to discover where `sku` lives, a redundant read, or
+      an extra call to work out how a variant identifies its option choice (such as a first attempt
+      that matched the choice by name, selected no variant because the response carried only choice
+      GUIDs, and had to be re-run after inspecting the product's options).
 
       Score 1-3: any Update Product call was REJECTED and then retried. Score here in particular
       when the rejection came from variant state the agent did not carry over — a variant rebuilt

--- a/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
+++ b/yaml/wix-manage-evals/stores/update-product-sku-full-variant.yml
@@ -1,12 +1,13 @@
 name: stores/update-product-sku-full-variant
 description: >
-  A store owner asks to set an existing Catalog V3 product's SKU. Verifies the agent loads the
-  Update Product with Options (Catalog V3) recipe and sends each variant complete in the Update
-  Product PATCH. `variantsInfo.variants` replaces both the array and each variant object, so a
-  variant rebuilt from only its `id` plus the changed field loses the fields it did not carry and
-  the request is rejected with `price must not be empty`.
+  A store owner asks to set the SKU on one variant of a Catalog V3 product that has two variants.
+  Verifies the agent loads the Update Product with Options (Catalog V3) recipe and sends every
+  variant complete in the Update Product PATCH. `variantsInfo.variants` replaces both the array and
+  each variant object, so sending only the changed variant drops the other one, and rebuilding a
+  variant from just its `id` plus the changed field drops the fields it did not carry — rejected
+  with `price must not be empty`.
 triggerPrompt: >
-  Set the SKU of my Eval Gate Mug to MUG-001.
+  Set the SKU of the Large size of my Eval Gate Mug to MUG-L-001.
 tags: [stores]
 assertions:
   - tool: ReadFullDocsArticle
@@ -16,25 +17,30 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: >
-      The user's request (verbatim): "Set the SKU of my Eval Gate Mug to MUG-001."
+      The user's request (verbatim): "Set the SKU of the Large size of my Eval Gate Mug to
+      MUG-L-001."
 
-      The site is a Catalog V3 store seeded with a physical product named "Eval Gate Mug" priced
-      at $12.00, with a single variant and no product options. The template also ships other demo
-      products; those are irrelevant and must not affect the score.
+      The site is a Catalog V3 store seeded with a physical product "Eval Gate Mug" that has one
+      option, Size, with two choices: Small (price $12.00) and Large (price $16.00). Each size is a
+      separate variant. The template also ships other demo products; those are irrelevant and must
+      not affect the score.
 
-      Score 9-10: the agent located the existing "Eval Gate Mug" and set its variant SKU to
-      "MUG-001" with a successful (2xx) Catalog V3 Update Product PATCH, and confirmed it back to
-      the user.
+      Score 9-10: after a successful (2xx) Update Product PATCH, the Large variant's SKU is
+      "MUG-L-001", AND the product still has both variants, AND the Small variant is untouched
+      (still $12.00), AND the Large variant kept its $16.00 price. The agent confirmed the change.
 
-      Score 7-8: the SKU is "MUG-001" on the existing product after a successful update, but the
-      confirmation to the user is vague or omits the SKU.
+      Score 7-8: the same end state, but the confirmation to the user is vague or omits the SKU.
 
-      Score 4-6: the SKU ends up correct but the variant lost data in the process — for example
-      its price is no longer $12.00, or the variant was replaced and carries a new id.
+      Score 4-6: the SKU is set on the Large variant but the product lost state in the process —
+      the Small variant is missing, either variant's price changed or was cleared, or a variant
+      carries a new id.
 
-      Score 1-3: the agent created a NEW product instead of updating the existing one; OR set the
-      SKU on a different product, or to a value other than "MUG-001"; OR the final update call
-      errored (non-2xx); OR it only described how to do it without doing it.
+      Score 1-3: the SKU was set on the wrong variant or to a different value; OR a NEW product was
+      created instead of updating the existing one; OR the final update call errored (non-2xx); OR
+      the agent only described how to do it without doing it.
+
+      Judge the end state, not the number of attempts — a run that was rejected and then recovered
+      to the correct end state still scores here on correctness.
 
       Do not deduct for merely reading or listing the other demo products.
 
@@ -43,23 +49,24 @@ assertions:
     minScore: 7
     maxTokens: 2048
     prompt: >
-      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call
-      trace, including the request bodies and any error bodies.
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call trace,
+      including the request bodies and any error bodies.
 
-      Score 9-10: a direct path — the product was located, re-read with Get Product, and updated
-      in one successful PATCH whose variant carried its existing fields alongside the new SKU. No
-      non-2xx responses, no retried request bodies.
+      Score 9-10: a direct path — the product was located, re-read with Get Product, and updated in
+      one successful PATCH that carried BOTH variants with their existing fields, changing only the
+      Large variant's SKU. No non-2xx responses, no retried request bodies.
 
-      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
-      a probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant
-      read.
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example a
+      probing or repeated API-spec/schema lookup to discover where `sku` lives, or a redundant read.
 
-      Score 1-3: any Update Product call was REJECTED and then retried. In particular, score here
-      when a variant was rebuilt from only its `id` plus the changed field and the PATCH came back
-      with `price must not be empty` (or any other REQUIRED_FIELD violation on
-      `product.variantsInfo.variants[...]` caused by fields the agent did not carry over), even
-      though a later call succeeded. Also score here for a wrong endpoint or wrong catalog version
-      tried first.
+      Score 1-3: any Update Product call was REJECTED and then retried. Score here in particular
+      when the rejection came from variant state the agent did not carry over — a variant rebuilt
+      from only its `id` plus the changed field returning `price must not be empty` or any other
+      REQUIRED_FIELD violation on `product.variantsInfo.variants[...]`, or only the changed variant
+      being sent so the other one was dropped (`Missing option choices`,
+      `INVALID_DEFAULT_VARIANT`, or a variants array shorter than the product's) — even though a
+      later call succeeded. Also score here for a wrong endpoint or wrong catalog version tried
+      first.
 
       Do not deduct for reading the seeded store's other demo products.
 
@@ -71,7 +78,7 @@ siteSetup:
   templateId: stores-v3-editor
   bootstrap:
     steps:
-      - label: seed mug product
+      - label: seed mug product with two size variants
         method: post
         url: https://www.wixapis.com/stores/v3/products
         body:
@@ -79,8 +86,30 @@ siteSetup:
             name: Eval Gate Mug
             productType: PHYSICAL
             physicalProperties: {}
+            options:
+              - name: Size
+                optionRenderType: TEXT_CHOICES
+                choicesSettings:
+                  choices:
+                    - choiceType: CHOICE_TEXT
+                      name: Small
+                    - choiceType: CHOICE_TEXT
+                      name: Large
             variantsInfo:
               variants:
-                - price: { actualPrice: { amount: "12.00" } }
+                - choices:
+                    - optionChoiceNames:
+                        optionName: Size
+                        choiceName: Small
+                        renderType: TEXT_CHOICES
+                  price: { actualPrice: { amount: "12.00" } }
+                  physicalProperties: {}
+                  visible: true
+                - choices:
+                    - optionChoiceNames:
+                        optionName: Size
+                        choiceName: Large
+                        renderType: TEXT_CHOICES
+                  price: { actualPrice: { amount: "16.00" } }
                   physicalProperties: {}
                   visible: true


### PR DESCRIPTION
Three Catalog V3 frictions found in recorded runs, across the two recipes an agent uses together to change something on an existing product. They are in one PR because they compound: an agent answering "set the SKU on the Large size" reads Find Products to locate the product and Update Product to change it, and each defect below costs it a rejected call or a wasted round trip on that single task.

## 1. Price questions were routed into a full-catalog scan

`Query Products` cannot filter on price. The recipe listed its filterable fields and said nothing further, so agents paged the whole catalog and compared amounts in their own code.

Price **is** filterable — on Search Products, via `actualPriceRange.minValue.amount`, which accepts `$lt`, `$gt`, `$lte`, `$gte` and the rest. STEP 1 now shows an executable filter, the routing table gains a price row, and STEP 4 says explicitly that price is not in Query Products' set.

Worth recording: adding the routing-table row **alone did not change behaviour** — the agent kept scanning client-side after reading the recipe, twice. Only making the example executable made it stable.

## 2. The response envelope was never shown

Neither Search nor Query documented where results arrive. Agents fell back to a Catalog V1-shaped guess and lost a round trip:

```
the first API execution failed to locate the product because it incorrectly parsed the
search response using Catalog V1/V2 structure (productResults.results) instead of V3
(products), requiring a second corrected API execution
```

STEP 1 now shows the envelope. Prose competes with a strong prior weakly; an example does not compete at all.

Also corrects the `fields` enum `MIN_VARIANT_PRICE_INFO` → `MIN_PRICE_VARIANT`. The old name does not exist in the API.

## 3. Variant updates dropped state, twice over

**Each variant object is replaced, not merged.** The recipe said to pass the entire array and include each existing `id` — both of which an agent can satisfy while rebuilding each variant from just its `id` plus the field it is changing. Everything else goes with it:

```
400 product is invalid: variantsInfo is invalid: variants [at index 0] is invalid:
    price must not be empty
    (REQUIRED_FIELD on product.variantsInfo.variants[0].price)
```

The error table made this harder to spot — it attributed the error to "new" variants, so an agent updating an existing one read it as not applying.

**Variant choice names are opt-in on read.** The recipe tells you to write `optionChoiceNames`, so agents expect to read them back. Get Product returns `optionChoiceIds` only, and populates names just when the request's `fields` includes `"VARIANT_OPTION_CHOICE_NAMES"`. Matching on a name the response never carried raises nothing — it selects no variant. In a recorded run the agent spent two extra calls inspecting the product's options before resolving the choice GUID.

## Coverage

Two scenarios, three assertions each with the path judge gating at 7, per this repo's eval-scenario guide:

- `stores/find-products-under-price-catalog-v3`
- `stores/update-product-sku-full-variant` — seeds a two-variant product so the agent must send both variants complete; a single-variant fixture let a run pass without exercising the rule at all.

## What is and isn't proven

The price-filter change earned `required` on a decision assertion, path judge 9/10 against 2/10 on production.

The variant changes are supported but not certified. In a paired run where both arms read the recipe, production reproduced the choice-name defect and the PR arm did not — the change doing its job — but the PR arm still fell short of a clean path because of defect 2, which is why these are now in one PR rather than two. Earlier runs also confirmed defect 3's rejection appears without the fix.

These recipes carry more residual friction than any single change removes, so a scenario here can fail its path judge for a reason unrelated to the change under test. Each claim above is tied to a specific recorded run rather than to the verdict.
