### PR TITLE
feat(wix-manage): add Wix Events recipes

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -216,10 +216,10 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## Events
 
-### [Create an Event](references/events/create-wix-event.md)
+### [Create Event](references/events/create-wix-event.md)
 **Technical:** Creates an event with the Wix Events V3 API — required request body, ISO-8601 date and time settings, venue/online/TBD location and street addresses, RSVP vs ticketed registration, guest capacity, and short vs Ricos rich-text descriptions. Distinguishes Wix Events from the Calendar, Marketing Calendar and Automations APIs that share the "events" name. Key endpoint: /events/v3/events.
 
-### [Manage Wix Events](references/events/manage-wix-events.md)
+### [Manage Events](references/events/manage-wix-events.md)
 **Technical:** Manages existing events with the Wix Events V3 API — ticket definitions and pricing (fixed, free, donation, multiple tiers), publishing a draft, cancelling, deleting, cloning, updating an event's date, counting events, and building recurring series from explicit occurrence dates. Key endpoints: /events/v3/events, /events/v3/ticket-definitions.
 
 ---

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, site-properties, ecommerce, marketing, google-ads, analytics, dashboard-navigation."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, dashboard-navigation."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -211,6 +211,16 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 </details>
 
 > Dashboard links for eCommerce surfaces (orders, abandoned checkouts, gift cards, shipping, tax, checkout settings) are in [Stores Dashboard Navigation](references/stores/stores-dashboard-navigation.md).
+
+---
+
+## Events
+
+### [Create an Event](references/events/create-wix-event.md)
+**Technical:** Creates an event with the Wix Events V3 API — required request body, ISO-8601 date and time settings, venue/online/TBD location and street addresses, RSVP vs ticketed registration, guest capacity, and short vs Ricos rich-text descriptions. Distinguishes Wix Events from the Calendar, Marketing Calendar and Automations APIs that share the "events" name. Key endpoint: /events/v3/events.
+
+### [Manage Wix Events](references/events/manage-wix-events.md)
+**Technical:** Manages existing events with the Wix Events V3 API — ticket definitions and pricing (fixed, free, donation, multiple tiers), publishing a draft, cancelling, deleting, cloning, updating an event's date, counting events, and building recurring series from explicit occurrence dates. Key endpoints: /events/v3/events, /events/v3/ticket-definitions.
 
 ---
 

