### PR TITLE
fix(wix-vibe-headless): deploy writes wix-config.js and proves the client id

### DIFF
--- a/skills/wix-vibe-headless/SKILL.md
+++ b/skills/wix-vibe-headless/SKILL.md
@@ -149,7 +149,8 @@ installed, not what the business is about. Never default to store/bookings on si
    `INSTRUCTIONS.md`.
 3. **Ensure the vertical's files are in place** — copy `references/<vertical>/app/` and
    `references/shared/app/` into the app's `src/`, and set `WIX_CLIENT_ID` in `wix-config.js`. (Where
-   and how they get there is your platform's call — see its instructions.)
+   and how they get there is your platform's call — see its instructions. On base44 the install step
+   writes and verifies `wix-config.js` for you, so there's nothing to set by hand.)
 4. **Wire the shipped client** following the vertical's INSTRUCTIONS: the components are themed by
    base44's design tokens (`src/index.css` — shadcn palette, already set by the design phase), so
    there's no re-skin step; just wire routes + header/footer through the Layout. The UI ships as

--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -1,6 +1,9 @@
 // Post-install deploy — run by base44.md STEP 1 with the vertical(s) the app needs:
-//   node deploy.cjs <vertical> [<vertical> …]
+//   node deploy.cjs <vertical> [<vertical> …] --client-id <id> --metasite-id <id>
 //   (storefront | bookings | blog | cms | portfolio | pricing-plans | events | members)
+// Pass the two ids from the prompt and this writes src/rest/wix-config.js for you, then proves the
+// client id against Wix before the build continues — see WRITE + VERIFY below. Retyping those ids
+// into the file by hand is how a storefront ships with a dead client id.
 // ONE mechanism: recursively copy `app/` -> /app/src. The shared transport (app/rest/wix-client.js,
 // wix-config.js) is copied always; then each named vertical's app/ (its UI + app/rest/ helpers).
 // Deploy every vertical the app actually uses, in one call or across several — an app that needs both
@@ -13,9 +16,11 @@
 // No vertical arg -> deploys just the shared transport; re-run with the vertical(s) once known.
 // NOTE: .cjs on purpose — the app is an ESM package ("type":"module"); a .js here would load as ESM
 // and require()/module.exports would throw.
-const { existsSync, cpSync, readFileSync } = require('fs');
+const { existsSync, cpSync, readFileSync, writeFileSync } = require('fs');
 
 const REF = '/app/.agents/skills/wix-vibe-headless/references';
+const WIX_CONFIG = '/app/src/rest/wix-config.js';
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VERTICALS = ['storefront', 'bookings', 'blog', 'cms', 'portfolio', 'pricing-plans', 'events', 'members', 'restaurants'];
 
 // force:false + errorOnExist:false — fill in only files that AREN'T there yet; never overwrite.
@@ -66,11 +71,56 @@ function replaceMembersAuthLeftovers() {
   return result;
 }
 
+// --- WRITE + VERIFY the credentials -------------------------------------------------------------
+//
+// The two ids arrive as flags so this script writes them once, character-for-character, instead of a
+// later hand-edit of the placeholder file. Then the client id is proved against Wix: a wrong id is
+// invisible until a page tries to load data, and by then the build reads as finished.
+//
+// The check is the same anonymous-token mint wix-client.js does at runtime, so a pass here means the
+// browser client will authenticate. A 400/401 means the id itself is rejected — that is never
+// "pending Wix-side setup", it is a wrong value, and it fails the install loudly on the spot.
+// A network fault is reported but not fatal: an unreachable Wix must not block a build.
+function writeWixConfig(clientId, metaSiteId) {
+  const body = [
+    '// Wix credentials — written by the skill\'s deploy step from the ids in your prompt.',
+    '// Safe to commit: WIX_CLIENT_ID is a public, buyer-facing id (it only mints anonymous visitor',
+    '// tokens); WIX_METASITE_ID just identifies the site.',
+    `export const WIX_CLIENT_ID = "${clientId}";`,
+    `export const WIX_METASITE_ID = "${metaSiteId}";`,
+    '',
+  ].join('\n');
+  writeFileSync(WIX_CONFIG, body);
+}
+
+async function verifyClientId(clientId) {
+  try {
+    const res = await fetch('https://www.wixapis.com/oauth2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId, grantType: 'anonymous' }),
+    });
+    if (res.ok) return { ok: true };
+    return { ok: false, status: res.status, body: (await res.text()).slice(0, 200) };
+  } catch (e) {
+    return { unreachable: true, message: String(e && e.message).slice(0, 200) };
+  }
+}
+
 // --- main ---------------------------------------------------------------------------------------
 
 // Accept one or many: `deploy.cjs members cms`. Duplicates collapse; order is preserved so the
 // first vertical listed wins any same-path file (the copy never overwrites).
-const requested = [...new Set(process.argv.slice(2))];
+const argv = process.argv.slice(2);
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i !== -1 && argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : null;
+};
+const clientId = flag('client-id');
+const metaSiteId = flag('metasite-id');
+// Verticals are the positional args — drop the flags and their values.
+const flagArgs = new Set(['--client-id', '--metasite-id', clientId, metaSiteId].filter(Boolean));
+const requested = [...new Set(argv.filter((a) => !flagArgs.has(a)))];
 const deployed = { verticals: [] };
 
 // Shared transport — always (app/rest/wix-client.js, wix-config.js -> src/rest/).
