### PR TITLE
fix(wix-vibe-headless): gate the manage banner on preview, not on a dev build

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -156,11 +156,11 @@ parallelize independent work (API calls, multiple entities).
 
 Once the site is built and seeded:
 
-1. **Mount the dev-only manage banner** (required; links the app to its Wix back office; shipped,
-   self-gates to dev builds, never in production): render the `<WixManageBanner/>` component in your
-   Layout's fixed top region, above the header, per your vertical's INSTRUCTIONS STEP 4.
+1. **Mount the preview-only manage banner** (required; links the app to its Wix back office; shipped,
+   self-gates to the preview, never on the published site): render the `<WixManageBanner/>` component
+   in your Layout's fixed top region, above the header, per your vertical's INSTRUCTIONS STEP 4.
 2. **Ask the user to open** `https://manage.wix.com/dashboard/{metaSiteId}` (substitute your
-   metasite id) to complete setup in Wix (required), and mention that dev builds show a dismissible
+   metasite id) to complete setup in Wix (required), and mention that the preview shows a dismissible
    top banner linking to this same dashboard.
 
 **Preview briefly, don't chase images.** A quick render check is enough. Generated images show as

--- a/skills/wix-vibe-headless/platforms/generic.md
+++ b/skills/wix-vibe-headless/platforms/generic.md
@@ -114,8 +114,9 @@ installed + seeded (expected; the seed modules install it first). Image seeding 
 
 ### 4 · Done
 
-Mount the dev-only manage banner (regenerate `WixManageBanner` for your stack — it reads
+Mount the preview-only manage banner (regenerate `WixManageBanner` for your stack — it reads
 `WIX_METASITE_ID` from `wix-config`, already set in step 2, and self-hides while it's still the
-placeholder; mount above the header, SSR-safe, portable dev-gate, **never in production**), then tell
+placeholder; mount above the header, SSR-safe, portable preview-gate, **never on the published
+site**), then tell
 the user to open `https://manage.wix.com/dashboard/{metaSiteId}` to finish setup in Wix (payments,
 content).

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -25,7 +25,7 @@ don't need to open them:**
 | `hooks/usePostDetail.js` | post-detail data — load by slug, not-found state, resolved category/tag chips, body paragraphs |
 | `components/PostCard.jsx`, `PostGrid.jsx` | post listing UI (grid + card, with cover image + empty state) |
 | `components/PostChips.jsx` | category/tag chips for a post (resolves ids via the taxonomy, routes by slug) |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Blog.jsx` | the feed route (`/blog`) — lists posts, paginates, empty state |
 | `pages/PostDetail.jsx` | the post route (`/blog/:slug`) |
 | `pages/CategoryPage.jsx`, `TagPage.jsx` | the taxonomy landing routes (`/blog/category/:slug`, `/blog/tag/:slug`) |
@@ -64,7 +64,7 @@ replace it.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Blog` / `PostDetail` / category / tag pages — so you **never edit the
   shipped pages to add a header/footer** (they render inside `<Outlet/>` as-is).
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's measured height so it clears the chrome and self-corrects when the
@@ -76,7 +76,7 @@ replace it.
 import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 import { TaxonomyProvider } from "@/context/TaxonomyContext";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Blog from "@/pages/Blog";                       // shipped · default export, no props
 import PostDetail from "@/pages/PostDetail";           // shipped · default export, no props
 import CategoryPage from "@/pages/CategoryPage";       // shipped · default export, no props
