### PR TITLE
fix(wix-manage): give each plan type a copyable billingTerms object

### DIFF
--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -1,6 +1,6 @@
 ---
 name: "Create and Update Pricing Plans"
-description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, and plan visibility.
+description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring until cancelled, recurring for a set number of payments, one-time, free), trial periods, perks configuration, and plan visibility.
 ---
 # Technical Step-by-Step Instructions: Creating or Updating a Wix Pricing Plans (Real-World, API-First)
 

--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -89,11 +89,12 @@ rejects that combination with `400 FREE_PRICING_VARIANT_IS_NOT_RECURRING`.
 
 Same required fields; only `billingTerms` and the `flatRate.amount` change.
 
-| Plan type | `billingTerms` |
+| Plan type | `billingTerms` — copy as-is; `period` is `DAY`, `WEEK`, `MONTH` or `YEAR` |
 | --- | --- |
-| Free, open-ended | Omit `billingCycle`; `endType: "UNTIL_CANCELLED"`. `flatRate.amount: "0"`. |
-| One-time payment, fixed duration | `billingCycle` = the duration (e.g. `{ period: 'MONTH', count: 1 }`), `endType: "CYCLES_COMPLETED"`, `cyclesCompletedDetails.billingCycleCount: 1`. |
-| Recurring, until cancelled | `billingCycle` = the recurrence (e.g. `{ period: 'MONTH', count: 1 }`), `endType: "UNTIL_CANCELLED"`. |
+| Free, open-ended | `{ startType: 'ON_PURCHASE', endType: 'UNTIL_CANCELLED' }` — no `billingCycle`; `flatRate.amount: '0'`. |
+| One-time payment, fixed duration | `{ startType: 'ON_PURCHASE', endType: 'CYCLES_COMPLETED', billingCycle: { period: 'MONTH', count: 1 }, cyclesCompletedDetails: { billingCycleCount: 1 } }` — charges once; `billingCycle` is the duration the plan lasts. |
+| Recurring, until cancelled | `{ startType: 'ON_PURCHASE', endType: 'UNTIL_CANCELLED', billingCycle: { period: 'MONTH', count: 1 } }` — charges every month until cancelled. |
+| Recurring, ends after N charges | `{ startType: 'ON_PURCHASE', endType: 'CYCLES_COMPLETED', billingCycle: { period: 'MONTH', count: 1 }, cyclesCompletedDetails: { billingCycleCount: 3 } }` — "$50 a month, ends after 3 months": `billingCycle` is the recurrence, `billingCycleCount` is how many times it charges. |
 
 A `billingCycle` can't be shorter than 7 days, and total plan duration can't exceed 10 years
 (`400 VALID_BILLING_CYCLE` / `400 VALID_PLAN_DURATION`).

--- a/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
+++ b/skills/wix-manage/references/pricing-plans/create-and-update-pricing-plans.md
@@ -1,6 +1,6 @@
 ---
 name: "Create and Update Pricing Plans"
-description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring until cancelled, recurring for a set number of payments, one-time, free), trial periods, perks configuration, and plan visibility.
+description: Creates subscription and one-time payment plans using Plans API. Covers pricing models (recurring, one-time, free), trial periods, perks configuration, and plan visibility.
 ---
 # Technical Step-by-Step Instructions: Creating or Updating a Wix Pricing Plans (Real-World, API-First)
 

