### PR TITLE
wix-manage: add Manage an Existing Gift Card Product routing + recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -175,6 +175,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 - **Pricing & promotions** (coupons, discount rules, ribbons, sales) → use the [Pricing & Promotions](references/ecommerce/ecom-pricing.md) dispatcher.
 - **Shipping setup** (rates, regions, pickup, free shipping, fix coverage) → use the [Shipping](references/ecommerce/ecom-shipping.md) dispatcher.
 - **Gift cards** ("should I sell gift cards", "add a gift card", "what amounts should my gift card have") → these are recommendations, so they go through [Recommend: eCommerce Strategy](references/ecommerce/recommend-ecommerce-strategy.md), which activates its GIFT_CARDS domain and loads the gift-cards goal itself. Issuing/redeeming an individual gift card is the Gift Cards API, not a recommendation.
+- **Manage an existing gift card product** ("rename my gift card", "change my gift card amounts / denominations", "edit gift card expiration") → [Manage an Existing Gift Card Product](references/ecommerce/gift-cards/ecom-gift-cards-manage-gift-card-product.md) — read the product (Get/Query) for its id + revision, then Update Gift Card Product via the Gift Cards Products API.
 
 ### [eCommerce: Load Context](references/ecommerce/ecom-load-context.md)
 **L1 loader** — loads general site data (siteId, country, currency, industry, catalog analytics) needed by every eCommerce category. Each category dispatcher loads this before tag-matching; runs once per session.
@@ -200,6 +201,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 #### Gift-cards leaf (loaded by the strategy orchestrator when it activates the GIFT_CARDS domain)
 - [Goal: Sell Gift Cards](references/ecommerce/gift-cards/ecom-gift-cards-goal-sell-gift-cards.md) — existing-product gate (one per site), eligibility, denomination sizing from AOV / catalog prices, no-expiry-by-default policy, and the mapping onto Create Gift Card Product
+- [Manage an Existing Gift Card Product](references/ecommerce/gift-cards/ecom-gift-cards-manage-gift-card-product.md) — rename, change denominations, or change expiration on an existing gift card product, via Get/Query then Update Gift Card Product
 
 #### Shipping leaves (loaded by the Shipping dispatcher)
 - [Set Up Rates](references/ecommerce/shipping/ecom-shipping-setup-rates.md)

--- a/skills/wix-manage/references/ecommerce/gift-cards/ecom-gift-cards-manage-gift-card-product.md
+++ b/skills/wix-manage/references/ecommerce/gift-cards/ecom-gift-cards-manage-gift-card-product.md
@@ -1,0 +1,37 @@
+# Manage an Existing Gift Card Product
+
+Use this recipe for any request to **edit an existing gift card product** — rename it, change its
+denominations (preset/custom variants), or change its expiration policy. Gift card products have their
+own API; manage them through the **Gift Cards Products API**.
+
+> A site currently has at most one gift card product.
+
+## Flow
+
+1. **Read it first.** Call [Query Gift Card Products](https://dev.wix.com/docs/api-reference/business-solutions/gift-cards/gift-card-products/query-gift-card-products)
+   (`POST /gift-cards/v1/gift-card-products/query`) or [Get Gift Card Product](https://dev.wix.com/docs/api-reference/business-solutions/gift-cards/gift-card-products/get-gift-card-product)
+   (`GET /gift-cards/v1/gift-card-products/{giftCardProductId}`) to get the product `id` and current `revision`.
+2. **Update it.** Call [Update Gift Card Product](https://dev.wix.com/docs/api-reference/business-solutions/gift-cards/gift-card-products/update-gift-card-product)
+   (`PATCH /gift-cards/v1/gift-card-products/{giftCardProduct.id}`). Send `id`, the current `revision`, and only
+   the field you are changing. `revision` must match the latest or the update is rejected.
+
+### Rename example
+
+```http
+PATCH https://www.wixapis.com/gift-cards/v1/gift-card-products/{giftCardProductId}
+```
+```json
+{
+  "giftCardProduct": {
+    "id": "{giftCardProductId}",
+    "revision": "{currentRevision}",
+    "name": "Holiday Gift Card 2025"
+  }
+}
+```
+
+## Notes
+
+- The `name` field is a top-level string on the gift card product — updating it only changes the name.
+- To change denominations, send the **entire** `presetVariants` list (the list is replaced, not merged).
+- Deleting is [Delete Gift Card Product](https://dev.wix.com/docs/api-reference/business-solutions/gift-cards/gift-card-products/delete-gift-card-product); already-purchased gift cards stay valid.


### PR DESCRIPTION
## What

Adds a `wix-manage` recipe and routing entry for **managing an existing gift card product** — rename, change denominations, or change expiration.

- New: `references/ecommerce/gift-cards/ecom-gift-cards-manage-gift-card-product.md`
- SKILL.md: one routing line + one leaf-list entry pointing to it.

## Why

Editing an existing gift card product is served by the **Gift Cards Products API** (`PATCH /gift-cards/v1/gift-card-products/{id}`), a separate entity with its own id space. `wix-manage` had no management route for gift card products — the only gift-cards entry is the "sell gift cards" recommendation goal, which maps onto *Create*. With no "edit an existing gift card" route, an agent handling "rename my gift card" could resolve to the nearest available product-edit recipe (Stores catalog Update Product) and use the wrong API.

Measured on an eval harness: without this route the agent used the wrong API ~1 in 3 runs; with the route present, a blind test picked the correct Gift Cards Products API 4/4 (Stores Update Product route present as a distractor).

## Notes

Recipe wording is positive-only (states the correct route); it does not reference the Stores catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)