--- a/skills/wix-manage/references/events/create-wix-event.md
+++ b/skills/wix-manage/references/events/create-wix-event.md
@@ -1,0 +1,175 @@
+---
+name: "RECIPE: Create an Event with the Wix Events API"
+description: "Creates an event with the Wix Events V3 API — the required request body, ISO-8601 date and time settings, venue/online/TBD location, RSVP vs ticketed registration, guest capacity, and short vs rich-text descriptions. Covers the exact field shapes and the API's misleading validation messages. Use when the user wants to create an event, set its date, location, description or guest limit, or choose between RSVP and ticketing."
+---
+
+# RECIPE: Create an Event with the Wix Events API
+
+## Goal
+Create an event on a Wix site — one-off or recurring, RSVP or ticketed — with the Wix Events
+V3 API. To publish, cancel, clone, count, add tickets or set up a recurring series, see
+[Manage Wix Events](manage-wix-events.md).
+
+## First: pick the right "Events" API
+
+Several unrelated Wix APIs are called "Events". Routing to the wrong one is the most expensive
+mistake on this surface, because the wrong API answers plausibly for several calls before
+failing.
+
+| The user means | API | Base path |
+| --- | --- | --- |
+| A public event guests attend — gala, concert, workshop, meetup | **Wix Events V3** — this recipe | `/events/v3/events` |
+| A bookable session on a staff or service calendar | Calendar Events V3 | `/calendar/v3/events` |
+| An entry on the marketing plan calendar | Marketing Calendar Event V1 | `/promote/marketing-plan-service/v1/events` |
+| An automation trigger | Triggered Events | `/automations/v1/events/report` |
+
+A recurring *class or course that guests book* is Bookings, not Wix Events. A recurring
+*event series guests attend* is Wix Events.
+
+## Prerequisite — the Wix Events app must be installed
+
+Every `/events/v3` call against a site without the app returns:
+
+```
+428  {"message":"Events app not installed for metaSiteId=...",
+      "details":{"applicationError":{"code":"WIX_EVENTS_APP_NOT_INSTALLED"}}}
+```
+
+Install it with appDefId `140603ad-af8d-84a5-2c80-a0f60cb47351` — see
+[Install Wix Apps](../app-installation/install-wix-apps.md). Confirm with the user first unless
+they already asked for the event to be created.
+
+## Create the event
+
+```bash
+curl -X POST 'https://www.wixapis.com/events/v3/events' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "event": {
+      "title": "Summer Gala",
+      "location": { "name": "Grand Hall", "type": "VENUE" },
+      "dateAndTimeSettings": {
+        "startDate": "2026-09-15T19:00:00.000Z",
+        "endDate": "2026-09-15T22:00:00.000Z",
+        "timeZoneId": "America/New_York"
+      },
+      "registration": { "initialType": "RSVP" }
+    },
+    "draft": true
+  }'
+```
+
+`title`, `location`, `dateAndTimeSettings` and `registration.initialType` are all required.
+Drop `"draft": true` to create the event already published; a draft has `status: "DRAFT"` and
+is invisible on the site until published.
+
+## Date and time
+
+**`startDate` and `endDate` are ISO-8601 strings, not `{seconds, nanos}` objects.**
+
+The spec types these fields as `string` / `format: date-time` but also carries a pointer to the
+`google.protobuf.Timestamp` message, whose fields are `seconds` and `nanos`. That message
+describes the *internal* representation and must not be sent — it fails with
+`400 {"message":"Expected a string."}`. This applies to every date-time field across the Wix
+APIs, not only Events.
+
+| Rule | If broken |
+| --- | --- |
+| `startDate` / `endDate` are ISO-8601 strings | `400 Expected a string.` |
+| `endDate` is required | `400 endDate.isDefined must be true, event cannot have negative duration` |
+| `timeZoneId` is required, in [TZ database](https://www.iana.org/time-zones) form (`America/New_York`) | `400 getTimeZoneId is not supported` |
+
+> The `timeZoneId` error reads as though the field is unsupported. It is not — it means the
+> field is **missing**. Add `timeZoneId`; do not remove it.
+
+**Date to be announced:** send `dateAndTimeSettings` as
+`{ "dateAndTimeTbd": true, "dateAndTimeTbdMessage": "Date coming soon" }` and nothing else. The
+message is mandatory — omitting it fails with `400 getScheduleTbdMessage must not be a blank`.
+
+## Location
+
+`location.type` is `VENUE` or `ONLINE`. There is no `TBD` type — a to-be-announced location is
+a `VENUE` with `locationTbd: true`.
+
+| Body | Result |
+| --- | --- |
+| `{ "name": "Grand Hall", "type": "VENUE" }` | Accepted |
+| `{ "name": "Zoom", "type": "ONLINE" }` | Accepted |
+| `{ "name": "To be announced", "locationTbd": true }` | Accepted — `type` defaults to `VENUE` |
+| `{ "locationTbd": true }` | `400 Event location is invalid ... Location address must not be a blank` |
+| `{ "name": "TBA", "type": "TBD", "locationTbd": true }` | `400 type enum must be in [VENUE(0), ONLINE(1)]` |
+
+For a real street address, add an `address` object:
+
+```json
+"location": {
+  "name": "Javits Center", "type": "VENUE",
+  "address": {
+    "country": "US", "subdivision": "US-NY", "city": "New York", "postalCode": "10001",
+    "streetAddress": { "number": "429", "name": "11th Ave" }
+  }
+}
+```
+
+`subdivision` is the ISO-3166-2 code (`US-NY`), and the API fills in `formattedAddress` and
+`geocode` on the response. A `VENUE` with no `address` comes back with `locationTbd: true` set
+by the API whether or not you sent it.
+
+## Registration type and capacity
+
+`initialType` must be nested under `registration`; at the root of `event` it is treated as
+omitted and fails with the same error. Accepted values are **`RSVP`**, **`TICKETING`**,
+`EXTERNAL` and `NONE`.
+
+> The API's error text for this field advertises `[RSVP,TICKETS,RSVP_AND_TICKETS]`. Those
+> values do not work — `TICKETS` is rejected. Use `TICKETING`.
+
+`initialType` is immutable: an `RSVP` event can never become a `TICKETING` event or vice versa
+(either can later become `EXTERNAL` or `NONE` via `registration.type`). Choose correctly at
+creation time — "people should register by RSVP, not tickets" means `RSVP`.
+
+**Guest limit.** For an RSVP event, the cap is `registration.rsvp.limit`:
+
+```json
+"registration": { "initialType": "RSVP", "rsvp": { "limit": 30 } }
+```
+
+A `limit` placed directly on `registration` is **silently ignored** — the event is created with
+no cap and no error. Set `waitlistEnabled: true` alongside it to let guests join a waitlist once
+the limit is reached. For a ticketed event the cap is per ticket type, via `initialLimit` on the
+ticket definition — see [Manage Wix Events](manage-wix-events.md).
+
+## Description — two different fields
+
+| Field | Type | Use for |
+| --- | --- | --- |
+| `shortDescription` | plain string, max 500 | A one-line description under the event title |
+| `description` | Ricos rich content object | The formatted body on the event page |
+
+A plain sentence belongs in `shortDescription`. Sending a string to `description` fails with
+`400 {"message":"Expected an object"}` — it takes a Ricos `{ "nodes": [...] }` tree, as built in
+[Rich Content](../rich-content/author-ricos-rich-content.md):
+
+```json
+"description": { "nodes": [ { "type": "PARAGRAPH", "id": "p1", "paragraphData": {},
+  "nodes": [ { "type": "TEXT", "id": "", "nodes": [],
+               "textData": { "text": "Monthly meetup to discuss a new book.", "decorations": [] } } ] } ] }
+```
+
+`shortDescription` is only returned when the request asks for `"fields": ["DETAILS"]`, and
+`description` only with `"fields": ["TEXTS"]`. Both are stored regardless.
+
+## Gotchas & troubleshooting
+
+- **An invalid enum value reports as a missing one.** Sending a value outside an enum returns
+  `<field> value is required` rather than "invalid value". If a field you *did* send is reported
+  as required, suspect the value, not its presence.
+- **Error text names internal accessors, not request fields.** `getTimeZoneId`,
+  `getScheduleTbdMessage` and `endDate.isDefined` each map to the plain field of the same name.
+- `title` is required, min 1 and max 120 characters. There is no separate name field.
+
+## Related APIs
+- **Wix Events V3**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3)
+- [Manage Wix Events](manage-wix-events.md) — tickets, publish, cancel, clone, recurring, count
+- [Install Wix Apps](../app-installation/install-wix-apps.md) — the `428` pre-flight

