### PR TITLE
chore: release @wix/agent-skills v1.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wix",
   "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": {
     "name": "Wix",
     "url": "https://dev.wix.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wix",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Build and deploy Wix apps and headless websites, and manage your Wix business. Includes CLI development skills, Wix Headless for any frontend framework, and Wix MCP server for eCommerce, CMS, dashboard extensions, and more.",
   "author": {
     "name": "Wix",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wix",
   "description": "Build, manage, and deploy Wix sites and apps directly from Cursor. Includes CLI development skills for creating dashboard extensions, backend APIs, site widgets, and service plugins. Connects to the Wix MCP server for site management.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": {
     "name": "Wix",
     "url": "https://dev.wix.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "wix",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
   "mcpServers": {
     "wix-mcp": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/agent-skills",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Wix Skills for AI coding agents — versioned npm distribution of the wix/skills content.",
   "license": "MIT",
   "repository": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wix",
   "description": "Build, manage, and deploy Wix sites and apps. Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": {
     "name": "Wix",
     "url": "https://dev.wix.com"


### PR DESCRIPTION
Release PR for **v1.16.0** (minor bump from 1.15.1).

Bumps `package.json` and syncs all five plugin manifests (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`, `plugin.json`, `gemini-extension.json`).

Opened manually because `release-bump.yml` could not be dispatched. On merge, [`release.yml`](.github/workflows/release.yml) publishes to npm via Trusted Publishing and pushes the `v1.16.0` tag — that workflow triggers on the PR-merge event, so no dispatch is needed.

Needs one approval from someone other than the author (ruleset requires `require_last_push_approval`).