### PR TITLE
🦞 igor-claw: add recipe for diagnosing a live site stuck stale after successful writes

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -369,6 +369,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Sites Dashboard Navigation](references/sites/sites-dashboard-navigation.md)
 **Technical:** Direct links to the account-level My Sites list (manage.wix.com/account/websites) and per-site dashboard homes, paired with the Query Sites read API.
 
+### [Diagnosing: Live Site Not Updating After a Successful Write](references/sites/diagnosing-live-site-not-updating-after-successful-write.md)
+**Technical:** Bisection recipe for when every write (Editor save, Publish Site, Velo deploy, REST call) reports success with real revisions/timestamps but the live-served HTML never changes. Rules out downstream/CDN caching via response headers, then uses a no-publish-required Create Custom Embed probe to isolate a publish-flow issue from a deeper origin serving/cache incident. Use when the user reports changes "not going live" after normal republishing hasn't helped — tells you when to stop retrying write APIs and escalate to Wix Support instead.
+
 ---
 
 ## Stores

--- a/skills/wix-manage/references/sites/diagnosing-live-site-not-updating-after-successful-write.md
+++ b/skills/wix-manage/references/sites/diagnosing-live-site-not-updating-after-successful-write.md
@@ -1,0 +1,30 @@
+---
+name: "Diagnosing: Live Site Not Updating After a Successful Write"
+description: What to do when Editor saves, Publish Site, or a normally-immediate write (e.g. Create Custom Embed) all report success with real revisions/timestamps, but the live-served HTML never changes. Bisects the problem to rule out client/CDN caching vs. a backend serving-layer incident, since the fix (if any) is not reachable from any public API.
+---
+# Diagnosing: Live Site Not Updating After a Successful Write
+
+## Symptom
+
+Every write path the user tries reports success — Editor saves, [Publish Site](https://dev.wix.com/docs/api-reference/account-level/sites/site-actions/publish-site), a Velo/code deploy, a REST call — and the site's `updatedDate`/revision visibly advances. But the live-served HTML on the public URL never reflects the change, no matter how long you wait or how many times you republish.
+
+**Do not treat this as a normal "my publish didn't work" question and start replaying every write flow again.** If the checks below confirm the write path is healthy, this is very likely a backend serving/cache incident on that one site, not something fixable by retrying APIs, re-publishing, or changing how the agent calls things.
+
+## Step 1 — Rule out a downstream (CDN/browser) cache first
+
+Fetch the live URL directly (`curl -D -`) and check the response headers:
+- `cache-control: private, max-age=0, must-revalidate` and `age: 0` mean the **outer edge is not caching** — every request is a fresh pass to origin. If you see this, a downstream/browser cache is NOT the explanation, even though the content still looks stale.
+- If instead you see a long `max-age`/`s-maxage`, a high `age` value, or a `cf-cache-status: HIT`, that IS a real downstream cache — the fix there is a normal CDN purge or waiting out the TTL, not an incident.
+
+## Step 2 — Bisect using a no-publish-required write
+
+[Create Custom Embed](https://dev.wix.com/docs/api-reference/business-management/custom-embeds/create-custom-embed) is documented to apply to the live site **immediately, with no publish step**. Create one with a unique, greppable HTML marker (e.g. a harmless `<meta>` tag) and re-fetch the live URL right after:
+
+- **Marker appears live** → the general write→serve pipeline for this site is healthy. Whatever else isn't updating is a narrower, specific problem (e.g. a particular content type, page, or app) — debug that directly instead of assuming a platform-wide incident.
+- **Marker does NOT appear**, even though `Create Custom Embed`'s own response returned a real `revision` → this bisects the problem to below the write layer entirely. Since Custom Embeds don't go through Publish Site at all, this rules out every publish-flow-specific theory (a stuck deploy job, a Velo-specific runtime issue, etc.) in one call. What's left is the site's serving/render origin itself failing to pick up new revisions — most likely a stuck or un-invalidated origin-side cache (separate from and invisible to the CDN-edge headers checked in Step 1).
+
+## Step 3 — What to tell the user if Step 2 confirms the deeper case
+
+There is **no public API to force-refresh or query the state of a site's serving-origin cache** — this is backend infrastructure, not something reachable via the Wix MCP, REST API, or CLI. Don't keep trying more write APIs or re-publishing; it won't help; and don't spend further "trying-harder" write-path tool calls once Step 2 has produced the second (no-marker) outcome.
+
+Tell the user this looks like a platform-side serving incident specific to their site, and to escalate it to **Wix Support** with the concrete evidence you gathered (the response headers from Step 1 and the Custom Embed bisection result from Step 2) — that evidence lets support skip straight to the serving/cache layer instead of re-treading the write-path debugging you already ruled out.

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -22,3 +22,7 @@ apiDoc:
       title: Sites Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
       tags: [sites]
+    - file: ../../../skills/wix-manage/references/sites/diagnosing-live-site-not-updating-after-successful-write.md
+      title: "Diagnosing: Live Site Not Updating After a Successful Write"
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites/site-actions/publish-site
+      tags: [sites]


### PR DESCRIPTION
## Why

Investigated a feedback report: a Premium customer's site had every write path — Editor saves, Publish Site, and Create Custom Embed (which the API docs say applies immediately, no publish needed) — report success with real revisions/updated timestamps, but the live-served HTML never changed. Response headers (`age:0`, `cache-control: private,max-age=0,must-revalidate`) ruled out a downstream/CDN cache.

I reproduced the write→serve path on a fresh test site and confirmed it works correctly in general (Create Custom Embed did appear live immediately, matching docs). So this specific report is a genuine site-specific serving-infra incident, not a systemic API/docs bug — no public API exists to diagnose or force-fix it. That determination itself is useful and repeatable: an agent hitting this pattern should recognize it quickly (via the same 2-step bisection I used) and stop retrying write APIs, rather than re-treading publish/republish attempts.

## What this adds

A new recipe, `skills/wix-manage/references/sites/diagnosing-live-site-not-updating-after-successful-write.md`, registered in `SKILL.md` and `yaml/wix-manage/sites/documentation.yaml`:
1. Check response headers to rule out downstream/CDN caching.
2. Use a **Create Custom Embed** probe (immediate-effect, no-publish-required by its own docs) to bisect a publish-flow issue from a deeper origin-serving/cache incident.
3. If the deeper case is confirmed, tell the agent to stop trying more write APIs and tell the user to escalate to Wix Support with the gathered evidence — there is no public API to force-refresh a site's serving-origin cache.

Slack thread for the originating report: https://wix.slack.com/archives/C08P5DKLJR5/p1786375972182859

---
This PR was opened automatically by an AI agent acting on behalf of Ayal (ayalg@wix.com) — not personally written by them.