@@ -95,7 +95,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -36,7 +36,7 @@ so you don't need to open them:**
 | `components/ServiceCard.jsx`, `ServiceGrid.jsx` | service listing UI (grid + card, with empty state); the card shows price, tagline and a `60 min · 1-to-1` meta row |
 | `components/SlotPicker.jsx` | bookable-slot chips + paging (pure UI, driven by `useServiceDetail`) |
 | `components/BookingForm.jsx` | contact + participant form (pure UI, driven by `useServiceDetail`) |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Services.jsx`, `pages/ServiceDetail.jsx` | the two shipped routes (`/services`, `/service/:serviceId`); the detail page is two-column — service + a duration/price/where strip on the left, the sticky booking panel on the right |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
 | `rest/wix-client.js` | REST transport — mints/persists the anonymous visitor token |
@@ -74,7 +74,7 @@ its own detail page), so there's nothing to wrap the tree in.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Services` / `ServiceDetail` — so you **never edit the shipped pages to add
   a header/footer** (they render inside `<Outlet/>` as-is).
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's **ResizeObserver-measured** height so it clears the chrome and
@@ -85,7 +85,7 @@ its own detail page), so there's nothing to wrap the tree in.
 ```jsx
 import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Services from "@/pages/Services";               // shipped · default export, no props
 import ServiceDetail from "@/pages/ServiceDetail";     // shipped · default export, no props
 import Home from "@/pages/Home";           // YOU build
@@ -102,7 +102,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -29,7 +29,7 @@ using the official Wix Data endpoints — never hand-build a Wix Data URL, never
 ## Build the UI from the utils
 Generate whatever the app needs — a list/grid, a detail page, a home page, a submit form — with your
 framework, your router, and your design tokens. Wire the data with the helpers below (the shapes are
-the bug-prone part). Mount the shared `WixManageBanner` (dev-only) in your Layout. Route conventions
+the bug-prone part). Mount the shared `WixManageBanner` (preview-only) in your Layout. Route conventions
 are yours (e.g. a list path + `/item/:slugOrId` detail).
 
 ## Data shapes (load-bearing — keep this wiring)

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -32,7 +32,7 @@ don't need to open them:**
 | `components/EventRegistration.jsx` | branches on `registration.type` (RSVP / TICKETING / EXTERNAL / NONE) |
 | `components/RsvpForm.jsx` | RSVP form UI over `useRsvpForm` |
 | `components/TicketPicker.jsx` | ticket list + quantity + checkout UI over `useTicketing` |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Events.jsx`, `pages/EventDetail.jsx` | the two shipped routes (`/events`, `/events/:slug`) |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
 | `rest/wix-client.js` | visitor-token mint/refresh + REST transport (reads `wix-config.js`) |
@@ -71,7 +71,7 @@ to the detail page.)
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Events` / `EventDetail` — so you **never edit the shipped pages to add a
   header/footer** (they render inside `<Outlet/>` as-is).
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's **ResizeObserver-measured** height so it clears the chrome and
@@ -82,7 +82,7 @@ to the detail page.)
 ```jsx
 import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Events from "@/pages/Events";                   // shipped · default export, no props
 import EventDetail from "@/pages/EventDetail";         // shipped · default export, no props
 import Home from "@/pages/Home";       // YOU build
@@ -99,7 +99,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -52,7 +52,7 @@ so you don't need to open them:**
 | `components/SocialButtons.jsx` | "Continue with Google/Facebook" buttons (kick off the redirect) |
 | `components/MemberMenu.jsx` | header account control — "Log in" vs. member name + log-out (like a cart button) |
 | `components/RequireAuth.jsx` | route gate: renders children for a member, else redirects to `/login` |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Login.jsx`, `pages/Account.jsx` | the shipped login + account routes (`/login`, `/account`) |
 | `pages/Callback.jsx` | social/SSO return route — mount at **exactly** `/callback` |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
@@ -96,7 +96,7 @@ name, **`MemberProvider`/`useMember`**, so the two never collide (do NOT rename 
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Login`/`Account`/`Callback` — so you **never edit the shipped pages to add
   a header/footer** (they render inside `<Outlet/>` as-is).
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's measured height so it clears the chrome and self-corrects when the
@@ -109,7 +109,7 @@ name, **`MemberProvider`/`useMember`**, so the two never collide (do NOT rename 
 import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 import { MemberProvider } from "@/context/MemberContext";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import RequireAuth from "@/components/RequireAuth";           // shipped route gate
 import Login from "@/pages/Login";                     // shipped · default export, no props
 import Account from "@/pages/Account";                 // shipped · default export, no props
@@ -128,7 +128,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -33,7 +33,7 @@ so you don't need to open them:**
 | `components/CollectionCard.jsx`, `CollectionGrid.jsx` | collections listing UI (grid + card, with empty state) |
 | `components/ProjectCard.jsx`, `ProjectGrid.jsx` | projects listing UI (grid + card, with empty state) |
 | `components/ProjectMedia.jsx` | one gallery item — branches on `item.type` (IMAGE / VIDEO) |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Portfolio.jsx` | collections gallery route (`/portfolio`) |
 | `pages/CollectionPage.jsx` | collection page route (`/collection/:slug`) |
 | `pages/ProjectDetail.jsx` | project detail route (`/project/:slug`) |
@@ -71,7 +71,7 @@ cart equivalent) — just the Layout and the routes.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Portfolio` / `CollectionPage` / `ProjectDetail` — so you **never edit the
   shipped pages to add a header/footer** (they render inside `<Outlet/>` as-is).
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's measured height so it clears the chrome and self-corrects when the
@@ -82,7 +82,7 @@ cart equivalent) — just the Layout and the routes.
 ```jsx
 import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Portfolio from "@/pages/Portfolio";             // shipped · default export, no props
 import CollectionPage from "@/pages/CollectionPage";   // shipped · default export, no props
 import ProjectDetail from "@/pages/ProjectDetail";     // shipped · default export, no props
@@ -100,7 +100,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -36,7 +36,7 @@ map, so you don't need to open them:**
 | `components/PlanCard.jsx` | plan card — name, description, price, perks, Subscribe (when `buyable`) |
 | `components/PlanGrid.jsx` | responsive plans grid + empty state |
 | `components/OrderCard.jsx` | one member order row for the "my plans" list |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Plans.jsx` | the plans-table route (`/plans`) — grid + paging + checkout |
 | `pages/PlanDetail.jsx` | the plan-detail route (`/plans/:slug`) — perks, terms, checkout |
 | `pages/MyPlans.jsx` | the member's memberships + post-checkout confirmation (`/my-plans`) |
