### PR TITLE
wix-vibe-headless: vertical capability map, restaurants fix, and images in a CMS collection

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -16,7 +16,7 @@
 const { existsSync, cpSync, readFileSync } = require('fs');
 
 const REF = '/app/.agents/skills/wix-vibe-headless/references';
-const VERTICALS = ['storefront', 'bookings', 'blog', 'cms', 'portfolio', 'pricing-plans', 'events', 'members'];
+const VERTICALS = ['storefront', 'bookings', 'blog', 'cms', 'portfolio', 'pricing-plans', 'events', 'members', 'restaurants'];
 
 // force:false + errorOnExist:false — fill in only files that AREN'T there yet; never overwrite.
 // A re-run (e.g. the "files missing? re-run" fallback) then restores what's missing without

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -23,16 +23,31 @@ skills, then runs `deploy.cjs <vertical…>` (lays the shared transport + **each
 REST scaffolds and UI client into `src/`) and `pin-agents-md.cjs` (pins the project's AGENTS.md
 note so later turns keep the rules).
 
-**Set `VERTICALS`** to what the prompt asks for, from `storefront`, `bookings`, `blog`, `cms`,
-`portfolio`, `pricing-plans`, `events`, `members` (too vague to tell? do STEP 2 first, then set it).
+**Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
+
+| vertical | pick it when the app needs to |
+|---|---|
+| `storefront` | sell products |
+| `bookings` | take appointments or service bookings |
+| `blog` | publish articles |
+| `events` | publish events with RSVPs or ticket sales |
+| `portfolio` | showcase creative work |
+| `pricing-plans` | sell memberships or subscriptions |
+| `restaurants` | show a menu, take orders, book tables |
+| `members` | let visitors sign in — this is **auth** |
+| `cms` | keep its own structured content — user submissions, galleries, listings, anything the rows above don't already cover |
+
 **List every vertical the app actually uses** — one is the common case, and name more when the intent
-spans them, so all their scaffolds come from the skill rather than being written by hand. Adding one
-later is fine too: re-run with the extra name (the copy only fills in missing files).
+spans them, so all their scaffolds come from the skill rather than being written by hand. Anything the
+app stores itself needs `cms`, and anything where visitors sign in needs `members`, so those two often
+join whichever vertical is the main one. Adding one later is fine too: re-run with the extra name (the
+copy only fills in missing files).
 
 ```js
 const { execSync } = require('child_process');
 const { readdirSync } = require('fs');
-const VERTICALS = ['storefront']; // ← set from the prompt; list every vertical the app uses
+const VERTICALS = ['storefront'];        // ← set from the prompt; list every vertical the app uses
+// const VERTICALS = ['members', 'cms']; // ← e.g. visitors sign in AND the app stores what they submit
 const results = {};
 for (const skill of ['wix-vibe-headless', 'wix-docs']) {
   try {

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -100,12 +100,43 @@ holds up when `useMember().member` is `null` — which is the state a logged-in 
 Members Area app is absent (see the members vertical's "Identity vs. profile"), where a client-side id is
 unavailable. For a public list **and** private rows, use **two collections** — permissions are per-collection.
 
+## Images in a collection
+Reading one goes through `wixImage()` (see the code block). Writing one has two shapes, because
+**uploading to Wix Media takes a Manage-scope credential**: `generate-file-upload-url` and
+`import-file` each require `SCOPE.DC-MEDIA.MANAGE-MEDIAMANAGER`, which a member or visitor token
+never carries — a client-side upload answers **403 with an HTML body**. Pick by how the image is used:
+
+| shape | field type | reach for it when |
+|---|---|---|
+| **data URL in the item** — `canvas.toDataURL()`, or any base64 string, written straight into the row | `TEXT` | small images: canvases, signatures, thumbnails, prototypes. An item caps at **500 KB** and base64 adds about a third, so keep the source under ~350 KB. Wix's own visitor-upload tutorial takes this route. |
+| **real Wix Media asset** — a backend route uploads with an elevated credential and returns the CDN URL for the client to store | `IMAGE` | production images: CDN delivery, `wixImage()` transforms, reuse across the site, anything past that size cap |
+
+**On base44 the elevated route is a backend function** — it holds the credential the client lacks:
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // admin-level
+// → POST /site-media/v1/files/generate-upload-url, PUT the bytes to it, return the file URL
+```
+That's the same Wix connector the seed step uses, and it's the supported way to reach a Manage-scope
+API at runtime — a different thing from the Base44 solution kits the build rules exclude. Keep the
+asset on Wix: `base44.integrations.Core.UploadFile` parks the file on Base44 instead, which splits the
+source of truth away from the site.
+
+**Authorize that function against the Wix member**, using the member token the client sends.
+`base44.auth.me()` resolves the *Base44* account — you, the builder — so a function gated on it turns
+real visitors away, while a `test_backend_function` run passes on your own token and reads as working.
+Validate the mime type and the size there as well.
+
+- Tutorial, data URL + elevated route: https://dev.wix.com/docs/go-headless/wix-managed-headless/full-integration-astro/feature-guides/upload-images-to-cms.md
+- Generate File Upload Url: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/generate-file-upload-url.md
+- Import File: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+
 ## Hard rules
 - Set `WIX_CLIENT_ID` (in `wix-config`) — not the placeholder.
 - Read/write **only** through the `wix-cms.js` helpers (official Wix Data endpoints) — never hand-build a URL.
 - `queryDataItems` → `{ items, nextCursor }` (destructure, iterate `.items`); `sort` is `[{ fieldName, order }]`; date comparands wrap as `{ "$date": ISO }`.
 - Read date fields through the wrapper — `new Date(v?.$date ?? v)`. Dates arrive as `{ "$date": ISO }` (including `_createdDate` / `_updatedDate`), and `new Date(object)` puts the text "Invalid Date" on the page. See RETRIEVAL SHAPES in `rest/wix-cms.js` for the field types that need a converter.
 - Convert `wix:image://` URIs via `wixImage()` before `<img src>`.
