### PR TITLE
feat(wix-vibe-headless): render variant swatches and earn the product tile

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -24,12 +24,12 @@ so you don't need to open them:**
 | `context/CartContext.jsx` | `useCart()` provider: server cart, add/update/remove, checkout |
 | `hooks/useProductDetail.js` | PDP data — product + variant resolution for a slug, plus load/add state |
 | `hooks/useShop.js` | catalog listing — category menu, cursor paging, sort, failure state |
-| `components/ProductCard.jsx`, `ProductGrid.jsx` | product listing UI (grid + card, skeletons, empty state) |
+| `components/ProductCard.jsx`, `ProductGrid.jsx` | product listing UI (grid + card, skeletons, empty state). The tile carries quick add for single-variant products, colour dots + an option summary, and pre-order / sold-out / limited-stock / percent-off / merchant-ribbon badges — all from the list query, no extra request |
 | `components/ProductGallery.jsx` | PDP main image + thumbnails |
 | `lib/storeImage.js` | `productImage()` / `productGallery()` / `storeImage()` — normalise Wix image urls |
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
-| `components/VariantPicker.jsx` | option/variant selector used on the PDP |
+| `components/VariantPicker.jsx` | option/variant selector used on the PDP — colour options render as real swatches, and picking one moves the gallery to that colour's photo |
 | `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
@@ -1,39 +1,156 @@
 // Grid tile. Styled with base44 design tokens (shadcn Tailwind classes: bg-card / text-foreground /
 // border-border) — re-skin via the app's design tokens (src/index.css :root/.dark), not this JSX.
-// The price / out-of-stock field paths are load-bearing; image URLs go through lib/storeImage so the
+// The price / stock / ribbon field paths are load-bearing; image URLs go through lib/storeImage so the
 // grid, the PDP gallery and the cart all normalise them the same way.
+//
+// Everything here comes from the list query — the tile costs no extra request. What the list query
+// does NOT carry is a stock COUNT (inventory has availabilityStatus only), so "Limited stock" is as
+// precise as a tile can honestly get; "Only 2 left" would need per-variant inventory per product.
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { productImage } from "@/lib/storeImage";
+import { productGallery, productImage } from "@/lib/storeImage";
+import { useCart } from "@/context/CartContext";
+
+// Percent off, from the raw amounts — the formatted strings ("€129.00") can't be subtracted.
+function discountPercent(product) {
+  const now = Number(product?.actualPriceRange?.minValue?.amount);
+  const was = Number(product?.compareAtPriceRange?.minValue?.amount);
+  if (!now || !was || was <= now) return null;
+  return Math.round(((was - now) / was) * 100);
+}
+
+// What the buyer gets to choose, previewed on the tile: colour options become real dots (the colours
+// say more than "3 colors" could), everything else becomes "4 sizes". Pluralised from the option's own
+// name, so the wording follows the merchant's catalogue rather than a hardcoded English word.
+function optionsPreview(product) {
+  const labels = [], colors = [];
+  for (const o of product?.options || []) {
+    const choices = (o.choicesSettings?.choices || []).filter((c) => c.visible !== false);
+    if (!choices.length) continue;
+    const swatches = choices.map((c) => c.colorCode).filter(Boolean);
+    if (swatches.length) { colors.push(...swatches); continue; }
+    const n = o.name.toLowerCase();
+    labels.push(`${choices.length} ${choices.length === 1 || n.endsWith("s") ? n : `${n}s`}`);
+  }
+  return { label: labels.join(" · "), colors };
+}
+
+const badge = "px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide rounded-full";
 
 export default function ProductCard({ product }) {
+  const { addToCart } = useCart();
+  const [adding, setAdding] = useState(false);
+
   const image = productImage(product);
+  const hoverImage = productGallery(product)[1]?.url;
   const price = product?.actualPriceRange?.minValue?.formattedAmount;
   const priceMax = product?.actualPriceRange?.maxValue?.formattedAmount;
   const compareAt = product?.compareAtPriceRange?.minValue?.formattedAmount;
-  const soldOut = product?.inventory?.availabilityStatus === "OUT_OF_STOCK";
+
+  const status = product?.inventory?.availabilityStatus;
+  const soldOut = status === "OUT_OF_STOCK";
+  const preorder = product?.inventory?.preorderStatus === "ENABLED";
+  const discount = discountPercent(product);
+  // A merchant-set ribbon ("New", "Best Seller") is the catalogue's own badge, so it beats anything
+  // derived here — a "new" label computed from createdDate would flag the whole catalogue at once
+  // right after seeding. Suppressed when a discount badge is showing, since that ribbon is "Sale".
+  const ribbon = product?.ribbon?.name;
+  const { label: optionLabel, colors } = optionsPreview(product);
+  const hasOptions = (product?.options?.length || 0) > 0;
+
+  // No options means a single variant, which the cart resolves from the product id alone — so the
+  // tile can add straight to the cart with no extra request. The drawer opening is the confirmation
+  // (and carries the reason when it fails), which is why there's no "Added ✓" state to fake here.
+  const quickAdd = async () => {
+    setAdding(true);
+    await addToCart(product.id);
+    setAdding(false);
+  };
 
   return (
-    <Link to={`/product/${product.slug}`}
-      className="flex flex-col no-underline text-foreground bg-card border border-border rounded-lg overflow-hidden shadow-sm">
+    <div className="group relative flex flex-col bg-card border border-border rounded-lg overflow-hidden shadow-sm">
       <div className="relative aspect-square bg-background">
-        {image
-          ? <img src={image} alt={product.name} loading="lazy" className="w-full h-full object-cover" />
-          : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
-        {soldOut && (
-          <span className="absolute top-2 left-2 px-2 py-0.5 text-xs bg-destructive text-white rounded-sm">Sold out</span>
+        <Link to={`/product/${product.slug}`} aria-label={product.name} className="block w-full h-full">
+          {image ? (
+            <>
+              {/* Fade out only when there IS a second shot behind it — a one-photo product would
+                  otherwise hover to an empty frame. */}
+              <img src={image} alt={product.name} loading="lazy"
+                className={`w-full h-full object-cover ${hoverImage ? "transition-opacity duration-300 md:group-hover:opacity-0" : ""}`} />
+              {/* Second catalogue shot on hover. `hidden` below md so phones never fetch it. */}
+              {hoverImage && (
+                <img src={hoverImage} alt="" aria-hidden="true" loading="lazy"
+                  className="hidden md:block absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+              )}
+            </>
+          ) : (
+            <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true">
+              <svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" />
+              </svg>
+            </div>
+          )}
+        </Link>
+
+        <div className="absolute top-2 left-2 flex flex-col items-start gap-1 pointer-events-none">
+          {soldOut && preorder && <span className={`${badge} bg-foreground text-background`}>Pre-order</span>}
+          {soldOut && !preorder && <span className={`${badge} bg-destructive text-white`}>Sold out</span>}
+          {status === "PARTIALLY_OUT_OF_STOCK" && <span className={`${badge} bg-muted text-foreground`}>Limited stock</span>}
+        </div>
+        <div className="absolute top-2 right-2 pointer-events-none">
+          {discount ? <span className={`${badge} bg-primary text-primary-foreground`}>−{discount}%</span>
+            : ribbon ? <span className={`${badge} bg-foreground text-background`}>{ribbon}</span> : null}
+        </div>
+
+        {/* Sold out with no pre-order has nothing to offer, so no control appears at all. */}
+        {(!soldOut || preorder) && (
+          <div className="absolute inset-x-2 bottom-2 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
+            {hasOptions || soldOut ? (
+              <Link to={`/product/${product.slug}`}
+                className="block w-full text-center py-2.5 px-4 rounded-full bg-foreground text-background no-underline text-sm font-semibold">
+                {soldOut ? "Pre-order" : "Choose options"}
+              </Link>
+            ) : (
+              <button onClick={quickAdd} disabled={adding}
+                className="w-full py-2.5 px-4 rounded-full bg-foreground text-background border-none text-sm font-semibold cursor-pointer transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-wait">
+                {adding ? "Adding…" : "Quick add"}
+              </button>
+            )}
+          </div>
         )}
       </div>
+
       <div className="p-3 flex flex-col gap-1">
-        <h3 className="m-0 font-display text-[15px] font-semibold">{product.name}</h3>
-        <div className="flex gap-2 items-baseline flex-wrap">
-          {/* A product whose variants differ in price spans a range — showing only minValue reads as
-              the price of everything, then the PDP appears to raise it once a variant is picked. */}
-          <span className="font-semibold">{priceMax && priceMax !== price ? `${price} – ${priceMax}` : price}</span>
-          {compareAt && compareAt !== price && (
-            <span className="text-muted-foreground line-through text-[13px]">{compareAt}</span>
-          )}
+        {/* Side by side once the tile is wide enough; stacked on a phone's two-up grid, where a long
+            name wrapping to three lines against a top-right price reads as broken. */}
+        <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-3">
+          <h3 className="m-0 font-display text-[15px] font-semibold">
+            <Link to={`/product/${product.slug}`} className="no-underline text-foreground">{product.name}</Link>
+          </h3>
+          <div className="flex gap-2 items-baseline flex-wrap md:justify-end">
+            {/* A product whose variants differ in price spans a range — showing only minValue reads as
+                the price of everything, then the PDP appears to raise it once a variant is picked. */}
+            <span className="font-semibold whitespace-nowrap">{priceMax && priceMax !== price ? `${price} – ${priceMax}` : price}</span>
+            {compareAt && compareAt !== price && (
+              <span className="text-muted-foreground line-through text-[13px] whitespace-nowrap">{compareAt}</span>
+            )}
+          </div>
         </div>
+
+        {(colors.length > 0 || optionLabel) && (
+          <div className="flex items-center gap-2 text-[13px] text-muted-foreground min-h-[18px]">
+            {colors.length > 0 && (
+              <span className="flex items-center gap-1" aria-label={`${colors.length} colors available`}>
+                {colors.slice(0, 5).map((c, i) => (
+                  <span key={`${c}-${i}`} className="w-3 h-3 rounded-full ring-1 ring-inset ring-black/20" style={{ backgroundColor: c }} />
+                ))}
+                {colors.length > 5 && <span>+{colors.length - 5}</span>}
+              </span>
+            )}
+            {optionLabel && <span>{optionLabel}</span>}
+          </div>
+        )}
       </div>
-    </Link>
+    </div>
   );
 }

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductGallery.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductGallery.jsx
@@ -4,10 +4,19 @@
 // Styled with base44 design tokens (shadcn Tailwind classes).
 import { useEffect, useState } from "react";
 
-export default function ProductGallery({ images, name }) {
+export default function ProductGallery({ images, name, focusUrl }) {
   const [index, setIndex] = useState(0);
   // Reset when navigating between products — the component stays mounted across a slug change.
+  // `images` must keep a stable identity per product (the PDP memoises it), or every parent render —
+  // a quantity bump, an option click — would land here and throw away the image the buyer picked.
   useEffect(() => { setIndex(0); }, [images]);
+
+  // Picking a colour swatch shows that colour: focusUrl is the choice's linked photo. Runs after the
+  // reset effect, so a first paint with a colour pre-selected opens on the right image.
+  useEffect(() => {
+    const i = images?.findIndex((img) => img.url === focusUrl) ?? -1;
+    if (i >= 0) setIndex(i);
+  }, [focusUrl, images]);
 
   const current = images?.[index];
 

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductGrid.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductGrid.jsx
@@ -1,6 +1,9 @@
 // Responsive product grid, with the two states a fresh store spends most of its life in: loading and
 // empty. Styled with base44 design tokens (shadcn Tailwind classes).
 //
+// Two columns on phones — a 220px minmax leaves room for only one, and a one-up catalog scrolls
+// forever — then auto-fill from md up.
+//
 // The empty state carries weight here — a catalog is seeded separately from the build, so it is
 // routinely empty when the merchant first opens the page. Say why, rather than showing a bare line.
 import ProductCard from "./ProductCard";
@@ -9,13 +12,16 @@ import ProductCard from "./ProductCard";
 // products land.
 export function ProductGridSkeleton({ count = 8 }) {
   return (
-    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]" aria-hidden="true">
+    <div className="grid gap-4 grid-cols-2 md:[grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]" aria-hidden="true">
       {Array.from({ length: count }).map((_, i) => (
         <div key={i} className="bg-card border border-border rounded-lg overflow-hidden">
           <div className="aspect-square bg-muted animate-pulse" />
           <div className="p-3 flex flex-col gap-2">
-            <div className="h-3.5 w-3/4 bg-muted rounded-sm animate-pulse" />
-            <div className="h-3.5 w-1/3 bg-muted rounded-sm animate-pulse" />
+            <div className="flex justify-between gap-3">
+              <div className="h-3.5 w-1/2 bg-muted rounded-sm animate-pulse" />
+              <div className="h-3.5 w-1/5 bg-muted rounded-sm animate-pulse" />
+            </div>
+            <div className="h-3 w-1/3 bg-muted rounded-sm animate-pulse" />
           </div>
         </div>
       ))}
@@ -41,7 +47,7 @@ export default function ProductGrid({ products, loading, empty = "No products ye
   }
 
   return (
-    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
+    <div className="grid gap-4 grid-cols-2 md:[grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
       {products.map((p) => <ProductCard key={p.id} product={p} />)}
     </div>
   );

--- a/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
@@ -7,16 +7,74 @@ const chipIdle = "border-border bg-card text-foreground";
 const chipActive = "border-primary bg-primary text-primary-foreground";
 const label = "block mb-1.5 text-[13px] font-semibold text-muted-foreground";
 
+// A colour/swatch option renders as swatches, a text option as pills — the render type is on the
+// option (`optionRenderType`) and mirrored per choice (`choiceType`: ONE_COLOR vs CHOICE_TEXT).
+// Colour choices carry `colorCode` (hex) and usually `linkedMedia`, so a swatch is real colour, and
+// picking one moves the gallery to that colour's photo.
+const isColorChoice = (option, choice) =>
+  option?.optionRenderType === "COLOR_CHOICES" ||
+  option?.optionRenderType === "SWATCH_CHOICES" ||
+  choice?.choiceType === "ONE_COLOR";
+
 function OptionSelector({ option, selected, onSelect }) {
+  // `visible: false` is a choice the merchant retired — it stays in the payload, so filter it out or
+  // the buyer can pick something the catalogue no longer offers.
+  const choices = (option.choicesSettings?.choices || []).filter((c) => c.visible !== false);
+  if (!choices.length) return null;
+  const swatches = choices.some((c) => isColorChoice(option, c) && c.colorCode);
+
   return (
     <div className="mb-4">
-      <label className={label}>{option.name}</label>
+      <label className={label}>
+        {option.name}
+        {/* With swatches the chosen colour's name isn't otherwise on screen — echo it. */}
+        {swatches && selected && (
+          <span className="ml-1.5 font-normal text-foreground">
+            {choices.find((c) => c.choiceId === selected)?.name}
+          </span>
+        )}
+      </label>
       <div className="flex flex-wrap gap-2">
-        {option.choicesSettings?.choices?.map((c) => (
-          <button key={c.choiceId} disabled={c.inStock === false}
-            aria-pressed={selected === c.choiceId} onClick={() => onSelect(option.id, c.choiceId)}
-            className={`${chipBase} ${selected === c.choiceId ? chipActive : chipIdle} ${c.inStock === false ? "opacity-40 line-through" : ""}`}>{c.name}</button>
-        ))}
+        {choices.map((c) => {
+          const active = selected === c.choiceId;
+          const out = c.inStock === false;
+          if (swatches && c.colorCode) {
+            return (
+              <button
+                key={c.choiceId}
+                type="button"
+                disabled={out}
+                onClick={() => onSelect(option.id, c.choiceId)}
+                aria-pressed={active}
+                aria-label={`${c.name}${out ? " (out of stock)" : ""}`}
+                title={c.name}
+                className={`relative w-9 h-9 rounded-full cursor-pointer transition-shadow ring-1 ring-inset ring-black/15 ${
+                  active ? "ring-2 ring-offset-2 ring-offset-background ring-primary" : ""
+                } ${out ? "opacity-40 cursor-not-allowed" : "hover:ring-2 hover:ring-offset-1 hover:ring-offset-background hover:ring-border"}`}
+                style={{ backgroundColor: c.colorCode }}
+              >
+                {/* A struck line reads as "unavailable" without hiding which colour it was. */}
+                {out && (
+                  <span aria-hidden="true" className="absolute inset-0 grid place-items-center">
+                    <span className="w-full h-px bg-destructive rotate-45" />
+                  </span>
+                )}
+              </button>
+            );
+          }
+          return (
+            <button
+              key={c.choiceId}
+              type="button"
+              disabled={out}
+              aria-pressed={active}
+              onClick={() => onSelect(option.id, c.choiceId)}
+              className={`${chipBase} ${active ? chipActive : chipIdle} ${out ? "opacity-40 line-through" : ""}`}
+            >
+              {c.name}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useProductDetail.js
@@ -5,6 +5,7 @@
 // renders what this returns.
 import { useState, useEffect, useMemo } from "react";
 import { getProductBySlug } from "@/rest/wix-store-catalog";
+import { storeImage } from "@/lib/storeImage";
 import { useCart } from "@/context/CartContext";
 
 export function useProductDetail(slug) {
@@ -62,6 +63,18 @@ export function useProductDetail(slug) {
 
   const price = variant?.price?.actualPrice?.formattedAmount || product?.actualPriceRange?.minValue?.formattedAmount || "";
 
+  // A colour choice carries `linkedMedia` — the shots of the product in that colour. Picking "Dark
+  // Green" should move the gallery to the green photo, so resolve the selection to a URL here; only
+  // colour-style choices have linked media, so the first hit across the options is the right one.
+  const focusMediaUrl = useMemo(() => {
+    for (const o of options) {
+      const choice = (o.choicesSettings?.choices || []).find((c) => c.choiceId === selectedOptions[o.id]);
+      const url = storeImage(choice?.linkedMedia?.[0]);
+      if (url) return url;
+    }
+    return null;
+  }, [options, selectedOptions]);
+
   const selectOption = (optionId, choiceId) => setSelectedOptions((s) => ({ ...s, [optionId]: choiceId }));
   const setModifier = (key, value) => setModifierValues((s) => ({ ...s, [key]: value }));
 
@@ -91,6 +104,6 @@ export function useProductDetail(slug) {
     product, notFound, error, retry: () => setReloadKey((k) => k + 1),
     options, modifiers,
     selectedOptions, selectOption, modifierValues, setModifier,
-    quantity, setQuantity, variant, inStock, canAdd, adding, price, submit,
+    quantity, setQuantity, variant, inStock, canAdd, adding, price, submit, focusMediaUrl,
   };
 }

--- a/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
@@ -3,6 +3,7 @@
 //
 // The price shown follows the selection: once options resolve to a variant the hook returns that
 // variant's price, so a picked size can cost more than the "from" figure the grid tile showed.
+import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useProductDetail } from "@/hooks/useProductDetail";
 import { productGallery } from "@/lib/storeImage";
@@ -12,6 +13,8 @@ import VariantPicker from "@/components/VariantPicker";
 export default function ProductDetail() {
   const { slug } = useParams();
   const d = useProductDetail(slug);
+  // Memoised so the gallery keeps its selected image across re-renders (see ProductGallery).
+  const images = useMemo(() => productGallery(d.product), [d.product]);
 
   if (d.error) {
     return (
@@ -31,7 +34,6 @@ export default function ProductDetail() {
   }
   if (!d.product) return <ProductDetailSkeleton />;
 
-  const images = productGallery(d.product);
   const compareAt = d.product?.compareAtPriceRange?.minValue?.formattedAmount;
 
   return (
@@ -43,7 +45,7 @@ export default function ProductDetail() {
       </nav>
 
       <div className="grid gap-8 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
-        <ProductGallery images={images} name={d.product.name} />
+        <ProductGallery images={images} name={d.product.name} focusUrl={d.focusMediaUrl} />
 
         <div>
           <h1 className="font-display m-0 mb-2">{d.product.name}</h1>

--- a/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-catalog.js
+++ b/skills/wix-vibe-headless/references/storefront/app/rest/wix-store-catalog.js
@@ -13,10 +13,29 @@ import { wixApiRequest } from "./wix-client.js";
  *   actualPriceRange.minValue.formattedAmount {string} — lowest price with currency symbol,
  *   actualPriceRange.maxValue.formattedAmount {string} — highest price with currency symbol,
  *   compareAtPriceRange.minValue.formattedAmount {string} — strikethrough price (present when on sale),
+ *   actualPriceRange/compareAtPriceRange .minValue.amount {string} — the same figures unformatted
+ *     ("129.00"). Use these for arithmetic: a percent-off badge can't be computed from "€129.00",
  *   inventory.availabilityStatus {string} — "IN_STOCK"|"OUT_OF_STOCK"|"PARTIALLY_OUT_OF_STOCK",
+ *   inventory.preorderStatus {string} — "ENABLED"|"DISABLED". ENABLED + OUT_OF_STOCK is a pre-order,
+ *     which is buyable — label it "Pre-order" rather than "Sold out",
+ *     NB: inventory carries no stock COUNT. "Limited stock" (from PARTIALLY_OUT_OF_STOCK) is the most
+ *     precise scarcity signal a tile can show; "Only 2 left" needs per-variant inventory, i.e. a
+ *     getProductBySlug call per product,
+ *   ribbon {object} — { id, name } merchant-set badge: "New", "Sale", "Best Seller". This is the
+ *     catalogue's own label, so prefer it over anything derived — a "new" badge computed from
+ *     createdDate flags every product at once right after seeding,
+ *   additionalRibbons {array} — further { id, name } badges,
+ *   createdDate / updatedDate {string} — ISO timestamps,
+ *   variantSummary.variantCount {number} — how many variants exist, without fetching them,
  *   options {array} — product options e.g. Size, Color:
  *     [{ id, name, optionRenderType "TEXT_CHOICES"|"COLOR_CHOICES"|"SWATCH_CHOICES",
- *        choicesSettings.choices [{ choiceId, key, name, inStock, visible, linkedMedia }] }],
+ *        choicesSettings.choices [{ choiceId, key, name, inStock, visible, choiceType, colorCode,
+ *                                   linkedMedia }] }],
+ *     A COLOR/SWATCH option's choices carry choiceType "ONE_COLOR" and colorCode "#395E55" — render
+ *     those as real colour swatches, not text pills. linkedMedia [{ image.url }] holds that colour's
+ *     photos, so selecting a swatch can move the gallery to the matching shot. visible false is a
+ *     retired choice the merchant no longer sells: filter it out. (TEXT_CHOICES choices are
+ *     choiceType "CHOICE_TEXT" with no colorCode.)
  *   modifiers {array} — non-variant customizations (engraving, gift wrap):
  *     [{ id, name, mandatory, modifierRenderType "TEXT_CHOICES"|"FREE_TEXT",
  *        key, choicesSettings.choices, freeTextSettings.key }],


### PR DESCRIPTION
The generated storefront rendered **every** product option as an identical text pill, and every grid tile as image + name + price — while the list query already carried the data for much more.

The root cause sat upstream of the components: `wix-store-catalog.js`'s JSDoc listed `choiceId, key, name, inStock, visible, linkedMedia` and omitted `choiceType`, `colorCode`, `ribbon`, `preorderStatus` and the unformatted `.amount` fields entirely. Nothing told the agent those fields existed, so nothing used them. This PR fixes the components **and** the doc they read.

Verified throughout against a live seeded store (19 products, real Wix catalog), at desktop and at 390px.

## PDP — options become real choices

| before | after |
|---|---|
| Size and Color both as grey text pills | Color renders as swatches filled from `colorCode` |

- Branches on `optionRenderType` / `choiceType`. Swatches get an inset ring so `#FFFFFF` stays visible on a white card; text options keep the pills.
- **Picking a colour moves the gallery** to that choice's `linkedMedia` photo.
- **Retired choices are gone.** `visible: false` ships in the payload and was selectable — a buyer could pick something the catalogue no longer sells.
- Out-of-stock choices grey to 40% with a diagonal strike rather than vanishing, so which colour it was stays readable.
- The label echoes the chosen colour name ("Color **Dark Green**") — a swatch alone can't say what it's called.

