### PR TITLE
docs(wix-app): drop the stray blank line before the dashboard-page heading

### DIFF
--- a/skills/wix-app/references/DASHBOARD_PAGE.md
+++ b/skills/wix-app/references/DASHBOARD_PAGE.md
@@ -1,4 +1,3 @@
-
 # Wix Dashboard Page Builder
 
 > **🛑 STOP — Read this first.**


### PR DESCRIPTION
Same one-line fix as #974, for `DASHBOARD_PAGE.md`.

## Why this PR exists

This is the first real exercise of the change-impact comparison. The path derives the `dashboard-page` tag, which both wix-app scenarios carry, so the gate should:

- create one PR capability version (`pr-<n>-<sha7>`) from the whole skill dir
- start **two** eval runs in one comparison group — `pr` pinning that version, `base` pinning nothing so EvalForge live-fetches `skills/wix-app@main`
- label each scenario and post an impact table

**Expected label: `still-failing`.** The `employee-shift-dashboard` scenario currently fails 3 of its 7 assertions, identically on both arms — verified directly against the API before this PR. A one-line markdown fix will not change that, so `still-failing` is the correct answer, not a regression this PR introduced. Anything else in the table is the interesting result.

The gate is in soak (`WIX_APP_EVAL_BLOCK_MERGE=false`), so the check should stay green with a warning even though the scenario is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)