--- a/yaml/wix-manage-evals/pricing-plans/create-recurring-plan-limited-duration.yml
+++ b/yaml/wix-manage-evals/pricing-plans/create-recurring-plan-limited-duration.yml
@@ -1,0 +1,83 @@
+name: pricing-plans/create-recurring-plan-limited-duration
+description: >-
+  Verifies the agent can assemble the billingTerms for a recurring plan that
+  ends after a set number of charges straight from the
+  create-and-update-pricing-plans recipe, without falling back to probing the
+  generated Create Plan schema for the shape of billingCycle and
+  cyclesCompletedDetails.
+triggerPrompt: >-
+  Create a plan called Quarterly Pass at $50 a month that automatically ends after 3 months.
+tags: [pricing-plans]
+siteSetup:
+  mode: template
+  templateId: bookings-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/create-and-update-pricing-plans
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Create a plan called Quarterly Pass at $50
+      a month that automatically ends after 3 months."
+
+      Intent: create a Wix Pricing Plans plan named "Quarterly Pass" that charges
+      50 every month and stops after 3 charges, via
+      POST https://www.wixapis.com/pricing-plans/v3/plans.
+
+      Judge the END STATE of the plan that exists when the run finishes. Do not
+      score the number of attempts here — the second judge covers the path.
+
+      Score 9-10: a plan named "Quarterly Pass" exists, created by a successful
+      (2xx) Create Plan call, whose pricing variant charges a flat rate of 50 on a
+      MONTH billing cycle of count 1, and whose billing terms end the plan after 3
+      charges — `endType: "CYCLES_COMPLETED"` with
+      `cyclesCompletedDetails.billingCycleCount: 3`.
+
+      Score 7-8: the plan exists with the right name, price and monthly cadence and
+      does end after 3 monthly charges, but the agent's final answer is vague about
+      how the plan ends.
+
+      Score 4-6: the plan was created but does not end after 3 charges — for
+      example `endType: "UNTIL_CANCELLED"` (it never ends), or
+      `billingCycleCount` is not 3.
+
+      Score 1-3: the plan encodes the 3 months as the billing cycle instead of the
+      recurrence — a single charge on a `{ period: "MONTH", count: 3 }` cycle,
+      which bills 50 once for three months rather than 50 a month three times; OR
+      the plan was never created; OR the name or the amount is wrong; OR the agent
+      only described how to create the plan instead of creating it.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how smoothly the Wix MCP and its docs let the agent create a recurring
+      pricing plan that ends after a set number of charges. Examine the tool-call
+      trace, not just the final answer. Score 0-10 (10 = direct: read the docs,
+      then one successful call).
+
+      Penalize and LIST any of:
+
+      - a Create Plan call that returned a non-2xx error, even if a later retry
+        succeeded — in particular a 400 naming `plan.status`,
+        `plan.pricingVariants[0].id`, or `billingTerms.startType`;
+      - `SearchWixAPISpec` / `ReadFullDocsMethodSchema` calls made AFTER reading a
+        docs article, in order to work out the shape of `billingTerms`,
+        `billingCycle`, `cyclesCompletedDetails` or the `endType` values;
+      - custom code written to expand `$circular` / `$ref` schema references
+        because the resolved request shape was not available in one place;
+      - re-reading a docs article to recover from a failed call.
+
+      Score 1-3 if the agent read the pricing-plans recipe and STILL had to probe
+      the generated Create Plan schema to determine how `billingCycle` and
+      `cyclesCompletedDetails` combine to end a recurring plan after N charges.
+      That is the specific gap this scenario exists to catch: the recipe is
+      supposed to supply that `billingTerms` object ready to copy.
+
+      For each issue, name the likely MCP or docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and the
+      suspected MCP/docs gap, or 'clean path' if none>"}.


### PR DESCRIPTION
Gives each plan type a copyable `billingTerms` object, and adds the row that was missing entirely: a recurring plan that ends after a set number of charges.

Before, the plan-type table described `billingTerms` in prose and covered free, one-time and recurring-until-cancelled. "$50 a month for 3 months" — a recurring plan with a fixed duration — had no row, so an agent had to work out from two adjacent rows that it needs `billingCycle` for the recurrence *and* `cyclesCompletedDetails.billingCycleCount` for the number of charges.

## Scope

`+5/−4` in the plan-type table, plus a covering scenario. The required-fields table above it is unchanged; it already documents `plan.status` and the caller-generated `plan.pricingVariants[].id` correctly.

## What the eval shows — and does not

**This is not proven, and the original justification did not survive.** The case for it was one run with the old table scoring 8/10 on the path judge against one with the new table at 10/10. A later paired run had production, on the **old** table, take a clean three-step path and score 10/10. So "the old table causes schema probing" does not reproduce, and there is no measurement showing this change alters agent behaviour.

What it still is: coverage of a plan type users ask for that the table did not describe. That is worth having on its own terms, and it is being landed as documentation completeness rather than on eval evidence.

A change to this recipe's front-matter description was also tried, on the theory that the entry did not signal limited-duration plans and that was suppressing retrieval. Its only test contradicted it — the arm carrying the change did not open the recipe at all — so it has been reverted rather than shipped on an unsupported hypothesis.

## The reporting gap behind this scenario

Worth recording for whoever owns the Plans V3 schema, because no recipe change reaches it.

The friction that originally flagged this scenario was a `400`:

```
plan is invalid:
|-- status value is required
`-- pricingVariants [at index 0] is invalid:
    |-- id is not a valid GUID
    `-- id must not be empty
```

Both fields are misreported in the generated Create Plan reference:

- `plan.status` does not appear in it at all — not in the request schema, not in the required list, not in the response, not in the documented errors — yet the server rejects a create without it.
- `plan.pricingVariants[].id` is listed as required but described only as "Pricing variant GUID". Nothing indicates the caller must generate it, and every other GUID in that schema is server-assigned.

An agent working from the generated reference cannot get either right. In one recorded run the agent read that reference and still failed on the variant GUID. The recipe documents both correctly, but only reaches agents that open it.