@@ -74,7 +74,7 @@ state) — so unlike the storefront there's no `<CartProvider>` to wrap.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every**
   page — including the shipped `Plans` / `PlanDetail` / `MyPlans` — so you **never edit the shipped
   pages to add a header/footer** (they render inside `<Outlet/>` as-is).
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's **ResizeObserver-measured** height so it clears the chrome and
@@ -85,7 +85,7 @@ state) — so unlike the storefront there's no `<CartProvider>` to wrap.
 ```jsx
 import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Plans from "@/pages/Plans";                     // shipped · default export, no props
 import PlanDetail from "@/pages/PlanDetail";           // shipped · default export, no props
 import MyPlans from "@/pages/MyPlans";                 // shipped · default export, no props
@@ -103,7 +103,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -35,7 +35,7 @@ so you don't need to open them:**
 | `components/ItemDialog.jsx` | dish detail modal — description, price/variants, modifier groups (display), quantity, add-to-order |
 | `components/OrderCartButton.jsx` | header order **icon** button with a live-count badge |
 | `components/OrderCartDrawer.jsx` | slide-over order cart (mount once; opens from `useOrderCart`) |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Menu.jsx`, `pages/Reservations.jsx` | the two shipped routes (`/menu`, `/reservations`) |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
 | `rest/wix-client.js` | REST transport + visitor-token mint/refresh (the refresh token IS the cart identity) |
@@ -75,7 +75,7 @@ replace it.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Menu` / `Reservations` — so you **never edit the shipped pages to add a
   header/footer** (they render inside `<Outlet/>` as-is). Mount `<OrderCartDrawer/>` once in the Layout.
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's measured height so it clears the chrome and self-corrects when the
@@ -88,7 +88,7 @@ import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 import { OrderCartProvider } from "@/context/OrderCartContext";
 import OrderCartDrawer from "@/components/OrderCartDrawer";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Menu from "@/pages/Menu";                       // shipped · default export, no props
 import Reservations from "@/pages/Reservations";       // shipped · default export, no props
 import Home from "@/pages/Home";       // YOU build
@@ -105,7 +105,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}

--- a/skills/wix-vibe-headless/references/shared/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/shared/app/components/WixManageBanner.jsx
@@ -1,5 +1,6 @@
-// Dev-only banner linking the running app to its Wix Business Manager (the back office).
-// Renders ONLY in a dev build (never in production) and is dismissible (persisted per site).
+// Preview-only banner linking the running app to its Wix Business Manager (the back office).
+// Renders while the app is previewed or run locally, never on the published site, and is
+// dismissible (persisted per site).
 // Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
 // banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
 import { useState } from "react";
@@ -7,14 +8,25 @@ import { WIX_METASITE_ID } from "@/rest/wix-config";
 
 const DASHBOARD_URL = `https://manage.wix.com/dashboard/${WIX_METASITE_ID}`;
 const DISMISS_KEY = `wix-manage-banner-dismissed-${WIX_METASITE_ID}`;