## Grid tile — quick add, option preview, badges

- **Quick add** for single-variant products. The cart resolves the variant from the product id alone — checked against the live cart API before building on it (200, line added) — so the tile costs no extra request. Products *with* options get "Choose options" → PDP instead of a dead end.
  - No "Added ✓" state on purpose: `addToCart` never throws (it catches internally and reports through the drawer), so a success state would lie on failure. The drawer opening *is* the confirmation.
- **Option preview** — colour options become dots; others read "4 sizes", pluralised from the option's own name so the wording follows the merchant's catalogue rather than a hardcoded English word.
- **Badges**, all from the list query:
  - `Pre-order` — `preorderStatus: ENABLED` + `OUT_OF_STOCK` is **buyable**; it previously read "Sold out".
  - `Sold out`, `Limited stock` (`PARTIALLY_OUT_OF_STOCK`).
  - `−47%` computed from the raw `.amount` fields (`"€129.00"` can't be subtracted).
  - The merchant's own `ribbon` ("New", "Best Seller"). Deliberately **not** derived from `createdDate` — freshly seeded products all share a timestamp, so a date rule would flag an entire catalogue as new.
  - Discount suppresses the ribbon, so "Sale" + "−47%" never doubles up.
- Second catalogue photo on hover, `hidden` below `md` so phones never fetch it (confirmed: 12 hover images in the DOM, 0 loaded at 390px).
- Two columns on phones — a 220px minmax left room for only one, and a one-up catalogue scrolls forever.

## Gallery bug fixed along the way

`productGallery(product)` was called in render, so `images` was a new array every time and the gallery's reset effect fired on **every parent render**. Measured: click thumbnail 3 → press `+` on quantity → the main image jumps back to the first photo. Now memoised per product, so the reset only fires on a slug change. This was also a prerequisite for the swatch→gallery wiring, which would have fought the same effect.

## The honest limit, now documented

`inventory` carries `availabilityStatus` only — **no stock count**. "Limited stock" is as precise as a tile can get; "Only 2 left" needs per-variant inventory, i.e. a `getProductBySlug` per product. That's written into the JSDoc rather than left for the next agent to rediscover.

## Cases exercised on the live store

`knitted-golf-sweater` (text + swatch options, 4 photos) · `minimalist-tote-bag` (2 swatches) · `crew-t-shirt` (`PARTIALLY_OUT_OF_STOCK`) · `hydrating-eye-serum` (`OUT_OF_STOCK` + pre-order) · `baseball-cap` (−47% + "Sale" ribbon) · `round-eyeglasses` ("New" ribbon) · `ceramic-flower-vase` ("Best Seller") · single-photo tiles (hover must not blank) · quick add → drawer opens with the line item.