--- a/skills/wix-manage/references/events/create-wix-event.md
+++ b/skills/wix-manage/references/events/create-wix-event.md
@@ -1,9 +1,9 @@
 ---
-name: "RECIPE: Create an Event with the Wix Events API"
+name: "Create an Event with the Wix Events API"
 description: "Creates an event with the Wix Events V3 API — the required request body, ISO-8601 date and time settings, venue/online/TBD location, RSVP vs ticketed registration, guest capacity, and short vs rich-text descriptions. Covers the exact field shapes and the API's misleading validation messages. Use when the user wants to create an event, set its date, location, description or guest limit, or choose between RSVP and ticketing."
 ---
 
-# RECIPE: Create an Event with the Wix Events API
+# Create an Event with the Wix Events API
 
 ## Goal
 Create an event on a Wix site — one-off or recurring, RSVP or ticketed — with the Wix Events

--- a/skills/wix-manage/references/events/create-wix-event.md
+++ b/skills/wix-manage/references/events/create-wix-event.md
@@ -62,7 +62,8 @@ curl -X POST 'https://www.wixapis.com/events/v3/events' \
 
 `title`, `location`, `dateAndTimeSettings` and `registration.initialType` are all required.
 Drop `"draft": true` to create the event already published; a draft has `status: "DRAFT"` and
-is invisible on the site until published.
+is invisible on the site until published with `POST /events/v3/events/{eventId}/publish`
+(empty body), which moves it to `UPCOMING`.
 
 ## Date and time
 

--- a/skills/wix-manage/references/events/manage-wix-events.md
+++ b/skills/wix-manage/references/events/manage-wix-events.md
@@ -10,8 +10,24 @@ Operate on events that already exist: sell tickets, publish, cancel, delete, clo
 count, and build recurring series. To create the event in the first place — including its date,
 location, description and guest limit — see [Create an Event](create-wix-event.md).
 
-All endpoints need the Wix Events app installed, or they return
-`428 WIX_EVENTS_APP_NOT_INSTALLED`. See [Install Wix Apps](../app-installation/install-wix-apps.md).
+## Prerequisite — the Wix Events app must be installed
+
+Every endpoint here returns `428 WIX_EVENTS_APP_NOT_INSTALLED` against a site without the app.
+Install it first — do not guess the install path, which is easy to get wrong:
+
+```bash
+curl -X POST 'https://www.wixapis.com/apps-installer-service/v1/app-instance/install' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "tenant": { "tenantType": "SITE", "id": "<SITE_ID>" },
+    "appInstance": { "appDefId": "140603ad-af8d-84a5-2c80-a0f60cb47351" }
+  }'
+```
+
+`appDefId` nests under `appInstance`, not at the root — at the root it fails with
+`400 appInstance must not be empty`. See [Install Wix Apps](../app-installation/install-wix-apps.md)
+for the full flow.
 
 ## Ticket definitions
 

--- a/skills/wix-manage/references/events/manage-wix-events.md
+++ b/skills/wix-manage/references/events/manage-wix-events.md
@@ -1,9 +1,9 @@
 ---
-name: "RECIPE: Manage Wix Events — Tickets, Publishing, Cloning and Recurring Series"
+name: "Manage Wix Events — Tickets, Publishing, Cloning and Recurring Series"
 description: "Manages existing events with the Wix Events V3 API — ticket definitions and pricing (fixed price, free, donation, multiple tiers), publishing a draft, cancelling, deleting, cloning, updating an event's date or details, counting events, and creating a recurring series. Use when the user wants to add or price tickets, publish or cancel an event, duplicate an event, move an event's date, count their events, or set up a repeating event."
 ---
 
