### PR TITLE
wix-vibe-headless: replace the PDP quantity input with a real stepper

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
@@ -76,7 +76,9 @@ export function useProductDetail(slug) {
     try {
       // addToCart reports its own failures through the cart context (it opens the drawer with the
       // reason), so nothing is swallowed by leaving this unguarded beyond resetting the button.
-      await addToCart(product.id, variant?.id, quantity, {
+      // Coerce the quantity: the shipped stepper lets the field sit empty mid-edit, and a keyboard
+      // submit from that state would otherwise post "" as the quantity.
+      await addToCart(product.id, variant?.id, Math.max(1, Number(quantity) || 1), {
         modifierChoices: Object.keys(modifierChoices).length ? modifierChoices : undefined,
         customTextFields: Object.keys(customTextFields).length ? customTextFields : undefined,
       });

--- a/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
@@ -71,19 +71,47 @@ export default function ProductDetail() {
             <p className="text-[13px] text-muted-foreground m-0 mt-1">Pick an option from each list to continue.</p>
           )}
 
-          <div className="flex items-center gap-3 mt-4">
-            <label className="sr-only" htmlFor="pdp-qty">Quantity</label>
-            <input id="pdp-qty" type="number" min={1} value={d.quantity}
-              onChange={(e) => d.setQuantity(Math.max(1, Number(e.target.value) || 1))}
-              className="w-[72px] p-2.5 text-center border border-border rounded-sm bg-background text-foreground" />
+          <div className="flex items-stretch gap-3 mt-4">
+            <QuantityStepper value={d.quantity} onChange={d.setQuantity} disabled={!d.inStock} />
             <button disabled={!d.canAdd || d.adding} onClick={d.submit}
-              className="flex-1 py-3 px-6 bg-primary text-primary-foreground border-none rounded-sm text-[15px] font-semibold cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
+              className="flex-1 h-12 px-6 bg-primary text-primary-foreground border-none rounded-md text-[15px] font-semibold cursor-pointer transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed">
               {d.adding ? "Adding…" : d.inStock ? "Add to cart" : "Out of stock"}
             </button>
           </div>
         </div>
       </div>
     </main>
+  );
+}
+
+// Segmented −/+ stepper, height-matched to the Add-to-cart button so the row reads as one control.
+// A native number input is avoided on purpose: its spinners are ~10px, OS-rendered (so they ignore
+// the app's tokens), effectively untappable, and they accept "e"/"+"/"1e5" plus scroll-wheel edits.
+// The value stays typeable — inputMode="numeric" brings up a keypad — but only digits survive, and
+// blur restores 1 when the field is left empty. `tabular-nums` keeps the width steady across digits.
+function QuantityStepper({ value, onChange, disabled }) {
+  const set = (n) => onChange(Math.max(1, n));
+  return (
+    <div data-disabled={disabled || undefined}
+      className="inline-flex items-stretch h-12 rounded-md border border-border bg-background overflow-hidden data-[disabled]:opacity-50">
+      <StepButton label="Decrease quantity" disabled={disabled || value <= 1} onClick={() => set(value - 1)}>−</StepButton>
+      <label className="sr-only" htmlFor="pdp-qty">Quantity</label>
+      <input id="pdp-qty" type="text" inputMode="numeric" autoComplete="off" disabled={disabled}
+        value={value} aria-live="polite"
+        onChange={(e) => { const n = e.target.value.replace(/\D/g, ""); onChange(n === "" ? "" : Math.max(1, Number(n))); }}
+        onBlur={(e) => { if (!e.target.value) set(1); }}
+        className="w-12 text-center bg-transparent text-foreground font-semibold tabular-nums border-x border-border outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed" />
+      <StepButton label="Increase quantity" disabled={disabled} onClick={() => set(Number(value || 0) + 1)}>+</StepButton>
+    </div>
+  );
+}
+
+function StepButton({ children, label, onClick, disabled }) {
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} aria-label={label}
+      className="w-11 grid place-items-center text-lg leading-none text-muted-foreground bg-transparent border-none cursor-pointer transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent">
+      {children}
+    </button>
   );
 }
 


### PR DESCRIPTION
The PDP paired a native `<input type="number">` with the Add-to-cart button. That control is the wrong primitive here:

- the spinner arrows are ~10px and **rendered by the OS**, so they ignore the app's design tokens entirely — they read as grey chrome next to a branded button
- effectively untappable on touch
- it accepts `e`, `+`, `1e5`, and changes value on a stray scroll over the page
- it stood at a **different height** from the CTA beside it, so the row never looked like one control

## Now

A segmented `− value +` control, `h-12` to height-match the button:

- `type="text"` with `inputMode="numeric"` — still typeable, numeric keypad on mobile, but only digits survive and blur restores `1` when the field is left empty
- 44px hit targets with hover feedback; decrement disabled at 1; the whole control dims via `data-disabled` when the selection is out of stock
- `tabular-nums` so the width doesn't jitter between `1` and `11`; `aria-live` on the value; `aria-label` on both buttons
- CTA and stepper share `rounded-md`, so the row has one corner radius

## Also fixed

`submit()` passed `quantity` straight to `addToCart`. The field can sit empty mid-edit, and a keyboard submit from that state would have posted `""` as the quantity. Clicking the button happens to fire blur first, which is why this never surfaced by hand. Now coerced with `Math.max(1, Number(quantity) || 1)`.

## No upper cap, deliberately

Checked against a live Stores catalog: the product endpoint returns only `inventory.availabilityStatus`. The numeric `quantityAvailable` exists on **cart line items** alone — which is why the cart drawer caps its stepper and the PDP can't.

## Verified

Applied to a real app's sandbox with `base44 sandbox edit` and reviewed in the running preview before committing, so the rendered control is what ships. Both touched files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)