### PR TITLE
fix(wix-headless): document 12 auto-created demo products and verify-after-delete (GPV-8744)

### DIFF
--- a/skills/wix-headless/references/inline-recipes/how-to-code-a-store.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-a-store.md
@@ -52,7 +52,7 @@ A concise contract for writing the **frontend code** of a storefront against a C
 The exact field paths the storefront reads, and the **plausible-wrong sibling** each is mistaken for — the sections below reference these instead of re-describing them. All `amount`s are **strings**. These are **read** shapes; the cart-add body (under *Adding to cart*) is a separate **write** shape, and the `_id` rule applies to read **entities**, not to method-return wrappers (note `checkoutId`).
 
 ```jsonc
-// productsV3.queryProducts() / .searchProducts()  →  result.items[]
+// productsV3.queryProducts() / .searchProducts()  →  result.products[]
 product = {
   _id,                                            // links · cart catalogItemId · variant filter   (NOT .id → empty → HTTP 500)
   slug, name, visible,                            // only visible:true is returned to a visitor token
@@ -119,7 +119,7 @@ const res = await categories.queryCategories({
 **⚠️ CRITICAL: category filtering MUST use `searchProducts`, NOT `queryProducts`.** `directCategoriesInfo.categories` is **not declared as filterable in `queryProducts`** — passing it there returns HTTP `400 "... is not declared as filterable"`, which the SDK **swallows silently**, leaving an empty category page that looks like "no products". This is the #1 way this breaks. Use Search Products:
 
 ```js
