### PR TITLE
fix: pin the @wix/cli example in the replatform auth comment

### DIFF
--- a/skills/wix-replatform/resources/rp-target-wix/lib/wix-writers.js
+++ b/skills/wix-replatform/resources/rp-target-wix/lib/wix-writers.js
@@ -324,7 +324,7 @@ function applySafeModeToRequestBody(body, safeModeOptions) {
 // media import, Contacts manage/schema, and Members manage.
 //
 // Auth scheme normalization: Wix API keys (`IST.…`) are sent RAW in the Authorization
-// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli token --site …`)
+// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli@latest token --site …`)
 // must be sent as `Bearer <token>`. Detect and prefix so both credential kinds work.
 function authHeaderValue(token) {
   const t = String(token).trim();


### PR DESCRIPTION
`Check @wix/cli pinned to @latest` has failed on **every PR touching `skills/**`** since #854 landed on 2026-08-06. One line causes it, and it is the only occurrence in the repo:

`skills/wix-replatform/resources/rp-target-wix/lib/wix-writers.js:327`

```diff
-// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli token --site …`)
+// header; OAuth access tokens (e.g. a Wix CLI token from `npx @wix/cli@latest token --site …`)
```

It is a comment rather than a call, so the check is strictly a false positive. But `@latest` is the form this comment should be showing anyway — so pinning it makes the comment *more* accurate, not less. The check then passes with no change to how it works.

It went unnoticed because the workflow triggers only on `pull_request`, so it never runs on `main`.

## Why not teach the check to skip comments

I tried that first (#976, now closed). It is worse:

`*` and `#` open a comment in some places and are real code in others — a JS generator method (`*gen() { … }`), a TS private field (`#cmd = …`). A regex cannot tell them apart, so the filter silently stopped catching real violations in `.js` and `.ts`. Doing it properly needs per-language parsing, which is far more machinery than this rule is worth, and a check that misses things is worse than one that is noisy: you notice noise.

## Verified

`bash .github/scripts/check-cli-pinned.sh` → `All npx @wix/cli invocations are pinned to @latest ✓`