### PR TITLE
🦞 igor-claw: cross-link Events mainImage SDK read-shape divergence in setup-events.md

### DIFF
--- a/skills/wix-headless/references/inline-recipes/setup-events.md
+++ b/skills/wix-headless/references/inline-recipes/setup-events.md
@@ -175,6 +175,7 @@ curl -X PATCH 'https://www.wixapis.com/events/v3/events/<eventId>' \
 
 - **`mainImage` reads back only under the `DETAILS` fieldset** — pass `"fields": ["DETAILS"]` (as above, and on any confirming `getEvent`/`queryEvents`) or the response omits it and a confirm check looks empty.
 - **Never block on image failure** (`SEED.md` § "Entity images" / IMAGE_GENERATION "Credits, cost & the not-generating fallback") — on failure, skip and leave the event text-only.
+- **⚠️ This OBJECT shape is the write/REST-confirm shape only — the frontend SDK read is a different shape.** `wixEventsV2.getEventBySlug`/`queryEvents` (`@wix/events`) run this same field through the SDK's generic media-ref transform, so `event.mainImage` comes back as a plain `wix:image://v1/<id>/<altText>#originWidth=…&originHeight=…` **string**, not this `{ id, url, height, width, altText }` object — `event.mainImage.url` is `undefined` there. Coding the frontend against this write shape reproduces a silent "every image missing" bug. The correct read-side shape + render helper is in `how-to-code-events.md` ("Rendering & mounting" → **Image**) — read it before building any image-rendering frontend code, not just this seed step.
 
 ### Paid-ticket precondition — record it, do NOT block
 


### PR DESCRIPTION
## Summary

Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), from a headless-platform feedback report. Slack thread: https://wix.slack.com/archives/C0BDXM5LLE7/p1786352538961499

A developer seeded an Events V3 event's `mainImage` per `setup-events.md`'s documented write shape (`{id, url, height, width, altText}`), confirmed it round-trips via REST, then built the frontend against that same object shape — and got `event.mainImage.url === undefined` everywhere, with no error anywhere in the stack.

**Root cause (confirmed live + in source):**
- `PATCH /events/v3/events/{id}` with `mainImage` as the object round-trips correctly via REST (verified against a throwaway test site).
- But `wixEventsV2.getEventBySlug` / `queryEvents` (`@wix/events`) run that same field through `@wix/sdk-runtime`'s `transformRESTImageToSDKImage` (see `packages/sdk-dependencies/public-sdk/events/wix-events-v-2/src/events-v3-event-wix-events-v-2.public.ts` in `wix-private/auto-sdk-packages`), so `event.mainImage` comes back as a plain `wix:image://v1/<id>/<altText>#originWidth=…&originHeight=…` **string**, not the object. Confirmed by actually calling the published `@wix/events` SDK against a live test event.
- This is a deliberate, platform-wide SDK convention (the same one Stores' `media.main.image` uses, already documented in `how-to-code-a-store.md`) — not a bug to fix in the API. `how-to-code-events.md` already documents the correct read-side shape and render helper, but nothing cross-links it from the seed recipe, so an agent that seeds first and builds the frontend off that same object mental model reproduces this by default.

**Fix:** one cross-reference line in `setup-events.md`'s "Attach images" step, pointing at `how-to-code-events.md`'s existing "Rendering & mounting → Image" note, right where the write shape is shown.

## Test plan
- [ ] Docs-only change — no code path affected. Reviewed the added line for accuracy against the live repro (REST PATCH → object; `wixEventsV2.getEventBySlug` → string).