### PR TITLE
fix(site-properties): cover time zone and language in the regional-properties recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -345,7 +345,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ## Site Properties
 
 ### [Change Payment Currency](references/site-properties/change-payment-currency-site-properties.md)
-**Technical:** Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask.
+**Technical:** Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask. Also covers the site time zone and primary language, which use the same field-mask PATCH with top-level field names — not nested `locale.*` paths.
 
 ### [Site Settings Dashboard Navigation](references/site-properties/site-properties-dashboard-navigation.md)
 **Technical:** Direct links to the site-settings dashboard pages on manage.wix.com (settings hub, website settings, language & region), paired with the Site Properties read API.

--- a/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
+++ b/skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md
@@ -1,21 +1,23 @@
 ---
-name: "RECIPE: Change a Site's Payment (Store) Currency via Site Properties API"
-description: "Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask."
+name: "RECIPE: Change a Site's Regional Properties (Currency, Time Zone, Language) via Site Properties API"
+description: "Updates the site-level payment currency (store billing currency) using Site Properties API, including the required request body shape and field mask. Covers the site time zone and primary language through the same call, whose field mask names top-level properties."
 ---
 
-# RECIPE: Change a Site's Payment (Store) Currency via Site Properties API
+# RECIPE: Change a Site's Regional Properties via Site Properties API
 
 ## Goal
-Update a Wix site's **payment currency** (the ISO-4217 currency code used to bill customers) programmatically.
+Update a Wix site's **regional properties** — payment currency, time zone, or primary language — programmatically.
 
 ## When to use
 - You need to switch a site's store/payment currency (for example, from `USD` to `EUR`).
+- You need to change a site's time zone or primary language.
 - You want to automate regional/business setup for sites.
 
 ## Important notes before you start
-- The `paymentCurrency` field is part of **Site Properties** (often shown in the dashboard under regional/business info).
+- These fields are part of **Site Properties** (often shown in the dashboard under regional/business info).
 - A successful update increments the Site Properties `version`.
 - Use a **field mask** (`fields.paths`) to indicate which fields you're updating.
+- **Field mask paths are top-level property names.** The read response also contains a `locale` object, but it is not the write surface — see Gotchas.
 
 ## Step 1 — (Optional) Read current site properties version
 This is useful to understand the current snapshot version and other regional fields.
@@ -25,8 +27,14 @@ curl -X GET 'https://www.wixapis.com/site-properties/v4/properties' \
   -H 'Authorization: <AUTH>'
 ```
 
-## Step 2 — Update the payment currency
-Use the `PATCH /site-properties/v4/properties` endpoint: put the new currency under `properties.paymentCurrency` and include a `fields.paths` mask.
+## Step 2 — Update the properties you need
+Use the `PATCH /site-properties/v4/properties` endpoint: put the new values under `properties` and name each one in a `fields.paths` mask.
+
+| Property | Field name | Value format |
+|---|---|---|
+| Payment currency | `paymentCurrency` | 3-letter ISO-4217 code — `USD`, `EUR`, `GBP` |
+| Time zone | `timeZone` | IANA time zone name — `America/New_York`, `Europe/Rome` |
+| Primary language | `language` | 2-letter ISO 639-1 code — `en`, `es`, `it` |
 
 ```bash
 curl -X PATCH 'https://www.wixapis.com/site-properties/v4/properties' \
@@ -42,18 +50,49 @@ curl -X PATCH 'https://www.wixapis.com/site-properties/v4/properties' \
   }'
 ```
 
+Time zone, same shape:
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/site-properties/v4/properties' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: <AUTH>' \
+  --data-binary '{
+    "properties": {
+      "timeZone": "America/New_York"
+    },
+    "fields": {
+      "paths": ["timeZone"]
+    }
+  }'
+```
+
+To update several properties at once, include each one in `properties` and name each in `paths`:
+
+```bash
+--data-binary '{
+    "properties": { "timeZone": "Europe/Rome", "language": "en" },
+    "fields": { "paths": ["timeZone", "language"] }
+  }'
+```
+
 ### Expected response
