### PR TITLE
🦞 igor-claw: CONNECT.md — document the no-attach-existing-site CLI gap

### DIFF
--- a/skills/wix-headless/references/managed/CONNECT.md
+++ b/skills/wix-headless/references/managed/CONNECT.md
@@ -31,6 +31,22 @@ place it into CWD **first** — unzip/copy/fetch the design's files into the wor
 project on disk — **then** `init`. An empty CWD plus a brought-in design is still `connect`, not create:
 land the design, then attach Wix to it.
 
+> **No supported way to target a pre-existing siteId/clientId.** `init` (and `create` / `headless
+> link`) always **provisions a brand-new site + private app** — there is no flag or config to point
+> any of them at a specific `siteId`/`clientId` a user already has (e.g. from Wix's own headless
+> onboarding, which hands over a real siteId/clientId/dashboard link before any code exists).
+> Hand-writing `wix.config.json` with that pre-existing siteId/appId is **not** a working substitute:
+> every backend REST call succeeds (install, seed, even `wix release` itself) because those only need
+> a valid, authorized siteId/appId — but the deployed frontend never serves (Wix's edge 404s as if the
+> site doesn't exist), because `init`/`create`/`link` perform an origin-registration step
+> (`updateOAuthApp` with `redirectUrlWixPages` set) that only they can reach, and nothing else — no
+> error, no warning — flags it as missing. **If the user already has a pre-provisioned siteId and
+> wants it specifically, say so and stop rather than hand-writing `wix.config.json`** (do not spend the
+> run's time on hand-authored-config debugging — it cannot work today). The field-tested fallback,
+> approved by the user first: run `init`/`create` normally (it provisions a **new** site + app pair),
+> re-run Setup/Seed against that new `SITE_ID`, and tell the user the original pre-provisioned site
+> is being left unused (they may want to delete it from the dashboard later).
+
 ## 2 · Authenticate
 
 Per `references/managed/AUTHENTICATION.md` — `whoami`/login if needed, then mint the site token


### PR DESCRIPTION
## Summary
A user with a pre-provisioned headless site (siteId/clientId handed over by Wix's own onboarding UX before any code existed) had no supported way to attach a Wix CLI project to it. `init`, `create`, and `headless link` all unconditionally provision a **brand-new** site+app pair — confirmed in `wix-cli` source: `getHeadlessInitCommand`'s `init` command takes zero options, and `create-headless`'s `CommandOptions` has no `siteId`/`clientId` field.

Hand-writing `wix.config.json` with the existing, correctly-authorized siteId/appId looks like it works — every backend REST call succeeds (app install, content seed), and even `wix release` itself reports success — but the deployed frontend never serves; Wix's edge returns a generic 404 as if the site doesn't exist. Root cause (from `wix-cli` source): `init`'s `create-project.ts` calls Dev Center's `updateOAuthApp(..., redirectUrlWixPages, origin: 'other')` to register the app as the site's active frontend — a step **only** reachable through `init`/`create`/`link`, never exposed as a standalone/repairable call. No CLI command, REST call, or `wix release` output flags this as missing.

This is a real product/CLI gap (needs a design decision — new command/flag, or a "claim existing site" mode), so no code PR for the underlying gap. This PR instead updates the skill so a future run doesn't burn time hand-authoring a config that can't work, and instead surfaces the limitation + uses the field-tested fallback (provision a fresh site+app pair, re-seed against it).

## Change
`skills/wix-headless/references/managed/CONNECT.md` — new caveat after §1: stop and tell the user rather than hand-write `wix.config.json` around a pre-existing siteId, and the fallback flow that's confirmed to work.

---
Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`). Report thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1786351421432449