### PR TITLE
fix(wix-vibe-headless): make every vertical's components read the design tokens consistently

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -153,7 +153,9 @@ installed, not what the business is about. Never default to store/bookings on si
 4. **Wire the shipped client** following the vertical's INSTRUCTIONS: the components are themed by
    base44's design tokens (`src/index.css` — shadcn palette, already set by the design phase), so
    there's no re-skin step; just wire routes + header/footer through the Layout. The UI ships as
-   files — you compose the home page and wire it, you don't rebuild the client.
+   files — you compose the home page and wire it, you don't rebuild the client. Style what you add
+   from the same tokens: every background paired with its own foreground (`bg-primary` with
+   `text-primary-foreground`), `border-input` on form controls, `border-border` on cards and dividers.
 5. **Verify** against the vertical's checklist before declaring done: token persists across
    reload, live data renders (or a real empty state), and purchases go through the Wix redirect.
 

--- a/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
@@ -3,7 +3,7 @@
 // selector shows ONLY when maxParticipants > 1 (commonly 1 → no selector, book exactly one).
 // Styled with base44 design tokens (shadcn Tailwind classes).
 const fieldCls =
-  "px-3 py-2.5 box-border font-body border border-border rounded-sm bg-background text-foreground";
+  "px-3 py-2.5 box-border font-body border border-input rounded-sm bg-background text-foreground";
 
 export default function BookingForm({
   contact, setContactField, maxParticipants, participants, setParticipants,

--- a/skills/wix-vibe-headless/references/events/app/components/EventCard.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/EventCard.jsx
@@ -22,7 +22,7 @@ export default function EventCard({ event }) {
           ? <img src={image} alt={event.title} loading="lazy" className="w-full h-full object-cover" />
           : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
         {isTicketing && soldOut && (
-          <span className="absolute top-2 left-2 py-0.5 px-2 text-xs bg-destructive text-white rounded-sm">Sold out</span>
+          <span className="absolute top-2 left-2 py-0.5 px-2 text-xs bg-destructive text-destructive-foreground rounded-sm">Sold out</span>
         )}
       </div>
       <div className="p-3 flex flex-col gap-1">

--- a/skills/wix-vibe-headless/references/events/app/components/RsvpForm.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/RsvpForm.jsx
@@ -3,7 +3,7 @@
 // "YES_AND_NO"; a WAITLIST result (event full) is surfaced distinctly from a confirmed YES.
 import { useRsvpForm } from "@/hooks/useRsvpForm";
 
-const input = "w-full px-3 py-2.5 box-border font-body border border-border rounded-sm bg-background text-foreground";
+const input = "w-full px-3 py-2.5 box-border font-body border border-input rounded-sm bg-background text-foreground";
 const label = "block mb-1.5 text-[13px] font-semibold text-muted-foreground";
 const field = "mb-4";
 

--- a/skills/wix-vibe-headless/references/events/app/components/TicketPicker.jsx
+++ b/skills/wix-vibe-headless/references/events/app/components/TicketPicker.jsx
@@ -6,7 +6,7 @@
 import { useState } from "react";
 import { useTicketing } from "@/hooks/useTicketing";
 
-const input = "px-3 py-2.5 box-border font-body border border-border rounded-sm bg-background text-foreground";
+const input = "px-3 py-2.5 box-border font-body border border-input rounded-sm bg-background text-foreground";
 
 function ticketPrice(def) {
   if (def.free) return "Free";

--- a/skills/wix-vibe-headless/references/members/app/components/LoginForm.jsx
+++ b/skills/wix-vibe-headless/references/members/app/components/LoginForm.jsx
@@ -5,7 +5,7 @@
 import { useLoginForm } from "@/hooks/useLoginForm";
 
 const inputCls =
-  "w-full py-[11px] px-3 box-border text-[15px] border border-border rounded-sm bg-background text-foreground";
+  "w-full py-[11px] px-3 box-border text-[15px] border border-input rounded-sm bg-background text-foreground";
 const labelCls = "block text-[13px] text-muted-foreground mb-1.5";
 
 export default function LoginForm({ onSuccess }) {

--- a/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
+++ b/skills/wix-vibe-headless/references/pricing-plans/app/components/OrderCard.jsx
@@ -3,18 +3,23 @@
 // look it up in the Orders API reference (wix-docs) — never invent it. Styled with base44 design
 // tokens (shadcn Tailwind classes).
 
-const STATUS_BG = {
-  ACTIVE: "bg-primary",
-  PAUSED: "bg-muted",
-  ENDED: "bg-muted",
-  CANCELED: "bg-destructive",
+// Each status carries its OWN text colour: a shared `text-primary-foreground` over a varying
+// background is unreadable the moment the two tokens are close in value — on the default light
+// palette --primary-foreground (98%) over --muted (96.1%) is white on white, so PAUSED and ENDED
+// vanished. A background token and its foreground token always travel together.
+const STATUS_STYLE = {
+  ACTIVE: "bg-primary text-primary-foreground",
+  PAUSED: "bg-muted text-foreground",
+  ENDED: "bg-muted text-foreground",
+  CANCELED: "bg-destructive text-destructive-foreground",
 };
+const STATUS_FALLBACK = "bg-muted text-foreground";
 
 export default function OrderCard({ order }) {
   return (
     <li className="list-none flex flex-wrap items-center gap-3 bg-card text-foreground border border-border rounded-lg shadow-sm p-4">
       <span className="font-display font-semibold flex-1">{order.planName}</span>
-      <span className={`text-[13px] font-semibold px-2.5 py-0.5 rounded-full text-primary-foreground ${STATUS_BG[order.status] || "bg-muted"}`}>{order.status}</span>
+      <span className={`text-[13px] font-semibold px-2.5 py-0.5 rounded-full ${STATUS_STYLE[order.status] || STATUS_FALLBACK}`}>{order.status}</span>
       {order.startDate && (
         <span className="text-muted-foreground text-[13px]">
           from {new Date(order.startDate).toLocaleDateString()}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/ItemDialog.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/ItemDialog.jsx
@@ -67,7 +67,7 @@ export default function ItemDialog({ item, menuId, sectionId, onClose }) {
           <div className="flex items-center gap-3 mt-1">
             <input type="number" min={1} value={d.quantity}
               onChange={(e) => d.setQuantity(Math.max(1, Number(e.target.value) || 1))}
-              className="w-[72px] p-2.5 text-center border border-border rounded-sm bg-background text-foreground" />
+              className="w-[72px] p-2.5 text-center border border-input rounded-sm bg-background text-foreground" />
             <button disabled={!d.canAdd} onClick={d.submit}
               className="flex-1 py-3 px-6 cursor-pointer bg-primary text-primary-foreground border-none rounded-sm text-[15px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed">
               {!d.ordering ? "Ordering unavailable" : d.inStock ? (d.adding ? "Adding…" : "Add to order") : "Sold out"}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/MenuItemCard.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/MenuItemCard.jsx
@@ -27,13 +27,15 @@ export default function MenuItemCard({ item, onOpen }) {
           <img src={image} alt={item.name} loading="lazy"
             className="w-full h-full object-cover" />
           {soldOut && (
-            <span className="absolute top-2 left-2 py-0.5 px-2 text-xs bg-destructive text-white rounded-sm">Sold out</span>
+            <span className="absolute top-2 left-2 py-0.5 px-2 text-xs bg-destructive text-destructive-foreground rounded-sm">Sold out</span>
           )}
         </div>
       )}
       <div className="p-3 flex flex-col gap-1.5">
         <div className="flex justify-between items-baseline gap-2">
-          <h3 className="m-0 font-display text-base font-semibold">
+          {/* Clamped like the storefront tile: the same title-beside-price row turns a long name
+              into three ragged lines. */}
+          <h3 className="m-0 font-display text-base font-semibold line-clamp-2">
             {item.name}{item.featured && <span className="text-primary"> ★</span>}
           </h3>
           {/* price: single string, OR one-of variants — render one label per variant */}

--- a/skills/wix-vibe-headless/references/restaurants/app/components/OrderCartButton.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/components/OrderCartButton.jsx
@@ -14,7 +14,7 @@ export default function OrderCartButton() {
         <path d="M16 10a4 4 0 0 1-8 0" />
       </svg>
       {itemCount > 0 && (
-        <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-[5px] inline-flex items-center justify-center text-[11px] font-semibold bg-primary text-white rounded-full">{itemCount}</span>
+        <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-[5px] inline-flex items-center justify-center text-[11px] font-semibold bg-primary text-primary-foreground rounded-full">{itemCount}</span>
       )}
     </button>
   );

--- a/skills/wix-vibe-headless/references/restaurants/app/pages/Reservations.jsx
+++ b/skills/wix-vibe-headless/references/restaurants/app/pages/Reservations.jsx
@@ -4,7 +4,7 @@
 // approval (pending). Styled with base44 design tokens (shadcn Tailwind classes).
 import { useReservation } from "@/hooks/useReservation";
 
-const field = "w-full py-2.5 px-3 box-border border border-border rounded-sm bg-background text-foreground font-body";
+const field = "w-full py-2.5 px-3 box-border border border-input rounded-sm bg-background text-foreground font-body";
 const primaryBtn = "py-3 px-6 cursor-pointer border-none rounded-sm bg-primary text-primary-foreground text-[15px] font-semibold";
 
 function slotLabel(iso) {

--- a/skills/wix-vibe-headless/references/storefront/app/components/CartButton.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/CartButton.jsx
@@ -13,7 +13,7 @@ export default function CartButton() {
         <path d="M16 10a4 4 0 0 1-8 0" />
       </svg>
       {itemCount > 0 && (
-        <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-[5px] py-0 inline-flex items-center justify-center text-[11px] font-semibold bg-primary text-white rounded-full">{itemCount}</span>
+        <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-[5px] py-0 inline-flex items-center justify-center text-[11px] font-semibold bg-primary text-primary-foreground rounded-full">{itemCount}</span>
       )}
     </button>
   );

--- a/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/ProductCard.jsx
@@ -35,7 +35,13 @@ function optionsPreview(product) {
   return { label: labels.join(" · "), colors };
 }
 
+// One rule for every chip on the tile, so a new badge has an obvious home instead of a fresh colour:
+// promotional shouts in the brand colour, informational sits quietly on a card surface, and only a
+// blocking state is destructive. Each background travels with its own foreground token.
 const badge = "px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide rounded-full";
+const badgePromo = `${badge} bg-primary text-primary-foreground`;
+const badgeInfo = `${badge} bg-card text-foreground border border-border`;
+const badgeBlocked = `${badge} bg-destructive text-destructive-foreground`;
 
 export default function ProductCard({ product }) {
   const { addToCart } = useCart();
@@ -93,26 +99,29 @@ export default function ProductCard({ product }) {
         </Link>
 
         <div className="absolute top-2 left-2 flex flex-col items-start gap-1 pointer-events-none">
-          {soldOut && preorder && <span className={`${badge} bg-foreground text-background`}>Pre-order</span>}
-          {soldOut && !preorder && <span className={`${badge} bg-destructive text-white`}>Sold out</span>}
-          {status === "PARTIALLY_OUT_OF_STOCK" && <span className={`${badge} bg-muted text-foreground`}>Limited stock</span>}
+          {soldOut && preorder && <span className={badgeInfo}>Pre-order</span>}
+          {soldOut && !preorder && <span className={badgeBlocked}>Sold out</span>}
+          {status === "PARTIALLY_OUT_OF_STOCK" && <span className={badgeInfo}>Limited stock</span>}
         </div>
+        {/* Discount and ribbon are mutually exclusive, so both can claim the promotional slot. */}
         <div className="absolute top-2 right-2 pointer-events-none">
-          {discount ? <span className={`${badge} bg-primary text-primary-foreground`}>−{discount}%</span>
-            : ribbon ? <span className={`${badge} bg-foreground text-background`}>{ribbon}</span> : null}
+          {discount ? <span className={badgePromo}>−{discount}%</span>
+            : ribbon ? <span className={badgePromo}>{ribbon}</span> : null}
         </div>
 
         {/* Sold out with no pre-order has nothing to offer, so no control appears at all. */}
         {(!soldOut || preorder) && (
           <div className="absolute inset-x-2 bottom-2 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
+            {/* Same tokens as the PDP's Add-to-cart button: one action, one treatment, so the tile's
+                CTA is the brand colour rather than "whatever the text colour is". */}
             {hasOptions || soldOut ? (
               <Link to={`/product/${product.slug}`}
-                className="block w-full text-center py-2.5 px-4 rounded-full bg-foreground text-background no-underline text-sm font-semibold">
+                className="block w-full text-center py-2.5 px-4 rounded-full bg-primary text-primary-foreground no-underline text-sm font-semibold">
                 {soldOut ? "Pre-order" : "Choose options"}
               </Link>
             ) : (
               <button onClick={quickAdd} disabled={adding}
-                className="w-full py-2.5 px-4 rounded-full bg-foreground text-background border-none text-sm font-semibold cursor-pointer transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-wait">
+                className="w-full py-2.5 px-4 rounded-full bg-primary text-primary-foreground border-none text-sm font-semibold cursor-pointer transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-wait">
                 {adding ? "Adding…" : "Quick add"}
               </button>
             )}
@@ -124,7 +133,9 @@ export default function ProductCard({ product }) {
         {/* Side by side once the tile is wide enough; stacked on a phone's two-up grid, where a long
             name wrapping to three lines against a top-right price reads as broken. */}
         <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-3">
-          <h3 className="m-0 font-display text-[15px] font-semibold">
+          {/* Clamped to two lines: a 220px tile turns a long product name into three or four ragged
+              lines beside a top-right price. The full name is on the tile's link and the PDP. */}
+          <h3 className="m-0 font-display text-[15px] font-semibold line-clamp-2">
             <Link to={`/product/${product.slug}`} className="no-underline text-foreground">{product.name}</Link>
           </h3>
           <div className="flex gap-2 items-baseline flex-wrap md:justify-end">

--- a/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
@@ -87,7 +87,7 @@ function ModifierSelector({ modifier, value, onChange }) {
       <div className="mb-4">
         <label className={label}>{modifier.name}{modifier.mandatory && " *"}</label>
         <input value={value || ""} onChange={(e) => onChange(key, e.target.value)}
-          className="w-full py-2 px-3 font-body border border-border rounded-sm bg-background text-foreground" />
+          className="w-full py-2 px-3 font-body border border-input rounded-sm bg-background text-foreground" />
       </div>
     );
   }

--- a/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/ProductDetail.jsx
@@ -95,14 +95,14 @@ function QuantityStepper({ value, onChange, disabled }) {
   const set = (n) => onChange(Math.max(1, n));
   return (
     <div data-disabled={disabled || undefined}
-      className="inline-flex items-stretch h-12 rounded-md border border-border bg-background overflow-hidden data-[disabled]:opacity-50">
+      className="inline-flex items-stretch h-12 rounded-md border border-input bg-background overflow-hidden data-[disabled]:opacity-50">
       <StepButton label="Decrease quantity" disabled={disabled || value <= 1} onClick={() => set(value - 1)}>−</StepButton>
       <label className="sr-only" htmlFor="pdp-qty">Quantity</label>
       <input id="pdp-qty" type="text" inputMode="numeric" autoComplete="off" disabled={disabled}
         value={value} aria-live="polite"
         onChange={(e) => { const n = e.target.value.replace(/\D/g, ""); onChange(n === "" ? "" : Math.max(1, Number(n))); }}
         onBlur={(e) => { if (!e.target.value) set(1); }}
-        className="w-12 text-center bg-transparent text-foreground font-semibold tabular-nums border-x border-border outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed" />
+        className="w-12 text-center bg-transparent text-foreground font-semibold tabular-nums border-x border-input outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed" />
       <StepButton label="Increase quantity" disabled={disabled} onClick={() => set(Number(value || 0) + 1)}>+</StepButton>
     </div>
   );

--- a/skills/wix-vibe-headless/references/storefront/app/pages/Shop.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/pages/Shop.jsx
@@ -16,7 +16,7 @@ export default function Shop() {
           <label className="flex items-center gap-2 text-sm text-muted-foreground">
             Sort
             <select value={s.sort} onChange={(e) => s.setSort(e.target.value)}
-              className="py-1.5 px-2 border border-border rounded-sm bg-background text-foreground text-sm">
+              className="py-1.5 px-2 border border-input rounded-sm bg-background text-foreground text-sm">
               {Object.entries(SORTS).map(([key, { label }]) => <option key={key} value={key}>{label}</option>)}
             </select>
           </label>


### PR DESCRIPTION
Audited all 100 shipped files across the ten verticals for design-token use. Four things were wrong; three were real contrast or consistency bugs.

## 1. A status pill was invisible — `pricing-plans/OrderCard.jsx`

One `text-primary-foreground` was applied over a background that changes per status:

```jsx
const STATUS_BG = { ACTIVE: "bg-primary", PAUSED: "bg-muted", ENDED: "bg-muted", CANCELED: "bg-destructive" };
<span className={`… text-primary-foreground ${STATUS_BG[order.status] || "bg-muted"}`}>
```

On the default light palette `--primary-foreground` is 98% and `--muted` is 96.1% — **white text on a near-white pill**, so PAUSED and ENDED (and the fallback) were unreadable. Each status now carries its own paired foreground.

## 2. Five chips hardcoded `text-white` over a token background

Three sold-out badges (storefront, restaurants, events) and two cart-count bubbles. The bubbles are the risky ones: `bg-primary text-white` disappears the moment a brand's `--primary` is pale. All five now use the matching `-foreground` token. No literal colour words remain in any vertical.

## 3. All 29 form controls used the wrong border token

Every `<input>` / `<select>` across bookings, events, members, restaurants and storefront outlined with `border-border`. `--input` exists for exactly this, and it's what base44's own `ui/input.jsx` uses, so a theme that distinguishes the two made our controls the odd ones out. Six shared field constants plus three inline controls and the PDP's segmented stepper now use `border-input`; `border-border` stays on cards and dividers.

## 4. The storefront tile styled the same action two ways

`Quick add` / `Choose options` were `bg-foreground text-background` while the PDP's `Add to cart` was `bg-primary text-primary-foreground` — one action, two treatments, and the tile CTA rendered as "whatever the text colour is" instead of the brand. The tile now matches the PDP.

Its chips also follow a single rule so a new badge has an obvious home rather than a fresh colour:

| intent | token | example |
|---|---|---|
| promotional | `bg-primary text-primary-foreground` | `−47%`, `BEST SELLER`, `NEW` |
| informational | `bg-card text-foreground` + border | `PRE-ORDER`, `LIMITED STOCK` |
| blocking | `bg-destructive text-destructive-foreground` | `SOLD OUT` |

And long titles clamp to two lines on the storefront tile and the restaurants menu card — they share a title-beside-price row that went ragged at three or four lines on a 220–260px tile.

## Deliberately unchanged

- **Modal scrims** (`bg-black/40`) and the **colour-swatch hairline** (`ring-black/15`) stay raw: a scrim and a white swatch's edge must not follow the theme.
- **Grid density on the other verticals.** Every other grid is single-column on a phone. Making them two-up is a per-vertical design decision (a menu with descriptions and a pricing comparison want one column; a portfolio grid probably wants two), not a token fix — worth deciding separately.
- `secondary`, `accent`, `popover` remain unused. They carry two incompatible meanings depending on how the app was themed: shadcn treats `accent` as a subtle hover surface (`96.1%` in the template, identical to `muted`), while the branding pipeline maps it to the brand's real accent colour. A chip built on `bg-accent` would be an invisible grey pill in an unbranded app and a loud brand chip in a branded one.

## Verification

Rendered against a live seeded store: chips resolve to the brand gold `rgb(201,162,64)` with its paired dark ink `rgb(15,15,15)`, the tile CTA matches the PDP button, `line-clamp: 2` applies. Plus a full re-scan of all ten verticals: no hardcoded colours outside the two documented cases, no foreground token without its background, no form control left on `border-border`, and every changed file parses.

`SKILL.md` gained one sentence so the header/home the agent composes follows the same tokens.