### PR TITLE
fix(wix-vibe-headless): retry both provisioning 428s, and seed a catalog that shows the UI off

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -16,14 +16,18 @@ const ctx = { token: accessToken, siteId: WIX_METASITE_ID };
 
 // ONE call: install (+ wait for V3) → create products → categories → attach images, ids kept
 // in memory (no hand-threading). Categories map name -> product NAMES. Pass an imageUrl per product
-// to attach its image; omit it to skip images. options ONLY for real buyer choices (Size/Color); default none.
+// to attach its image; omit it to skip images.
 // imageUrl must be the FINAL https://media.base44.com/... url from the COMPLETED generate_image
 // result — not a still-generating /__generating__/<id>.png placeholder (Wix can't fetch that).
 // generate_image runs in the background while you build, so the urls are ready by seed time.
 const result = await seed.setupStore(ctx, {
   products: [
     { name: "The Glam Rocker", description: "Sequin-studded velvet legend…", price: 49.99, quantity: 12, imageUrl: imageUrls[0] },
-    // …just the catalog data
+    // a product with buyer choices — see "Options, variants and sale prices" below
+    { name: "The Understudy", description: "…", price: 245, quantity: 8, imageUrl: imageUrls[1],
+      options: [{ name: "Color", type: "color", choices: [{ name: "Ink", colorCode: "#1B1B2F" }, { name: "Bone", colorCode: "#EDE6D6" }] }] },
+    // a product on sale — compareAtPrice drives the strikethrough + the tile's percent-off badge
+    { name: "Encore Jacket", description: "…", price: 68, compareAtPrice: 129, quantity: 5, imageUrl: imageUrls[2] },
   ],
   categories: { "Legends": ["The Glam Rocker"], "Rising Stars": [] },   // omit if the brief names none
 });
