### PR TITLE
docs(wix-manage): add a data retrieval reference for the Wix API Query Language

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -390,3 +390,10 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Stores Dashboard Navigation](references/stores/stores-dashboard-navigation.md)
 **Technical:** Direct links to Wix Stores and eCommerce dashboard pages on manage.wix.com (products list, edit product, categories, inventory, orders list, order details, abandoned checkouts, gift cards, shipping, tax), pairing each main Stores/eCommerce entity with its read API for "view it in your dashboard" links.
+
+---
+
+## Work with Wix APIs
+
+### [Data Retrieval Across Wix APIs](references/work-with-wix-apis/data-retrieval.md)
+**Technical:** In-depth reference for data retrieval across Wix API endpoints: the Wix API Query Language, its operator vocabulary and semantics, how search, query, and list methods differ, and sorting and paging mechanics. Each API implements the language partially or in full.

--- a/skills/wix-manage/references/work-with-wix-apis/data-retrieval.md
+++ b/skills/wix-manage/references/work-with-wix-apis/data-retrieval.md
@@ -1,0 +1,20 @@
+---
+name: "Data Retrieval Across Wix APIs"
+description: >-
+  In-depth reference for data retrieval across Wix API endpoints: the Wix API Query Language,
+  its operator vocabulary and semantics, how search, query, and list methods differ, and
+  sorting and paging mechanics. Each API implements the language partially or in full.
+---
+
+# Data Retrieval Across Wix APIs
+
+Search and query methods share one request language across every Wix API that offers them.
+What doesn't carry over is the field set: each method's own API reference declares which of
+its fields can be filtered and sorted on, and a field it doesn't declare can't be pushed to
+the server at all.
+
+| Article | What it covers |
+| --- | --- |
+| [About the Wix API Query Language](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/data-retrieval/about-the-wix-api-query-language) | The operator vocabulary and what each operator matches — comparison (`$in`/`$nin`, `$startsWith`, `$isEmpty` among them), logical (`$and`/`$or`/`$not`), element (`$exists`), and array (`$hasAll`/`$hasSome`) — how conditions compose, array matching semantics, `fields`/`fieldsets` projection, aggregation types, free-text `search` parameters including `fuzzy`, and `timeZone` for date filters and aggregations. |
+| [About Search, Query, and List Methods](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/data-retrieval/about-search-query-and-list-methods) | The differences between the three methods: what each can express, aggregations and free-text search, result counts, and their consistency and latency trade-offs. |
+| [About Sorting and Paging](https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/data-retrieval/about-sorting-and-paging) | The default `createdDate` DESC sort order, where sort and paging parameters sit on list calls (query parameters) versus query and search (request body), and why search typically uses cursors — consistent results when data changes mid-pagination. |

--- a/yaml/wix-manage/work-with-wix-apis/documentation.yaml
+++ b/yaml/wix-manage/work-with-wix-apis/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Data Retrieval Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/work-with-wix-apis/data-retrieval.md
+      title: Data Retrieval Across Wix APIs
+      docsEntry: https://dev.wix.com/docs/api-reference/articles/work-with-wix-apis/data-retrieval
+      tags: [work-with-wix-apis]


### PR DESCRIPTION
Adds a cross-cutting `wix-manage` reference for composing read requests against Wix REST APIs, under a new **Work with Wix APIs** section.

Routes to three articles — the Wix API Query Language, Search/Query/List Methods, and Sorting and Paging — rather than restating them. `About Field Projection` was left out: beyond the query-language article's own `fields`/`fieldsets` sections it adds only a vague current-vs-legacy split.

States one fact inline that no article covers: the language is shared across APIs, but the filterable and sortable field set is declared per method.

Eval scenarios follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)