### PR TITLE
docs(wix-vibe-headless): load the reference as concat blobs (the agent's prompt)

### DIFF
--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -63,9 +63,22 @@ CI=1 npx skills@latest add wix/skills/skills/wix-docs --yes
 
 ### 2 · Build the client
 
-Read `SKILL.md` + each target `references/<vertical>/INSTRUCTIONS.md` (through **"What you've got"**
-above). Read and use the `rest/` layer, regenerate the UI for your framework, and set `WIX_CLIENT_ID`
-+ `WIX_METASITE_ID` in `wix-config`.
+Pull the whole client reference into context in two reads — **this is basically your prompt: it's all
+the client code you need.** Build the client from it in your own stack's idiom (your router, file
+extensions, design tokens), and set `WIX_CLIENT_ID` + `WIX_METASITE_ID` in `wix-config`.
+
+```bash
+V=<vertical>   # the vertical you're building
+
+# utils — transport + data layer (plain fetch, already SSR-guarded; use ~as-is)
+find .agents/skills/wix-vibe-headless/references/shared/app/rest \
+     .agents/skills/wix-vibe-headless/references/$V/app/rest \
+     -type f -name '*.js' -exec tail -n +1 {} +
+
+# components/pages — a reference UI (rebuild for your framework; keep the field shapes + route patterns)
+find .agents/skills/wix-vibe-headless/references/$V/app \
+     -type f \( -name '*.jsx' -o -name '*.js' \) -not -path '*/rest/*' -exec tail -n +1 {} +
+```
 
 ### 3 · Seed the content
 
@@ -86,10 +99,17 @@ curl -X POST 'https://www.wixapis.com/stores/v3/products/query' \
   -H 'Content-Type: application/json' -d '{"query":{"cursorPaging":{"limit":10}}}'
 ```
 
-Seed by reusing the functions in `references/<vertical>/seed/seed-*.js` (they encode the Wix API
-sequences, incl. app-install + provisioning-race handling); use `wix-docs` for anything they don't
-cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is installed + seeded
-(expected; the seed modules install it first). Image seeding = two Wix Media calls
+Pull the seed code into context — **this is your seeding prompt: it's all the code you need.** Run
+these functions (adapting the exec + auth to your platform) to create the content:
+
+```bash
+V=<vertical>
+find .agents/skills/wix-vibe-headless/references/$V/seed -name '*.js' -exec tail -n +1 {} +
+```
+
+They encode the Wix API sequences (incl. app-install + provisioning-race handling); use `wix-docs`
+for anything they don't cover. Content queries return `REQUIRED_APP_NOT_INSTALLED` until the app is
+installed + seeded (expected; the seed modules install it first). Image seeding = two Wix Media calls
 (`generate-upload-url` → `PUT` the bytes) before attaching.
 
 ### 4 · Done


### PR DESCRIPTION
Adds one-shot `find … -exec tail -n +1 {} +` loads so the agent ingests the code as its prompt instead of opening files one by one:

- **Step 2 (build client)** — two blobs:
  - **utils** — `shared/app/rest` + `<v>/app/rest` (transport + data layer, use ~as-is)
  - **components/pages** — `<v>/app` minus `rest/` (reference UI, rebuild for your stack)
- **Step 3 (seed)** — one blob of `<v>/seed/*.js`.

Framed as **"this is basically your prompt — it's all the code you need; build/seed to your own stack."** Uses the empty-safe `-exec {} +` form (an empty `find | xargs` would hang on members, which has no seed `.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)