### PR TITLE
wix-vibe-headless: deploy.cjs takes one or many verticals

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -1,12 +1,16 @@
-// Post-install deploy — run by base44.md STEP 1 with the target VERTICAL:
-//   node deploy.cjs <vertical>   (storefront | bookings | blog | cms | portfolio | pricing-plans | events | members)
+// Post-install deploy — run by base44.md STEP 1 with the vertical(s) the app needs:
+//   node deploy.cjs <vertical> [<vertical> …]
+//   (storefront | bookings | blog | cms | portfolio | pricing-plans | events | members)
 // ONE mechanism: recursively copy `app/` -> /app/src. The shared transport (app/rest/wix-client.js,
-// wix-config.js) is copied always; then ONLY the chosen vertical's app/ (its UI + app/rest/ helpers).
-// Deploying a single vertical is deliberate: every vertical's app/ has files at the SAME paths
-// (components/…, pages/…), so copying all of them into one src/ would clobber and pile up. Two
-// copies (not one) only because shared stays DRY. paths are the Base44 sandbox's /app. Re-running is
-// non-destructive: it fills in only missing files, never overwriting the agent's edits (see COPY).
-// No vertical arg -> deploys just the shared transport; re-run with the vertical once known.
+// wix-config.js) is copied always; then each named vertical's app/ (its UI + app/rest/ helpers).
+// Deploy every vertical the app actually uses, in one call or across several — an app that needs both
+// members and cms names both, and its CMS helpers then come from the skill instead of being
+// hand-written. Order matters only where two verticals ship a file at the SAME path (both have
+// components/…, pages/…): the first one listed wins, since the copy never overwrites. Verticals whose
+// file sets don't overlap (cms ships utils only, no UI) combine freely.
+// paths are the Base44 sandbox's /app. Re-running is non-destructive: it fills in only missing files,
+// never overwriting the agent's edits (see COPY), so a later call can add a vertical safely.
+// No vertical arg -> deploys just the shared transport; re-run with the vertical(s) once known.
 // NOTE: .cjs on purpose — the app is an ESM package ("type":"module"); a .js here would load as ESM
 // and require()/module.exports would throw.
 const { existsSync, cpSync, readFileSync } = require('fs');
