### PR TITLE
fix(evalforge): mark optional scenarios with X

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -64887,7 +64887,7 @@ function formatComparisonResult(result, projectId) {
         const timeWithout = `${(s.without.durationMs / 1000).toFixed(1)}s`;
         const runWith = projectId && s.with.runId ? `[PR](${(0, evalforge_core_1.evalRunUrl)(projectId, s.with.runId, s.with.name)})` : '—';
         const runWithout = projectId && s.without.runId ? `[prod](${(0, evalforge_core_1.evalRunUrl)(projectId, s.without.runId, s.without.name)})` : '—';
-        lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel(s)} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
+        lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '❌'} | ${winnerLabel(s)} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
     }
     for (const s of (scenarios ?? [])) {
         const reason = noWinnerReason(s);

--- a/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
@@ -153,7 +153,7 @@ export function formatComparisonResult(result: CompareGroupComplete, projectId?:
     const timeWithout = `${(s.without.durationMs / 1000).toFixed(1)}s`;
     const runWith = projectId && s.with.runId ? `[PR](${evalRunUrl(projectId, s.with.runId, s.with.name)})` : '—';
     const runWithout = projectId && s.without.runId ? `[prod](${evalRunUrl(projectId, s.without.runId, s.without.name)})` : '—';
-    lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '—'} | ${winnerLabel(s)} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
+    lines.push(`| ${s.scenarioName} | ${s.required ? '✅' : '❌'} | ${winnerLabel(s)} | $${costWith} / $${costWithout} | ${tokWith} / ${tokWithout} | ${timeWith} / ${timeWithout} | ${runWith} / ${runWithout} |`);
   }
 
   for (const s of (scenarios ?? [])) {

--- a/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
@@ -220,7 +220,7 @@ describe('comment formatters', () => {
     });
 
     expect(out).toContain('## ⚠️ EvalForge YAML Gate: Eval Comparison');
-    expect(out).toContain('| bookings/diagnose-availability-issues | — | - |');
+    expect(out).toContain('| bookings/diagnose-availability-issues | ❌ | - |');
     expect(out).toContain('**No winner:** both runs failed the LLM judge.');
     expect(out).not.toContain('⬆️ with (high)');
   });


### PR DESCRIPTION
## Summary
- show a red X for scenarios that are not required
- keep the green check for required scenarios
- rebuild the committed GitHub Action bundle

## Testing
- `yarn typecheck`
- `yarn test` (98 tests passed)
- `yarn build`