### PR TITLE
feat(wix-manage): add Create Contact with Address and Update a Contact recipes

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -139,6 +139,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Bulk Label and Unlabel Contacts](references/contacts/bulk-label-and-unlabel-contacts.md)
 **Technical:** Adds/removes labels from multiple contacts using Contacts API bulk operations. Covers label creation, contact filtering, batch processing, and rate limit handling.
 
+### [Create Contact with Address](references/contacts/create-contact-with-address.md)
+**Technical:** Creates a contact with a physical address in one Contacts API call. Covers the minimum identifying fields and the ISO 3166-2 `subdivision` format (`US-NY`, not `NY`) that state, region and province codes are validated against.
+
 ### [Contacts Dashboard Navigation](references/contacts/contacts-dashboard-navigation.md)
 **Technical:** Direct links to Wix Contacts (CRM) dashboard pages on manage.wix.com (contacts list, view a specific contact, contact import, segments), pairing each main contacts entity with its read API for "view it in your dashboard" links.
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -142,6 +142,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Create Contact with Address](references/contacts/create-contact-with-address.md)
 **Technical:** Creates a contact with a physical address in one Contacts API call. Covers the minimum identifying fields and the ISO 3166-2 `subdivision` format (`US-NY`, not `NY`) that state, region and province codes are validated against.
 
+### [Update a Contact](references/contacts/update-a-contact.md)
+**Technical:** Updates an existing contact's email, phone, name or address. Covers locating the contact with Search Contacts when the user names it (Query Contacts cannot filter by name), passing the current `revision`, appending an address via the contact's `addresses` sub-resource, and the ISO 3166-2 `subdivision` format (`US-NY`, not `NY`).
+
 ### [Contacts Dashboard Navigation](references/contacts/contacts-dashboard-navigation.md)
 **Technical:** Direct links to Wix Contacts (CRM) dashboard pages on manage.wix.com (contacts list, view a specific contact, contact import, segments), pairing each main contacts entity with its read API for "view it in your dashboard" links.
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -139,8 +139,8 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Bulk Label and Unlabel Contacts](references/contacts/bulk-label-and-unlabel-contacts.md)
 **Technical:** Adds/removes labels from multiple contacts using Contacts API bulk operations. Covers label creation, contact filtering, batch processing, and rate limit handling.
 
-### [Create Contact with Address](references/contacts/create-contact-with-address.md)
-**Technical:** Creates a contact with a physical address in one Contacts API call. Covers the minimum identifying fields and the ISO 3166-2 `subdivision` format (`US-NY`, not `NY`) that state, region and province codes are validated against.
+### [Create a Contact](references/contacts/create-a-contact.md)
+**Technical:** Creates a contact in one Contacts API call. Covers the minimum identifying fields, the single-object shape of `email` and `phone` (a list is accepted and silently discarded), optionally attaching a physical address, and the ISO 3166-2 `subdivision` format (`US-NY`, not `NY`) that state, region and province codes are validated against.
 
 ### [Update a Contact](references/contacts/update-a-contact.md)
 **Technical:** Updates an existing contact's email, phone, name or address. Covers locating the contact with Search Contacts when the user names it (Query Contacts cannot filter by name), passing the current `revision`, appending an address via the contact's `addresses` sub-resource, and the ISO 3166-2 `subdivision` format (`US-NY`, not `NY`).

--- a/skills/wix-manage/references/contacts/create-a-contact.md
+++ b/skills/wix-manage/references/contacts/create-a-contact.md
@@ -1,20 +1,36 @@
 ---
-name: "Create Contact with Address"
-description: Creates a contact with a physical address using the Contacts API. Covers the minimum identifying fields and the ISO 3166-2 subdivision format required for state, region, and province codes.
+name: "Create a Contact"
+description: Creates a contact with the Contacts API. Covers the minimum identifying fields, the single-object shape of `email` and `phone`, and adding a physical address with the ISO 3166-2 subdivision format required for state, region, and province codes.
 ---