-# RECIPE: Manage Wix Events — Tickets, Publishing, Cloning and Recurring Series
+# Manage Wix Events — Tickets, Publishing, Cloning and Recurring Series
 
 ## Goal
 Operate on events that already exist: sell tickets, publish, cancel, delete, clone, update,

--- a/skills/wix-manage/references/events/manage-wix-events.md
+++ b/skills/wix-manage/references/events/manage-wix-events.md
@@ -1,0 +1,158 @@
+---
+name: "RECIPE: Manage Wix Events — Tickets, Publishing, Cloning and Recurring Series"
+description: "Manages existing events with the Wix Events V3 API — ticket definitions and pricing (fixed price, free, donation, multiple tiers), publishing a draft, cancelling, deleting, cloning, updating an event's date or details, counting events, and creating a recurring series. Use when the user wants to add or price tickets, publish or cancel an event, duplicate an event, move an event's date, count their events, or set up a repeating event."
+---
+
+# RECIPE: Manage Wix Events — Tickets, Publishing, Cloning and Recurring Series
+
+## Goal
+Operate on events that already exist: sell tickets, publish, cancel, delete, clone, update,
+count, and build recurring series. To create the event in the first place — including its date,
+location, description and guest limit — see [Create an Event](create-wix-event.md).
+
+All endpoints need the Wix Events app installed, or they return
+`428 WIX_EVENTS_APP_NOT_INSTALLED`. See [Install Wix Apps](../app-installation/install-wix-apps.md).
+
+## Ticket definitions
+
+Ticket definitions belong to events created with `"initialType": "TICKETING"`. Tickets are a
+separate API; up to 100 definitions per event.
+
+```bash
+curl -X POST 'https://www.wixapis.com/events/v3/ticket-definitions' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "ticketDefinition": {
+      "eventId": "<EVENT_ID>",
+      "name": "General Admission",
+      "pricingMethod": { "fixedPrice": { "value": "25.00", "currency": "USD" } },
+      "feeType": "FEE_ADDED_AT_CHECKOUT",
+      "initialLimit": 100
+    }
+  }'
+```
+
+| To create | `pricingMethod` |
+| --- | --- |
+| A fixed-price ticket | `{ "fixedPrice": { "value": "25.00", "currency": "USD" } }` |
+| A free ticket | `{ "fixedPrice": { "value": "0", "currency": "USD" } }` |
+| A donation / pay-what-you-want ticket, with a minimum | `{ "guestPrice": { "value": "5.00", "currency": "USD" } }` |
+
+Easy to get wrong:
+
+- **`feeType` is required** — `FEE_ADDED_AT_CHECKOUT` (fee on top of the price) or
+  `FEE_INCLUDED` (fee absorbed into it).
+- **`value` is a string.** `"value": 10` fails with `400 Unexpected value for field value`.
+- **There is no writable `free` flag.** `pricingMethod.free` is read-only, computed from the
+  price; sending `{"free": true}` fails with `value fixedPrice or guestPrice or pricingOptions
+  must not be empty`.
+- **The quantity field is `initialLimit`**, not `initialQuantity`. Omit it for unlimited tickets.
+- `limitPerCheckout` is read-only — it cannot be set on create.
+- `name` is capped at 30 characters, `description` at 500.
+
+**Multiple tiers** — call the endpoint once per tier with the same `eventId`. For "General
+Admission at $20 and VIP at $50", that is two calls, each with its own `name`, `fixedPrice` and
+`initialLimit`. There is no bulk-create for ticket definitions.
+
+## Publish, cancel and delete
+
+| Action | Call | Resulting `status` |
+| --- | --- | --- |
+| Publish a draft | `POST /events/v3/events/{eventId}/publish` | `UPCOMING` |
+| Cancel | `POST /events/v3/events/{eventId}/cancel` | `CANCELED` |
+| Delete | `DELETE /events/v3/events/{eventId}` | — |
+
+All three take an empty body. Publishing is irreversible — a published event cannot return to
+`DRAFT`. Cancelling closes registration but keeps the event; deleting removes it.
+
+## Clone an event
+
+`POST /events/v3/events/{eventId}/clone` with an empty body copies the registration form,
+notifications, translations and ticket configuration.
+
+> **The clone does not keep the original's date.** Its start date is reset to roughly 14 days
+> from now, and it comes back as a `DRAFT`. If the user wanted a duplicate on a particular date,
+> follow the clone with an update, then publish it.
+
+## Update an event
+
+`PATCH /events/v3/events/{event.id}` with the fields to change nested under `event`:
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/events/v3/events/<EVENT_ID>' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "event": {
+      "dateAndTimeSettings": {
+        "startDate": "2026-10-15T19:00:00.000Z",
+        "endDate": "2026-10-15T22:00:00.000Z",
+        "timeZoneId": "America/New_York"
+      }
+    }
+  }'
+```
+
+The Events API takes **no field mask and no `revision`** on update — send only the fields you
+are changing. Send `dateAndTimeSettings` complete when moving a date: `startDate`, `endDate` and
+`timeZoneId` together, since the same required-field rules apply as on create.
+
+Ticket definitions are the exception — `PATCH /events/v3/ticket-definitions/{ticketDefinition.id}`
+*does* require the current `revision`, which increments on every update.
+
+## Count events
+
+`POST /events/v3/events/query` and read `pagingMetadata.total`:
+
+```json
+{ "query": { "paging": { "limit": 100 } } }
+```
+
+Query Events returns only published events — **drafts are excluded from both the results and the
+total**. Create with `"draft": false`, or publish first, if the count is meant to include the
+event you just made.
+
+`POST /events/v3/events/count-by-status` exists but returns empty `facets` unless the request
+carries filter criteria, so it is not a reliable way to answer "how many events do I have".
+
+## Recurring events
+
+Wix Events has **no recurrence rule** — no `RRULE`, no "weekly" pattern. Calculate every
+occurrence date yourself and list them all (up to 1000), alongside the normal top-level
+`startDate` / `endDate` / `timeZoneId`:
+
+```json
+"dateAndTimeSettings": {
+  "startDate": "2026-10-20T18:00:00.000Z",
+  "endDate": "2026-10-20T19:00:00.000Z",
+  "timeZoneId": "America/New_York",
+  "recurringEvents": {
+    "individualEventDates": [
+      { "startDate": "2026-10-20T18:00:00.000Z", "endDate": "2026-10-20T19:00:00.000Z", "timeZoneId": "America/New_York" },
+      { "startDate": "2026-10-27T18:00:00.000Z", "endDate": "2026-10-27T19:00:00.000Z", "timeZoneId": "America/New_York" }
+    ]
+  }
+}
+```
+
+For "a weekly event starting next week", generate the dates yourself — pick a sensible horizon
+(a few months) and say how many occurrences you created. The event returns
+`recurrenceStatus: "RECURRING"`. Each occurrence is an independent event with its own ID,
+updatable and deletable on its own; all share a generated `recurringEvents.categoryId`. Query by
+that `categoryId` to retrieve the whole series.
+
+## Gotchas & troubleshooting
+
+- **An invalid enum value reports as a missing one.** A value outside an enum returns
+  `<field> value is required` rather than "invalid value" — true for `feeType` and
+  `registration.initialType`. If a field you *did* send is reported as required, suspect the
+  value, not its presence.
+- Dates are always ISO-8601 strings, never `{seconds, nanos}` — see
+  [Create an Event](create-wix-event.md).
+
+## Related APIs
+- **Wix Events V3**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3)
+- **Ticket Definitions V3**: [REST](https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/ticket-definitions-v3)
+- **Event Guests**: `POST /events/v2/guests/query` — who registered
+- [Create an Event](create-wix-event.md) — the create body, dates, location, capacity

--- a/skills/wix-manage/references/events/manage-wix-events.md
+++ b/skills/wix-manage/references/events/manage-wix-events.md
@@ -63,8 +63,8 @@ Admission at $20 and VIP at $50", that is two calls, each with its own `name`, `
 | Cancel | `POST /events/v3/events/{eventId}/cancel` | `CANCELED` |
 | Delete | `DELETE /events/v3/events/{eventId}` | — |
 