+- Upload images from a backend route holding an elevated credential, and keep a member-submitted image under the 500 KB item cap when storing it as a data URL — a client-side Wix Media upload answers 403 (see **Images in a collection**).
 - Owner field is `_owner` (Wix Data v2), not `_ownerId`; the member id lives at `member.id`, so "my items" → `{ filter: { _owner: member.id } }` (see above).
 - **Give every filter key a defined value** — add the key only once you hold one: `...(memberId ? { _owner: memberId } : {})`. `JSON.stringify` drops `undefined`, so an undefined comparand would match every row (`{ _owner: undefined }`) or none (`{ _owner: { $eq: undefined } }`) with no error from the server; the helpers throw so it surfaces at the call site.
 - **Let the query do the scoping** (a `filter`, or `read: SITE_MEMBER_AUTHOR` for privacy) so the server returns exactly the rows to show. A wrong result means the filter or the permission needs fixing — a client-side `.filter()` over rows the browser already holds only hides the symptom.


### PR DESCRIPTION
Three changes, all traced to real generated builds.

## 1. STEP 1 gets a capability map (`platforms/base44.md`)
The bare list of vertical names becomes a table pairing each vertical with the capability it provides — `cms` spelled out as the one for content the app keeps itself (submissions, galleries, listings), `members` as auth, with a note that those two often join whichever vertical is the main one. A commented `['members', 'cms']` sits beside the single-vertical example so a multi-vertical value is visible in the code too.

**Why:** on **Canvas Collective Hub** the agent set `VERTICALS = ['members']` at STEP 1, then hit the gap four messages later, in its own words:

> *"I need the CMS REST helpers. Since the deploy only covered 'members' vertical, I need to also deploy CMS."*

It understood multi-vertical fine — it just couldn't tell at STEP 1 that it needed `cms`, because getting from "stores the drawings" to `cms` takes knowledge that lives in the CMS instructions, which it reads *after* STEP 1. The outcome was already correct thanks to #954, so this saves a round-trip rather than fixing a break.

## 2. `restaurants` added to `deploy.cjs`'s accepted `VERTICALS`
`references/restaurants/` has shipped a full `app/` + `INSTRUCTIONS.md` all along and the pinned AGENTS.md note already advertises the vertical, yet `deploy.cjs restaurants` failed as an *unknown vertical*. Listing it in the new table without this would have been a trap.

Verified: the STEP 1 table and the accepted list now match **exactly in both directions** — nothing documented is rejected, nothing accepted is undocumented — and `deploy.cjs restaurants` lays down `Menu.jsx` + `Reservations.jsx`.

## 3. "Images in a collection" (`references/cms/INSTRUCTIONS.md`)
Reading an image was covered (`wixImage`); writing one was not, so three builds of the same prompt improvised three different answers — a client-side upload that 403'd, `base44.integrations.Core.UploadFile` (stores the file on Base44, not the site), and a raw data URL in the row.

The constraint behind all of it: `generate-file-upload-url` and `import-file` each require `SCOPE.DC-MEDIA.MANAGE-MEDIAMANAGER`, so **a member or visitor token cannot upload to Wix Media at all** — that 403 was unavoidable, not a mistake.

The section presents two shapes as a choice:

| shape | field type | for |
|---|---|---|
| data URL in the item | `TEXT` | small images — with the **500 KB** item cap and base64's ~⅓ overhead stated, so the source stays under ~350 KB. Wix's own visitor-upload tutorial takes this route. |
| real Wix Media asset | `IMAGE` | production images: CDN delivery, `wixImage()` transforms, anything past the cap |

On base44 the elevated route is a backend function using **the same Wix connector the seed step already uses**, stated plainly so it reads as supported rather than as one of the excluded Base44 solution kits.

It also records the authorization detail Canvas Collective got wrong: gate that function on the **Wix member token the client sends**. `base44.auth.me()` resolves the *Base44* account — the builder — so a function gated on it turns real visitors away, while a `test_backend_function` run passes on the builder's own token and looks correct. That build's only successful upload test ran exactly that way, so the member path was never exercised.

Links the tutorial and both method pages; all three verified to resolve with content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)