### PR TITLE
fix(wix-app-evals): close the mismatched quote in the shift-dashboard prompt

### DIFF
--- a/yaml/wix-app-evals/employee-shift-dashboard.yml
+++ b/yaml/wix-app-evals/employee-shift-dashboard.yml
@@ -3,7 +3,7 @@ description: Dashboard page for store owners to manage employee shifts with a ta
 triggerPrompt: |-
   Build a dashboard page that lets store owners manage employee shifts. The page should have a table where each row is a shift with these fields: employee name, date, and hours. The store owner must be able to add new shifts to the table.
   APP_NAMESPACE: "@mirivo/my-app31ceim", Use this namespace when creating data collections (for idSuffix scoping).
-  CODE_IDENTIFIER: "MirivoMyApp31ceim" When generating editor React component or function library extensions, use this identifier as the type prefix (e.g. type: 'MirivoMyApp31ceim"ComponentName').
+  CODE_IDENTIFIER: "MirivoMyApp31ceim" When generating editor React component or function library extensions, use this identifier as the type prefix (e.g. type: 'MirivoMyApp31ceimComponentName').
 templateId: 33f2cb85-054e-4281-b617-3bc21ac0803f
 tags: [dashboard-page, data-collection, auto-patterns-dashboard]
 assertions:


### PR DESCRIPTION
The `CODE_IDENTIFIER` example in `triggerPrompt` read:

```
type: 'MirivoMyApp31ceim"ComponentName'
```

A double quote inside a single-quoted string — so the example handed to the agent is not valid code.

## Why this PR exists

It also exercises a gate path the other verification PRs don't: this changes **only scenario YAML**, no skill file. The gate triggers through the scenario glob, and both arms then evaluate identical skill content, so the diff cannot move any measured behaviour.

It is also the first PR to exercise draft-sync with an actual scenario edit — the changed scenario should be pushed to EvalForge draft-tagged, and PR-close cleanup should restore it. Worth watching that the restore happens.

Expected: `still-failing` again (the scenario fails on both arms today, for reasons unrelated to a quote), and a `Runs per scenario` line absent since it stays at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)