### PR TITLE
wix-vibe-headless: repair dead doc links and reference the APIs each vertical calls

### DIFF
--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -90,3 +90,15 @@ first** (`installBlogApp`, idempotent), so seeding works even if the site doesn'
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix Blog API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-blog.md`.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Bulk Create Draft Posts: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/bulk-create-draft-posts.md
+- Create Draft Post: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post.md
+- Publish Draft Post: https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/publish-draft-post.md
+- Create Category: https://dev.wix.com/docs/api-reference/business-solutions/blog/category/create-category.md
+- Create Tag: https://dev.wix.com/docs/api-reference/business-solutions/blog/tags/create-tag.md
+- Create Member (post authors): https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/create-member.md

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -86,12 +86,11 @@ await seed.attachPostCovers(ctx, posts.map((p, i) => ({ postId: p.id, fileId: fi
 pass a pre-built Ricos `richContent` on the post instead. `setupBlog` **installs the Wix Blog app
 first** (`installBlogApp`, idempotent), so seeding works even if the site doesn't have it yet.
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix Blog API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-blog.md`.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -213,7 +213,13 @@ in the **`wix-docs`** skill first (never guess):
   them see their own appointments.
 
 Fallback only — when you hit an error or need something not shown here: read the relevant shipped
-file under `src/`, or look it up via the **`wix-docs`** skill.
+file under `src/`, or look it up via the **`wix-docs`** skill. Each helper in
+`wix-bookings-services.js` / `wix-bookings-checkout.js` links its own reference page inline; these are
+the areas they sit in:
+- Bookings (services, categories, bookings): https://dev.wix.com/docs/api-reference/business-solutions/bookings.md
+- Availability time slots: https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots.md
+- eCommerce checkout (paid bookings): https://dev.wix.com/docs/api-reference/business-solutions/e-commerce.md
+- Headless redirect session (hosted checkout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
 
 ## Hard rules
 - Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.

--- a/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-checkout.js
+++ b/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-checkout.js
@@ -104,7 +104,7 @@ export async function createBooking(slot, contactDetails, { totalParticipants = 
  * Create an eCommerce checkout for a created booking and return the hosted checkout URL.
  * Redirect the buyer there (window.location.href = ...). On return, the booking is confirmed.
  * Throws if no redirect URL is produced.
- * https://dev.wix.com/docs/rest/business-solutions/e-commerce/checkout/create-checkout.md
+ * https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout.md
  * @param {string} bookingId  booking.id from createBooking().
  * @returns {Promise<string>} The hosted-checkout URL to redirect to.
  */

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -83,12 +83,11 @@ await seed.attachServiceImage(ctx, { serviceId: services[0].id, revision: servic
 Both bulk calls report per-item `success`/`error` — retry only the failed items **once** with the
 same body; don't loop and don't re-create the ones that already succeeded.
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-bookings.md`.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -87,3 +87,14 @@ same body; don't loop and don't re-create the ones that already succeeded.
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-bookings.md`.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Bulk Create Services: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/services-v2/bulk-create-services.md
+- Create Category: https://dev.wix.com/docs/api-reference/business-solutions/bookings/services/categories-v2/create-category.md
+- Create Staff Member: https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/create-staff-member.md
+- Query Staff Members: https://dev.wix.com/docs/api-reference/business-solutions/bookings/staff-members/staff-members/query-staff-members.md
+- Bulk Create Event (calendar sessions): https://dev.wix.com/docs/api-reference/business-management/calendar/events-v3/bulk-create-event.md

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -131,7 +131,14 @@ curl -sS -X PUT "$API/wix-data/v2/items/<itemId>" "${AUTH[@]}" -d '{
 - Any PUT/update **replaces** the whole item — always fetch + merge (or use Patch Data Item).
 - Verify with a query; a non-error POST is not proof of persistence.
 
-## Reference
+## Reference — the admin methods this seed calls
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Create Data Collection: https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/create-data-collection.md
+- Bulk Insert Data Items: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-items.md
+- Bulk Insert Data Item References: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-item-references.md
+
+### More
 - Data Items API: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
 - Collections: https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections.md
 - Anything not covered → use the `wix-docs` skill (search + read the live reference); never guess.

--- a/skills/wix-vibe-headless/references/cms/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/cms/seed/SEED.md
@@ -131,14 +131,15 @@ curl -sS -X PUT "$API/wix-data/v2/items/<itemId>" "${AUTH[@]}" -d '{
 - Any PUT/update **replaces** the whole item — always fetch + merge (or use Patch Data Item).
 - Verify with a query; a non-error POST is not proof of persistence.
 
-## Reference — the admin methods this seed calls
+## Reference
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
 - Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
 - Create Data Collection: https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections/create-data-collection.md
 - Bulk Insert Data Items: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-items.md
 - Bulk Insert Data Item References: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items/bulk-insert-data-item-references.md
-
-### More
 - Data Items API: https://dev.wix.com/docs/api-reference/business-solutions/cms/data-items.md
 - Collections: https://dev.wix.com/docs/api-reference/business-solutions/cms/collection-management/data-collections.md
+- Anything not covered → use the `wix-docs` skill (search + read the live reference); never guess.
 - Anything not covered → use the `wix-docs` skill (search + read the live reference); never guess.

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -96,3 +96,13 @@ Free/RSVP events need neither.
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-events.md`.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Create Event: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/events-v3/create-event.md
+- Create Ticket Definition: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/ticket-definitions-v3/create-ticket-definition.md
+- Create Category: https://dev.wix.com/docs/api-reference/business-solutions/events/event-management/categories/create-category.md
+- Get Site Properties (timezone / currency): https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties.md

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -92,12 +92,11 @@ Free/RSVP events need neither.
 | `importImage(ctx, url)` | import an external url into Wix Media → `{id,url}` (file id + wixstatic url); the main image binds by this file id |
 | `setEventMainImage(ctx, {eventId,id,url,height,width,altText})` | optional — PATCH `mainImage` (no revision); `id` = a Wix Media file id from `importImage` |
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-events.md`.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -241,6 +241,13 @@ const callbackUri = new URL("/callback", window.location.origin).href;   // must
 startSocialLogin(IDP.GOOGLE, callbackUri, window.location.pathname);      // custom SSO: pass a connectionId as idp
 ```
 
+Every export in `wix-members-auth.js` links its own reference page inline. The two areas they sit in
+map onto the identity / profile split below — auth is the headless OAuth app, the profile is the
+Members Area app:
+- Headless authentication (login, register, verify, tokens): https://dev.wix.com/docs/api-reference/business-management/headless/authentication.md
+- Headless redirects (social/SSO + logout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
+- Members (the member profile, needs the Members Area app): https://dev.wix.com/docs/api-reference/crm/members-contacts/members.md
+
 ## Identity vs. profile — don't conflate them
 - **Identity / auth** — sign up, log in, log out, "is this caller a member?". Native to the headless
   OAuth app. **No app install needed** — every login mechanism here runs on this layer alone.

--- a/skills/wix-vibe-headless/references/members/app/rest/wix-members-auth.js
+++ b/skills/wix-vibe-headless/references/members/app/rest/wix-members-auth.js
@@ -41,9 +41,12 @@ import {
  * Members Area app or they're silently dropped. Social (B) can't collect any of
  * these — that's the reason to pick direct-credential.
  *
- * Docs (curl the .md): custom login <https://dev.wix.com/docs/go-headless/self-managed-headless/authentication/members/custom-login-page/custom-login/custom-login-using-the-js-sdk.md>
- * · external/social login <https://dev.wix.com/docs/rest/business-management/headless-authentication/redirects/create-redirect-session>
- * · Retrieve Tokens <https://dev.wix.com/docs/rest/business-management/headless-authentication/authentication/retrieve-tokens>
+ * Docs (curl the .md): Login https://dev.wix.com/docs/api-reference/business-management/headless/authentication/login-v-2.md
+ * · Register https://dev.wix.com/docs/api-reference/business-management/headless/authentication/register-v-2.md
+ * · Logout https://dev.wix.com/docs/api-reference/business-management/headless/authentication/logout.md
+ * · Change Password https://dev.wix.com/docs/api-reference/business-management/headless/authentication/change-password.md
+ * · Retrieve Tokens https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens.md
+ * · external/social login https://dev.wix.com/docs/api-reference/business-management/headless/redirects/create-redirect-session.md
  */
 
 const AUTH_BASE = "/_api/iam/authentication/v2";

--- a/skills/wix-vibe-headless/references/members/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/members/seed/SEED.md
@@ -11,3 +11,12 @@ _Optional, off by default:_ only if a run's prompt explicitly asks to exercise t
 purchase path end-to-end, one test member may be created — keep this off so headless runs stay
 deterministic and don't stall on an interactive login. If you need that, use the **`wix-docs`**
 skill for the current member-create shape (source: `wix-headless/references/SEED.md` § members).
+
+## Reference
+Members self-register, so this vertical seeds nothing. These are the methods to read if you do reach
+for one — each page carries the exact body shape, the required permission scope, and the response
+envelope. `Create Member` needs an elevated credential; the rest run from the client.
+- Create Member (admin — pre-creating a member, e.g. a blog author): https://dev.wix.com/docs/api-reference/crm/members-contacts/members/member-management/members/create-member.md
+- Login: https://dev.wix.com/docs/api-reference/business-management/headless/authentication/login-v-2.md
+- Register: https://dev.wix.com/docs/api-reference/business-management/headless/authentication/register-v-2.md
+- Retrieve Tokens: https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens.md

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -199,7 +199,9 @@ Cover images live at `collection.coverImage.imageInfo.url` and `project.coverIma
 
 Fallback only — when you hit an error or need something not shown here (collection SEO, portfolio
 settings, a field these snippets don't have): read the relevant shipped file under `src/`, or look
-it up via the **`wix-docs`** skill / the Portfolio API reference.
+it up via the **`wix-docs`** skill / the Portfolio API reference. Each helper in `wix-portfolio.js`
+links its own reference page inline; the whole area is here:
+- Portfolio (collections, projects, project items): https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
 
 ## Hard rules
 - Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -77,7 +77,7 @@ await seed.createProjectItems(ctx, [{ projectId: projects[0].id, sortOrder: 1, t
 `hidden` defaults to `false` (shown) — omit it for visible entities; send `hidden: true` only to
 hide. `setupPortfolio` **installs the Wix Portfolio app first** (`installPortfolioApp`, idempotent), so seeding works even if the site doesn't have it yet.
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-portfolio.md`.
@@ -85,7 +85,6 @@ authoritative source recipe is `wix-headless/references/inline-recipes/setup-por
 **Transcribed from the recipe — NOT yet live-verified.** The endpoints/fields mirror
 `setup-portfolio.md`; confirm against a real run or the Wix docs before trusting edge shapes.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -84,3 +84,12 @@ authoritative source recipe is `wix-headless/references/inline-recipes/setup-por
 
 **Transcribed from the recipe — NOT yet live-verified.** The endpoints/fields mirror
 `setup-portfolio.md`; confirm against a real run or the Wix docs before trusting edge shapes.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Create Collection: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/collections/create-collection.md
+- Create Project: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/projects/create-project.md
+- Create Project Item: https://dev.wix.com/docs/api-reference/business-solutions/portfolio/project-items/create-project-item.md

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -76,3 +76,12 @@ is NOT a plan field or a perk). Those ids come from the **bookings seed**
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-pricing-plans.md`.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Create Plan: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/plans-v3/create-plan.md
+- Create Pool Definition (benefits): https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/pool-definitions/create-pool-definition.md
+- Bulk Create Items (benefits): https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/items/bulk-create-items.md
+- Get Program Definition By External Id And Namespace: https://dev.wix.com/docs/api-reference/business-solutions/benefit-programs/program-definitions/get-program-definition-by-external-id-and-namespace.md

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -72,12 +72,11 @@ is NOT a plan field or a perk). Those ids come from the **bookings seed**
 (`seeded.bookings.serviceIds[]`), so **seed bookings before pricing-plans** and pass the ids in as
 `coveredServiceIds`. A plans-only run (no bookings) stops after `createPlans` — skip STEP 2 entirely.
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-pricing-plans.md`.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -153,14 +153,13 @@ await seed.createExperiences(ctx, loc.id, [{ configuration: { /* per Create-Expe
 - **Booking an experience** is premium-gated the same way (create works on a free site; booking needs
   premium + online reservations enabled).
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover, use the
 **`wix-docs`** skill to search + read the live Wix API reference — never guess. The **Experiences** create
 payload especially lives in the docs (fields evolve). The authoritative source recipes are
 `wix-headless/references/inline-recipes/setup-restaurants.md`, `setup-restaurant-orders.md`,
 `setup-restaurant-reservations.md`, and `setup-restaurant-experiences.md`.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -159,3 +159,23 @@ If a call returns a shape you didn't expect, or you need an operation this modul
 payload especially lives in the docs (fields evolve). The authoritative source recipes are
 `wix-headless/references/inline-recipes/setup-restaurants.md`, `setup-restaurant-orders.md`,
 `setup-restaurant-reservations.md`, and `setup-restaurant-experiences.md`.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Create Menu: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/menus/create-menu.md
+- Create Section: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/create-section.md
+- Bulk Create Sections: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/sections/bulk-create-sections.md
+- Create Item: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/create-item.md
+- Bulk Create Items: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/menus/items/items/bulk-create-items.md
+- List Operations: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/list-operations.md
+- Update Operation: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/operations/update-operation.md
+- Create Fulfillment Method: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/fulfillment-methods/create-fulfillment-method.md
+- Create Location: https://dev.wix.com/docs/api-reference/business-management/locations/create-location.md
+- List Reservation Locations: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/list-reservation-locations.md
+- Update Reservation Location: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/reservation-locations/update-reservation-location.md
+- Query Menu Ordering Settings: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/menu-ordering-settings/query-menu-ordering-settings.md
+- Upsert Menu Ordering Settings By Menu Id: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/online-orders/menu-ordering-settings/upsert-menu-ordering-settings-by-menu-id.md
+- Create Experience: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/experiences/create-experience.md

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -216,7 +216,11 @@ const { products: inCategory } = await queryProductsByCategory(menu[0].id, { lim
 
 Fallback only — when you hit an error or need something not shown here (coupons, members, a field
 these snippets don't have): read the relevant shipped file under `src/`, or look it up via the
-**`wix-docs`** skill.
+**`wix-docs`** skill. Each helper in `wix-store-catalog.js` / `wix-store-cart.js` links its own
+reference page inline; these are the areas they sit in:
+- Stores catalog (products, categories, inventory): https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3.md
+- eCommerce (cart, checkout, orders): https://dev.wix.com/docs/api-reference/business-solutions/e-commerce.md
+- Headless redirect session (hosted checkout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
 
 ## Hard rules
 - Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.

--- a/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-cart.js
+++ b/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-cart.js
@@ -8,7 +8,7 @@ const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
 
 /**
  * Wix eCom Cart — key fields for building a cart UI.
- * Full model: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart/get-cart.md
+ * Full model: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart-v2/get-current-cart.md
  *
  *   id {string}, currency {string},
  *   lineItems[].id {string} — lineItemId for update/remove (NOT catalogItemId),

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -58,12 +58,11 @@ await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: ima
 | `addProductsToCategories(ctx, {catId:[pid]})` | sequential add-items |
 | `attachProductImages(ctx, [{id,url,altText}])` | one bulk media attach; no revision to pass. Wix re-hosts each url server-side; the media can take a little while to appear on read-back (propagation) — normal, not a failure |
 
-## Fallback
+## Reference
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-online-store.md`.
 
-## Reference — the admin methods this seed calls
 Read a method's page before writing its call: it carries the exact body shape, the required
 permission scope, and the response envelope.
 - Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -62,3 +62,16 @@ await seed.attachProductImages(ctx, products.map((p, i) => ({ id: p.id, url: ima
 If a call returns a shape you didn't expect, or you need an operation this module doesn't cover,
 use the **`wix-docs`** skill to search + read the live Wix API reference — never guess. The
 authoritative source recipe is `wix-headless/references/inline-recipes/setup-online-store.md`.
+
+## Reference — the admin methods this seed calls
+Read a method's page before writing its call: it carries the exact body shape, the required
+permission scope, and the response envelope.
+- Install a Wix app onto the site: https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/install-app.md
+- Import an image into Wix Media: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
+- Create Category: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/create-category.md
+- Bulk Update Categories: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/bulk-update-categories.md
+- Bulk Add Items To Category: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/bulk-add-items-to-category.md
+- Bulk Create Products With Inventory: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-create-products-with-inventory.md
+- Bulk Update Products: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-update-products.md
+- Bulk Create Inventory Items: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/inventory-items-v3/bulk-create-inventory-items.md
+- Query Products: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/query-products.md


### PR DESCRIPTION
Every link in this PR was verified by fetching its `.md` form and confirming a real page came back.

## 1. Five dead links, already shipping
Checked all 66 `dev.wix.com` links carried in the verticals' `app/rest` JSDoc. Five returned nothing, so an agent following them today lands nowhere:

| where | was | now |
|---|---|---|
| `storefront/wix-store-cart.js` | `purchase-flow/cart/get-cart` | `purchase-flow/cart-v2/get-current-cart` |
| `bookings/wix-bookings-checkout.js` | `/docs/rest/…/checkout/create-checkout` | the `purchase-flow/checkout` menu (no method page exists under that tree) |
| `members/wix-members-auth.js` | a go-headless JS-SDK guide + two retired `/docs/rest/business-management/headless-authentication/…` paths | the REST auth family this helper actually calls: Login, Register, Logout, Change Password, Retrieve Tokens, Create Redirect Session |

All **69** util links now fetch real content.

## 2. Seed docs: the admin methods each one calls
Every seed doc except `cms` had zero API links while walking through admin calls. Each now lists the methods that seed actually uses — **67 links**, keyed by **operation name rather than raw path**, because several of these methods document a host path that differs from what the scripts use (portfolio shows an internal form alongside the short one; benefit-programs shows an `_api` prefix). The operation name is the stable label.

## 3. One `## Reference` section per seed doc
The links first landed as a *second* closing section, sitting after each doc's existing `## Fallback` — which already said "use the `wix-docs` skill, never guess". Merged into a single `## Reference`, identical in shape across all nine: the vertical's own guidance first, then the links. Each Fallback's specifics are preserved verbatim — all 7 inline-recipe pointers, portfolio's "transcribed from the recipe, NOT yet live-verified" caveat, and the restaurants note that the Experiences create payload lives in the docs.

## 4. Instructions: the client API areas
`storefront`, `bookings`, `portfolio` and `members` carried no API links at all (portfolio's text even sent readers to "the Portfolio API reference" without linking it). They now follow the pattern `blog` already set — **name the API areas the client sits in, and note that each helper links its own method page inline**, rather than copying all 69 per-method links into a second place that would drift.

For `members` the areas are split along the identity / profile line the vertical already documents, since the profile half needs the Members Area app installed.

## Coverage
All 9 verticals now have links in both `INSTRUCTIONS.md` and `seed/SEED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)