-All three take an empty body. Publishing is irreversible — a published event cannot return to
-`DRAFT`. Cancelling closes registration but keeps the event; deleting removes it.
+Publish and cancel take an empty body. Publishing is irreversible — a published event cannot
+return to `DRAFT`. Cancelling closes registration but keeps the event; deleting removes it.
 
 ## Clone an event
 
@@ -113,8 +113,8 @@ Query Events returns only published events — **drafts are excluded from both t
 total**. Create with `"draft": false`, or publish first, if the count is meant to include the
 event you just made.
 
-`POST /events/v3/events/count-by-status` exists but returns empty `facets` unless the request
-carries filter criteria, so it is not a reliable way to answer "how many events do I have".
+`POST /events/v3/events/count-by-status` exists, but an empty request body returns empty `facets`
+even when the site has events, so it is not the way to answer "how many events do I have".
 
 ## Recurring events
 

--- a/yaml/wix-manage-evals/events/create-event.yml
+++ b/yaml/wix-manage-evals/events/create-event.yml
@@ -11,7 +11,21 @@ tags: [events]
 maxTokens: 30000
 siteSetup:
   mode: template
-  templateId: events-editor
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      # Wix Events is not bundled by any template alias, and every /events/v3 call
+      # against a site without it returns 428. Installing here keeps the app out of
+      # the agent's path, so the run measures the recipe and not an incidental setup step.
+      - label: Install the Wix Events app
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 140603ad-af8d-84a5-2c80-a0f60cb47351
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/events/create-event.yml
+++ b/yaml/wix-manage-evals/events/create-event.yml
@@ -11,21 +11,10 @@ tags: [events]
 maxTokens: 30000
 siteSetup:
   mode: template