-# Create a Contact with an Address
+# Create a Contact
 
 ## Description
-Creates a contact and attaches a physical address in the same call.
+Creates a contact, optionally with a physical address in the same call.
 
 ## API Endpoint
 `POST https://www.wixapis.com/contacts/v5/contacts`
 
 ## Steps
 
-### 1. Send the contact with its address
+### 1. Create the contact
 
 At least one of `name.first`, `name.last`, `email.email`, or `phone.phone` must be present. Copy this body and change the values:
+
+```json
+{
+  "contact": {
+    "name": { "first": "Maria", "last": "Gomez" },
+    "email": { "email": "maria.gomez@example.com" },
+    "phone": { "phone": "+1 212 555 0134" }
+  }
+}
+```
+
+`email` is a single object, exactly as above. Send a list instead — `emails: [{ tag: 'MAIN', email: '…' }]` — and the request still returns `200`, but the field is discarded: the contact is created with no email at all. Nothing in the response reports this, so it surfaces only when something later reads the contact back and the email is missing. The same holds for `phone`. Read `contact.email.email` off the create response to confirm it was stored.
+
+### 2. Add an address (optional)
+
+Include `addresses` in the same create call when the user gave a street address:
 
 ```json
 {
@@ -41,9 +57,7 @@ At least one of `name.first`, `name.last`, `email.email`, or `phone.phone` must 
 
 `tag` is one of `OTHER`, `HOME`, `WORK`, `BILLING`, `SHIPPING`, and that list is closed — there is no "untagged" or "none" member. When the user did not say what kind of address it is, leave `tag` out and it defaults to `OTHER`; inventing a value for that case is rejected with `400`.
 
-`email` is a single object, exactly as above. Send a list instead — `emails: [{ tag: 'MAIN', email: '…' }]` — and the request still returns `200`, but the field is discarded: the contact is created with no email at all. Nothing in the response reports this, so it surfaces only when something later reads the contact back and the email is missing. The same holds for `phone`. Read `contact.email.email` off the create response to confirm it was stored.
-
-### 2. Write `subdivision` in ISO 3166-2 form
+### 3. Write `subdivision` in ISO 3166-2 form
 
 `subdivision` is the 2-letter country code, a hyphen, then 1-3 characters for the state, region, prefecture or province: `US-NY`, `GB-ENG`, `FR-976`. A bare state code is rejected:
 

--- a/skills/wix-manage/references/contacts/create-contact-with-address.md
+++ b/skills/wix-manage/references/contacts/create-contact-with-address.md
@@ -39,6 +39,8 @@ At least one of `name.first`, `name.last`, `email.email`, or `phone.phone` must 
 
 `addresses[].address` takes either `addressLine` as free text, or a structured `streetAddress` object — not both.
 
+`email` is a single object, exactly as above. Send a list instead — `emails: [{ tag: 'MAIN', email: '…' }]` — and the request still returns `200`, but the field is discarded: the contact is created with no email at all. Nothing in the response reports this, so it surfaces only when something later reads the contact back and the email is missing. The same holds for `phone`. Read `contact.email.email` off the create response to confirm it was stored.
+
 ### 2. Write `subdivision` in ISO 3166-2 form
 
 `subdivision` is the 2-letter country code, a hyphen, then 1-3 characters for the state, region, prefecture or province: `US-NY`, `GB-ENG`, `FR-976`. A bare state code is rejected:

--- a/skills/wix-manage/references/contacts/create-contact-with-address.md
+++ b/skills/wix-manage/references/contacts/create-contact-with-address.md
@@ -1,0 +1,64 @@
+---
+name: "Create Contact with Address"
+description: Creates a contact with a physical address using the Contacts API. Covers the minimum identifying fields and the ISO 3166-2 subdivision format required for state, region, and province codes.
+---
+# Create a Contact with an Address
+
+## Description
+Creates a contact and attaches a physical address in the same call.
+
+## API Endpoint
+`POST https://www.wixapis.com/contacts/v5/contacts`
+
+## Steps
+
+### 1. Send the contact with its address
+
+At least one of `name.first`, `name.last`, `email.email`, or `phone.phone` must be present. Copy this body and change the values:
+
+```json
+{
+  "contact": {
+    "name": { "first": "Maria", "last": "Gomez" },
+    "email": { "email": "maria.gomez@example.com" },
+    "addresses": [
+      {
+        "tag": "HOME",
+        "address": {
+          "addressLine": "350 Fifth Avenue",
+          "city": "New York",
+          "subdivision": "US-NY",
+          "postalCode": "10118",
+          "country": "US"
+        }
+      }
+    ]
+  }
+}
+```
+
+`addresses[].address` takes either `addressLine` as free text, or a structured `streetAddress` object — not both.
+
+### 2. Write `subdivision` in ISO 3166-2 form
+
+`subdivision` is the 2-letter country code, a hyphen, then 1-3 characters for the state, region, prefecture or province: `US-NY`, `GB-ENG`, `FR-976`. A bare state code is rejected:
+
+```
+HTTP 400 {"message":"contact is invalid:
+`-- addresses [at index 0] is invalid:
+    `-- address is invalid:
+       `-- subdivision is not a valid subdivision code",
+ "details":{"validationError":{"fieldViolations":[{
+   "field":"contact.addresses[0].address.subdivision",
+   "description":"is not a valid subdivision code","violatedRule":"FORMAT",
+   "data":{"type":"SUBDIVISION"}}]}}}
+```
+
+The Create Contact reference describes this field as a "short code (2 or 3 letters)" and gives `NY` as the example, which the server does not accept. Use the hyphenated form.
+
+`country` is the plain [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code — `US`, no hyphen. Only `subdivision` carries the country prefix.
+
+## Related
+
+- [Create Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/create-contact)
+- [Update Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/update-contact)

--- a/skills/wix-manage/references/contacts/create-contact-with-address.md
+++ b/skills/wix-manage/references/contacts/create-contact-with-address.md
@@ -39,6 +39,8 @@ At least one of `name.first`, `name.last`, `email.email`, or `phone.phone` must 
 
 `addresses[].address` takes either `addressLine` as free text, or a structured `streetAddress` object — not both.
 
+`tag` is one of `OTHER`, `HOME`, `WORK`, `BILLING`, `SHIPPING`, and that list is closed — there is no "untagged" or "none" member. When the user did not say what kind of address it is, leave `tag` out and it defaults to `OTHER`; inventing a value for that case is rejected with `400`.
+
 `email` is a single object, exactly as above. Send a list instead — `emails: [{ tag: 'MAIN', email: '…' }]` — and the request still returns `200`, but the field is discarded: the contact is created with no email at all. Nothing in the response reports this, so it surfaces only when something later reads the contact back and the email is missing. The same holds for `phone`. Read `contact.email.email` off the create response to confirm it was stored.
 
 ### 2. Write `subdivision` in ISO 3166-2 form

--- a/skills/wix-manage/references/contacts/update-a-contact.md
+++ b/skills/wix-manage/references/contacts/update-a-contact.md
@@ -1,0 +1,111 @@
+---
+name: "Update a Contact"
+description: Updates an existing contact's email, phone, name, or address with the Contacts API. Covers locating the contact when the user identifies it by name, passing its current revision, and the ISO 3166-2 subdivision format required for state, region and province codes.
+---
+# Update a Contact
+
+## Description
+Changes fields on a contact that already exists — its email, phone, name, or address.
+
+## API Endpoints
+- `POST https://www.wixapis.com/contacts/v5/contacts/search` — locate the contact
+- `PATCH https://www.wixapis.com/contacts/v5/contacts/{contactId}` — change its fields
+- `POST https://www.wixapis.com/contacts/v5/contacts/{contactId}/addresses` — add one address
+
+Contacts has two live versions. Use the v5 endpoints above for updates; the v4 update takes a
+different, more deeply nested body, and mixing the two shapes is rejected with
+`400 {"message":"Expected an object"}`.
+
+## Steps
+
+### 1. Locate the contact with Search Contacts, not Query Contacts
+
+When the user identifies a contact by name — "my contact Jordan Lee" — the lookup is Search
+Contacts. Query Contacts filters on a small closed set of fields that does not include the
+contact's name, so a query filtered by name is rejected:
+
+```
+HTTP 400 {"message":"value Field 'name.first' is not declared as filterable",
+ "details":{"validationError":{"fieldViolations":[{"field":"value",
+   "description":"Field 'name.first' is not declared as filterable"}]}}}
+```
+
+Search Contacts takes a free-text expression, and matches on names. Note the doubled `search` —
+the outer one is the search request, the inner one is the free-text clause:
+
+```json
+{ "search": { "search": { "expression": "Jordan Lee" } } }
+```
+
+Read both `id` and `revision` off the contact it returns. Step 2 needs both. Query Contacts is
+still the right call when you already have an email address, a phone number or an id to filter on.
+
+### 2. Send the update with the contact's current revision
+
+Copy this body and change the values. Only the fields you send are being set; `id` and `revision`
+identify which contact and which version you are updating:
+
+```json
+{
+  "contact": {
+    "id": "<contact id from step 1>",
+    "revision": "<revision from step 1>",
+    "email": { "email": "jordan.lee@newmail.com" }
+  }
+}
+```
+
+Swap `email` for `phone` (`{ "phone": { "phone": "+1-212-555-0100" } }`) or `name` to change those
+instead. `revision` changes on every write, so re-read it if an update conflicts.
+
+### 3. Add an address with Add Contact Address
+
+To attach one more address, post it to the contact's `addresses` sub-resource rather than sending
+the whole contact — the address is appended, so existing addresses survive:
+
+```json
+{
+  "revision": "<revision from step 1>",
+  "address": {
+    "tag": "WORK",
+    "address": {
+      "addressLine": "350 Fifth Avenue",
+      "city": "New York",
+      "subdivision": "US-NY",
+      "postalCode": "10118",
+      "country": "US"
+    }
+  }
+}
+```
+
+Note the doubled `address` here too: the outer object is the contact's address entry, which carries
+the `tag`, and the inner one is the postal address itself.
+
+### 4. Write `subdivision` in ISO 3166-2 form
+
+`subdivision` is the 2-letter country code, a hyphen, then 1-3 characters for the state, region,
+prefecture or province: `US-NY`, `GB-ENG`, `FR-976`. A bare state code is rejected, on updates as
+well as on creates:
+
+```
+HTTP 400 {"message":"address is invalid:
+`-- address is invalid:
+    `-- subdivision is not a valid subdivision code",
+ "details":{"validationError":{"fieldViolations":[{
+   "field":"address.address.subdivision",
+   "description":"is not a valid subdivision code","violatedRule":"FORMAT",
+   "data":{"type":"SUBDIVISION"}}]}}}
+```
+
+The Contacts reference describes this field as a "short code (2 or 3 letters)" and gives `NY` as
+the example, which the server does not accept. Use the hyphenated form.
+
+`country` is the plain [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code
+— `US`, no hyphen. Only `subdivision` carries the country prefix.
+
+## Related
+
+- [Update Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/update-contact)
+- [Search Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/search-contacts)
+- [Add Contact Address](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5/add-contact-address)

--- a/skills/wix-manage/references/contacts/update-a-contact.md
+++ b/skills/wix-manage/references/contacts/update-a-contact.md
@@ -67,7 +67,6 @@ the whole contact — the address is appended, so existing addresses survive:
 {
   "revision": "<revision from step 1>",
   "address": {
-    "tag": "WORK",
     "address": {
       "addressLine": "350 Fifth Avenue",
       "city": "New York",
@@ -79,8 +78,17 @@ the whole contact — the address is appended, so existing addresses survive:
 }
 ```
 
-Note the doubled `address` here too: the outer object is the contact's address entry, which carries
-the `tag`, and the inner one is the postal address itself.
+Note the doubled `address` here too: the outer object is the contact's address entry, which can
+carry a `tag`, and the inner one is the postal address itself.
+
+`tag` is one of `OTHER`, `HOME`, `WORK`, `BILLING`, `SHIPPING`, and that list is closed — there is
+no "untagged" or "none" member. When the user did not say what kind of address it is, leave `tag`
+out, exactly as above; inventing a value for that case is rejected:
+
+```
+HTTP 400 {"message":"address is invalid:
+`-- tag enum must be in [UNKNOWN_ADDRESS_TAG(0), OTHER(1), HOME(2), WORK(3), BILLING(4), SHIPPING(5)]"}
+```
 
 ### 4. Write `subdivision` in ISO 3166-2 form
 

--- a/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
+++ b/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
@@ -57,8 +57,9 @@ assertions:
       Score 1-3: any create call was REJECTED and then retried. Score here in particular when a
       create was rejected with `subdivision is not a valid subdivision code` (a `FORMAT` violation
       on `contact.addresses[0].address.subdivision`) because the subdivision was sent without its
-      country prefix, even though a later call succeeded. Also score here for a wrong endpoint or
-      wrong API version tried first.
+      country prefix, or when it was rejected for an address `tag` outside the accepted set
+      (`OTHER`, `HOME`, `WORK`, `BILLING`, `SHIPPING`), even though a later call succeeded. Also
+      score here for a wrong endpoint or wrong API version tried first.
 
       For each issue found, name the likely MCP/docs gap.
 

--- a/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
+++ b/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
@@ -49,7 +49,10 @@ assertions:
       request bodies.
 
       Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
-      repeated API-spec or schema lookups to resolve the nested address shape, or a redundant read.
+      repeated API-spec or schema lookups to resolve the nested address shape, a redundant read, or
+      a follow-up update to set a field that the create call should already have stored (such as
+      sending the main email as a list, which is accepted and silently discarded, and then patching
+      it in afterwards).
 
       Score 1-3: any create call was REJECTED and then retried. Score here in particular when a
       create was rejected with `subdivision is not a valid subdivision code` (a `FORMAT` violation

--- a/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
+++ b/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
@@ -1,0 +1,65 @@
+name: contacts/create-contact-with-address
+description: >
+  A site owner asks to add a contact with a street address. Verifies the agent loads the Create
+  Contact with Address recipe and sends `subdivision` in ISO 3166-2 form. The Create Contact
+  reference documents this field with the example `NY`, which the server's SUBDIVISION format
+  validator rejects — it requires the country prefix, `US-NY` — so an agent working from the
+  generated reference takes a 400 and has to retry.
+triggerPrompt: >
+  Add a contact named Maria Gomez, email maria.gomez@example.com, with the address 350 Fifth Avenue, New York, NY 10118.
+tags: [contacts]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/create-contact-with-address
+  - type: llm_judge          # correctness — the user's outcome
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Add a contact named Maria Gomez, email
+      maria.gomez@example.com, with the address 350 Fifth Avenue, New York, NY 10118."
+
+      Score 9-10: a contact named Maria Gomez was created with a successful (2xx) Contacts API
+      call, carrying the email maria.gomez@example.com and an address whose street is 350 Fifth
+      Avenue, city New York, postal code 10118, and a New York state subdivision. The agent
+      confirmed the result.
+
+      Score 7-8: the same end state, but the confirmation to the user is vague or omits the
+      address.
+
+      Score 4-6: the contact was created but part of the address is missing or wrong — no
+      subdivision stored, wrong city, or the address was dropped entirely.
+
+      Score 1-3: no contact was created; OR the final create call errored (non-2xx); OR the agent
+      only described how to do it without doing it.
+
+      Judge the end state, not the number of attempts — a run that was rejected and then recovered
+      to the correct end state still scores on the end state here.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the tool-call path (gates, per docs/eval-scenarios.md)
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call trace,
+      including request bodies and any error bodies.
+
+      Score 9-10: a direct path — the contact was created in one successful call whose
+      `subdivision` was already in the accepted ISO 3166-2 form. No non-2xx responses, no retried
+      request bodies.
+
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
+      repeated API-spec or schema lookups to resolve the nested address shape, or a redundant read.
+
+      Score 1-3: any create call was REJECTED and then retried. Score here in particular when a
+      create was rejected with `subdivision is not a valid subdivision code` (a `FORMAT` violation
+      on `contact.addresses[0].address.subdivision`) because the subdivision was sent without its
+      country prefix, even though a later call succeeded. Also score here for a wrong endpoint or
+      wrong API version tried first.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor

--- a/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
+++ b/yaml/wix-manage-evals/contacts/create-contact-with-address.yml
@@ -1,7 +1,7 @@
 name: contacts/create-contact-with-address
 description: >
-  A site owner asks to add a contact with a street address. Verifies the agent loads the Create
-  Contact with Address recipe and sends `subdivision` in ISO 3166-2 form. The Create Contact
+  A site owner asks to add a contact with a street address. Verifies the agent loads the Create a
+  Contact recipe and sends `subdivision` in ISO 3166-2 form. The Create Contact
   reference documents this field with the example `NY`, which the server's SUBDIVISION format
   validator rejects — it requires the country prefix, `US-NY` — so an agent working from the
   generated reference takes a 400 and has to retry.
@@ -11,7 +11,7 @@ tags: [contacts]
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/create-contact-with-address
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/create-a-contact
   - type: llm_judge          # correctness — the user's outcome
     minScore: 7
     maxTokens: 2048

--- a/yaml/wix-manage-evals/contacts/update-a-contact.yml
+++ b/yaml/wix-manage-evals/contacts/update-a-contact.yml
@@ -1,0 +1,76 @@
+name: contacts/update-a-contact
+description: >
+  A site owner asks to add a street address to a contact they identify by name. Verifies the agent
+  loads the Update a Contact recipe, locates the contact with Search Contacts rather than filtering
+  a query by name (which the API rejects as not filterable), and writes `subdivision` in ISO 3166-2
+  form. The Contacts reference documents that field with the example `NY`, which the server's
+  SUBDIVISION format validator rejects on updates as well as on creates.
+triggerPrompt: >
+  Add the address 350 Fifth Avenue, New York, NY 10118 to my contact Jordan Lee.
+tags: [contacts]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/update-a-contact
+  - type: llm_judge          # correctness — the user's outcome
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      The user's request (verbatim): "Add the address 350 Fifth Avenue, New York, NY 10118 to my
+      contact Jordan Lee." A contact named Jordan Lee already exists on the site.
+
+      Score 9-10: the existing Jordan Lee contact now carries an address whose street is 350 Fifth
+      Avenue, city New York, postal code 10118, and a New York state subdivision, set by a
+      successful (2xx) Contacts API call. The agent confirmed the result.
+
+      Score 7-8: the same end state, but the confirmation to the user is vague or omits the address.
+
+      Score 4-6: the address was attached but part of it is missing or wrong — no subdivision
+      stored, wrong city, or the contact's existing email or name was destroyed in the process.
+
+      Score 1-3: a NEW contact was created instead of updating the existing one; OR no address was
+      attached; OR the final call errored (non-2xx); OR the agent only described how to do it
+      without doing it.
+
+      Judge the end state, not the number of attempts — a run that was rejected and then recovered
+      to the correct end state still scores on the end state here.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the tool-call path (gates, per docs/eval-scenarios.md)
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine the tool-call trace,
+      including request bodies and any error bodies.
+
+      Score 9-10: a direct path — the contact was located by name in one successful call, and the
+      address was attached in one successful call whose `subdivision` was already in the accepted
+      ISO 3166-2 form. No non-2xx responses, no retried request bodies.
+
+      Score 4-6: the outcome was reached, but the path cost an avoidable round trip — for example
+      repeated API-spec or schema lookups to resolve the nested address shape, a redundant read of
+      the contact, or a second write to repair something the first should have set.
+
+      Score 1-3: any call was REJECTED and then retried. Score here in particular when a lookup was
+      rejected with `Field 'name.first' is not declared as filterable` because the agent filtered a
+      contacts query by name instead of using the free-text contacts search, or when a write was
+      rejected with `subdivision is not a valid subdivision code` (a `FORMAT` violation on a
+      `subdivision` field) because the subdivision was sent without its country prefix — even
+      though a later call succeeded. Also score here for a wrong endpoint or wrong API version
+      tried first.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: seed contact Jordan Lee
+        method: post
+        url: https://www.wixapis.com/contacts/v5/contacts
+        body:
+          contact:
+            name: { first: Jordan, last: Lee }
+            email: { email: jordan.lee@example.com }

--- a/yaml/wix-manage-evals/contacts/update-a-contact.yml
+++ b/yaml/wix-manage-evals/contacts/update-a-contact.yml
@@ -55,9 +55,10 @@ assertions:
       rejected with `Field 'name.first' is not declared as filterable` because the agent filtered a
       contacts query by name instead of using the free-text contacts search, or when a write was
       rejected with `subdivision is not a valid subdivision code` (a `FORMAT` violation on a
-      `subdivision` field) because the subdivision was sent without its country prefix — even
-      though a later call succeeded. Also score here for a wrong endpoint or wrong API version
-      tried first.
+      `subdivision` field) because the subdivision was sent without its country prefix, or when it
+      was rejected for an address `tag` outside the accepted set (`OTHER`, `HOME`, `WORK`,
+      `BILLING`, `SHIPPING`) — even though a later call succeeded. Also score here for a wrong
+      endpoint or wrong API version tried first.
 
       For each issue found, name the likely MCP/docs gap.
 

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -10,8 +10,8 @@ apiDoc:
       title: Bulk Label and Unlabel Contacts
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
       tags: [contacts]
-    - file: ../../../skills/wix-manage/references/contacts/create-contact-with-address.md
-      title: Create Contact with Address
+    - file: ../../../skills/wix-manage/references/contacts/create-a-contact.md
+      title: Create a Contact
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
       tags: [contacts]
     - file: ../../../skills/wix-manage/references/contacts/update-a-contact.md

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -10,6 +10,10 @@ apiDoc:
       title: Bulk Label and Unlabel Contacts
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
       tags: [contacts]
+    - file: ../../../skills/wix-manage/references/contacts/create-contact-with-address.md
+      title: Create Contact with Address
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
+      tags: [contacts]
     - file: ../../../skills/wix-manage/references/contacts/contacts-dashboard-navigation.md
       title: Contacts Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -14,6 +14,10 @@ apiDoc:
       title: Create Contact with Address
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
       tags: [contacts]
+    - file: ../../../skills/wix-manage/references/contacts/update-a-contact.md
+      title: Update a Contact
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
+      tags: [contacts]
     - file: ../../../skills/wix-manage/references/contacts/contacts-dashboard-navigation.md
       title: Contacts Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts


### PR DESCRIPTION
Adds two contacts recipes — one for creating a contact with a physical address, one for updating an existing contact — and puts the values the API actually accepts in copyable bodies.

## Defect 1 — the documented `subdivision` example is rejected

The Contacts reference documents `subdivision` as:

> Subdivision shorthand. Usually, a short code (2 or 3 letters) that represents a state, region, prefecture, or province. For example, `NY`.

The field is validated as ISO 3166-2 — country code, hyphen, then 1-3 characters — so the documented example is rejected:

```
HTTP 400 {"message":"contact is invalid:
`-- addresses [at index 0] is invalid:
    `-- address is invalid:
       `-- subdivision is not a valid subdivision code",
 "details":{"validationError":{"fieldViolations":[{
   "field":"contact.addresses[0].address.subdivision",
   "description":"is not a valid subdivision code","violatedRule":"FORMAT",
   "data":{"type":"SUBDIVISION"}}]}}}
```

In a recorded run an agent sent `subdivision: "NY"`, took that 400, and retried with `"US-NY"`, which succeeded. It had not guessed — it used the value the reference gives.

The same field is validated the same way on the update path, where the rejection names a different field path:

```
HTTP 400 {"message":"address is invalid:
`-- address is invalid:
    `-- subdivision is not a valid subdivision code",
 "details":{"validationError":{"fieldViolations":[{
   "field":"address.address.subdivision",
   "description":"is not a valid subdivision code","violatedRule":"FORMAT",
   "data":{"type":"SUBDIVISION"}}]}}}
```

`country` is unaffected: it stays the plain 2-letter code, `US`, with no prefix. Only `subdivision` carries the country.

## Defect 2 — a contact cannot be found by name with Query Contacts

Every "update my contact <name>" request has to resolve a name to an id first. Query Contacts filters on a small closed set that does not include the contact's name, so the obvious first attempt is rejected:

```
HTTP 400 {"message":"value Field 'name.first' is not declared as filterable",
 "details":{"validationError":{"fieldViolations":[{"field":"value",
   "description":"Field 'name.first' is not declared as filterable"}]}}}
```

Search Contacts takes a free-text expression and matches names. Recorded runs confirm it: `POST /contacts/v5/contacts/search` with `{"search":{"search":{"expression":"Jordan Lee"}}}` returned `200` with the matching contact. Neither method's own page tells you to make that choice, so the update recipe makes it step 1.

## Defect 3 — an address `tag` invented outside the accepted set

Surfaced by this PR's own gate run: with the subdivision corrected, an agent following the update recipe invented `tag: "UNTAGGED"` because the worked body showed one member of the enum without saying the list was closed.

```
HTTP 400 {"message":"address is invalid:
`-- tag enum must be in [UNKNOWN_ADDRESS_TAG(0), OTHER(1), HOME(2), WORK(3), BILLING(4), SHIPPING(5)]",
 "details":{"validationError":{"fieldViolations":[{"field":"address.tag",
   "description":"enum must be in [UNKNOWN_ADDRESS_TAG(0), OTHER(1), HOME(2), WORK(3), BILLING(4), SHIPPING(5)]",
   "violatedRule":"OTHER","ruleName":"UnrecognizedEnumValidator"}]}}}
```

Both recipes now state the five accepted values and say to leave `tag` out when the request does not say what kind of address it is.

## Why recipes

The contacts area had recipes for bulk delete, bulk labelling and dashboard navigation, but none for creating a contact and none for updating one. So both request shapes are answered directly from the generated reference, with no recipe in the index for them to load.

Each recipe is four files, per this repo's requirements: the reference, its `SKILL.md` index entry, the `documentation.yaml` entry, and a covering scenario with three assertions and the path judge gating at 7.

The update recipe carries the sequence — resolve the name, read the contact's `revision`, then write — plus the two values the reference gets wrong. It deliberately does **not** restate the request shapes, the revision semantics or the update restrictions: those are correct in the reference and the agent reads them on demand.

## Scope, and what this does not fix

**This does not fix the underlying reference.** The rejected `subdivision` example is still live on every contacts page that renders the address type, so any agent that does not load one of these recipes will keep hitting the same 400. The durable fix is to correct the field description at its source; these recipes cover the requests that reach them in the meantime.

A separate, unrelated defect turned up while checking this: a plausible-looking method docs URL without the version segment fails to resolve in the API-spec lookup —

```
No API resource matches docsUrl: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/update-contact
```

That is not a content problem and nothing here addresses it; it is reported separately to the tooling owners.

## Evals

- `contacts/create-contact-with-address` — a create whose path-judge 1-3 band is a `FORMAT` violation on the address subdivision, or a `tag` outside the accepted set.
- `contacts/update-a-contact` — a request that names the contact rather than giving its id, whose path-judge 1-3 band adds a query rejected for filtering on a non-filterable name field.

Both scenarios come back `required` on the PR branch, each with the path judge passing on the PR content and failing on what is live today.
