### PR TITLE
docs(wix-app): drop the stray blank line before the backend-event heading

### DIFF
--- a/skills/wix-app/references/BACKEND_EVENT.md
+++ b/skills/wix-app/references/BACKEND_EVENT.md
@@ -1,4 +1,3 @@
-
 # Wix CLI Backend Event Extension
 
 Event extensions run custom logic when something happens on a site — a contact is created, an order is placed, a booking is confirmed, a blog post is published. Each extension is built on a Wix JavaScript SDK webhook; the CLI subscribes your project to it.


### PR DESCRIPTION
A markdown file should not open with a blank line before its `# ` heading. `BACKEND_EVENT.md` did; `DASHBOARD_PAGE.md` has the same issue and is fixed separately.

## Why this PR exists

It is also the cheapest possible exercise of the change-impact gate that just landed. This path derives the `backend-event` tag, and **no scenario carries that tag** — so the coverage guard should block *before* any EvalForge write, meaning zero capability versions and zero eval runs.

Expected: a guard-violation comment naming the uncovered tag, and no run link. The gate is in its soak period (`WIX_APP_EVAL_BLOCK_MERGE=false`), so the check should stay green with a warning.

If the guard instead lets this through and starts two eval runs, that is a bug worth knowing about — the guard exists so a missing scenario costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)