-  templateId: blank-editor
-  bootstrap:
-    steps:
-      # Wix Events is not bundled by any template alias, and every /events/v3 call
-      # against a site without it returns 428. Installing here keeps the app out of
-      # the agent's path, so the run measures the recipe and not an incidental setup step.
-      - label: Install the Wix Events app
-        method: post
-        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
-        body:
-          tenant:
-            id: "{{siteId}}"
-            tenantType: SITE
-          appInstance:
-            appDefId: 140603ad-af8d-84a5-2c80-a0f60cb47351
+  # events-studio, not events-editor: the Editor events dev-site template ships
+  # without Wix Events, so every /events/v3 call returns 428 until the agent
+  # installs it — an incidental setup step this scenario is not measuring.
+  templateId: events-studio
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/events/create-event.yml
+++ b/yaml/wix-manage-evals/events/create-event.yml
@@ -15,7 +15,7 @@ siteSetup:
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/events/skills/create-an-event
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/events/skills/create-event
   - type: llm_judge          # correctness
     minScore: 7
     maxTokens: 2048

--- a/yaml/wix-manage-evals/events/create-event.yml
+++ b/yaml/wix-manage-evals/events/create-event.yml
@@ -1,0 +1,72 @@
+name: events/create-event-with-capacity-and-description
+description: >-
+  Verifies the create-an-event recipe carries the field shapes the Events API actually accepts,
+  so the agent sets the date, guest limit and description in one call — rather than discovering
+  by rejection that dates are ISO strings, that timeZoneId is required, that the guest limit
+  belongs under registration.rsvp, and that description is rich content rather than a string.
+triggerPrompt: >-
+  Create an event called Autumn Gala next month at 7pm at the Grand Hall, limit it to 40 guests,
+  and give it the description "An evening of music and food."
+tags: [events]
+maxTokens: 30000
+siteSetup:
+  mode: template
+  templateId: events-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/events/skills/create-an-event
+  - type: llm_judge          # correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Create an event called Autumn Gala next month at 7pm at the
+      Grand Hall, limit it to 40 guests, and give it the description "An evening of music and food.""
+
+      Examine the tool-call trace, including request bodies and any error bodies.
+
+      Pass only if a successful (2xx) `POST /events/v3/events` created an event where ALL of these hold:
+      - the title is "Autumn Gala";
+      - it starts about a month from now at 7pm, with a `timeZoneId` set;
+      - the location names the Grand Hall;
+      - a guest limit of 40 is in effect — it must sit at `registration.rsvp.limit`, NOT at
+        `registration.limit`, which the API accepts and silently ignores;
+      - the description text was stored, either as `shortDescription` (plain string) or as
+        `description` (a Ricos rich-content object).
+
+      Fail if any of those is missing; OR the guest limit was sent at `registration.limit` and so
+      never applied; OR every write attempt errored; OR the agent only explained how without doing it.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the path
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how directly the agent got from the request to a created event. Examine the tool-call
+      trace, including request bodies and any error bodies. 10 = no wasted calls and no errors.
+
+      Reading the recipe is expected and is never a wasted call.
+
+      Penalize and LIST any of the following, even where a later call succeeded:
+
+      - any non-2xx response, in particular:
+        - `400 Expected a string.` — a date sent as a `{seconds, nanos}` object instead of ISO-8601;
+        - `400 getTimeZoneId is not supported` — which means `timeZoneId` was omitted, not that it
+          is unsupported;
+        - `400 initialType is unexpected` — `registration.initialType` missing, nested wrongly, or
+          set to `TICKETS` rather than `TICKETING`;
+        - `400 Expected an object` — a plain string sent to `description`;
+        - `400 Location address must not be a blank`;
+      - a guest limit written to `registration.limit` instead of `registration.rsvp.limit` — this
+        returns 2xx and applies no limit, so treat it as a silent failure, not a clean path;
+      - two or more `SearchWixAPISpec` / `ReadFullDocsMethodSchema` calls spent working out a shape
+        the recipe already gives;
+      - a documentation article URL passed to a schema-inspection tool, which cannot resolve it;
+      - a `428 WIX_EVENTS_APP_NOT_INSTALLED` that the agent did not anticipate.
+
+      A crash inside a Wix MCP tool itself — for example `Cannot read properties of undefined` — is
+      an MCP defect, not an agent mistake: name it in the reason but do NOT deduct for it.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage-evals/events/manage-events.yml
+++ b/yaml/wix-manage-evals/events/manage-events.yml
@@ -11,7 +11,21 @@ tags: [events]
 maxTokens: 30000
 siteSetup:
   mode: template