@@ -32,6 +36,37 @@ const result = await seed.setupStore(ctx, {
 
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.
+
+## Options, variants and sale prices
+
+The shipped storefront renders colour options as real swatches, shows a size/colour summary on each
+tile, and puts a percent-off badge on a discounted product. A catalog of plain single-price products
+leaves all of that invisible, so **seed a catalog that exercises it**: unless the brief says
+otherwise, give at least one product a colour option and put one product on sale. Keep it truthful
+to the business — a ceramics studio has glaze colours, a bakery does not.
+
+```js
+options: [
+  { name: "Color", type: "color", choices: [{ name: "Ink", colorCode: "#1B1B2F" }, { name: "Bone", colorCode: "#EDE6D6" }] },
+  { name: "Size",  type: "text",  choices: ["Small", "Medium", "Large"] },   // or [{ name: "Small" }, …]
+]
+```
+
+- `type: "color"` → `SWATCH_CHOICES` with each choice's `colorCode`, which the PDP draws as a swatch.
+  Any other `type` → text pills. Give every colour choice a `colorCode`.
+- Variants are expanded for you: the full cross-product of the options, each carrying the product's
+  `price`, `compareAtPrice` and `quantity`. Two options with 2 and 3 choices means 6 variants — keep
+  option counts small.
+- `compareAtPrice` (> `price`) is the "was" price: strikethrough on the PDP and a `−N%` badge on the
+  tile, computed from the two amounts. It works with or without options.
+
+Two things this module does **not** seed, so don't try:
+
+- **Ribbons** ("New", "Best Seller"). The tile renders `product.ribbon` when it's there, but ribbons
+  are set in the Wix dashboard — tell the merchant that's where to add them.
+- **Per-choice linked media** (`linkedMedia`), which is what makes picking a colour swap the gallery
+  photo. Seeded swatches select and price correctly; the gallery just doesn't follow the colour until
+  the merchant links photos to choices in the dashboard.
 
 ## Escape hatch — individual functions
 Reach for the functions below only when the one-call `setupStore` doesn't fit (partial re-seed, custom

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -21,10 +21,10 @@ const API = "https://www.wixapis.com";
 const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
 
 async function req(ctx, path, { method = "POST", body } = {}) {
-  // Retry the catalog-V1 provisioning race: right after a fresh Stores install the V3 WRITE path
-  // clears CATALOG_V1 a bit later than the V3 read path, so even once waitForCatalogV3 (a read probe)
-  // returns, the first bulk-create can still 428 with CATALOG_V1_SITE_CALLING_CATALOG_V3_API. Wait it
-  // out on that code only (~80s budget); every other error throws on the first try as before.
+  // Retry while the catalog is still provisioning: right after a fresh Stores install the V3 WRITE
+  // path becomes usable a bit later than the V3 read path, so even once waitForCatalogV3 (a read
+  // probe) returns, the first bulk-create can still 428. Wait it out (~80s budget); every other
+  // error throws on the first try as before.
   for (let attempt = 0; ; attempt++) {
     const res = await fetch(API + path, {
       method,
@@ -37,7 +37,7 @@ async function req(ctx, path, { method = "POST", body } = {}) {
     });
     const json = await res.json().catch(() => ({}));
     if (res.ok) return json;
-    if (json?.details?.applicationError?.code === "CATALOG_V1_SITE_CALLING_CATALOG_V3_API" && attempt < 40) {
+    if (isProvisioning(res.status, json) && attempt < 40) {
       await sleep(2000);
       continue;
     }
@@ -47,11 +47,23 @@ async function req(ctx, path, { method = "POST", body } = {}) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// A freshly installed Stores catalog transiently reports CATALOG_V1: V3 calls 428 with
-// applicationError.code === "CATALOG_V1_SITE_CALLING_CATALOG_V3_API" until provisioning settles to
-// V3. Poll a cheap V3 read until that code clears (bounded ~80s), so we don't fire the expensive
-// bulk-create repeatedly during the window. This is a cheap pre-gate on the READ path; the WRITE path
-// clears slightly later, so the real guarantee is req()'s retry on the same code — this just minimizes
+// A freshly installed catalog isn't writable yet, and Wix has signalled that with two different
+// 428s: the older CATALOG_V1_SITE_CALLING_CATALOG_V3_API (site still reports V1) and the current
+// CATALOG_V3_SITE_PROVISIONING ("Site is currently being provisioned for CATALOG_V3"). Sites exist
+// on both behaviours, so match either. The message check catches a further rename: on this endpoint
+// a 428 means "not ready, retry", and treating an unknown one as fatal turns a wait into a failed
+// seed — which is exactly how the V3 code slipped through when only the V1 code was matched.
+const PROVISIONING_CODES = new Set(["CATALOG_V1_SITE_CALLING_CATALOG_V3_API", "CATALOG_V3_SITE_PROVISIONING"]);
+
+function isProvisioning(status, json) {
+  if (PROVISIONING_CODES.has(json?.details?.applicationError?.code)) return true;
+  return status === 428 && /provision/i.test(json?.message || "");
+}
+
+// A freshly installed Stores catalog 428s on V3 calls until provisioning settles (see
+// isProvisioning for the codes). Poll a cheap V3 read until that clears (bounded ~80s), so we don't
+// fire the expensive bulk-create repeatedly during the window. This is a pre-gate on the READ path;
+// the WRITE path clears slightly later, so the real guarantee is req()'s retry — this just minimizes
 // how many times the actual write has to retry.
 async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   for (let i = 0; i < attempts; i++) {
@@ -62,7 +74,10 @@ async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
     });
     if (res.ok) return;
     const json = await res.json().catch(() => ({}));
-    if (json?.details?.applicationError?.code !== "CATALOG_V1_SITE_CALLING_CATALOG_V3_API") return;
+    // Anything that isn't a provisioning signal is a real error — return and let the caller's own
+    // request surface it. Matching only one of the two codes here made this exit the wait on the
+    // other one, handing the caller straight to a write that then 428'd.
+    if (!isProvisioning(res.status, json)) return;
     await sleep(delayMs);
   }
 }


### PR DESCRIPTION
Both defects came out of reading a real prod build's conversation — **Dragon Kintsugi Store**, 7m 40s wall-clock, 30 tool calls, one hard error.

## 1. Seeding hard-failed on a 428 the retry didn't recognise

Wix improved the catalog provisioning signal, but provisioning still takes time. A fresh install can now answer:

```
428  applicationError.code = "CATALOG_V3_SITE_PROVISIONING"
     "Site is currently being provisioned for CATALOG_V3. Retry the request."
```

`seed-store.js` only matched the older `CATALOG_V1_SITE_CALLING_CATALOG_V3_API`. Sites exist on **both** behaviours, so both are now matched through a single `isProvisioning()` predicate shared by `req()` and `waitForCatalogV3()`.

`waitForCatalogV3()` was the worse half: it `return`ed on any code it didn't recognise, so it read "still provisioning", concluded "ready", exited the wait loop, and handed the caller straight into a write that then 428'd. The pre-gate defeated itself.

A 428 whose message mentions provisioning now retries too — on this endpoint a 428 means "not ready", and treating an unknown one as fatal is exactly how the V3 code slipped through. Unrelated failures still throw on the first try.

What it cost in the observed build: the seed threw, and the agent hand-rolled `await sleep(15000)` and re-ran the entire 4.8k-char seed call.

| case | before | after |
|---|---|---|
| `CATALOG_V3_SITE_PROVISIONING` (current API) | throws | retries |
| `CATALOG_V1_SITE_CALLING_CATALOG_V3_API` (older API) | retries | retries |
| 428, provisioning in the message, unknown code | throws | retries |
| 428 unrelated / 403 / 409 | throws | throws |

## 2. The seeded catalog left the shipped UI invisible

The agent seeded 7 products with **no options, no variants, no `compareAtPrice`** — so the storefront's colour swatches, option summary and percent-off badge never appeared in the finished store.

The doc caused it. SEED.md mentioned options exactly once — *"options ONLY for real buyer choices (Size/Color); default none"* — and never mentioned `compareAtPrice`, `colorCode` or swatches, even though `seed-store.js` has always supported them (`buildOptions` emits `SWATCH_CHOICES` with `colorCode`; `expandVariants` takes `compareAtPrice`). The agent followed the doc correctly and produced a feature-poor demo.

SEED.md now:
- asks for a catalog that exercises the shipped UI — at least one product with a colour option, one on sale — while staying truthful to the business (a ceramics studio has glaze colours; a bakery does not);
- documents the `options` / `compareAtPrice` input shape, including `type: "color"` → swatches and the variant cross-product;
- states the two things the module **cannot** seed, so nobody wastes a round trying: **ribbons** ("New"/"Best Seller" — dashboard only) and **per-choice `linkedMedia`**, which is what makes a swatch swap the gallery photo.

## Verification

- The predicate against the exact payload from the failed build, the old-API payload, and four should-not-retry cases (428 unrelated, 403, 409, empty body).
- The documented option shape through the real `buildOptions` / `expandVariants`: `Color=SWATCH_CHOICES` with both `colorCode`s, `Size=TEXT_CHOICES`, 2×3 → 6 variants, and `compareAtPrice` present on an **option-less** product (`{"actualPrice":{"amount":"68"},"compareAtPrice":{"amount":"129"}}`).
- `node --check` on the script.

One claim was deliberately left out of the doc: that `quantity: 0` yields the sold-out treatment. `expandVariants` sets no explicit quantity-tracking flag, so I can't assert the rendered outcome without seeding a live store.