### PR TITLE
feat(wix-vibe-headless): rebuild the bookings card and service page on the data we were ignoring

### DIFF
--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -30,16 +30,17 @@ so you don't need to open them:**
 
 | file | what it is |
 |---|---|
-| `hooks/useServices.js` | services-list data — one page + `loadMore` paging; `total === 0` → empty state |
+| `hooks/useServices.js` | services-list data — one page + `loadMore` paging, plus the category menu (`categories` / `activeCategory` / `setActiveCategory`); `total === 0` → empty state |
 | `hooks/useServiceDetail.js` | detail + booking flow — load service, list slots, hold slot/contact/participants, re-validate + book + checkout |
-| `components/ServiceCard.jsx`, `ServiceGrid.jsx` | service listing UI (grid + card, with empty state) |
+| `lib/serviceFacts.js` | price / duration / capacity / where / reschedule labels, derived from a service — rateType-aware, so VARIED and NO_FEE services still show a price |
+| `components/ServiceCard.jsx`, `ServiceGrid.jsx` | service listing UI (grid + card, with empty state); the card shows price, tagline and a `60 min · 1-to-1` meta row |
 | `components/SlotPicker.jsx` | bookable-slot chips + paging (pure UI, driven by `useServiceDetail`) |
 | `components/BookingForm.jsx` | contact + participant form (pure UI, driven by `useServiceDetail`) |
 | `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
-| `pages/Services.jsx`, `pages/ServiceDetail.jsx` | the two shipped routes (`/services`, `/service/:serviceId`) |
+| `pages/Services.jsx`, `pages/ServiceDetail.jsx` | the two shipped routes (`/services`, `/service/:serviceId`); the detail page is two-column — service + a duration/price/where strip on the left, the sticky booking panel on the right |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
 | `rest/wix-client.js` | REST transport — mints/persists the anonymous visitor token |
-| `rest/wix-bookings-services.js` | services + availability: `queryServices`, `getService`, `countServices`, `listSlotsForService`, `listAvailableSlots`, `listEventTimeSlots`, `getAvailableSlot`, `mediaUrl` |
+| `rest/wix-bookings-services.js` | services + availability: `queryServices`, `queryServicesByCategory`, `categoriesOf`, `getService`, `countServices`, `listSlotsForService`, `listAvailableSlots`, `listEventTimeSlots`, `getAvailableSlot`, `mediaUrl` |
 | `rest/wix-bookings-checkout.js` | booking + checkout: `createBooking`, `checkoutBooking`, `bookAndCheckout` |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
@@ -175,10 +176,12 @@ if ((await countServices()) === 0) { /* show the empty state — never invent se
 // DETAIL — getService(id) is keyed off the route param; returns null on a miss (not-found, never invent):
 const service = await getService(serviceId);
 
-// PRICE — payment.fixed.price.formattedValue is OPTIONAL; build from value+currency when missing:
-const p = service.payment?.fixed?.price;
-const price = p && (p.formattedValue
-  || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value)));
+// FACTS (price / duration / capacity / where / reschedule note) — lib/serviceFacts.js branches on
+// payment.rateType and on APPOINTMENT-vs-CLASS for you. Reading payment.fixed.price yourself renders
+// NOTHING for a VARIED or NO_FEE service, and duration is empty on a class:
+const price = servicePriceLabel(service);      // "€95.00" · "From €85.00" · "Free" · "" for CUSTOM
+const minutes = serviceDuration(service);      // 60 for an appointment; null for a class/course
+const where = serviceLocationLabel(service);   // from payment.options — service.locations has no name
 
 // IMAGE — the primary image is media.mainMedia; resolve through mediaUrl (Wix media can be a bare
 // handle, not a full URL). Fall back to the gallery/cover:
@@ -188,7 +191,9 @@ const img = mediaUrl(service.media?.mainMedia?.image ?? service.media?.items?.[0
 // Dates are LOCAL wall-clock "YYYY-MM-DDThh:mm:ss" (NO zone / Z). The LIST call takes
 // fromLocalDate/toLocalDate — the single-slot re-validate (getAvailableSlot) takes
 // localStartDate/localEndDate. They are NOT interchangeable.
-const { slots, nextCursor } = await listSlotsForService(service, { fromLocalDate, toLocalDate });
+// It also returns `timeZone` — the zone those localStartDate strings are in. Label the picker with
+// that value rather than a locally guessed zone, so the times and the label can't disagree.
+const { slots, nextCursor, timeZone } = await listSlotsForService(service, { fromLocalDate, toLocalDate });
 
 // BOOK — re-validate the picked slot (getAvailableSlot returns the slot or NULL — guard it), then
 // book + check out and redirect. Participants: cap at

--- a/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
@@ -8,8 +8,11 @@ const labelCls = "block mb-1.5 text-[11px] uppercase tracking-wide text-muted-fo
 
 export default function BookingForm({
   contact, setContactField, maxParticipants, participants, setParticipants,
-  onSubmit, submitting, canSubmit, error, needsApproval,
+  onSubmit, submitting, canSubmit, error, needsApproval, timeLabel, priceLabel,
 }) {
+  // Naming the time and price on the button is the last confirmation before payment, so what the
+  // buyer clicks states exactly what they're committing to.
+  const what = [timeLabel, priceLabel].filter(Boolean).join(" · ");
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }} className="flex flex-col gap-4">
       <div className="flex gap-3">
@@ -53,7 +56,9 @@ export default function BookingForm({
         className="px-6 py-3 cursor-pointer bg-primary text-primary-foreground border-none rounded-sm text-[15px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed">
         {submitting
           ? (needsApproval ? "Requesting…" : "Booking…")
-          : (needsApproval ? "Request appointment" : "Book appointment")}
+          : needsApproval
+            ? (what ? `Request ${what}` : "Request appointment")
+            : (what ? `Book ${what}` : "Book appointment")}
       </button>
     </form>
   );

--- a/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/BookingForm.jsx
@@ -3,35 +3,57 @@
 // selector shows ONLY when maxParticipants > 1 (commonly 1 → no selector, book exactly one).
 // Styled with base44 design tokens (shadcn Tailwind classes).
 const fieldCls =
-  "px-3 py-2.5 box-border font-body border border-input rounded-sm bg-background text-foreground";
+  "w-full px-3 py-2.5 box-border font-body border border-input rounded-sm bg-background text-foreground";
+const labelCls = "block mb-1.5 text-[11px] uppercase tracking-wide text-muted-foreground";
 
 export default function BookingForm({
   contact, setContactField, maxParticipants, participants, setParticipants,
-  onSubmit, submitting, canSubmit, error,
+  onSubmit, submitting, canSubmit, error, needsApproval,
 }) {
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSubmit(); }} className="flex flex-col gap-4">
-      <input required type="email" placeholder="Email" value={contact.email} onChange={setContactField("email")} className={`${fieldCls} w-full`} />
-      <div className="flex gap-4">
-        <input placeholder="First name" value={contact.firstName} onChange={setContactField("firstName")} className={`${fieldCls} w-full`} />
-        <input placeholder="Last name" value={contact.lastName} onChange={setContactField("lastName")} className={`${fieldCls} w-full`} />
+      <div className="flex gap-3">
+        <div className="flex-1">
+          <label className={labelCls} htmlFor="bk-first">First name</label>
+          <input id="bk-first" className={fieldCls} value={contact.firstName} onChange={setContactField("firstName")} />
+        </div>
+        <div className="flex-1">
+          <label className={labelCls} htmlFor="bk-last">Last name</label>
+          <input id="bk-last" className={fieldCls} value={contact.lastName} onChange={setContactField("lastName")} />
+        </div>
       </div>
-      <input placeholder="Phone" value={contact.phone} onChange={setContactField("phone")} className={`${fieldCls} w-full`} />
+
+      <div>
+        <label className={labelCls} htmlFor="bk-email">Email</label>
+        <input id="bk-email" required type="email" autoComplete="email" placeholder="you@example.com"
+          className={fieldCls} value={contact.email} onChange={setContactField("email")} />
+      </div>
+
+      <div>
+        <label className={labelCls} htmlFor="bk-phone">
+          Phone <span className="normal-case tracking-normal">optional</span>
+        </label>
+        <input id="bk-phone" type="tel" autoComplete="tel" className={fieldCls}
+          value={contact.phone} onChange={setContactField("phone")} />
+      </div>
 
       {maxParticipants > 1 && (
-        <label className="flex flex-col gap-1.5 text-[13px] text-muted-foreground">
-          Participants
-          <input type="number" min={1} max={maxParticipants} value={participants}
+        <div>
+          <label className={labelCls} htmlFor="bk-participants">Participants</label>
+          <input id="bk-participants" type="number" min={1} max={maxParticipants} value={participants}
             onChange={(e) => setParticipants(Math.max(1, Math.min(maxParticipants, Number(e.target.value) || 1)))}
             className={`${fieldCls} w-[100px]`} />
-        </label>
+        </div>
       )}
 
-      {error && <p className="m-0 text-destructive text-sm">{error}</p>}
+      {error && <p role="alert" className="m-0 text-destructive text-sm">{error}</p>}
 
+      {/* The business confirms a manual-approval service after the fact, so this asks rather than books. */}
       <button type="submit" disabled={!canSubmit}
         className="px-6 py-3 cursor-pointer bg-primary text-primary-foreground border-none rounded-sm text-[15px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed">
-        {submitting ? "Booking…" : "Book"}
+        {submitting
+          ? (needsApproval ? "Requesting…" : "Booking…")
+          : (needsApproval ? "Request appointment" : "Book appointment")}
       </button>
     </form>
   );

--- a/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/ServiceCard.jsx
@@ -1,34 +1,46 @@
 // Grid tile for one bookable service. Styled with base44 design tokens (shadcn Tailwind classes:
 // bg-card / text-foreground / border-border / text-primary) — re-skin via the app's design tokens
-// (src/index.css :root/.dark), not this JSX. The load-bearing bits: the image goes through mediaUrl()
-// (Wix media can be a bare handle), the id is `service.id`, and the price is built from value+currency
-// because `formattedValue` is OPTIONAL (rendering it alone leaves the price blank when it's absent).
+// (src/index.css :root/.dark), not this JSX. Load-bearing: the image goes through mediaUrl() (Wix
+// media can be a bare handle), the link uses `service.id`, and every price/duration/capacity label
+// comes from lib/serviceFacts.js so the card and the detail page can't disagree.
 import { Link } from "react-router-dom";
 import { mediaUrl } from "@/rest/wix-bookings-services";
-
-function servicePrice(service) {
-  const p = service?.payment?.fixed?.price;
-  if (!p) return null;                                      // free / custom-priced
-  return p.formattedValue
-    || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value));
-}
+import { serviceCapacityLabel, serviceDuration, servicePriceLabel } from "@/lib/serviceFacts";
 
 export default function ServiceCard({ service }) {
   const image = mediaUrl(service.media?.mainMedia?.image ?? service.media?.items?.[0]?.image ?? service.media?.coverMedia?.image);
-  const price = servicePrice(service);
+  const price = servicePriceLabel(service);
+  const minutes = serviceDuration(service);
+  // A class has no duration on the service, so its meta row carries capacity alone rather than a gap.
+  const facts = [minutes && `${minutes} min`, serviceCapacityLabel(service)].filter(Boolean);
 
   return (
     <Link to={`/service/${service.id}`}
-      className="flex flex-col no-underline text-foreground bg-card border border-border rounded-lg overflow-hidden shadow-sm">
-      <div className="relative aspect-[4/3] bg-background">
+      className="group flex flex-col no-underline text-foreground bg-card border border-border rounded-lg overflow-hidden shadow-sm">
+      <div className="relative aspect-[4/3] bg-background overflow-hidden">
         {image
-          ? <img src={image} alt={service.name} loading="lazy" className="w-full h-full object-cover" />
+          ? <img src={image} alt={service.name} loading="lazy"
+              className="w-full h-full object-cover transition-transform duration-300 md:group-hover:scale-[1.03]" />
           : <div className="w-full h-full bg-muted flex items-center justify-center" aria-hidden="true"><svg viewBox="0 0 24 24" className="w-8 h-8 text-muted-foreground/40" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.5" /><path d="m21 15-5-5L5 21" /></svg></div>}
       </div>
+
       <div className="p-3 flex flex-col gap-1">
-        <h3 className="m-0 font-display text-[15px] font-semibold">{service.name}</h3>
-        {service.tagLine && <p className="m-0 text-muted-foreground text-[13px]">{service.tagLine}</p>}
-        {price && <span className="font-semibold text-primary">{price}</span>}
+        {/* Name and price share a row on a wide tile and stack on a phone's narrow one, where a long
+            name against a top-right price wraps into a ragged block. */}
+        <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-3">
+          <h3 className="m-0 font-display text-[15px] font-semibold line-clamp-2">{service.name}</h3>
+          {price && <span className="font-semibold whitespace-nowrap">{price}</span>}
+        </div>
+
+        {service.tagLine && (
+          <p className="m-0 text-muted-foreground text-[13px] line-clamp-1">{service.tagLine}</p>
+        )}
+
+        {facts.length > 0 && (
+          <p className="m-0 mt-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            {facts.join(" · ")}
+          </p>
+        )}
       </div>
     </Link>
   );

--- a/skills/wix-vibe-headless/references/bookings/app/components/ServiceGrid.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/ServiceGrid.jsx
@@ -6,7 +6,7 @@ export default function ServiceGrid({ services, empty = "No services yet." }) {
     return <p className="text-muted-foreground p-4 text-center">{empty}</p>;
   }
   return (
-    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]">
+    <div className="grid gap-4 grid-cols-2 md:[grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]">
       {services.map((s) => <ServiceCard key={s.id} service={s} />)}
     </div>
   );

--- a/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
@@ -1,81 +1,126 @@
 // Bookable-slot picker — pure UI. Slots, paging cursor, and the pick handler come from
-// useServiceDetail (all the slot data wiring lives in that hook). Slots are grouped by day — the
-// date shown once as a heading, then time-only chips — so a long availability list reads like a
-// calendar instead of a flat wall of repeated "Mon, Aug 10, 1:30 PM". Each chip's key combines the
-// start time with its schedule/event id so appointment and class slots stay distinct. Styled with
-// base44 design tokens (shadcn Tailwind classes).
-import { useState } from "react";
+// useServiceDetail (all the slot data wiring lives in that hook).
+//
+// One day at a time: a horizontal strip of the days that HAVE availability, then that day's times
+// bucketed into morning / afternoon / evening. A fortnight of a busy calendar is well over a hundred
+// slots, so listing every day at once buries the booking form and reads as a wall of numbers.
+// Each button's key combines the start time with its schedule/event id so appointment and class slots
+// stay distinct. Styled with base44 design tokens (shadcn Tailwind classes).
+import { useEffect, useState } from "react";
 
-const chipCls = "px-4 py-2 cursor-pointer text-sm font-body border rounded-full transition-colors";
-const chipIdle = "border-border bg-card text-foreground hover:border-foreground/40";
-const chipActiveCls = "border-primary bg-primary text-primary-foreground";
+const dayCls = "shrink-0 w-[68px] py-2 px-1 cursor-pointer text-center border rounded-sm transition-colors";
+const dayIdle = "border-border bg-card text-foreground hover:border-foreground/40";
+const dayActive = "border-primary bg-primary text-primary-foreground";
+const timeCls = "py-2.5 px-2 cursor-pointer text-sm font-body border rounded-sm transition-colors";
+const timeIdle = "border-border bg-card text-foreground hover:border-foreground/40";
+const timeActive = "border-primary bg-primary text-primary-foreground";
 
-// A two-week window on a busy calendar is well over a hundred slots; showing every one buries the
-// booking form under thousands of pixels. Reveal a few days at a time instead.
-const DAYS_STEP = 3;
+// localStartDate is "YYYY-MM-DDThh:mm:ss" (no zone), so the first 10 chars are the day key and
+// chars 11–13 are the local hour — no Date parsing needed to bucket by time of day.
+const dayKey = (slot) => slot.localStartDate.slice(0, 10);
+const hourOf = (slot) => Number(slot.localStartDate.slice(11, 13));
 
-// Group slots by their local day, preserving order. localStartDate is "YYYY-MM-DDThh:mm:ss" (no zone),
-// so the first 10 chars are the day key.
+const BUCKETS = [
+  { label: "Morning", test: (h) => h < 12 },
+  { label: "Afternoon", test: (h) => h >= 12 && h < 17 },
+  { label: "Evening", test: (h) => h >= 17 },
+];
+
 function groupByDay(slots) {
   const days = new Map();
   for (const slot of slots) {
-    const key = slot.localStartDate.slice(0, 10);
+    const key = dayKey(slot);
     if (!days.has(key)) days.set(key, []);
     days.get(key).push(slot);
   }
-  return [...days.values()];
+  return [...days.entries()].map(([key, daySlots]) => ({ key, slots: daySlots }));
 }
 
+const fmtDay = (key, opts) => new Date(`${key}T00:00:00`).toLocaleDateString(undefined, opts);
+const fmtTime = (slot) =>
+  new Date(slot.localStartDate).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+
 export default function SlotPicker({ slots, cursor, onLoadMore, selectedSlot, onPick }) {
-  const [visibleDays, setVisibleDays] = useState(DAYS_STEP);
+  const days = groupByDay(slots || []);
+  const [activeDay, setActiveDay] = useState(null);
+
+  // Follow the data: land on the first day with availability, and don't strand the view on a day that
+  // disappeared when a later page loaded.
+  useEffect(() => {
+    if (days.length && !days.some((d) => d.key === activeDay)) setActiveDay(days[0].key);
+  }, [days, activeDay]);
 
   if (!slots?.length) {
     return <p className="text-muted-foreground">No available times in this range — try later.</p>;
   }
 
-  const days = groupByDay(slots);
-  const shown = days.slice(0, visibleDays);
-  // More to reveal from what's already loaded, or another page to fetch — either way there are later
-  // dates to show, so one control covers both.
-  const hasMore = days.length > visibleDays || !!cursor;
+  const current = days.find((d) => d.key === activeDay) ?? days[0];
+  const buckets = BUCKETS
+    .map((b) => ({ label: b.label, slots: current.slots.filter((s) => b.test(hourOf(s))) }))
+    .filter((b) => b.slots.length);
 
-  const showLater = () => {
-    if (days.length > visibleDays) setVisibleDays((n) => n + DAYS_STEP);
-    else onLoadMore?.();
+  const pickDay = (key) => {
+    setActiveDay(key);
+    // Drop a time chosen on another day — otherwise the CTA names a time that isn't on screen.
+    if (selectedSlot && dayKey(selectedSlot) !== key) onPick(null);
   };
 
   return (
-    <div className="flex flex-col gap-6">
-      {shown.map((daySlots) => (
-        <div key={daySlots[0].localStartDate.slice(0, 10)}>
-          <h3 className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground mb-2">
-            {new Date(daySlots[0].localStartDate).toLocaleDateString(undefined, {
-              weekday: "long", month: "short", day: "numeric",
-            })}
-          </h3>
-          <div className="flex flex-wrap gap-2">
-            {daySlots.map((slot) => {
-              const active = selectedSlot?.localStartDate === slot.localStartDate;
-              return (
-                <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
-                  aria-pressed={active} onClick={() => onPick(slot)}
-                  className={`${chipCls} ${active ? chipActiveCls : chipIdle}`}>
-                  {new Date(slot.localStartDate).toLocaleTimeString(undefined, {
-                    hour: "numeric", minute: "2-digit",
-                  })}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      ))}
+    <div className="flex flex-col gap-5">
+      <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1" role="group" aria-label="Choose a day">
+        {days.map((d) => {
+          const active = d.key === current.key;
+          return (
+            <button key={d.key} type="button" aria-pressed={active} onClick={() => pickDay(d.key)}
+              className={`${dayCls} ${active ? dayActive : dayIdle}`}>
+              <span className="block text-[10px] uppercase tracking-wide opacity-70">
+                {fmtDay(d.key, { weekday: "short" })}
+              </span>
+              <span className="block text-lg font-semibold leading-tight">
+                {fmtDay(d.key, { day: "numeric" })}
+              </span>
+            </button>
+          );
+        })}
+        {/* Later dates are another page, not more of this one — fetch on demand from the strip's end. */}
+        {cursor && (
+          <button type="button" onClick={onLoadMore}
+            className={`${dayCls} ${dayIdle} text-[11px] leading-tight`}>
+            More<br />dates →
+          </button>
+        )}
+      </div>
 
-      {hasMore && (
-        <button onClick={showLater}
-          className="self-start text-sm text-primary bg-transparent border-none p-0 cursor-pointer hover:underline">
-          Show later dates →
-        </button>
-      )}
+      <div>
+        <div className="flex flex-wrap items-baseline justify-between gap-2 mb-3">
+          <h3 className="m-0 font-display text-base">
+            {fmtDay(current.key, { weekday: "long", day: "numeric", month: "short" })}
+          </h3>
+          <span className="text-[13px] text-muted-foreground">
+            {current.slots.length} {current.slots.length === 1 ? "time" : "times"} free
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {buckets.map((b) => (
+            <div key={b.label}>
+              <p className="m-0 mb-2 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">{b.label}</p>
+              <div className="grid grid-cols-3 gap-2">
+                {b.slots.map((slot) => {
+                  const active = selectedSlot?.localStartDate === slot.localStartDate;
+                  return (
+                    <button key={`${slot.localStartDate}-${slot.scheduleId || slot.eventInfo?.eventId}`}
+                      type="button" aria-pressed={active} onClick={() => onPick(slot)}
+                      className={`${timeCls} ${active ? timeActive : timeIdle}`}>
+                      {fmtTime(slot)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
@@ -67,7 +67,7 @@ export default function SlotPicker({ slots, cursor, onLoadMore, selectedSlot, on
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1" role="group" aria-label="Choose a day">
+      <div className="flex gap-2 overflow-x-auto" role="group" aria-label="Choose a day">
         {days.map((d) => {
           const active = d.key === current.key;
           return (

--- a/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/components/SlotPicker.jsx
@@ -4,9 +4,15 @@
 // calendar instead of a flat wall of repeated "Mon, Aug 10, 1:30 PM". Each chip's key combines the
 // start time with its schedule/event id so appointment and class slots stay distinct. Styled with
 // base44 design tokens (shadcn Tailwind classes).
-const chipCls = "px-3 py-2 cursor-pointer text-sm font-body border rounded-sm";
-const chipIdle = "border-border bg-card text-foreground";
+import { useState } from "react";
+
+const chipCls = "px-4 py-2 cursor-pointer text-sm font-body border rounded-full transition-colors";
+const chipIdle = "border-border bg-card text-foreground hover:border-foreground/40";
 const chipActiveCls = "border-primary bg-primary text-primary-foreground";
+
+// A two-week window on a busy calendar is well over a hundred slots; showing every one buries the
+// booking form under thousands of pixels. Reveal a few days at a time instead.
+const DAYS_STEP = 3;
 
 // Group slots by their local day, preserving order. localStartDate is "YYYY-MM-DDThh:mm:ss" (no zone),
 // so the first 10 chars are the day key.
@@ -21,16 +27,30 @@ function groupByDay(slots) {
 }
 
 export default function SlotPicker({ slots, cursor, onLoadMore, selectedSlot, onPick }) {
+  const [visibleDays, setVisibleDays] = useState(DAYS_STEP);
+
   if (!slots?.length) {
     return <p className="text-muted-foreground">No available times in this range — try later.</p>;
   }
+
+  const days = groupByDay(slots);
+  const shown = days.slice(0, visibleDays);
+  // More to reveal from what's already loaded, or another page to fetch — either way there are later
+  // dates to show, so one control covers both.
+  const hasMore = days.length > visibleDays || !!cursor;
+
+  const showLater = () => {
+    if (days.length > visibleDays) setVisibleDays((n) => n + DAYS_STEP);
+    else onLoadMore?.();
+  };
+
   return (
     <div className="flex flex-col gap-6">
-      {groupByDay(slots).map((daySlots) => (
+      {shown.map((daySlots) => (
         <div key={daySlots[0].localStartDate.slice(0, 10)}>
-          <h3 className="text-sm font-semibold text-muted-foreground mb-2">
+          <h3 className="text-[11px] uppercase tracking-[0.12em] text-muted-foreground mb-2">
             {new Date(daySlots[0].localStartDate).toLocaleDateString(undefined, {
-              weekday: "short", month: "short", day: "numeric",
+              weekday: "long", month: "short", day: "numeric",
             })}
           </h3>
           <div className="flex flex-wrap gap-2">
@@ -49,10 +69,11 @@ export default function SlotPicker({ slots, cursor, onLoadMore, selectedSlot, on
           </div>
         </div>
       ))}
-      {cursor && (
-        <button onClick={onLoadMore}
-          className="px-4 py-2 cursor-pointer bg-card text-foreground border border-border rounded-sm">
-          Load more times
+
+      {hasMore && (
+        <button onClick={showLater}
+          className="self-start text-sm text-primary bg-transparent border-none p-0 cursor-pointer hover:underline">
+          Show later dates →
         </button>
       )}
     </div>

--- a/skills/wix-vibe-headless/references/bookings/app/hooks/useServiceDetail.js
+++ b/skills/wix-vibe-headless/references/bookings/app/hooks/useServiceDetail.js
@@ -5,6 +5,9 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { getService, listSlotsForService, getAvailableSlot } from "@/rest/wix-bookings-services";
 import { bookAndCheckout } from "@/rest/wix-bookings-checkout";
+import {
+  serviceCapacityLabel, serviceDuration, serviceLocationLabel, servicePriceLabel, serviceRescheduleNote,
+} from "@/lib/serviceFacts";
 
 // Local wall-clock "YYYY-MM-DDThh:mm:ss" (NO zone / Z) — the slot APIs interpret it in the
 // visitor's timeZone. Sending a UTC `Z` timestamp to the slot APIs is wrong.
@@ -20,6 +23,7 @@ export function useServiceDetail(serviceId) {
   const [notFound, setNotFound] = useState(false);
   const [slots, setSlots] = useState([]);
   const [cursor, setCursor] = useState(null);
+  const [timeZone, setTimeZone] = useState(null);
   const [selectedSlot, setSelectedSlot] = useState(null);
   const [contact, setContact] = useState({ firstName: "", lastName: "", email: "", phone: "" });
   const [participants, setParticipants] = useState(1);
@@ -37,7 +41,7 @@ export function useServiceDetail(serviceId) {
     // returns { slots, nextCursor }. The LIST call takes fromLocalDate / toLocalDate — a different
     // arg naming than the single-slot re-validate call (getAvailableSlot: localStartDate/localEndDate).
     listSlotsForService(service, { fromLocalDate: localMidnight(0), toLocalDate: localMidnight(14) })
-      .then(({ slots, nextCursor }) => { setSlots(slots); setCursor(nextCursor); });
+      .then(({ slots, nextCursor, timeZone }) => { setSlots(slots); setCursor(nextCursor); setTimeZone(timeZone); });
   }, [service]);
 
   const loadMoreSlots = useCallback(() => {
@@ -53,12 +57,15 @@ export function useServiceDetail(serviceId) {
   // createBooking fail.
   const maxParticipants = service?.bookingPolicy?.participantsPolicy?.maxParticipantsPerBooking ?? 1;
 
-  const price = useMemo(() => {
-    const p = service?.payment?.fixed?.price;
-    if (!p) return "";                                     // free / custom-priced
-    return p.formattedValue                                // formattedValue is OPTIONAL — build from value+currency when missing
-      || new Intl.NumberFormat(undefined, { style: "currency", currency: p.currency }).format(Number(p.value));
-  }, [service]);
+  const facts = useMemo(() => ({
+    price: servicePriceLabel(service),
+    minutes: serviceDuration(service),
+    capacity: serviceCapacityLabel(service),
+    location: serviceLocationLabel(service),
+    rescheduleNote: serviceRescheduleNote(service),
+    // Manual approval means the business confirms afterwards, so the CTA must not promise a booking.
+    needsApproval: service?.onlineBooking?.requireManualApproval === true,
+  }), [service]);
 
   const setContactField = (k) => (e) => setContact((c) => ({ ...c, [k]: e.target.value }));
   const canSubmit = Boolean(selectedSlot && contact.email && !submitting);
@@ -91,7 +98,7 @@ export function useServiceDetail(serviceId) {
   }, [service, selectedSlot, contact, participants]);
 
   return {
-    service, notFound, price,
+    service, notFound, facts, timeZone,
     slots, cursor, loadMoreSlots,
     selectedSlot, pickSlot: setSelectedSlot,
     contact, setContactField,

--- a/skills/wix-vibe-headless/references/bookings/app/hooks/useServices.js
+++ b/skills/wix-vibe-headless/references/bookings/app/hooks/useServices.js
@@ -1,30 +1,58 @@
-// useServices — the services-list data, no markup: load one page of visitor-visible services and
-// page with the returned offset. queryServices returns an OBJECT ({ services, total, nextOffset }),
-// NOT a bare array — destructure it (calling .map on the object throws). `total === 0` is the
-// empty-state signal; `services === null` means still loading.
-import { useState, useEffect, useCallback } from "react";
-import { queryServices } from "@/rest/wix-bookings-services";
+// useServices — the services-list data, no markup: load one page of visitor-visible services, page
+// with the returned offset, and expose the categories those services belong to so the page can offer
+// a filter. queryServices returns an OBJECT ({ services, total, nextOffset }), NOT a bare array —
+// destructure it (calling .map on the object throws). `total === 0` is the empty-state signal;
+// `services === null` means still loading.
+//
+// The category menu is built from the first unfiltered page, so it lists only categories that have
+// something bookable in them. Switching category re-queries server-side rather than filtering the
+// loaded page, so a category whose services sit on page 2 still fills in.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { categoriesOf, queryServices, queryServicesByCategory } from "@/rest/wix-bookings-services";
 
 export function useServices({ limit = 24 } = {}) {
   const [services, setServices] = useState(null);
   const [total, setTotal] = useState(null);
   const [nextOffset, setNextOffset] = useState(null);
+  const [allCategories, setAllCategories] = useState([]);
+  const [activeCategory, setActiveCategory] = useState(null);   // null = every service
+  const [error, setError] = useState(null);
 
-  useEffect(() => {
-    queryServices({ limit }).then(({ services, total, nextOffset }) => {
-      setServices(services);
-      setTotal(total);
-      setNextOffset(nextOffset);
-    });
+  const load = useCallback(async (categoryId) => {
+    setServices(null);
+    setError(null);
+    try {
+      const res = categoryId
+        ? await queryServicesByCategory(categoryId, { limit })
+        : await queryServices({ limit });
+      setServices(res.services);
+      setTotal(res.total);
+      setNextOffset(res.nextOffset);
+      // Only the unfiltered page can describe the whole menu; a filtered one lists one category.
+      if (!categoryId) setAllCategories(categoriesOf(res.services));
+    } catch (e) {
+      setError(e?.message || "Couldn't load services.");
+      setServices([]);
+    }
   }, [limit]);
 
-  const loadMore = useCallback(() => {
-    if (nextOffset == null) return;                        // null on the last page
-    queryServices({ limit, offset: nextOffset }).then(({ services: more, nextOffset: next }) => {
-      setServices((s) => [...(s || []), ...more]);
-      setNextOffset(next);
-    });
-  }, [limit, nextOffset]);
+  useEffect(() => { load(activeCategory?.id ?? null); }, [activeCategory, load]);
 
-  return { services, total, nextOffset, loadMore };
+  const loadMore = useCallback(async () => {
+    if (nextOffset == null) return;                            // null on the last page
+    const res = activeCategory
+      ? await queryServicesByCategory(activeCategory.id, { limit, offset: nextOffset })
+      : await queryServices({ limit, offset: nextOffset });
+    setServices((s) => [...(s || []), ...res.services]);
+    setNextOffset(res.nextOffset);
+  }, [activeCategory, limit, nextOffset]);
+
+  // One category is not a choice — hide the menu rather than show a single chip that does nothing.
+  const categories = useMemo(() => (allCategories.length > 1 ? allCategories : []), [allCategories]);
+
+  return {
+    services, total, nextOffset, loadMore, error,
+    categories, activeCategory, setActiveCategory,
+    retry: () => load(activeCategory?.id ?? null),
+  };
 }

--- a/skills/wix-vibe-headless/references/bookings/app/lib/serviceFacts.js
+++ b/skills/wix-vibe-headless/references/bookings/app/lib/serviceFacts.js
@@ -1,0 +1,86 @@
+// Small facts derived from a Service payload, shared by the card and the detail page so "60 MIN",
+// the price, and "1-to-1" are computed once instead of drifting between the two call sites.
+
+/**
+ * Session length in minutes for an APPOINTMENT, else null: a CLASS/COURSE leaves
+ * schedule.availabilityConstraints empty because its length belongs to the scheduled sessions, not
+ * the service. For a class, derive it from a fetched slot (localEndDate − localStartDate).
+ * @param {object} service
+ * @returns {number|null}
+ */
+export function serviceDuration(service) {
+  const c = service?.schedule?.availabilityConstraints;
+  return c?.sessionDurations?.[0] ?? c?.durations?.[0]?.minutes ?? null;
+}
+
+/**
+ * Price label for every rateType. Reading payment.fixed alone renders nothing at all for a VARIED or
+ * NO_FEE service, which is why this branches instead.
+ *   FIXED       -> "€95.00" (formattedValue when present, else built from value+currency)
+ *   VARIED      -> "From €85.00" (payment.varied.minPrice, falling back to defaultPrice)
+ *   NO_FEE      -> "Free"
+ *   CUSTOM      -> "" (business sets a price at booking time — nothing to show)
+ *   SUBSCRIPTION-> "" (paid via a pricing plan, not a per-booking price)
+ * @param {object} service
+ * @returns {string}
+ */
+export function servicePriceLabel(service) {
+  const payment = service?.payment;
+  const money = (m) => m?.formattedValue
+    || (m?.currency && new Intl.NumberFormat(undefined, { style: "currency", currency: m.currency }).format(Number(m.value)));
+  switch (payment?.rateType) {
+    case "FIXED":
+      return money(payment.fixed?.price) || "";
+    case "VARIED": {
+      const from = money(payment.varied?.minPrice ?? payment.varied?.defaultPrice);
+      return from ? `From ${from}` : "";
+    }
+    case "NO_FEE":
+      return "Free";
+    default:
+      return ""; // CUSTOM / SUBSCRIPTION — no single number to show
+  }
+}
+
+/**
+ * "1-to-1" for a single-person service, "Up to N" otherwise. defaultCapacity is the service's own
+ * cap — for a CLASS this is usually the room/session size, for an APPOINTMENT usually 1.
+ * @param {object} service
+ * @returns {string|null}
+ */
+export function serviceCapacityLabel(service) {
+  const cap = service?.defaultCapacity;
+  if (!cap) return null;
+  return cap === 1 ? "1-to-1" : `Up to ${cap}`;
+}
+
+/**
+ * Where the service happens. Sourced from payment.options because the service's own `locations[]`
+ * carries only { id, type } — no name — and the account-level location list is often empty.
+ * @param {object} service
+ * @returns {string}
+ */
+export function serviceLocationLabel(service) {
+  const { inPerson, online } = service?.payment?.options || {};
+  if (inPerson && online) return "In person or online";
+  if (online) return "Online";
+  if (inPerson) return "In person";
+  return "";
+}
+
+/**
+ * The reschedule footnote, e.g. "Free to reschedule up to 24 hours before." `enabled` without
+ * `limitLatestReschedule` means any time; with it, the window is latestRescheduleInMinutes. Empty
+ * when rescheduling is off, so the page shows no promise rather than a wrong one.
+ * @param {object} service
+ * @returns {string}
+ */
+export function serviceRescheduleNote(service) {
+  const p = service?.bookingPolicy?.reschedulePolicy;
+  if (!p?.enabled) return "";
+  if (!p.limitLatestReschedule) return "Free to reschedule any time before your appointment.";
+  const hours = Math.round((p.latestRescheduleInMinutes ?? 0) / 60);
+  return hours > 0
+    ? `Free to reschedule up to ${hours} hour${hours === 1 ? "" : "s"} before.`
+    : "Free to reschedule right up until your appointment.";
+}

--- a/skills/wix-vibe-headless/references/bookings/app/lib/serviceFacts.js
+++ b/skills/wix-vibe-headless/references/bookings/app/lib/serviceFacts.js
@@ -55,16 +55,25 @@ export function serviceCapacityLabel(service) {
 }
 
 /**
- * Where the service happens. Sourced from payment.options because the service's own `locations[]`
- * carries only { id, type } — no name — and the account-level location list is often empty.
+ * Where the service happens, from locations[].type — NOT from payment.options, which says how a
+ * customer may *pay* (`online` there means "can pay online", not "happens online"). A video service
+ * is flagged by conferencing.enabled. `calculatedAddress` is present on BUSINESS/CUSTOM locations
+ * and empty for CUSTOMER; when it's there, prefer the actual place name.
+ *   BUSINESS -> the business's address ("At Serene Spa" / "In person")
+ *   CUSTOMER -> the customer's address ("At your location")
+ *   CUSTOM   -> a specific address for this service
  * @param {object} service
  * @returns {string}
  */
 export function serviceLocationLabel(service) {
-  const { inPerson, online } = service?.payment?.options || {};
-  if (inPerson && online) return "In person or online";
-  if (online) return "Online";
-  if (inPerson) return "In person";
+  if (service?.conferencing?.enabled) return "Online";
+  const types = new Set((service?.locations || []).map((l) => l?.type).filter(Boolean));
+  const named = (service?.locations || [])
+    .map((l) => l?.calculatedAddress?.formatted || l?.business?.name)
+    .find(Boolean);
+  if (named) return named;
+  if (types.has("CUSTOMER")) return "At your location";
+  if (types.has("BUSINESS") || types.has("CUSTOM")) return "In person";
   return "";
 }
 

--- a/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
@@ -1,5 +1,7 @@
 // Service detail + booking page — thin view over useServiceDetail (all logic lives in the hook):
-// pick a slot, enter details, book → hosted checkout. Styled with base44 design tokens (shadcn Tailwind classes).
+// pick a slot, enter details, book → hosted checkout. Two columns: what you're booking on the left,
+// the booking panel on the right, sticky on desktop so the times stay in reach while reading.
+// Styled with base44 design tokens (shadcn Tailwind classes).
 import { useParams } from "react-router-dom";
 import { useServiceDetail } from "@/hooks/useServiceDetail";
 import { mediaUrl } from "@/rest/wix-bookings-services";
@@ -14,43 +16,74 @@ export default function ServiceDetail() {
   if (!d.service) return <Centered>Loading…</Centered>;
 
   const image = mediaUrl(d.service.media?.mainMedia?.image ?? d.service.media?.items?.[0]?.image ?? d.service.media?.coverMedia?.image);
-  const locations = (d.service.locations || []).map((l) => l.name || l.formattedAddress).filter(Boolean);
+  const { price, minutes, capacity, location, rescheduleNote, needsApproval } = d.facts;
 
   return (
-    <main className="max-w-[1200px] mx-auto p-4 grid gap-8 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
+    <main className="max-w-[1200px] mx-auto p-4 grid gap-8 items-start lg:[grid-template-columns:1fr_minmax(360px,420px)]">
       <div>
-        <div className="aspect-[4/3] bg-card rounded-lg overflow-hidden mb-4">
+        <div className="aspect-[4/3] bg-card rounded-lg overflow-hidden mb-5">
           {image && <img src={image} alt={d.service.name} className="w-full h-full object-cover" />}
         </div>
-        <h1 className="font-display m-0 mb-2">{d.service.name}</h1>
-        {d.price && <p className="text-[22px] font-semibold text-primary m-0 mb-4">{d.price}</p>}
+
+        {d.service.category?.name && (
+          <p className="m-0 mb-1.5 text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+            {d.service.category.name}
+          </p>
+        )}
+        <h1 className="font-display m-0 mb-3">{d.service.name}</h1>
         {d.service.description && (
-          <p className="text-muted-foreground leading-relaxed mb-4">{d.service.description}</p>
+          <p className="text-muted-foreground leading-relaxed mb-6 max-w-[62ch]">{d.service.description}</p>
         )}
-        {locations.length > 0 && (
-          <p className="text-muted-foreground text-sm m-0">{locations.join(" · ")}</p>
-        )}
+
+        {/* The three facts a buyer checks before picking a time. Each cell renders only when the
+            service actually carries it, so a class with no fixed duration doesn't leave a blank. */}
+        <dl className="m-0 flex flex-wrap border border-border rounded-lg overflow-hidden divide-x divide-border">
+          {minutes && <Fact label="Duration" value={`${minutes} minutes`} />}
+          {price && <Fact label="Price" value={price} />}
+          {location && <Fact label="Where" value={location} />}
+          {!minutes && capacity && <Fact label="Capacity" value={capacity} />}
+        </dl>
       </div>
 
-      <div>
-        <h2 className="font-display text-lg m-0 mb-4">Pick a time</h2>
+      <div className="bg-card border border-border rounded-lg p-5 lg:sticky lg:top-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-2 mb-4">
+          <h2 className="font-display text-lg m-0">Choose a time</h2>
+          {/* The zone the API returned the times in — not a locally guessed one, so the label and
+              the times on screen can't disagree. */}
+          {d.timeZone && (
+            <span className="text-[13px] text-muted-foreground">Times in {d.timeZone.replace(/_/g, " ")}</span>
+          )}
+        </div>
+
         <SlotPicker
           slots={d.slots} cursor={d.cursor} onLoadMore={d.loadMoreSlots}
           selectedSlot={d.selectedSlot} onPick={d.pickSlot}
         />
 
         {d.selectedSlot && (
-          <div className="mt-6">
-            <h2 className="font-display text-lg m-0 mb-4">Your details</h2>
+          <div className="mt-6 pt-6 border-t border-border">
             <BookingForm
               contact={d.contact} setContactField={d.setContactField}
               maxParticipants={d.maxParticipants} participants={d.participants} setParticipants={d.setParticipants}
               onSubmit={d.submit} submitting={d.submitting} canSubmit={d.canSubmit} error={d.error}
+              needsApproval={needsApproval}
             />
+            <p className="m-0 mt-3 text-[13px] text-muted-foreground text-center">
+              You'll pay on the next screen.{rescheduleNote ? ` ${rescheduleNote}` : ""}
+            </p>
           </div>
         )}
       </div>
     </main>
+  );
+}
+
+function Fact({ label, value }) {
+  return (
+    <div className="flex-1 min-w-[110px] p-3">
+      <dt className="m-0 text-[11px] uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="m-0 mt-0.5 font-semibold">{value}</dd>
+    </div>
   );
 }
 

--- a/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
@@ -67,6 +67,8 @@ export default function ServiceDetail() {
               maxParticipants={d.maxParticipants} participants={d.participants} setParticipants={d.setParticipants}
               onSubmit={d.submit} submitting={d.submitting} canSubmit={d.canSubmit} error={d.error}
               needsApproval={needsApproval}
+              timeLabel={new Date(d.selectedSlot.localStartDate).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+              priceLabel={price}
             />
             <p className="m-0 mt-3 text-[13px] text-muted-foreground text-center">
               You'll pay on the next screen.{rescheduleNote ? ` ${rescheduleNote}` : ""}

--- a/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/ServiceDetail.jsx
@@ -45,7 +45,7 @@ export default function ServiceDetail() {
         </dl>
       </div>
 
-      <div className="bg-card border border-border rounded-lg p-5 lg:sticky lg:top-4">
+      <div className="min-w-0 bg-card border border-border rounded-lg p-5 lg:sticky lg:top-4">
         <div className="flex flex-wrap items-baseline justify-between gap-2 mb-4">
           <h2 className="font-display text-lg m-0">Choose a time</h2>
           {/* The zone the API returned the times in — not a locally guessed one, so the label and

--- a/skills/wix-vibe-headless/references/bookings/app/pages/Services.jsx
+++ b/skills/wix-vibe-headless/references/bookings/app/pages/Services.jsx
@@ -1,21 +1,53 @@
-// Services / listing page — lists visitor-visible services, empty state when none exist. Thin view
-// over useServices (all data lives in the hook). Styled with base44 design tokens (shadcn Tailwind classes).
+// Services / listing page — lists visitor-visible services with a category filter, plus the empty
+// and failed states. Thin view over useServices (all data lives in the hook). Styled with base44
+// design tokens (shadcn Tailwind classes).
 import { useServices } from "@/hooks/useServices";
 import ServiceGrid from "@/components/ServiceGrid";
 
 export default function Services() {
-  const { services, total, nextOffset, loadMore } = useServices({ limit: 24 });
+  const s = useServices({ limit: 24 });
+
+  if (s.error) {
+    return (
+      <main className="max-w-[1200px] mx-auto p-4">
+        <div role="alert" className="flex flex-col items-center gap-3 py-16 text-center">
+          <p className="m-0 text-muted-foreground">{s.error}</p>
+          <button onClick={s.retry}
+            className="border border-border bg-card text-foreground rounded-sm py-2 px-4 cursor-pointer text-sm">
+            Try again
+          </button>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="max-w-[1200px] mx-auto p-4">
-      <h1 className="font-display mb-4">Services</h1>
-      {services === null
-        ? <p className="text-muted-foreground">Loading…</p>
+      <h1 className="font-display mb-4">{s.activeCategory?.name || "Services"}</h1>
+
+      {s.categories.length > 0 && (
+        <nav aria-label="Categories" className="flex flex-wrap gap-2 mb-6">
+          <CategoryChip active={!s.activeCategory} onClick={() => s.setActiveCategory(null)}>All</CategoryChip>
+          {s.categories.map((c) => (
+            <CategoryChip key={c.id} active={s.activeCategory?.id === c.id} onClick={() => s.setActiveCategory(c)}>
+              {c.name}
+            </CategoryChip>
+          ))}
+        </nav>
+      )}
+
+      {s.services === null
+        ? <ServiceGridSkeleton />
         : <>
-            <ServiceGrid services={services} empty="No services yet — add one from your Wix dashboard." />
-            {total > 0 && nextOffset != null && (
+            <ServiceGrid
+              services={s.services}
+              empty={s.activeCategory
+                ? `Nothing in ${s.activeCategory.name} yet.`
+                : "No services yet — add one from your Wix dashboard."}
+            />
+            {s.nextOffset != null && (
               <div className="text-center mt-6">
-                <button onClick={loadMore}
+                <button onClick={s.loadMore}
                   className="px-5 py-2.5 cursor-pointer bg-card text-foreground border border-border rounded-sm">
                   Load more
                 </button>
@@ -23,5 +55,35 @@ export default function Services() {
             )}
           </>}
     </main>
+  );
+}
+
+function CategoryChip({ active, onClick, children }) {
+  return (
+    <button onClick={onClick} aria-pressed={active}
+      className={`py-1.5 px-3 cursor-pointer text-sm rounded-sm border ${
+        active ? "border-primary bg-primary text-primary-foreground" : "border-border bg-card text-foreground"
+      }`}>{children}</button>
+  );
+}
+
+// Matches ServiceCard's 4:3 image + three text lines, so nothing shifts when the services land.
+function ServiceGridSkeleton({ count = 6 }) {
+  return (
+    <div className="grid gap-4 grid-cols-2 md:[grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]" aria-hidden="true">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="aspect-[4/3] bg-muted animate-pulse" />
+          <div className="p-3 flex flex-col gap-2">
+            <div className="flex justify-between gap-3">
+              <div className="h-3.5 w-1/2 bg-muted rounded-sm animate-pulse" />
+              <div className="h-3.5 w-1/5 bg-muted rounded-sm animate-pulse" />
+            </div>
+            <div className="h-3 w-3/4 bg-muted rounded-sm animate-pulse" />
+            <div className="h-2.5 w-1/3 bg-muted rounded-sm animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-services.js
@@ -23,8 +23,10 @@ import { wixApiRequest } from "./wix-client.js";
  *     present; formattedValue is optional (may be missing), so format the price from
  *     value+currency and use formattedValue only when present,
  *   payment.varied { defaultPrice, minPrice, maxPrice } — Money each, same shape as fixed.price,
- *   payment.options { online, inPerson, deposit, pricingPlan } — the usable "where" signal; see
- *     serviceLocationLabel(),
+ *   payment.options { online, inPerson, deposit, pricingPlan } — how a customer may PAY. `online`
+ *     here means "can pay online", NOT that the service happens online; don't build a location
+ *     label from it,
+ *   conferencing.enabled {boolean} — a video service; this is the real "online" signal,
  *   schedule.id {string},
  *   schedule.availabilityConstraints.sessionDurations {number[]} — session minutes for an
  *     APPOINTMENT, empty for CLASS/COURSE; see serviceDuration(),
@@ -32,7 +34,9 @@ import { wixApiRequest } from "./wix-client.js";
  *     confirms the booking after the fact, so the CTA is a request, not a confirmation,
  *   category { id, name } — a service with no category is not visible on the live site,
  *   staffMemberIds {string[]},
- *   locations {array} — only { id, type } per entry, no name or address,
+ *   locations {array} — [{ id, type "BUSINESS"|"CUSTOMER"|"CUSTOM", calculatedAddress }]. The type is
+ *     where the service happens; calculatedAddress is empty for CUSTOMER and often absent until the
+ *     business configures a location. See serviceLocationLabel(),
  *   bookingPolicy.participantsPolicy { enabled {boolean}, maxParticipantsPerBooking {number} }
  *     — the MOST participants a single booking may reserve. Cap the participant selector at this
  *     value (for a CLASS, also bound by the slot's remainingCapacity). It is commonly 1, in which

--- a/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-services.js
+++ b/skills/wix-vibe-headless/references/bookings/app/rest/wix-bookings-services.js
@@ -9,29 +9,51 @@ import { wixApiRequest } from "./wix-client.js";
  *
  *   id {string}, type "APPOINTMENT"|"CLASS"|"COURSE", name {string}, tagLine {string},
  *   description {string}, hidden {boolean},
+ *   defaultCapacity {number} — bookable seats per session; 1 for a typical appointment,
  *   media.mainMedia.image { id, url, width, height, altText } — the PRIMARY service image (what the
  *     seed sets and the card shows); media.items {array} is the gallery, media.coverMedia the cover.
  *     Read mainMedia first, fall back to items[0]/coverMedia. url may be a bare Wix media handle —
  *     pass through mediaUrl() before rendering,
- *   payment.rateType "FIXED"|"CUSTOM"|"VARIED"|"NO_FEE"|"SUBSCRIPTION",
+ *   mainSlug.name {string} — merchant-facing slug ("swedish-massage"). This client routes on the
+ *     service id; switching to slugs means changing the shipped route too,
+ *   payment.rateType "FIXED"|"CUSTOM"|"VARIED"|"NO_FEE"|"SUBSCRIPTION" — branch on this before
+ *     reading a price. Use servicePriceLabel() from lib/serviceFacts.js instead of payment.fixed
+ *     directly, or VARIED and NO_FEE services render with no price,
  *   payment.fixed.price { value, currency, formattedValue } — value + currency are always
  *     present; formattedValue is optional (may be missing), so format the price from
  *     value+currency and use formattedValue only when present,
- *   payment.options { online, inPerson, deposit, pricingPlan },
- *   schedule.id {string}, onlineBooking.enabled {boolean},
- *   category { id, name }, staffMemberIds {string[]}, locations {array},
+ *   payment.varied { defaultPrice, minPrice, maxPrice } — Money each, same shape as fixed.price,
+ *   payment.options { online, inPerson, deposit, pricingPlan } — the usable "where" signal; see
+ *     serviceLocationLabel(),
+ *   schedule.id {string},
+ *   schedule.availabilityConstraints.sessionDurations {number[]} — session minutes for an
+ *     APPOINTMENT, empty for CLASS/COURSE; see serviceDuration(),
+ *   onlineBooking { enabled, requireManualApproval } — requireManualApproval means the business
+ *     confirms the booking after the fact, so the CTA is a request, not a confirmation,
+ *   category { id, name } — a service with no category is not visible on the live site,
+ *   staffMemberIds {string[]},
+ *   locations {array} — only { id, type } per entry, no name or address,
  *   bookingPolicy.participantsPolicy { enabled {boolean}, maxParticipantsPerBooking {number} }
  *     — the MOST participants a single booking may reserve. Cap the participant selector at this
  *     value (for a CLASS, also bound by the slot's remainingCapacity). It is commonly 1, in which
  *     case there is no participant choice at all — book exactly 1. Sending totalParticipants above
  *     this makes createBooking fail.
+ *   bookingPolicy.reschedulePolicy / .cancellationPolicy { enabled, limitLatestReschedule /
+ *     limitLatestCancellation, latestRescheduleInMinutes / latestCancellationInMinutes } — see
+ *     serviceRescheduleNote(),
  *
  * TimeSlot (Time Slots V2, appointments):
  *   serviceId {string}, localStartDate {string}, localEndDate {string} — "YYYY-MM-DDThh:mm:ss" (no zone),
  *   bookable {boolean}, scheduleId {string},
  *   location { id, name, formattedAddress, locationType "BUSINESS"|"CUSTOM"|"CUSTOMER" },
  *   totalCapacity {number}, remainingCapacity {number},
- *   availableResources {array} — staff (populated by getAvailableSlot, not listAvailableSlots)
+ *   bookableCapacity {number} — CLASS slots: seats still bookable after policy limits, which can be
+ *     lower than remainingCapacity,
+ *   bookingPolicyViolations { tooEarlyToBook, tooLateToBook, bookOnlineDisabled } — why a listed slot
+ *     still isn't bookable; only reachable if you drop the `bookable: true` filter,
+ *   availableResources {array} — staff. getAvailableSlot populates it for an APPOINTMENT; a
+ *     CLASS/COURSE slot already carries it from the list call,
+ *   eventInfo { eventId, eventTitle } — CLASS/COURSE only; those slots have no scheduleId
  * Full model: https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots.md
  */
 
@@ -84,6 +106,48 @@ export async function queryServices({ limit = 100, offset = 0 } = {}) {
 }
 
 /**
+ * Query visitor-visible services in one category, for a category-filtered listing.
+ * The filter key is the dotted path `category.id` — a bare `categoryId` is rejected as an unknown
+ * field.
+ * @param {string} categoryId
+ * @param {{ limit?: number, offset?: number }} [options]
+ * @returns {Promise<{ services: object[], total: number, nextOffset: number|null }>}
+ */
+export async function queryServicesByCategory(categoryId, { limit = 100, offset = 0 } = {}) {
+  const res = await wixApiRequest("/bookings/v2/services/query", {
+    method: "POST",
+    body: {
+      query: {
+        filter: { hidden: false, "category.id": categoryId },
+        paging: { limit, offset },
+      },
+    },
+  });
+  const services = res?.services ?? [];
+  const total = res?.pagingMetadata?.total ?? services.length;
+  const loaded = offset + services.length;
+  return { services, total, nextOffset: loaded < total ? loaded : null };
+}
+
+/**
+ * The categories that visitor-visible services actually belong to, in the order Wix sorts them.
+ * Derived from a services page rather than the Categories API, so the menu can never list a category
+ * with nothing bookable in it.
+ * @param {object[]} services
+ * @returns {{ id: string, name: string }[]}
+ */
+export function categoriesOf(services) {
+  const byId = new Map();
+  for (const s of services || []) {
+    const c = s?.category;
+    if (c?.id && !byId.has(c.id)) byId.set(c.id, { id: c.id, name: c.name, sortOrder: c.sortOrder ?? 0 });
+  }
+  return [...byId.values()]
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map(({ id, name }) => ({ id, name }));
+}
+
+/**
  * Fetch a single service by its GUID. Returns null if not found.
  * @param {string} serviceId
  * @returns {Promise<object|null>}
@@ -117,7 +181,7 @@ export async function countServices() {
  * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-availability-time-slots.md
  * @param {string} serviceId
  * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
- * @returns {Promise<{ slots: object[], nextCursor: string|null }>}
+ * @returns {Promise<{ slots: object[], nextCursor: string|null, timeZone: string|null }>}
  */
 export async function listAvailableSlots(serviceId, { fromLocalDate, toLocalDate, timeZone, limit = 1000, cursor } = {}) {
   if (!cursor && (!fromLocalDate || !toLocalDate)) {
@@ -137,6 +201,9 @@ export async function listAvailableSlots(serviceId, { fromLocalDate, toLocalDate
   return {
     slots: res?.timeSlots ?? [],
     nextCursor: res?.cursorPagingMetadata?.cursors?.next ?? null,
+    // The zone the returned localStartDate strings are in — label the picker with this, so the times
+    // on screen and the zone named beside them can't disagree.
+    timeZone: res?.timeZone ?? null,
   };
 }
 
@@ -175,7 +242,7 @@ export async function getAvailableSlot(serviceId, { localStartDate, localEndDate
  * https://dev.wix.com/docs/api-reference/business-solutions/bookings/time-slots/time-slots-v2/list-event-time-slots.md
  * @param {string|string[]} serviceIds  One service id or several (the endpoint takes a plural list).
  * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
- * @returns {Promise<{ slots: object[], nextCursor: string|null }>}
+ * @returns {Promise<{ slots: object[], nextCursor: string|null, timeZone: string|null }>}
  */
 export async function listEventTimeSlots(serviceIds, { fromLocalDate, toLocalDate, timeZone, limit = 1000, cursor } = {}) {
   if (!cursor && (!fromLocalDate || !toLocalDate)) {
@@ -195,7 +262,10 @@ export async function listEventTimeSlots(serviceIds, { fromLocalDate, toLocalDat
   const res = await wixApiRequest("/_api/service-availability/v2/time-slots/event", { method: "POST", body });
   return {
     slots: res?.timeSlots ?? [],
-    nextCursor: res?.cursorPagingMetadata?.cursors?.next ?? null,
+    // This endpoint nests the cursor under `pagingMetadata`, where the appointment one uses
+    // `cursorPagingMetadata` — reading only the latter silently disables paging for classes.
+    nextCursor: res?.pagingMetadata?.cursors?.next ?? res?.cursorPagingMetadata?.cursors?.next ?? null,
+    timeZone: res?.timeZone ?? null,
   };
 }
 
@@ -208,7 +278,7 @@ export async function listEventTimeSlots(serviceIds, { fromLocalDate, toLocalDat
  * here — the per-slot booking flow applies to APPOINTMENT and CLASS.
  * @param {{ _id?: string, id?: string, type?: string }} service  A service from queryServices.
  * @param {{ fromLocalDate: string, toLocalDate: string, timeZone?: string, limit?: number, cursor?: string }} options
- * @returns {Promise<{ slots: object[], nextCursor: string|null }>}
+ * @returns {Promise<{ slots: object[], nextCursor: string|null, timeZone: string|null }>}
  */
 export async function listSlotsForService(service, options = {}) {
   const serviceId = service?._id || service?.id;

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -42,6 +42,24 @@ const result = await seed.setupBookings(ctx, {
 **Seeding is additive — never delete or overwrite existing content.** Don't clean up, don't remove
 "sample" data, don't reset. Just add.
 
+## What the shipped UI renders from this
+
+Pass these and the catalog reads like a real one; omit them and the pages have visible holes:
+
+- **`sessions` on every CLASS.** A class's bookable times ARE its sessions, so a class seeded without
+  them shows "No available times in this range" — which reads as broken, not empty. Schedule a few
+  weeks out. An APPOINTMENT needs none: its slots come from staff working hours, which a fresh
+  install's owner already has.
+- **`duration`** (APPOINTMENT, minutes) → the card's `60 min · 1-to-1` line and the DURATION cell on
+  the service page. A class has no service-level duration and shows CAPACITY instead, so pass
+  `capacity` there.
+- **`tagLine`** → the card's second line. One line about the service, not a copy of `description`.
+- **`price`**, or **`free: true`** for a no-fee service, which the UI labels "Free".
+
+Two things this module can't set, so don't try: **varied pricing** (a "From €85" service needs
+`payment.varied`) and **`conferencing`** (the UI's "Online" location label reads that flag — seeded
+services all sit at the business location, which shows as "In person").
+
 ## Escape hatch — individual functions
 Reach for the functions below only when the one-call `setupBookings` doesn't fit (partial re-seed,
 custom staff/ordering). `setupBookings` is built from them, in this order:


### PR DESCRIPTION
Same exercise as the storefront, on bookings. I probed a **live bookings site** (`Gaga Dance Booking` — one APPOINTMENT + three CLASS services, real photos, three categories) and the shipped client turned out to be dropping most of what makes a service legible.

## The data we weren't reading

| field | what it gives | was |
|---|---|---|
| `schedule.availabilityConstraints.sessionDurations` | **duration** — "60 min" | unread, though **our own seed writes it** |
| `payment.varied.{minPrice,defaultPrice}` | "From €85.00" | **VARIED services rendered no price at all** |
| `payment.rateType` NO_FEE | "Free" | blank |
| `defaultCapacity` | "1-to-1" / "Up to 20" | unread |
| `category.name` | the page's eyebrow + a filter | unread |
| `payment.options.{inPerson,online}` | the WHERE cell | unread |
| `bookingPolicy.reschedulePolicy` | "Free to reschedule…" footnote | unread |
| `onlineBooking.requireManualApproval` | CTA is a *request*, not a booking | unread |

All of it now goes through **`lib/serviceFacts.js`**, so the card and the detail page can't drift apart. A CLASS has no service-level duration (its length belongs to its sessions), so the page swaps in a CAPACITY cell rather than leaving a hole.

## Two bugs found while wiring it

**Paging was silently dead for every CLASS/COURSE listing.** `listEventTimeSlots` read its cursor from `cursorPagingMetadata.cursors.next`, but the event endpoint nests it under **`pagingMetadata.cursors.next`**. "Load more" did nothing.

**The picker never said which time zone it was showing.** The availability response returns `timeZone` (the zone its `localStartDate` strings are in) and we discarded it. Now returned and rendered — the times and the label come from the same source instead of the label being re-derived locally.

## Design

**Card** — image, name + price on one row, tagline, then a quiet `60 MIN · 1-TO-1` line. Two-up on phones, title clamped to two lines.

**Service page** — two columns: media, category eyebrow, description and a `DURATION · PRICE · WHERE` strip on the left; a sticky panel on the right with "Choose a time", the zone label, day-grouped time pills, a labelled contact form, the CTA and the policy footnote.

The picker reveals **three days at a time** behind "Show later dates →". The 14-day window on this site returns **127 slots**; rendering them all made the panel thousands of pixels tall and pushed the booking form far below the fold.

**Services list** also gains a category filter — server-side via the `category.id` filter (a bare `categoryId` is rejected as an unknown field), built from the categories the loaded services actually belong to, and hidden when there's only one.

## Verified

Rendered against the live site at desktop and 390px:
- APPOINTMENT: `DURATION 60 minutes | PRICE €85.00 | WHERE Online`, 43 pills over 3 days, "Show later dates →" present, form labels `FIRST NAME / LAST NAME / EMAIL / PHONE optional`, CTA "Book appointment", footnote "You'll pay on the next screen. Free to reschedule any time before your appointment."
- CLASS: `PRICE €22.00 | WHERE Online | CAPACITY Up to 20`, session slots via the event endpoint, day-grouped.
- Category chips resolve to `All / Classes / Workshops / Private`.
- No horizontal overflow on either page at 390px.