-  templateId: events-editor
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      # Wix Events is not bundled by any template alias, and every /events/v3 call
+      # against a site without it returns 428. Installing here keeps the app out of
+      # the agent's path, so the run measures the recipe and not an incidental setup step.
+      - label: Install the Wix Events app
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 140603ad-af8d-84a5-2c80-a0f60cb47351
 assertions:
   - tool: ReadFullDocsArticle
     params:
@@ -67,6 +81,10 @@ assertions:
 
       A crash inside a Wix MCP tool itself — for example `Cannot read properties of undefined` — is
       an MCP defect, not an agent mistake: name it in the reason but do NOT deduct for it.
+
+      Likewise a `403` on draft events (`READ_DRAFT_EVENTS`) is a permission the caller does not
+      hold, not a wrong request: creating the event already published instead of as a draft is a
+      correct recovery. Name it in the reason but do NOT deduct for it.
 
       For each issue found, name the likely MCP/docs gap.
 

--- a/yaml/wix-manage-evals/events/manage-events.yml
+++ b/yaml/wix-manage-evals/events/manage-events.yml
@@ -11,21 +11,10 @@ tags: [events]
 maxTokens: 30000
 siteSetup:
   mode: template
-  templateId: blank-editor
-  bootstrap:
-    steps:
-      # Wix Events is not bundled by any template alias, and every /events/v3 call
-      # against a site without it returns 428. Installing here keeps the app out of
-      # the agent's path, so the run measures the recipe and not an incidental setup step.
-      - label: Install the Wix Events app
-        method: post
-        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
-        body:
-          tenant:
-            id: "{{siteId}}"
-            tenantType: SITE
-          appInstance:
-            appDefId: 140603ad-af8d-84a5-2c80-a0f60cb47351
+  # events-studio, not events-editor: the Editor events dev-site template ships
+  # without Wix Events, so every /events/v3 call returns 428 until the agent
+  # installs it — an incidental setup step this scenario is not measuring.
+  templateId: events-studio
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/events/manage-events.yml
+++ b/yaml/wix-manage-evals/events/manage-events.yml
@@ -1,0 +1,73 @@
+name: events/ticket-tiers-and-publish
+description: >-
+  Verifies the manage-events recipe carries the ticket-definition shape and the publish step, so
+  the agent prices two tiers and publishes in one pass — rather than discovering by rejection that
+  feeType is required, that a price value is a string, and that the registration type is TICKETING
+  rather than the TICKETS the API's own error text advertises.
+triggerPrompt: >-
+  Create a ticketed event called Winter Fest next month with two ticket types — General Admission
+  at $20 and VIP at $60 — then publish it.
+tags: [events]
+maxTokens: 30000
+siteSetup:
+  mode: template
+  templateId: events-editor
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/events/skills/manage-events
+  - type: llm_judge          # correctness
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Create a ticketed event called Winter Fest next month with two
+      ticket types — General Admission at $20 and VIP at $60 — then publish it."
+
+      Examine the tool-call trace, including request bodies and any error bodies.
+
+      Pass only if ALL of these hold:
+      - a successful (2xx) `POST /events/v3/events` created "Winter Fest", starting about a month
+        from now, with `registration.initialType` of `TICKETING`;
+      - two successful (2xx) `POST /events/v3/ticket-definitions` calls against that event id — one
+        named for General Admission priced at 20, one for VIP priced at 60, in the site's currency;
+      - the event was then published, ending in status `UPCOMING`.
+
+      Fail if only one ticket type exists; OR the prices are wrong; OR the event was created as an
+      RSVP event (an RSVP event can never be converted to ticketing); OR it was left as a draft; OR
+      the agent only explained how without doing it.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge          # quality — the path
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how directly the agent got from the request to a published, two-tier ticketed event.
+      Examine the tool-call trace, including request bodies and any error bodies. 10 = no wasted
+      calls and no errors.
+
+      Reading the recipe is expected and is never a wasted call. Two ticket-definition calls are
+      correct and are not redundancy — there is no bulk-create for ticket definitions.
+
+      Penalize and LIST any of the following, even where a later call succeeded:
+
+      - any non-2xx response, in particular:
+        - `400 feeType value is required` — either omitted, or set to a value outside
+          `FEE_ADDED_AT_CHECKOUT` / `FEE_INCLUDED`, since an invalid enum reports as a missing one;
+        - `400 Unexpected value for field value` — a price sent as a number instead of a string;
+        - `400 initialType is unexpected` — including using `TICKETS`, which the API's own error
+          text advertises but rejects; the accepted value is `TICKETING`;
+        - `400 Expected a string.` — a date sent as `{seconds, nanos}` instead of ISO-8601;
+        - `400 getTimeZoneId is not supported`, which means `timeZoneId` was omitted;
+      - a ticket quantity sent as `initialQuantity` rather than `initialLimit`, or an attempt to set
+        the read-only `limitPerCheckout` or `pricingMethod.free`;
+      - re-creating the event or a ticket because an earlier attempt was abandoned rather than fixed;
+      - two or more `SearchWixAPISpec` / `ReadFullDocsMethodSchema` calls spent working out a shape
+        the recipe already gives;
+      - a `428 WIX_EVENTS_APP_NOT_INSTALLED` that the agent did not anticipate.
+
+      A crash inside a Wix MCP tool itself — for example `Cannot read properties of undefined` — is
+      an MCP defect, not an agent mistake: name it in the reason but do NOT deduct for it.
+
+      For each issue found, name the likely MCP/docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage/events/documentation.yaml
+++ b/yaml/wix-manage/events/documentation.yaml
@@ -1,0 +1,12 @@
+apiDoc:
+  title: Wix Events Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/events/create-wix-event.md
+      title: Create an Event (Wix Events V3)
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3
+      tags: [events]
+    - file: ../../../skills/wix-manage/references/events/manage-wix-events.md
+      title: Manage Wix Events — Tickets, Publishing, Cloning, Recurring
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3
+      tags: [events]