-const IS_DEV = (() => { try { return Boolean(import.meta.env?.DEV); } catch { return false; } })();
+
+// Base44 serves the preview from a dev server (DEV true) or a prebuilt bundle (DEV false) and swaps
+// between them mid-session, so its hostname and injected marker are what hold the banner steady;
+// DEV is the best-effort signal elsewhere. Unrecognized host on a built bundle → hidden.
+const PREVIEW_HOST = /^(preview|preview-sandbox|checkpoint)--/;
+const IN_PREVIEW = (() => {
+  try {
+    return Boolean(import.meta.env?.DEV)
+      || PREVIEW_HOST.test(window.location.hostname)
+      || Boolean(document.querySelector("script[data-preview-inject]"));
+  } catch { return false; }
+})();
 
 export default function WixManageBanner() {
   const [dismissed, setDismissed] = useState(() => {
     try { return Boolean(window.localStorage.getItem(DISMISS_KEY)); } catch { return false; }
   });
-  // No flag → no banner. Never renders in prod, once dismissed, or before the id is filled in.
-  if (!IS_DEV || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
+  // Never renders on the published site, once dismissed, or before the id is filled in.
+  if (!IN_PREVIEW || dismissed || WIX_METASITE_ID.startsWith("<")) return null;
 
   const dismiss = () => {
     setDismissed(true);

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -30,7 +30,7 @@ so you don't need to open them:**
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
 | `components/VariantPicker.jsx` | option/variant selector used on the PDP — colour options render as real swatches, and picking one moves the gallery to that colour's photo |
-| `components/WixManageBanner.jsx` | dev-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
 | `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
 | `rest/wix-config.js` | **you set the ids here** (STEP 2) |
 | `rest/wix-client.js` + `rest/wix-store-*.js` | REST transport + catalog/cart helpers |
@@ -66,7 +66,7 @@ replace it.
   route under one pathless `<Route element={<Layout/>}>`. Your brand chrome then wraps **every** page
   — including the shipped `Shop` / `ProductDetail` — so you **never edit the shipped pages to add a
   header/footer** (they render inside `<Outlet/>` as-is). Mount `<CartDrawer/>` once in the Layout.
-- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, dev-only) **above**
+- **Pin the top chrome as one fixed block.** Put `<WixManageBanner/>` (shipped, preview-only) **above**
   your `<Header/>` inside a single `position:fixed` top region — the header itself is plain in-flow
   markup, the region owns the fixing — so banner + header ride together (no scroll drift/gap). Pad
   the content by the region's measured height so it clears the chrome and self-corrects when the
@@ -79,7 +79,7 @@ import { useRef, useState, useEffect } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
 import { CartProvider } from "@/context/CartContext";
 import CartDrawer from "@/components/CartDrawer";
-import WixManageBanner from "@/components/WixManageBanner";   // shipped, dev-only · default export, no props
+import WixManageBanner from "@/components/WixManageBanner";   // shipped, preview-only · default export, no props
 import Shop from "@/pages/Shop";                       // shipped · default export, no props
 import ProductDetail from "@/pages/ProductDetail";     // shipped · default export, no props
 import Home from "@/pages/Home";       // YOU build
@@ -96,7 +96,7 @@ function Layout() {
   }, []);
   return (<>
     <div ref={topRef} style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}>
-      <WixManageBanner />                    {/* null in prod / when dismissed */}
+      <WixManageBanner />                    {/* null on the published site / when dismissed */}
       <Header />                             {/* your brand header, in-flow inside this fixed block */}
     </div>
     <div style={{ paddingTop: offset }}>     {/* clears the chrome; shrinks when the banner is dismissed */}


### PR DESCRIPTION
## What

`WixManageBanner` gated on `import.meta.env.DEV`. That value reports **which build pipeline served the file**, not whether the app is published — so it is the wrong question for a "show this while building, hide it once live" banner.

Vibe hosts serve the preview pane from *either* a Vite dev server (`DEV === true`) or a prebuilt bundle (`DEV === false`), and swap between the two on their own. On Base44 the pane moves between `preview-sandbox--*` (dev server) and `preview--*` / `checkpoint--*` (prebuilt S3 bundle) on sandbox readiness, HMR websocket disconnect, tab visibility, and heartbeat reaping — none of which the app controls. Result: the banner blinked in and out of the same preview session.

## Change

The gate keeps `import.meta.env.DEV` and adds two indicators that the build pipeline cannot change. Any one is sufficient:

| indicator | covers |
|---|---|
| `PREVIEW_HOST` hostname test | Base44: `preview--`, `preview-sandbox--`, `checkpoint--` |
| injected `script[data-preview-inject]` | Base44 preview documents, whichever engine served them |
| `import.meta.env.DEV` | a local dev server — best effort on any other host (unchanged) |

An unrecognized host on a built bundle stays hidden, so the banner still cannot reach a published site. SSR-safe as before (the whole check is inside one `try`).

Behavior verified across every surface:

| surface | before | after |
|---|---|---|
| local dev server | banner | banner |
| sandbox preview (dev server) | banner | banner |
| static preview (prebuilt) | **hidden — the bug** | banner |
| checkpoint preview | **hidden** | banner |
| published `*.base44.app` | hidden | hidden |
| published custom domain | hidden | hidden |
| lookalike host (`previewer.myshop.com`) | hidden | hidden |
| SSR render | hidden | hidden |

The one intended behavior change: the banner now also shows on prebuilt previews, which is the point — the preview pane becomes consistent instead of engine-dependent.

## Docs

The nine verticals' `INSTRUCTIONS.md` plus both platform files described the component as "dev-only / never in production". Retermed to preview-only / never on the published site, so the docs match what the component now does. No new instructions for the agent.

No eval scenarios are required — `wix-vibe-headless` is outside the `wix-manage` / `wix-app` PR eval gate.