-const { items } = await productsV3.searchProducts({
+const { products } = await productsV3.searchProducts({
   filter: { 'directCategoriesInfo.categories': { $matchItems: [{ id: categoryId }] } },
 });
 ```

--- a/skills/wix-headless/references/inline-recipes/how-to-code-a-store.md
+++ b/skills/wix-headless/references/inline-recipes/how-to-code-a-store.md
@@ -52,7 +52,8 @@ A concise contract for writing the **frontend code** of a storefront against a C
 The exact field paths the storefront reads, and the **plausible-wrong sibling** each is mistaken for — the sections below reference these instead of re-describing them. All `amount`s are **strings**. These are **read** shapes; the cart-add body (under *Adding to cart*) is a separate **write** shape, and the `_id` rule applies to read **entities**, not to method-return wrappers (note `checkoutId`).
 
 ```jsonc
-// productsV3.queryProducts() / .searchProducts()  →  result.products[]
+// productsV3.queryProducts().…find()  →  result.items[]
+// productsV3.searchProducts({...})    →  result.products[]
 product = {
   _id,                                            // links · cart catalogItemId · variant filter   (NOT .id → empty → HTTP 500)
   slug, name, visible,                            // only visible:true is returned to a visitor token

--- a/skills/wix-headless/references/inline-recipes/setup-online-store.md
+++ b/skills/wix-headless/references/inline-recipes/setup-online-store.md
@@ -22,10 +22,13 @@ A concise checklist for preparing any new Wix site that uses the Online Stores a
 
 ### STEP 1: Clean the store — remove the default sample products
 
-A freshly provisioned Wix Stores app comes pre-seeded with demo/sample products. **Only remove products that are obviously the install's own demo/sample data on a fresh install.** Do **not** assume the existing products are samples: the site may already hold the owner's **real catalog** (a connect/iterate run, or an owner-populated store). If what's there isn't obviously install demo data, or you're unsure, **do not delete it — ask the user first** (`SEED.md`: seeding is additive; deleting real content needs the owner's approval). When they clearly are the install's samples, remove them **before** creating yours so the storefront shows only the intended catalog.
+**⚠️ Wix Stores installation automatically creates exactly 12 "Wix starter products" in the catalog.** These are created `visible: true` with no demo flag or label — they appear on the live public storefront immediately and are indistinguishable from real merchant products. Any merchant who then adds their own products ends up with a mix of dummy and real items on their published site. **Always delete these before seeding on a fresh install.**
+
+If the site is not a fresh install, apply the rule below: **Only remove products that are obviously the install's own demo/sample data.** Do **not** assume the existing products are samples: the site may already hold the owner's **real catalog** (a connect/iterate run, or an owner-populated store). If what's there isn't obviously install demo data, or you're unsure, **do not delete it — ask the user first** (`SEED.md`: seeding is additive; deleting real content needs the owner's approval). When they clearly are the install's samples, remove them **before** creating yours so the storefront shows only the intended catalog.
 
 1. **List the existing products** — `POST https://www.wixapis.com/stores/v3/products/query` with body `{"query": {"paging": {"limit": 50}}}`. Collect every `product.id` from the response.
-2. **Bulk-delete them in one call** — `POST https://www.wixapis.com/stores/v3/bulk/products/delete` with body `{"productIds": ["<id1>", "<id2>", …]}` (the ids from step 1; up to 100 per call). On a fresh install the query returns only the install's sample products — delete those. **If it returns anything that could be the owner's real catalog, stop and ask first** (above).
+2. **Bulk-delete them in one call** — `POST https://www.wixapis.com/stores/v3/bulk/products/delete` with body `{"productIds": ["<id1>", "<id2>", …]}` (the ids from step 1; up to 100 per call). On a fresh install the query returns only the install's 12 sample products — delete those. **If it returns anything that could be the owner's real catalog, stop and ask first** (above).
+3. **Verify the delete succeeded** — re-run the query from sub-step 1. If products are still present, the bulk-delete silently no-opped; retry the delete once with the same ids. **Do not proceed to STEP 2 until the catalog is empty.**
 
 ### STEP 2: Bulk-create the products (with options)
 

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -93,10 +93,14 @@ Run the agnostic flow against the scaffolded site:
   (`createClient({ modules, auth: OAuthStrategy({ clientId }) })`), where `clientId` is the public
   `appId` from the `wix.config.json` written by `init` (§1).
 
+**Before writing any page or component code, Read the inline recipe for each loaded capability** (`references/inline-recipes/how-to-code-*.md` — mapped per capability in `SDK_HANDOFF.md`). The recipe is the authoritative source for that capability's exact module names, method shapes, field paths, and silent-fail traps. Never write storefront, cart, booking, blog, or events code from memory or from the SDK docs alone — the recipe is what prevents convincing-looking UI that isn't wired to anything real (placeholder `addToCart` with no actual SDK call, a cart badge that never updates, a checkout button that goes nowhere).
+
 Then build the pages the user's intent calls for, **wired to the live backend**, using
 **`references/SDK_HANDOFF.md`** for the per-capability packages, the SDK docs, and the seeded schema to
 bind (collection/form names + field keys; all other content is queried live). Install the SDK packages the loaded verticals need, author the pages/components directly in the
 project, and bind them to the live backend content. Keep it scoped to what was asked — no speculative pages.
+
+> **Pre-release API-wiring check (stores + ecom capabilities):** Before releasing, verify the generated code actually calls the real SDK. For a store, grep the project source for `addToCurrentCart` and `productsV3` — if either is absent, the cart or product listing is a stub; wire it from the recipe before proceeding. Apply the same principle to every loaded capability: a bookings build must reference `getServiceAvailability` or equivalent; a blog build must reference `queryPosts`. A page that renders convincingly but calls nothing is a broken deliverable.
 
 > **`npm install` note (Astro):** always run **`npm install --ignore-scripts`**. Astro pulls `sharp`
 > as an *optional* transitive dep for **local, build-time**


### PR DESCRIPTION
## Summary

- Adds an explicit mandate in `CREATE.md §4` to Read each capability's inline recipe (`how-to-code-*.md`) **before** authoring any page or component code for that capability
- Adds a pre-release API-wiring check: grep the generated source for real SDK call sites (e.g. `addToCurrentCart`, `productsV3`) and treat their absence as a broken deliverable, not a warning

## Problem

Agents were generating convincing storefront UIs — product grids, cart badges, checkout buttons — that weren't wired to real `@wix/stores` / `@wix/ecom` SDK calls. The storefront looked complete but failed entirely at runtime (no items added to cart, currency dropdown with no `setCurrency()`, cart badge stuck at 0).

Root cause: `CREATE.md §4` directed agents to `SDK_HANDOFF.md` for package names, which *maps* each capability to its inline recipe — but never explicitly required **reading** that recipe before writing code. Agents could (and did) generate plausible-looking UI from model memory instead, producing stubs that matched the real API shape superficially but called nothing.

Jira: https://wix.atlassian.net/browse/GPV-8742

## Test plan

- [ ] A managed `create` run for a store site reads `how-to-code-a-store.md` before authoring product/cart/checkout pages
- [ ] Generated source contains real `productsV3` / `addToCurrentCart` calls (verifiable with the new grep check)
- [ ] A managed `create` run for a bookings site reads `how-to-code-bookings.md` before authoring availability/booking pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)