@@ -92,4 +142,40 @@ if (!requested.length) {
   deployed.note = 'no vertical given — deployed the shared transport only; re-run: node deploy.cjs <vertical> [<vertical> …]';
 }
 
-console.log(JSON.stringify(deployed));
+(async () => {
+  if (clientId && metaSiteId) {
+    const badShape = [
+      !UUID.test(clientId) && `--client-id "${clientId}" is not a uuid`,
+      !UUID.test(metaSiteId) && `--metasite-id "${metaSiteId}" is not a uuid`,
+    ].filter(Boolean);
+    if (badShape.length) {
+      deployed.wixConfig = { written: false, error: badShape.join('; ') };
+    } else {
+      writeWixConfig(clientId, metaSiteId);
+      const check = await verifyClientId(clientId);
+      if (check.ok) {
+        deployed.wixConfig = { written: true, clientIdVerified: true };
+      } else if (check.unreachable) {
+        deployed.wixConfig = { written: true, clientIdVerified: false, warning: `could not reach Wix to verify (${check.message})` };
+      } else {
+        // Wix rejected the id itself. Name the value written so the fix is a re-read of the
+        // prompt, not another guess — and fail the step so the build can't continue on it.
+        deployed.wixConfig = {
+          written: true,
+          clientIdVerified: false,
+          error: `Wix rejected WIX_CLIENT_ID "${clientId}" (${check.status}). This is a wrong id, not pending Wix setup. `
+            + 'Re-read the client id from the user\'s prompt and re-run this command with it.',
+        };
+      }
+    }
+  } else {
+    deployed.wixConfig = {
+      written: false,
+      note: 'no --client-id/--metasite-id given — src/rest/wix-config.js still holds placeholders; '
+        + 're-run with both ids rather than editing the file by hand',
+    };
+  }
+
+  console.log(JSON.stringify(deployed));
+  if (deployed.wixConfig && deployed.wixConfig.error) process.exitCode = 1;
+})();

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -19,8 +19,9 @@ Install two skills — they land under `.agents/skills/`:
   doesn't cover.
 
 Install via the skills CLI — run this through exec_tool, exactly as written. It installs the two