-A successful call returns an updated Site Properties snapshot version, for example:
+A successful call returns only the updated Site Properties snapshot version — it does **not** echo the properties back:
 
 ```json
 { "version": "123" }
 ```
 
+To confirm the new value, re-read with the Step 1 `GET`.
+
 ## Gotchas & troubleshooting
-- **Always send a field mask**: omitting `fields.paths` will fail with `400` and `"Illegal request - No updates on request body"`.
+- **Always send a field mask**: omitting `fields.paths` fails with `400` and `"Illegal request - No updates on request body"`.
+- **Do not nest the mask path under `locale`.** The `GET` response contains a `locale` object (`languageCode`, `country`), which makes a path like `locale.timezone` look plausible — it is rejected with `400` and `"Illegal request - Unknown field in field mask - locale.timezone"`. Time zone and language are the top-level `timeZone` and `language` fields.
+- **`locale.languageCode` is a read-only projection** and can differ from the top-level `language` value. Set `language`; read `language` back to verify.
 - Currency must be a **3-letter ISO-4217** code (for example, `USD`, `CAD`, `EUR`, `GBP`).
+- There is no separate per-field endpoint for currency, time zone, or language — all three go through this one call.
 
 ## Related APIs
 - **Site Properties API**: [REST](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/introduction)
+- **Get Site Properties** (full read shape): [REST](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties)
 - Stores Currency Converter (conversion utilities, not for setting the site currency):
   - `POST https://www.wixapis.com/currency_converter/v1/currencies/amounts/{from}/convert/{to}`

--- a/yaml/wix-manage-evals/site-properties/change-site-timezone.yml
+++ b/yaml/wix-manage-evals/site-properties/change-site-timezone.yml
@@ -5,7 +5,7 @@ description: >-
   probing calls to discover the field name.
 triggerPrompt: >-
   Change my site's time zone to America/New_York.
-tags: [site-properties, aria]
+tags: [site-properties]
 maxTokens: 30000
 assertions:
   - tool: ReadFullDocsArticle

--- a/yaml/wix-manage-evals/site-properties/change-site-timezone.yml
+++ b/yaml/wix-manage-evals/site-properties/change-site-timezone.yml
@@ -1,0 +1,49 @@
+name: site-properties/change-site-timezone
+description: >-
+  Verifies the agent reads the Site Properties regional-properties recipe and updates the
+  site's time zone in one direct field-mask PATCH, without a rejected mask path or a run of
+  probing calls to discover the field name.
+triggerPrompt: >-
+  Change my site's time zone to America/New_York.
+tags: [site-properties, aria]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/change-payment-currency-site-properties
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Change my site's time zone to America/New_York."
+
+      Pass only if the trace shows the agent successfully (2xx) updated the site's time zone to
+      America/New_York and confirmed it in its final answer.
+
+      Fail if it set a different time zone; OR the update call errored (non-2xx) and was never
+      corrected; OR it only described how to do it without doing it; OR it asked platform-level
+      clarifying questions instead of acting.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence>"}.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how smoothly the agent reached the outcome. Examine the tool-call trace.
+      Score 0-10 (10 = direct: read the recipe, then one successful update call).
+
+      Penalize and LIST any of:
+      - an update call rejected because the field mask named a nested path (for example
+        `locale.timezone`) instead of the top-level `timeZone` field;
+      - an update call rejected for a missing field mask;
+      - API-spec or schema lookups made *after* a failed update in order to discover the correct
+        field name or endpoint;
+      - more than one attempt at the update call;
+      - probing calls that the recipe's content would have made unnecessary.
+
+      For each issue, name the likely docs gap.
+
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions + suspected docs gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor


### PR DESCRIPTION
## What

Extends the Site Properties recipe so it covers the site **time zone** and **primary language** alongside payment currency. All three are written through the same `PATCH /site-properties/v4/properties` call with a `fields.paths` mask, but the recipe documented only currency.

## Why

