### PR TITLE
🦞 igor-claw: warn about in-app-browser checkout failures in domain purchase recipe

### DIFF
--- a/skills/wix-manage/references/domains/domain-search-and-purchase.md
+++ b/skills/wix-manage/references/domains/domain-search-and-purchase.md
@@ -358,6 +358,8 @@ Once the cart is populated, give the user a checkout link:
 
 This opens the checkout page with the pre-filled cart. The user only needs to complete payment.
 
+**Important**: The checkout page requires the user's logged-in Wix session. If you're running inside a chat app's own in-app browser/webview (as opposed to the device's default browser), that embedded view often doesn't share cookies/session with the user's regular browser and the page can fail to load with a generic error. If the user reports the checkout link failing to load or showing a technical-issue error, ask them to open it in their device's default browser (Safari/Chrome) instead of an in-app browser -- the cart itself persists server-side, so no purchase progress is lost.
+
 ---
 
 ## Error Handling
@@ -369,6 +371,7 @@ This opens the checkout page with the pre-filled cart. The user only needs to co
 | Offering API returns no products | TLD not supported by Wix | Tell user to try a different TLD (.com, .net, .org) |
 | Intent API validation error | Missing/invalid contact fields | Show the error, ask user to correct, retry |
 | Cart add-items fails | Product ID or format issue | Verify product ID came from offering API response |
+| Checkout link shows a generic "technical issue" error page | Session not shared by an in-app browser/webview | Cart is unaffected server-side; ask the user to open the checkout link in their device's default browser instead |
 
 ---
 


### PR DESCRIPTION
## Summary
- Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching Wix MCP user feedback. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1786224261667799
- A user hit `manage.wix.com/cart/checkout` inside an MCP client's own in-app browser (Claude iOS app) and got a generic "technical issue" error, even though the cart was created correctly and confirmed intact server-side afterwards.
- Root cause is being fixed in wix-private/premium-cart#1010: a 401 (expired/invalid session — the expected failure when a checkout link opens in a webview that doesn't share the site's session cookies) was falling into a generic, non-actionable error page instead of the existing permission-error page.
- Until that fix is deployed everywhere, this recipe should tell agents to proactively suggest the device's default browser if the checkout link fails to load — the cart persists server-side regardless, so nothing is lost.

## Test plan
- [ ] Docs-only change — reviewed for accuracy against the reported failure and the linked code fix