-skills, then runs `deploy.cjs <vertical…>` (lays the shared transport + **each** listed vertical's
-REST scaffolds and UI client into `src/`) and `pin-agents-md.cjs` (pins the project's AGENTS.md
+skills, then runs `deploy.cjs <vertical…> --client-id … --metasite-id …` (lays the shared transport +
+**each** listed vertical's REST scaffolds and UI client into `src/`, writes `wix-config.js` from
+those two ids and proves the client id against Wix) and `pin-agents-md.cjs` (pins the project's AGENTS.md
 note so later turns keep the rules).
 
 **Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
@@ -48,6 +49,10 @@ const { execSync } = require('child_process');
 const { readdirSync } = require('fs');
 const VERTICALS = ['storefront'];        // ← set from the prompt; list every vertical the app uses
 // const VERTICALS = ['members', 'cms']; // ← e.g. visitors sign in AND the app stores what they submit
+// COPY these two straight from the prompt — deploy writes them into src/rest/wix-config.js and proves
+// the client id against Wix, so never retype either one into a file by hand afterwards.
+const WIX_CLIENT_ID = '<client id from the prompt>';
+const WIX_METASITE_ID = '<site id from the prompt>';
 const results = {};
 for (const skill of ['wix-vibe-headless', 'wix-docs']) {
   try {
@@ -57,8 +62,9 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
       : out.includes('No valid skills') ? 'not_found' : 'unknown';
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-// Deploy the shared transport + each listed vertical's scaffolds/UI into src/.
-const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')}`, { cwd: '/app' }).toString();
+// Deploy the shared transport + each listed vertical's scaffolds/UI into src/, and write+verify
+// wix-config.js. A rejected client id exits non-zero here — fix the id, don't carry on.
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')} --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
 // Pin the project's AGENTS.md note (idempotent) so the rules survive after this doc leaves context.
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
@@ -96,9 +102,8 @@ fails or shows nothing relevant, ask the user what they offer.
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — the single source of
 truth for how the client is built.
 
-**REST scaffolds are already in `src/rest/`** (STEP 1). Write `src/rest/wix-config.js` with your
-`WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the one place both ids live (a single write,
-nothing to read). Some
+**REST scaffolds are already in `src/rest/`** (STEP 1), `wix-config.js` among them — STEP 1 wrote both
+ids into it and proved the client id, so there is nothing to write or re-check here. Some
 verticals also ship a **ready UI client** under `src/` (STEP 1 deployed it) — theme + wire it per
 `INSTRUCTIONS.md`, don't rebuild. STEP 1 already deployed these files — **don't `read_file` the
 deployed component/page source to inspect them**; every field shape is in `INSTRUCTIONS.md`. Read a

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -40,8 +40,13 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/blog/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens in

--- a/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/blog/INSTRUCTIONS.md
@@ -25,11 +25,11 @@ don't need to open them:**
 | `hooks/usePostDetail.js` | post-detail data — load by slug, not-found state, resolved category/tag chips, body paragraphs |
 | `components/PostCard.jsx`, `PostGrid.jsx` | post listing UI (grid + card, with cover image + empty state) |
 | `components/PostChips.jsx` | category/tag chips for a post (resolves ids via the taxonomy, routes by slug) |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Blog.jsx` | the feed route (`/blog`) — lists posts, paginates, empty state |
 | `pages/PostDetail.jsx` | the post route (`/blog/:slug`) |
 | `pages/CategoryPage.jsx`, `TagPage.jsx` | the taxonomy landing routes (`/blog/category/:slug`, `/blog/tag/:slug`) |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` + `rest/wix-blog.js` | REST transport + blog helpers (posts/categories/tags) |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
@@ -39,16 +39,8 @@ real fallback — a runtime error, or a field the snippets don't cover (see "Fal
 end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/blog/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens in
 `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
 `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
@@ -56,10 +48,10 @@ The shipped components carry **no palette of their own** — they render from ba
 are **already set to the brand by the design phase**, so the shipped pages are themed with zero work
 here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way; **never add
 a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the Home/Header you add
-(STEP 4) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
+(STEP 3) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
 base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it.
@@ -125,7 +117,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
-(STEP 4) so they wrap every route — plus the overall brand story, styled with the same base44
+(STEP 3) so they wrap every route — plus the overall brand story, styled with the same base44
 tokens/classes. **Compose the shipped pieces** — a "latest posts" strip is just `queryPosts` + the shipped
 `PostGrid`; a category nav is `useTaxonomy()` + links to `/blog/category/:slug`:
 
@@ -217,9 +209,8 @@ Fallback only — when you hit an error or need something not shown here: read t
 under `src/`, or look it up via the **`wix-docs`** skill.
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Blog`/`PostDetail`/category/tag pages to add chrome.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Blog`/`PostDetail`/category/tag pages to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Route by `slug` through the shipped helpers — never hand-build a post/category/tag URL. Display categories/tags by `.label` (not `.name`).
 - Render live Wix data or the shipped empty state — never mock posts, authors, comments, likes, or view counts; never use a stock/placeholder cover image.

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -51,8 +51,13 @@ the end). (Files missing? the install's `deploy` result lists what it wrote; re-
 `references/bookings/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens

--- a/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/bookings/INSTRUCTIONS.md
@@ -36,9 +36,9 @@ so you don't need to open them:**
 | `components/ServiceCard.jsx`, `ServiceGrid.jsx` | service listing UI (grid + card, with empty state); the card shows price, tagline and a `60 min · 1-to-1` meta row |
 | `components/SlotPicker.jsx` | bookable-slot chips + paging (pure UI, driven by `useServiceDetail`) |
 | `components/BookingForm.jsx` | contact + participant form (pure UI, driven by `useServiceDetail`) |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Services.jsx`, `pages/ServiceDetail.jsx` | the two shipped routes (`/services`, `/service/:serviceId`); the detail page is two-column — service + a duration/price/where strip on the left, the sticky booking panel on the right |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` | REST transport — mints/persists the anonymous visitor token |
 | `rest/wix-bookings-services.js` | services + availability: `queryServices`, `queryServicesByCategory`, `categoriesOf`, `getService`, `countServices`, `listSlotsForService`, `listAvailableSlots`, `listEventTimeSlots`, `getAvailableSlot`, `mediaUrl` |
 | `rest/wix-bookings-checkout.js` | booking + checkout: `createBooking`, `checkoutBooking`, `bookAndCheckout` |
@@ -50,16 +50,8 @@ on a real fallback — a runtime error, or a field the snippets don't cover (see
 the end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/bookings/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens
 in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`,
 `--muted`, `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`,
@@ -67,10 +59,10 @@ in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `
 `font-display`). Those tokens are **already set to the brand by the design phase**, so the shipped
 pages are themed with zero work here. To adjust the palette, edit `index.css` (`:root` **and**
 `.dark`) — the base44 way; **never add a parallel theme file (e.g. a `theme.css`) or restyle the
-shipped JSX.** Build the Home/Header you add (STEP 4) from the **same** base44 tokens/classes so it
+shipped JSX.** Build the Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it
 matches automatically. A dark brand is just base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it. Bookings needs **no cross-page provider** (there's no cart — each booking completes on
@@ -128,7 +120,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the
-`Layout` (STEP 4) so they wrap every route — plus the overall brand story, styled with the same
+`Layout` (STEP 3) so they wrap every route — plus the overall brand story, styled with the same
 base44 tokens/classes. **Compose the shipped pieces** — a "featured services" strip is just
 `queryServices` + the shipped `ServiceGrid`; the nav is a link to `/services`:
 
@@ -232,9 +224,8 @@ the areas they sit in:
 - Headless redirect session (hosted checkout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped
   `Services`/`ServiceDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
   `Header` is plain in-flow markup (not `position:fixed`).

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -13,7 +13,7 @@ using the official Wix Data endpoints — never hand-build a Wix Data URL, never
 | `rest/wix-cms.js` | Wix Data helpers over the official endpoints: `queryDataItems`, `getDataItem`, `getDataItemBy`, `countDataItems`, `insertDataItem`, `updateDataItem`, `removeDataItem`. |
 | `lib/wixImage.js` | `wixImage(uri)` — converts a `wix:image://…` media field into a renderable URL (passes `https://` / `//` through). |
 | `collection.config.js` | Optional one-file mapping: `COLLECTION_ID` (your collection's **name**, not a GUID) + `FIELDS` (map `title`/`image`/`summary`/`body`/`date`/`slug` to your field keys). Keeps field mapping in one place; skip it and pass field keys inline if you prefer. |
-| `wix-config.js` *(shared)* | Set `WIX_CLIENT_ID` + `WIX_METASITE_ID` here (the one place both ids live). |
+| `wix-config.js` *(shared)* | the two ids, written by the install step. |
 | `WixManageBanner` *(shared)* | Dev-only manage banner — mount it in your Layout (see the platform doc's "Done" step). |
 
 ## Prerequisites
@@ -131,7 +131,6 @@ Validate the mime type and the size there as well.
 - Import File: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/import-file.md
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (in `wix-config`) — not the placeholder.
 - Read/write **only** through the `wix-cms.js` helpers (official Wix Data endpoints) — never hand-build a URL.
 - `queryDataItems` → `{ items, nextCursor }` (destructure, iterate `.items`); `sort` is `[{ fieldName, order }]`; date comparands wrap as `{ "$date": ISO }`.
 - Read date fields through the wrapper — `new Date(v?.$date ?? v)`. Dates arrive as `{ "$date": ISO }` (including `_createdDate` / `_updatedDate`), and `new Date(object)` puts the text "Invalid Date" on the page. See RETRIEVAL SHAPES in `rest/wix-cms.js` for the field types that need a converter.

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -32,9 +32,9 @@ don't need to open them:**
 | `components/EventRegistration.jsx` | branches on `registration.type` (RSVP / TICKETING / EXTERNAL / NONE) |
 | `components/RsvpForm.jsx` | RSVP form UI over `useRsvpForm` |
 | `components/TicketPicker.jsx` | ticket list + quantity + checkout UI over `useTicketing` |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Events.jsx`, `pages/EventDetail.jsx` | the two shipped routes (`/events`, `/events/:slug`) |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` | visitor-token mint/refresh + REST transport (reads `wix-config.js`) |
 | `rest/wix-events-browse.js` | browse/discovery helpers (`queryEvents`, `getEventBySlug`, categories, count) |
 | `rest/wix-events-registration.js` | RSVP + ticketing helpers (`createRsvp`, `reserveTickets`, `getTicketCheckoutUrl`, `checkoutTickets`) |
@@ -46,19 +46,8 @@ real fallback — a runtime error, or a field the snippets don't cover (see "Fal
 end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/events/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-The visitor refresh token minted from this id is persisted to localStorage and **is** the identity
-of the visitor's ticket reservation — don't re-mint anonymously per load.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens in
 `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
 `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
@@ -66,10 +55,10 @@ The shipped components carry **no palette of their own** — they render from ba
 are **already set to the brand by the design phase**, so the shipped pages are themed with zero work
 here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way; **never add
 a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the Home/Header you add
-(STEP 4) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
+(STEP 3) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
 base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it. (Events needs no cross-page provider — there's no cart; the RSVP/ticketing state is local
@@ -127,7 +116,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
-(STEP 4) so they wrap every route — plus the overall brand story, styled with the same base44
+(STEP 3) so they wrap every route — plus the overall brand story, styled with the same base44
 tokens/classes. **Compose the shipped pieces** — a "featured events" strip is just `queryEvents` + the
 shipped `EventGrid`; the nav is a link to `/events`:
 
@@ -220,9 +209,8 @@ Fallback only — when you hit an error or need something not shown here: read t
 under `src/`, or look it up via the **`wix-docs`** skill.
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Events`/`EventDetail` to add chrome.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Events`/`EventDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Paid ticket checkout goes through the shipped reserve → `getTicketCheckoutUrl` redirect (the Wix-hosted ticket form) — never a hand-built registration/ticket/payment URL.
 - Render live Wix data or the shipped empty/closed/not-found state — never mock events, tickets, guest counts, or "X spots left".

--- a/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/events/INSTRUCTIONS.md
@@ -47,9 +47,16 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/events/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live. The visitor refresh token minted from this id is persisted to localStorage
-and **is** the identity of the visitor's ticket reservation — don't re-mint anonymously per load.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
+
+The visitor refresh token minted from this id is persisted to localStorage and **is** the identity
+of the visitor's ticket reservation — don't re-mint anonymously per load.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens in

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -52,10 +52,10 @@ so you don't need to open them:**
 | `components/SocialButtons.jsx` | "Continue with Google/Facebook" buttons (kick off the redirect) |
 | `components/MemberMenu.jsx` | header account control — "Log in" vs. member name + log-out (like a cart button) |
 | `components/RequireAuth.jsx` | route gate: renders children for a member, else redirects to `/login` |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Login.jsx`, `pages/Account.jsx` | the shipped login + account routes (`/login`, `/account`) |
 | `pages/Callback.jsx` | social/SSO return route — mount at **exactly** `/callback` |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` + `rest/wix-members-auth.js` | REST transport + the auth helper (copy verbatim) |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
@@ -71,16 +71,8 @@ fallback — a runtime error, or a field the snippets don't cover (see "Fallback
 > *calling* the exports, never by editing them. Its full JSDoc (state machine, `profile`, errors) is at
 > the top of the file — read that, not the whole body, if you need the contract.
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens
 in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
 `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
@@ -88,10 +80,10 @@ in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `
 are **already set to the brand by the design phase**, so the shipped auth surfaces are themed with
 zero work here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way;
 **never add a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the
-Home/Header you add (STEP 4) from the **same** base44 tokens/classes so it matches automatically. A
+Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it matches automatically. A
 dark brand is just base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`, the **Base44 builder
 account**) — edit it in, don't replace it. The Wix member session is separate and ships under its own
@@ -157,7 +149,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** (mount `<MemberMenu/>` in it) and a **`Footer`** — the
-two you drop into the `Layout` (STEP 4) so they wrap every route — plus the overall brand story,
+two you drop into the `Layout` (STEP 3) so they wrap every route — plus the overall brand story,
 styled from the same base44 tokens/classes. The nav's account control is a `<MemberMenu/>` (shows
 "Log in" for a visitor, the member's name + log-out once signed in — render it as-is, don't wrap it in
 your own auth text button):
@@ -265,13 +257,12 @@ connection ids, a profile field these snippets don't have): read the relevant sh
 `src/rest/`, or look it up via the **`wix-docs`** skill.
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
 - **Custom login only** — the member logs in on **your** UI; never redirect them to a Wix-hosted login page.
 - **One shared client** — login swaps the token set on `wix-client.js`; reuse it for everything so the
   member identity carries across the app. Never mint a second client or re-mint anonymously after login.
 - Copy `wix-members-auth.js` verbatim; extend by *calling* its exports, never by editing them.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Login`/`Account`/`Callback` to add chrome; the fixed top region owns positioning (`<WixManageBanner/>` above a plain in-flow `<Header/>`).
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Login`/`Account`/`Callback` to add chrome; the fixed top region owns positioning (`<WixManageBanner/>` above a plain in-flow `<Header/>`).
 - **Never fake a member** — no mock logged-in state, invented profile, or roles. Render the real member or the real logged-out state.
 - **Fail loudly** — the helper throws `MemberAuthError`; surface `.message`, don't swallow it.
 - No `elevate` / admin scope, and no headless MFA/TOTP — those security layers are dashboard-governed.

--- a/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/members/INSTRUCTIONS.md
@@ -72,8 +72,13 @@ fallback — a runtime error, or a field the snippets don't cover (see "Fallback
 > the top of the file — read that, not the whole body, if you need the contract.
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -33,11 +33,11 @@ so you don't need to open them:**
 | `components/CollectionCard.jsx`, `CollectionGrid.jsx` | collections listing UI (grid + card, with empty state) |
 | `components/ProjectCard.jsx`, `ProjectGrid.jsx` | projects listing UI (grid + card, with empty state) |
 | `components/ProjectMedia.jsx` | one gallery item — branches on `item.type` (IMAGE / VIDEO) |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Portfolio.jsx` | collections gallery route (`/portfolio`) |
 | `pages/CollectionPage.jsx` | collection page route (`/collection/:slug`) |
 | `pages/ProjectDetail.jsx` | project detail route (`/project/:slug`) |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` + `rest/wix-portfolio.js` | REST transport + portfolio read helpers |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
@@ -47,16 +47,8 @@ a real fallback — a runtime error, or a field the snippets don't cover (see "F
 end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/portfolio/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens in
 `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`, `--muted`,
 `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`, `text-foreground`,
@@ -64,10 +56,10 @@ The shipped components carry **no palette of their own** — they render from ba
 are **already set to the brand by the design phase**, so the shipped pages are themed with zero work
 here. To adjust the palette, edit `index.css` (`:root` **and** `.dark`) — the base44 way; **never add
 a parallel theme file (e.g. a `theme.css`) or restyle the shipped JSX.** Build the Home/Header you add
-(STEP 4) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
+(STEP 3) from the **same** base44 tokens/classes so it matches automatically. A dark brand is just
 base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it. Portfolio is read-only with no cross-page state, so there's **no provider to wrap** (no
@@ -127,7 +119,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the `Layout`
-(STEP 4) so they wrap every route — plus the overall brand story, styled with the same base44
+(STEP 3) so they wrap every route — plus the overall brand story, styled with the same base44
 tokens/classes. **Compose the shipped pieces** — a featured strip is just `queryCollections` (or
 `queryProjects`) + the shipped `CollectionGrid` / `ProjectGrid`; the nav is a link to `/portfolio`:
 
@@ -209,9 +201,8 @@ links its own reference page inline; the whole area is here:
 - Portfolio (collections, projects, project items): https://dev.wix.com/docs/api-reference/business-solutions/portfolio.md
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped
   `Portfolio`/`CollectionPage`/`ProjectDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
   `Header` is plain in-flow markup (not `position:fixed`).

--- a/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/portfolio/INSTRUCTIONS.md
@@ -48,8 +48,13 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/portfolio/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens in

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -51,8 +51,13 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/pricing-plans/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens

--- a/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/INSTRUCTIONS.md
@@ -36,11 +36,11 @@ map, so you don't need to open them:**
 | `components/PlanCard.jsx` | plan card — name, description, price, perks, Subscribe (when `buyable`) |
 | `components/PlanGrid.jsx` | responsive plans grid + empty state |
 | `components/OrderCard.jsx` | one member order row for the "my plans" list |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Plans.jsx` | the plans-table route (`/plans`) — grid + paging + checkout |
 | `pages/PlanDetail.jsx` | the plan-detail route (`/plans/:slug`) — perks, terms, checkout |
 | `pages/MyPlans.jsx` | the member's memberships + post-checkout confirmation (`/my-plans`) |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` + `rest/wix-pricing-plans.js` | REST transport + plans/orders/checkout helpers |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
@@ -50,16 +50,8 @@ a real fallback — a runtime error, or a field the snippets don't cover (see "F
 end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/pricing-plans/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens
 in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`,
 `--muted`, `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`,
@@ -67,10 +59,10 @@ in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `
 `font-display`). Those tokens are **already set to the brand by the design phase**, so the shipped
 pages are themed with zero work here. To adjust the palette, edit `index.css` (`:root` **and**
 `.dark`) — the base44 way; **never add a parallel theme file (e.g. a `theme.css`) or restyle the
-shipped JSX.** Build the Home/Header you add (STEP 4) from the **same** base44 tokens/classes so it
+shipped JSX.** Build the Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it
 matches automatically. A dark brand is just base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it. Pricing Plans needs **no** cross-page provider (checkout is a redirect, not client
@@ -130,7 +122,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** and a **`Footer`** — the two you drop into the
-`Layout` (STEP 4) so they wrap every route — plus the overall brand story, styled with the same
+`Layout` (STEP 3) so they wrap every route — plus the overall brand story, styled with the same
 base44 tokens/classes. **Compose the shipped pieces** — a "featured plans" strip is just `queryPlans` +
 the shipped `PlanGrid`; the nav is links to `/plans` and `/my-plans`:
 
@@ -219,9 +211,8 @@ Fallback only — when you hit an error or need something not shown here: read t
 file under `src/`, or look it up via the **`wix-docs`** skill.
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped
   `Plans`/`PlanDetail`/`MyPlans` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your
   `Header` is plain in-flow markup (not `position:fixed`).

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -35,9 +35,9 @@ so you don't need to open them:**
 | `components/ItemDialog.jsx` | dish detail modal — description, price/variants, modifier groups (display), quantity, add-to-order |
 | `components/OrderCartButton.jsx` | header order **icon** button with a live-count badge |
 | `components/OrderCartDrawer.jsx` | slide-over order cart (mount once; opens from `useOrderCart`) |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Menu.jsx`, `pages/Reservations.jsx` | the two shipped routes (`/menu`, `/reservations`) |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` | REST transport + visitor-token mint/refresh (the refresh token IS the cart identity) |
 | `rest/wix-restaurants-menu.js` | menu read helpers — `getFullMenu` (the assembled tree; start here) + raw `list*` |
 | `rest/wix-restaurants-ordering.js` | ordering — operations, add/update/remove, `checkout` |
@@ -50,16 +50,8 @@ real fallback — a runtime error, or a field the snippets don't cover (see "Fal
 end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/restaurants/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components (menu, item dialog, order cart, reservations) carry **no palette of their
 own** — they render from base44's design tokens in `src/index.css` (`:root`/`.dark`: `--background`,
 `--foreground`, `--card`, `--primary`, `--muted`, `--border`, `--radius`, `--font-*`) via shadcn
@@ -67,11 +59,11 @@ Tailwind classes (`bg-card`, `text-foreground`, `bg-primary`, `text-muted-foregr
 `border-border`, `rounded-lg`, `font-display`). Those tokens are **already set to the brand by the
 design phase**, so the shipped pages are themed with zero work here. To adjust the palette, edit
 `index.css` (`:root` **and** `.dark`) — the base44 way; **never add a parallel theme file (e.g. a
-`theme.css`) or restyle the shipped JSX.** Build the Home/Header you add (STEP 4) from the **same**
+`theme.css`) or restyle the shipped JSX.** Build the Home/Header you add (STEP 3) from the **same**
 base44 tokens/classes so it matches automatically. A dark brand is just base44's dark palette in
 `index.css` — no per-component work.
 
-## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it.
@@ -134,7 +126,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** (mount `<OrderCartButton/>` in it) and a **`Footer`** —
-the two you drop into the `Layout` (STEP 4) so they wrap every route — plus the overall brand story,
+the two you drop into the `Layout` (STEP 3) so they wrap every route — plus the overall brand story,
 styled with the same base44 tokens/classes. The nav is an `<OrderCartButton/>` (a clean order-**icon**
 button with a live-count badge — render it as-is, don't wrap it in your own text button) + links to
 `/menu` and `/reservations`:
@@ -234,9 +226,8 @@ Fallback only — when you hit an error or need something not shown here: read t
 file under `src/`, or look it up via the **`wix-docs`** skill.
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Menu`/`Reservations` to add chrome.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Menu`/`Reservations` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Order through the shipped cart: `addItem()` → `checkout()` (redirect-session) — never a hand-built `/checkout`, ordering, or reservation URL.
 - Reservations: offer only `AVAILABLE` slots; pass the hold's `revision` into reserve; `firstName` + `phone` (E.164) are mandatory.

--- a/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/restaurants/INSTRUCTIONS.md
@@ -51,8 +51,13 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/restaurants/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components (menu, item dialog, order cart, reservations) carry **no palette of their

--- a/skills/wix-vibe-headless/references/shared/app/components/WixManageBanner.jsx
+++ b/skills/wix-vibe-headless/references/shared/app/components/WixManageBanner.jsx
@@ -1,7 +1,7 @@
 // Preview-only banner linking the running app to its Wix Business Manager (the back office).
 // Renders while the app is previewed or run locally, never on the published site, and is
 // dismissible (persisted per site).
-// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 4) —
+// Mount it at the top of your Layout's fixed region, ABOVE <Header/> (see INSTRUCTIONS STEP 3) —
 // banner + header ride together as one fixed block, so nothing drifts or gaps on scroll.
 import { useState } from "react";
 import { WIX_METASITE_ID } from "@/rest/wix-config";

--- a/skills/wix-vibe-headless/references/shared/app/rest/wix-config.js
+++ b/skills/wix-vibe-headless/references/shared/app/rest/wix-config.js
@@ -1,6 +1,8 @@
-// Wix credentials — the ONLY file you set these in. Paste both values from your prompt,
-// replacing the placeholders. Safe to commit: WIX_CLIENT_ID is a public, buyer-facing id
-// (it only mints anonymous visitor tokens); WIX_METASITE_ID just identifies the site.
+// Wix credentials. The install step writes this file: deploy.cjs --client-id … --metasite-id …
+// If you're seeing the placeholders below, re-run that command with the ids from the prompt rather
+// than typing them in here — it also checks the client id actually mints a visitor token.
+// Safe to commit: WIX_CLIENT_ID is a public, buyer-facing id (it only mints anonymous visitor
+// tokens); WIX_METASITE_ID just identifies the site.
 // wix-client.js and wix-manage-banner.js read their ids from here.
 export const WIX_CLIENT_ID = "<YOUR-CLIENT-ID>";
 export const WIX_METASITE_ID = "<YOUR-METASITE-ID>";

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -30,9 +30,9 @@ so you don't need to open them:**
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
 | `components/VariantPicker.jsx` | option/variant selector used on the PDP — colour options render as real swatches, and picking one moves the gallery to that colour's photo |
-| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 4) |
+| `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
-| `rest/wix-config.js` | **you set the ids here** (STEP 2) |
+| `rest/wix-config.js` | the two ids, written by the install step |
 | `rest/wix-client.js` + `rest/wix-store-*.js` | REST transport + catalog/cart helpers |
 
 They're already in place — go **straight to theming + wiring**, nothing to verify first. **Don't
@@ -42,16 +42,8 @@ real fallback — a runtime error, or a field the snippets don't cover (see "Fal
 end). (Files missing? the install's `deploy` result lists what it wrote; re-run install, or copy
 `references/storefront/app/` → `src/`.)
 
-## STEP 2 — Credentials
-`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
---metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
 
-If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
-rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
-install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
-re-read the id from the prompt and re-run.
-
-## STEP 3 — Theme (nothing to style on the shipped components)
+## STEP 2 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens
 in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `--primary`,
 `--muted`, `--border`, `--radius`, `--font-*`) via shadcn Tailwind classes (`bg-card`,
@@ -59,10 +51,10 @@ in `src/index.css` (`:root`/`.dark`: `--background`, `--foreground`, `--card`, `
 `font-display`). Those tokens are **already set to the brand by the design phase**, so the shipped
 pages are themed with zero work here. To adjust the palette, edit `index.css` (`:root` **and**
 `.dark`) — the base44 way; **never add a parallel theme file (e.g. a `theme.css`) or restyle the
-shipped JSX.** Build the Home/Header you add (STEP 4) from the **same** base44 tokens/classes so it
+shipped JSX.** Build the Home/Header you add (STEP 3) from the **same** base44 tokens/classes so it
 matches automatically. A dark brand is just base44's dark palette in `index.css` — no per-component work.
 
-## STEP 4 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
+## STEP 3 — Wire routes + provider (surgical `find_replace` on `src/App.jsx`, never a rewrite)
 **No file reads needed to wire this.** Every shipped page and `WixManageBanner` is a default export that takes **no props** — wire them exactly as the snippet shows; nothing in those files needs looking up.
 `App.jsx` carries required platform auth scaffolding (`AuthProvider`/`useAuth`) — edit it in, don't
 replace it.
@@ -125,7 +117,7 @@ function Layout() {
 
 ## What you build (not shipped)
 The **home / landing page**, the **`Header`** (mount `<CartButton/>` in it) and a **`Footer`** — the
-two you drop into the `Layout` (STEP 4) so they wrap every route — plus the overall brand story,
+two you drop into the `Layout` (STEP 3) so they wrap every route — plus the overall brand story,
 styled from the same base44 tokens/classes. **Compose the shipped pieces** — a
 featured strip is just `queryProducts` + the shipped `ProductGrid`; the nav is a `<CartButton/>`
 (a clean cart-**icon** button with a live-count badge — render it as-is, don't wrap it in your own
@@ -248,9 +240,8 @@ reference page inline; these are the areas they sit in:
 - Headless redirect session (hosted checkout): https://dev.wix.com/docs/api-reference/business-management/headless/redirects.md
 
 ## Hard rules
-- Set `WIX_CLIENT_ID` (STEP 2) — not the placeholder.
 - Style via base44 design tokens (`index.css` / shadcn Tailwind classes), never by rewriting the shipped components or adding a parallel theme file.
-- Header/footer live in a `Layout` around `<Outlet/>` (STEP 4) — never edit the shipped `Shop`/`ProductDetail` to add chrome.
+- Header/footer live in a `Layout` around `<Outlet/>` (STEP 3) — never edit the shipped `Shop`/`ProductDetail` to add chrome.
 - The Layout's fixed top region owns positioning: `<WixManageBanner/>` above `<Header/>`; your `Header` is plain in-flow markup (not `position:fixed`).
 - Checkout goes through the shipped cart (redirect-session) — never a hand-built `/checkout` URL.
 - Render live Wix data or the shipped empty state — never mock products.

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -43,8 +43,13 @@ end). (Files missing? the install's `deploy` result lists what it wrote; re-run 
 `references/storefront/app/` → `src/`.)
 
 ## STEP 2 — Credentials
-Write `src/rest/wix-config.js` with your `WIX_CLIENT_ID` and `WIX_METASITE_ID` from the prompt — the
-one place both ids live.
+`src/rest/wix-config.js` was already written by the install step (`deploy.cjs --client-id …
+--metasite-id …`), which also proved the client id mints a visitor token. Nothing to do here.
+
+If it still holds `<YOUR-CLIENT-ID>` placeholders, re-run that command with both ids from the prompt
+rather than editing the file — retyping a uuid is how a build ships with a dead client id. And if the
+install reported `Wix rejected WIX_CLIENT_ID`, that is a wrong value, not pending Wix-side setup:
+re-read the id from the prompt and re-run.
 
 ## STEP 3 — Theme (nothing to style on the shipped components)
 The shipped components carry **no palette of their own** — they render from base44's design tokens


### PR DESCRIPTION
## The bug this closes

A real build (`Cozy Knit Shop`) shipped a storefront that couldn't load a single product. Cause was one line:

```js
// what the agent wrote                         // what the user gave
WIX_CLIENT_ID   = "15396729-ec3a-4d99-bd82-d6b53cba83c4"   // …-b9ec-4b568ddb2289
WIX_METASITE_ID = "a29c0dd1-1c1a-4da5-bd82-d6b53cba83c4"
```

The client id's **last two groups are the site id's**. The two values sat on adjacent lines of the prompt, and it was writing them onto adjacent lines of the file, inside a **nine-file, ~19KB parallel write**. It started one id and finished it with its neighbour.

Verified after the fact: the user's real id mints a visitor token (200) and returns the five seeded sweaters; the written one returns **400**. Seeding had worked — it uses the connector's own credentials, so nothing failed until the browser tried to authenticate.

**What made it ship** rather than get caught: the agent suspected the line twice, "fixed" it with a `find_replace` whose `find` and `replace` were **byte-identical** (which reported success), then verified by comparing its own output against the *site* id — a check that cannot detect this error — and finally classified the resulting `Wix OAuth failed: 400` as pending Wix-side setup, quoting the skill's own "flag it and continue" affordance. It told the user to go configure their dashboard.

## The change

Retyping two uuids was the hazard, so the agent no longer does it. `deploy.cjs` takes them as flags and writes the file itself:

```bash
node deploy.cjs storefront --client-id <id> --metasite-id <id>
```

- **Writes** `src/rest/wix-config.js` from those values — one mechanical copy, no hand-edit.
- **Proves the client id** with the same anonymous-token mint `wix-client.js` performs at runtime. Pass ⇒ the browser client will authenticate.
- **Fails the install** (exit 1) on rejection, naming the value it wrote:
  > `Wix rejected WIX_CLIENT_ID "15396729-ec3a-4d99-bd82-d6b53cba83c4" (400). This is a wrong id, not pending Wix setup. Re-read the client id from the user's prompt and re-run this command with it.`
- **Shape check** rejects a non-uuid before any network call.
- **Unreachable Wix warns, doesn't block** — a network fault must not fail a build.
- **No flags ⇒ unchanged behaviour**: placeholders, plus a note to re-run with the ids rather than editing by hand.

`STEP 2 — Credentials` in all eight verticals told the agent to do precisely what broke. It now says the file is already written and verified, and states that `Wix rejected WIX_CLIENT_ID` means a **wrong value, never pending Wix-side setup** — the conflation that let this reach the user.

## Verified

Against the real ids from that build, with the script running over a sandboxed `/app`:

| case | result |
|---|---|
| correct client id | `{written: true, clientIdVerified: true}`, config written, exit 0 |
| the blended id | exit **1** + the explanatory error |
| `--client-id not-a-uuid` | rejected on shape, no network call |
| no flags | placeholders kept, note emitted, exit 0 |
| `--flags` before / after verticals | both parse; `storefront members` → both deployed |
| unknown vertical | still reported |
| members auth repair | still fires |

## Not in scope

The `find_replace` that succeeded while changing nothing is a platform-side gap (`find === replace` is always an agent error and should fail loudly) — worth its own fix in apper, not here.