### PR TITLE
🦞 igor-claw: add Connect an External Domain skill

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -159,6 +159,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Domains Dashboard Navigation](references/domains/domains-dashboard-navigation.md)
 **Technical:** Direct links to the site-level domain settings page and the account-level My Domains page on manage.wix.com, paired with the Domain Search read APIs.
 
+### [Connect an External Domain](references/domains/connect-external-domain.md)
+**Technical:** Connect a domain the user already owns elsewhere to a Wix site via pointing or nameservers, using the Connected Domains and DNS Propagation APIs. Covers correctly interpreting DNS propagation status (which does NOT mean the site is actually being served yet) and the safe order of operations for domain migrations, so you don't advise reassigning primary before the new domain is confirmed live.
+
 ---
 
 ## eCommerce

--- a/skills/wix-manage/references/domains/connect-external-domain.md
+++ b/skills/wix-manage/references/domains/connect-external-domain.md
@@ -1,0 +1,65 @@
+---
+name: "Connect an External Domain"
+description: Connect a domain the user already owns (registered elsewhere, e.g. GoDaddy/Cloudflare/iwantmyname) to a Wix site by pointing or nameservers, monitor DNS propagation correctly, and avoid the two most common failure modes -- trusting a false "success" signal, and taking the live site offline by reassigning primary too early.
+---
+# Connect an External Domain
+
+Use this recipe when a user wants to:
+- Connect a domain they already own (bought elsewhere) to a Wix site
+- Point an existing domain at Wix, or migrate from one domain to another
+- Says something like "connect mydomain.com to my site", "point my domain at Wix", "switch my site to a shorter domain"
+
+This is **not** the domain-purchase flow -- if the user wants to buy a new domain through Wix, use [Domain Search and Purchase](domain-search-and-purchase.md) instead. This recipe is for domains registered with an external provider.
+
+## Required APIs
+
+- **Create Connected Domain**: `POST https://www.wixapis.com/domains/v1/connected-domains`
+- **Get Connected Domain**: `GET https://www.wixapis.com/domains/v1/connected-domains/{connectedDomainId}`
+- **Get DNS Propagation**: `GET https://www.wixapis.com/premium/domains/v1/dns-propagations/{domain}`
+- Connection requires an active Premium plan on the target site.
+
+Read the full method schemas via `SearchWixRESTDocumentation`/`SearchWixAPISpec` before calling -- the request body differs for `POINTING` vs `NAMESERVERS` connection types.
+
+## Step 1: Choose a connection type
+
+Ask (or infer from what the user already set up):
+- **Pointing**: the user keeps DNS hosted at their current provider (e.g. Cloudflare, GoDaddy) and just adds an A record (apex) + CNAME (`www` -> `pointing.wixdns.net`). Wix does **not** manage DNS for pointing domains.
+- **Nameservers**: the user changes their domain's nameservers to Wix's, and Wix hosts the DNS zone.
+
+Call `CreateConnectedDomain` with the chosen `connectionType`, then give the user the exact DNS records to add (from the response / Setup Info API) if they're doing this themselves at their registrar/DNS provider.
+
+## Step 2: Monitor DNS propagation -- and know what it does NOT tell you
+
+Poll `GetDnsPropagation` for the domain. `status` moves `IN_PROGRESS` -> `SUCCEEDED` (or `FAILED`, see the DNS Propagation API's error-handling docs for how to read `failureInfo`).
+
+**Critical: `status: SUCCEEDED` on this API is necessary but not sufficient for the site to actually be served.** It only confirms the DNS records themselves are correctly configured and visible from Wix's resolvers (`dnsResolverIncludesWixNs: true`). It does **not** confirm that:
+- The domain has stopped serving the "Your domain is being connected" placeholder page
+- An SSL certificate being issued for the domain (which can happen independently) means the site is live
+- Real end-to-end traffic through the domain actually reaches the site
+
+There is **no public API that reports "is this domain actually serving the site yet."** The only way to confirm the domain is truly live is to **have the user open the URL in a browser** and check they see their actual site, not a placeholder. Do not tell the user the domain is "connected" or "done" just because `GetDnsPropagation` returned `SUCCEEDED` -- say DNS has propagated and the site should go live "shortly," and ask them to check the live URL before relying on it.
+
+If propagation stays `SUCCEEDED` (or the site keeps showing the placeholder) for more than ~48 hours, there is no self-serve retry/force-resync API. Tell the user their only option at that point is to contact Wix support -- do not imply there's an API-level fix.
+
+## Step 3: Assigning primary -- do this LAST, and only once the new domain is confirmed live
+
+If the user is **migrating** from an existing working domain to a new one (the scenario that most often goes wrong), never reassign primary based on API status alone.
+
+**Do NOT set a domain as primary (or tell the user to) while it is still showing the placeholder page or before `GetDnsPropagation` has returned `SUCCEEDED` for it.** Reassigning primary immediately demotes the current primary to a redirect. If the new domain is not actually serving yet, this takes the site **fully offline on both domains** for however long the new domain remains stuck connecting -- there is no atomic "both domains up" intermediate state.
+
+Correct order of operations when migrating domains:
+1. Connect the new domain as a **secondary/redirect** domain first (not primary).
+2. Wait for `GetDnsPropagation` to return `SUCCEEDED` for the new domain.
+3. Have the user open the new domain's URL directly in a browser and confirm it shows the real site content, not the "being connected" placeholder.
+4. Only after that visual confirmation, reassign the new domain to primary and keep the old one as a redirect.
+
+If a user asks you to "just make the new domain primary now" while it's still connecting, warn them explicitly that this can take their live site offline until the new domain finishes connecting, and confirm they want to proceed anyway before doing it.
+
+## Error Handling
+
+| Situation | Action |
+|---|---|
+| `GetDnsPropagation` returns `FAILED` | Read `failureInfo.invalidRecords` and the matching `invalidARecordInfo`/`invalidNsRecordInfo`/`invalidCnameRecordInfo` object; tell the user exactly which record type and value to fix at their DNS provider. |
+| `SUCCEEDED` but site still shows placeholder after 48h | No API remediation exists. Tell the user to contact Wix support to request a manual re-sync. |
+| `NON_PREMIUM_SITE` error on create | The target site needs an active Premium plan before a domain can be connected. |
+| `DOMAINS_ALREADY_EXISTS` | The domain (or the same domain with different settings) is already connected -- check `ListConnectedDomains` first. |

--- a/yaml/wix-manage-evals/domains/connect-external-domain.yml
+++ b/yaml/wix-manage-evals/domains/connect-external-domain.yml
@@ -1,0 +1,36 @@
+name: domains/connect-external-domain
+description: Verifies the agent reads the connect-external-domain recipe and correctly advises against trusting DNS Propagation "SUCCEEDED" alone or reassigning primary before the new domain is confirmed live.
+triggerPrompt: >-
+  I'm migrating my Wix site from oldsite.com to newsite.com. I just connected newsite.com to the site by pointing, and calling the DNS Propagation API for newsite.com now returns status SUCCEEDED. Should I go ahead and set newsite.com as the primary domain now, replacing oldsite.com?
+tags: [domains]
+maxTokens: 25000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/account-level/domains/connected-domains/skills/connect-an-external-domain
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request: "I'm migrating my Wix site from oldsite.com to newsite.com. I just connected newsite.com to the site by pointing, and calling the DNS Propagation API for newsite.com now returns status SUCCEEDED. Should I go ahead and set newsite.com as the primary domain now, replacing oldsite.com?"
+
+      Pass if the response:
+      - does NOT simply say "yes, go ahead" on the basis of DNS Propagation status alone, AND
+      - explains that DNS Propagation SUCCEEDED confirms DNS records are correct but does not confirm the site is actually being served yet (the domain can still show a placeholder page), AND
+      - recommends the user open newsite.com directly in a browser and confirm it shows the real site (not a placeholder) BEFORE reassigning primary, AND
+      - warns that reassigning primary while newsite.com isn't confirmed live risks taking the site offline on both domains (since the old primary gets demoted to a redirect immediately).
+
+      Fail if the response:
+      - tells the user to reassign primary immediately because DNS propagation succeeded, OR
+      - never mentions the risk of the site going offline during the swap, OR
+      - never suggests visually confirming the new domain is live before making it primary.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill the request. Examine
+      the tool-call trace. Score 0-10 (10 = direct: no wasted calls, no errors). Penalize and LIST any
+      of: a non-2xx error even if recovered; guessing at a domain-status API instead of using the
+      documented DNS Propagation API; redundant/probing calls clearer docs would avoid; failing to
+      surface the primary-reassignment risk without being told to look for it.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected MCP/docs gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: Domains Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
       tags: [domains]
+    - file: ../../../skills/wix-manage/references/domains/connect-external-domain.md
+      title: Connect an External Domain
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains/connected-domains
+      tags: [domains]


### PR DESCRIPTION
## What's broken

The `wix-manage` domains skill has a recipe for buying a domain (`domain-search-and-purchase.md`) and one for dashboard links, but nothing teaching an agent how to connect a domain the user already owns externally. Agents following only the public Connected Domains / DNS Propagation API docs have no guidance that:

- `GetDnsPropagation` returning `SUCCEEDED` only confirms DNS records are correctly configured — it does **not** confirm the domain has stopped serving the "Your domain is being connected" placeholder or that the site is actually live at that URL.
- Reassigning a domain to primary before it's confirmed live can take the site **fully offline**, since the previous primary is demoted to a redirect immediately with no atomic "both domains up" intermediate state.

This is exactly what happened in a real user report: DNS propagation showed `SUCCEEDED` and an SSL cert had issued, yet the domain kept serving a Wix placeholder for 48+ hours with no error surfaced anywhere, and the account's Domains UI let the user promote that still-connecting domain to primary — taking the live site down.

## Fix

Adds `skills/wix-manage/references/domains/connect-external-domain.md`, covering:
- Pointing vs. nameservers connection setup
- Correctly interpreting `GetDnsPropagation` status (it's necessary but not sufficient for "site is live")
- The safe order of operations for domain migrations: connect as secondary -> wait for propagation success -> visually confirm the real site loads -> only then reassign primary
- What to tell the user if it's stuck past 48h (no self-serve API remediation exists — contact support)

Also adds the `SKILL.md` index entry, the `documentation.yaml` catalog entry, and a covering eval scenario per `CONTRIBUTING.md`.

Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), based on a user-reported feedback thread: https://wix.slack.com/archives/C08P5DKLJR5/p1786220997186009

## Reviewers

Requested `danielbrodi` and `yotamsu` — the two most recent human committers to the sibling `domain-search-and-purchase.md` / domains `documentation.yaml` (excluding this account's own commits, which show up under `ayal`).