--- a/yaml/wix-manage/events/documentation.yaml
+++ b/yaml/wix-manage/events/documentation.yaml
@@ -3,7 +3,7 @@ apiDoc:
 
   docs:
     - file: ../../../skills/wix-manage/references/events/create-wix-event.md
-      title: Create an Event
+      title: Create Event
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
       tags: [events]
     - file: ../../../skills/wix-manage/references/events/manage-wix-events.md

--- a/yaml/wix-manage/events/documentation.yaml
+++ b/yaml/wix-manage/events/documentation.yaml
@@ -3,10 +3,10 @@ apiDoc:
 
   docs:
     - file: ../../../skills/wix-manage/references/events/create-wix-event.md
-      title: Create an Event (Wix Events V3)
-      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3
+      title: Create an Event
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
       tags: [events]
     - file: ../../../skills/wix-manage/references/events/manage-wix-events.md
-      title: Manage Wix Events — Tickets, Publishing, Cloning, Recurring
-      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3
+      title: Manage Events
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
       tags: [events]


### PR DESCRIPTION
`wix-manage` had **no Wix Events coverage at all**, so every events request was answered by probing the API spec from scratch. This adds two recipes and registers them.

Every request body and every error quoted below was executed against the live Wix Events API on a scratch site; nothing is transcribed from the spec alone. That mattered — the first ticket bodies I wrote from the spec were wrong three ways (`feeType` is required, `pricingMethod.free` is read-only, the quantity field is `initialLimit`), and would have shipped as new defects.

## Why the friction is high on this surface

Several of the API's validation messages point *away* from the fix:

| Sent | Response | Why it misleads |
| --- | --- | --- |
| no `timeZoneId` | `400 getTimeZoneId is not supported` | Reads as "remove this field". It means the field is **missing**. |
| `initialType` omitted | `400 initialType is unexpected. Expected: [RSVP,TICKETS,RSVP_AND_TICKETS]` | `TICKETS` is **rejected** by the API. The accepted value is `TICKETING`. |
| `feeType: "FEE_AT_CHECKOUT"` | `400 feeType value is required` | An invalid enum value reports as a *missing* one — for `initialType` too. |
| `locationTbd: true` alone | `400 Location address must not be a blank` | A `name` is enough to satisfy it. |

Three more fail **silently**, which is worse than a 400:

- a `limit` set on `registration` instead of `registration.rsvp` is ignored with no error;
- a clone resets its start date to ~14 days out and returns as a `DRAFT`;
- Query Events excludes drafts from both results and `pagingMetadata.total`.

## Dates are ISO-8601 strings

The spec types `startDate`/`endDate` as `string` / `format: date-time` but *also* carries a `$circular` pointer to `google.protobuf.Timestamp`, whose fields are `seconds` and `nanos`. Sending that shape fails with `400 Expected a string.` Both recipes state the rule, and flag that it applies to every date-time field across the Wix APIs — not just Events.

## Contents

- **Create an Event** — required body, date/time rules, venue/online/TBD location and street addresses, RSVP vs ticketing, guest capacity, `shortDescription` (plain string) vs `description` (Ricos object). Also disambiguates the **five** unrelated Wix APIs called "Events" (Wix Events / Calendar / Marketing Calendar / Triggered / BI), which is what routes "recurring event" requests into Bookings.
- **Manage Wix Events** — ticket definitions and pricing (fixed, free, donation, multiple tiers), publish, cancel, delete, clone, update, counting, and recurring series from explicit occurrence dates (there is no `RRULE`).

Both are under the 10k serve limit, so neither is truncated in use.

## Testing

Walked all 14 `coverage/events-*` scenario prompts against the live API. Everything created was deleted and the Events app uninstalled; the scratch site is back to its prior state.

No eval comparison has been run yet, so the friction impact is **unmeasured** — the claims here are verified against the API, not against a score.