An agent asked to change a site's time zone had no worked example for that field, so it guessed the mask path from the shape of the read response — which contains a `locale` object — and got:

```
400 {"message":"Illegal request - Unknown field in field mask - locale.timezone",
     "details":{"applicationError":{"code":"ILLEGAL_ARGUMENT"}}}
```

It then made a further ten calls hunting for the correct field name before arriving at the top-level `timeZone`. The same guess is available for `language`. There is no published method page for this endpoint, so this recipe is the only place the call shape is documented — which is why the gap costs a run rather than being one lookup away.

## Verified against a live site

Every request and error below was executed against a real site before being written down, and the site was restored afterwards.

| Request | Result |
|---|---|
| `{"properties":{"timeZone":"America/New_York"},"fields":{"paths":["timeZone"]}}` | `{"version":"23"}`, persisted |
| `{"properties":{"language":"it"},"fields":{"paths":["language"]}}` | `{"version":"24"}`, persisted |
| `paths:["timeZone","language"]` in one call | `{"version":"26"}`, both persisted |
| `paths:["locale.timezone"]` | `400 Illegal request - Unknown field in field mask - locale.timezone` |
| `fields.paths` omitted | `400 Illegal request - No updates on request body` |

Two behaviours that testing surfaced and the recipe now records:

- the response returns **only** `{"version": …}` and does not echo the properties back, so confirming a write needs a re-read;
- `locale.languageCode` is a read-only projection and can differ from the top-level `language` value.

## Routing

Extending this recipe rather than adding new ones for time zone and language: all three fields share one endpoint, one mask mechanism and one sharp edge (top-level paths, not `locale.*`), so splitting them would put three copies of the same caveat in three files to drift apart. The recipe's existing canonical URL is unchanged, which also keeps the new scenario's coverage assertion anchored to a resolvable page.

`documentation.yaml` is deliberately untouched: the doc URL is derived from the `title` there, so retitling the entry would change the published page URL. The entry already lists this recipe.

## Files

- `skills/wix-manage/references/site-properties/change-payment-currency-site-properties.md` — field table with value formats, time zone example, multi-field mask form, two verified rejections, response-shape and `locale.languageCode` notes. Front-matter `description` extended additively (151 → 266 chars).
- `skills/wix-manage/SKILL.md` — index entry extended additively.
- `yaml/wix-manage-evals/site-properties/change-site-timezone.yml` — new scenario: `ReadFullDocsArticle` coverage assertion on this recipe's URL, an `llm_judge` on the outcome, and a gating `llm_judge` on the tool-call path whose rubric penalises exactly the failure above (a mask path rejected for nesting, and schema lookups made only *after* a failed update). Trigger prompt is deliberately plain — "Change my site's time zone to America/New_York" — so it does not tell the agent which field to use.

## The eval gate has not run

Actions is currently disabled repository-wide, so no workflow runs on this PR and the eval gate has not executed. **Please do not read the absence of a failing check as a passing one.** What would make it run: Actions being re-enabled plus a fresh push or a reopen, since the gate triggers on `opened`, `synchronize`, `reopened` and `ready_for_review`. I have not changed the repository's Actions setting.

The `SKILL.md` edit is unverifiable by the gate in any case — its path filter covers `references/**`, `yaml/wix-manage/**` and `yaml/wix-manage-evals/**`, so a change to `SKILL.md` itself triggers no scenarios.

## Merge order

#425 is open and adds `yaml/wix-manage-evals/site-properties/change-payment-currency-site-properties.yml`, a scenario covering the recipe this PR edits. If that merges first, its scenario will start covering a file this PR changed while being unaffected by the change, which can return `not-required` and block auto-approval for the group. Worth sequencing the two rather than landing them concurrently.

## Left alone deliberately

The currency example, its ISO-4217 note and the Currency Converter link are unchanged — they were correct. No confirmation prompt was added before the mutation: the surrounding request ("change my time zone to X") is already an explicit user-confirmed action, and adding a clarifying step would make the agent stop where it currently acts.