@@ -64,21 +68,28 @@ function replaceMembersAuthLeftovers() {
 
 // --- main ---------------------------------------------------------------------------------------
 
-const vertical = process.argv[2];
-const deployed = { vertical: null };
+// Accept one or many: `deploy.cjs members cms`. Duplicates collapse; order is preserved so the
+// first vertical listed wins any same-path file (the copy never overwrites).
+const requested = [...new Set(process.argv.slice(2))];
+const deployed = { verticals: [] };
 
 // Shared transport — always (app/rest/wix-client.js, wix-config.js -> src/rest/).
 if (existsSync(`${REF}/shared/app`)) cpSync(`${REF}/shared/app`, '/app/src', COPY);
 
-// The chosen vertical ONLY — its app/ (UI + app/rest/ helpers) -> src/.
-if (vertical && VERTICALS.includes(vertical) && existsSync(`${REF}/${vertical}/app`)) {
+// Each named vertical — its app/ (UI + app/rest/ helpers) -> src/.
+const unknown = requested.filter((v) => !VERTICALS.includes(v));
+for (const vertical of requested.filter((v) => VERTICALS.includes(v))) {
+  if (!existsSync(`${REF}/${vertical}/app`)) continue;
   cpSync(`${REF}/${vertical}/app`, '/app/src', COPY);
-  deployed.vertical = vertical;
+  deployed.verticals.push(vertical);
   if (vertical === 'members') deployed.authPagesFixed = replaceMembersAuthLeftovers();
-} else if (vertical) {
-  deployed.error = `unknown vertical "${vertical}" — expected one of: ${VERTICALS.join(', ')}`;
-} else {
-  deployed.note = 'no vertical given — deployed the shared transport only; re-run: node deploy.cjs <vertical>';
+}
+
+if (unknown.length) {
+  deployed.error = `unknown vertical(s) ${unknown.map((v) => `"${v}"`).join(', ')} — expected: ${VERTICALS.join(', ')}`;
+}
+if (!requested.length) {
+  deployed.note = 'no vertical given — deployed the shared transport only; re-run: node deploy.cjs <vertical> [<vertical> …]';
 }
 
 console.log(JSON.stringify(deployed));

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -19,16 +19,20 @@ Install two skills — they land under `.agents/skills/`:
   doesn't cover.
 
 Install via the skills CLI — run this through exec_tool, exactly as written. It installs the two
-skills, then runs `deploy.cjs <vertical>` (lays the shared transport + **your one vertical's**
+skills, then runs `deploy.cjs <vertical…>` (lays the shared transport + **each** listed vertical's
 REST scaffolds and UI client into `src/`) and `pin-agents-md.cjs` (pins the project's AGENTS.md
-note so later turns keep the rules). **Set `VERTICAL`** to what the
-prompt asks for — one of `storefront`, `bookings`, `blog`, `cms`, `portfolio`, `pricing-plans`,
-`events`, `members` (too vague to tell? do STEP 2 first, then set it).
+note so later turns keep the rules).
+
+**Set `VERTICALS`** to what the prompt asks for, from `storefront`, `bookings`, `blog`, `cms`,
+`portfolio`, `pricing-plans`, `events`, `members` (too vague to tell? do STEP 2 first, then set it).
+**List every vertical the app actually uses** — one is the common case, and name more when the intent
+spans them, so all their scaffolds come from the skill rather than being written by hand. Adding one
+later is fine too: re-run with the extra name (the copy only fills in missing files).
 
 ```js
 const { execSync } = require('child_process');
 const { readdirSync } = require('fs');
-const VERTICAL = 'storefront'; // ← set from the prompt (see the list above)
+const VERTICALS = ['storefront']; // ← set from the prompt; list every vertical the app uses
 const results = {};
 for (const skill of ['wix-vibe-headless', 'wix-docs']) {
   try {
@@ -38,8 +42,8 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
       : out.includes('No valid skills') ? 'not_found' : 'unknown';
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-// Deploy the shared transport + ONLY this vertical's scaffolds/UI into src/.
-const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICAL}`, { cwd: '/app' }).toString();
+// Deploy the shared transport + each listed vertical's scaffolds/UI into src/.
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')}`, { cwd: '/app' }).toString();
 // Pin the project's AGENTS.md note (idempotent) so the rules survive after this doc leaves context.
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };


### PR DESCRIPTION
## What
`deploy.cjs` now accepts a list: `node deploy.cjs members cms`. `base44.md` STEP 1 sets a `VERTICALS` array and says to list every vertical the app uses.

## Why
It accepted a single vertical, so an app whose intent spans two had no supported way to get both scaffold sets.

Observed on a real build (**Shared Canvas Studio** — a member drawing app with a public gallery, so `members` + `cms`). The agent deployed `members`, then probed `references/cms/app`, read `wix-cms.js` and `wixImage.js` — and **hand-typed shrunken copies into `src/`** instead of deploying `cms`: 75 lines / 4 exports against the shipped 231 / 7, with the JSDoc (and the undefined-filter guard) gone. It dropped `getDataItemBy`, `countDataItems`, `updateDataItem`.

An earlier build ("Art Gallery Maker") hit the identical wall and improvised the other way — a second `deploy.cjs cms` call. That works, and appears nowhere in the docs. Same gap, two different guesses, one of which lost real code.

## Behaviour
- Duplicates collapse; order is preserved, so the first vertical listed wins any same-path file (the copy still never overwrites).
- Unknown names are reported in `error` while the valid ones deploy.
- Output carries `verticals: [...]`.
- **A single argument keeps working unchanged** — published instructions in the wild call it that way.
- Adding a vertical in a later call works, since the copy only fills in missing files.

## Verified
Scratch sandbox, five scenarios: `members cms` in one call yields the full 231-line `wix-cms.js` **with the guard** plus `wixImage.js` and `MemberContext`; single vertical unchanged; a later `cms` call adds it incrementally; mixed unknown/duplicate args; no-argument case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)