### PR TITLE
fix(ci): stop the @wix/cli pin check flagging comments

### DIFF
--- a/.github/scripts/check-cli-pinned.sh
+++ b/.github/scripts/check-cli-pinned.sh
@@ -8,16 +8,51 @@
 # the @wix/cli surface grows.
 #
 # Run locally:   bash .github/scripts/check-cli-pinned.sh
+# Self-test:     bash .github/scripts/check-cli-pinned.sh --self-test
 # CI:            invoked by .github/workflows/check-cli-pinned.yml on PRs
 
 set -euo pipefail
 
 SUBCMDS="token|whoami|login|env|build|release|preview|dev"
 
-bare=$(grep -rnE "npx @wix/cli (${SUBCMDS})([[:space:]]|$)" \
-  --include='*.md' --include='*.sh' --include='*.mjs' --include='*.js' --include='*.ts' \
-  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
-  . 2>/dev/null || true)
+# The second grep drops matches sitting on a comment line in source files —
+# prose about the CLI, not a call. Markdown keeps every match: `#` opens a
+# heading there, and an unpinned command in docs is one a reader will copy.
+scan() {
+  grep -rnE "npx @wix/cli (${SUBCMDS})([[:space:]]|$)" \
+    --include='*.md' --include='*.sh' --include='*.mjs' --include='*.js' --include='*.ts' \
+    --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+    "$1" 2>/dev/null | grep -vE '\.(sh|mjs|js|ts):[0-9]+:[[:space:]]*(//|/\*|\*|#)' || true
+}
+
+# Guards both directions: that real invocations are still caught, and that
+# prose about the CLI is not. Without it, "still catches everything it used to"
+# is only ever checked by hand, once, by whoever last edited the matcher.
+if [[ "${1:-}" == "--self-test" ]]; then
+  dir=$(mktemp -d); trap 'rm -rf "$dir"' EXIT
+  # Built from $cli so this file never contains a literal match and cannot
+  # flag its own fixtures when the check scans the repo.
+  cli="npx @wix/cli"
+  printf 'Run `%s token --site x`\n'           "$cli" > "$dir/doc.md"
+  printf '%s login\n'                          "$cli" > "$dir/run.sh"
+  printf 'execSync("%s build --prod") // note\n' "$cli" > "$dir/call.js"
+  printf '// e.g. `%s token --site x`\n'       "$cli" > "$dir/line-comment.js"
+  printf ' * see `%s token --site x`\n'        "$cli" > "$dir/block-comment.js"
+  printf '# example: %s login\n'               "$cli" > "$dir/comment.sh"
+  printf 'run("%s@latest build --prod")\n'     "$cli" > "$dir/pinned.js"
+
+  found=$(scan "$dir"); rc=0
+  for f in doc.md run.sh call.js; do
+    grep -q "/$f:" <<<"$found" || { echo "FAIL: $f should be flagged" >&2; rc=1; }
+  done
+  for f in line-comment.js block-comment.js comment.sh pinned.js; do
+    grep -q "/$f:" <<<"$found" && { echo "FAIL: $f should be ignored" >&2; rc=1; }
+  done
+  [[ $rc -eq 0 ]] && echo "Self-test passed ✓"
+  exit $rc
+fi
+
+bare=$(scan .)
 
 if [[ -n "$bare" ]]; then
   echo "ERROR: unpinned 'npx @wix/cli <subcmd>' occurrences found." >&2

--- a/.github/workflows/check-cli-pinned.yml
+++ b/.github/workflows/check-cli-pinned.yml
@@ -16,4 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      # First: a green repo scan proves nothing if the matcher itself is broken.
+      - run: bash .github/scripts/check-cli-pinned.sh --self-test
       - run: bash .github/scripts/check-cli-pinned.sh


### PR DESCRIPTION
## The check is red on every PR, and has been since 2026-08-06

`Check @wix/cli pinned to @latest` fails on **every PR touching `skills/**`** — currently `igor-claw/site-import-no-support-dead-end`, `docs/dev3-site-import-source-url`, `forms-on-wix-headless` and `fix/events-draft-and-recurring`, none of which changed anything CLI-related.

The one offending line, added by #854 — `skills/wix-replatform/resources/rp-target-wix/lib/wix-writers.js:327`:

```js
// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli token --site …`)
```

Prose describing what a CLI token is, not a call. Pinning is meaningless for it, so the only way to satisfy the check was to edit a sentence into something it doesn't quite say. A check that fails on every PR for a reason no author can act on is one everybody learns to scroll past.

It went unnoticed because the workflow triggers only on `pull_request`, so it never runs on `main`.

## The fix — one pipe stage

```diff
-  . 2>/dev/null || true)
+  . 2>/dev/null | grep -vE '\.(sh|mjs|js|ts):[0-9]+:[[:space:]]*(//|/\*|\*|#)' || true)
```

Drops matches on comment lines in source files. It keys on the **file extension**, so Markdown keeps every match — `#` opens a heading there, and an unpinned command in docs is one a reader will copy. A comment *trailing* real code still counts, since that code runs.

## How we know it works, and that nothing broke

Nothing under `.github/scripts` had tests, so "it still catches what it used to" was only ever checked by hand by whoever last touched the pattern. This adds `--self-test`, which asserts **both directions** against fixtures in a temp directory:

| fixture | expected |
|---|---|
| unpinned in markdown prose | flagged |
| unpinned in `.sh` | flagged |
| unpinned in `.js` with a comment after it | flagged |
| `//` line comment | ignored |
| `*` block-comment body | ignored |
| `#` shell comment | ignored |
| already `@latest` | ignored |

CI runs it **before** the repo scan, because a green scan proves nothing if the matcher has stopped matching:

```yaml
- run: bash .github/scripts/check-cli-pinned.sh --self-test
- run: bash .github/scripts/check-cli-pinned.sh
```

Run it yourself with `bash .github/scripts/check-cli-pinned.sh --self-test`.

One wrinkle worth knowing: the fixtures are built from a `$cli` variable so this file never contains a literal match. Written the obvious way, the check flags its own test data.

## Not changed

`run("npx @wix/cli build")` is invisible to **both** the old and new versions — the pattern needs whitespace or end-of-line after the subcommand, and `"` is neither. Confirmed by running the pre-change script against the same input. A real pre-existing gap, left alone to keep this diff reviewable; the self-test would make it a one-line fix if you want it closed.