### PR TITLE
feat(evalforge): extend /re-eval to the wix-manage gate

### DIFF
--- a/.github/actions/evalforge-skill-gate/tests/re-eval-script.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/re-eval-script.test.ts
@@ -53,6 +53,15 @@ const FAILED_RUN: WorkflowRun = {
   html_url: 'https://github.com/wix/skills/actions/runs/900',
 };
 
+const MANAGE_RUN: WorkflowRun = {
+  id: 901,
+  status: 'completed',
+  conclusion: 'failure',
+  html_url: 'https://github.com/wix/skills/actions/runs/901',
+};
+
+const YAML_GATE = 'evalforge-yaml-gate.yml';
+
 const run = (overrides: Partial<WorkflowRun>): WorkflowRun => ({ ...FAILED_RUN, ...overrides });
 
 function harness(options: {
@@ -61,7 +70,10 @@ function harness(options: {
   pull?: Partial<PullRequest>;
   level?: { permission: string; role_name: string };
   levelError?: Error;
+  /** The wix-app gate's runs. */
   runs?: WorkflowRun[];
+  /** The wix-manage gate's runs — none by default, so a PR touching one skill is the base case. */
+  manageRuns?: WorkflowRun[];
   rerunError?: Error;
 } = {}) {
   const comments: string[] = [];
@@ -77,7 +89,10 @@ function harness(options: {
   });
   const listWorkflowRuns = vi.fn(async (query: Record<string, unknown>) => {
     runQueries.push(query);
-    return { data: { workflow_runs: options.runs ?? [FAILED_RUN] } };
+    const workflowRuns = query.workflow_id === YAML_GATE
+      ? options.manageRuns ?? []
+      : options.runs ?? [FAILED_RUN];
+    return { data: { workflow_runs: workflowRuns } };
   });
   const reRunWorkflow = vi.fn(async ({ run_id }: { run_id: number }) => {
     if (options.rerunError) throw options.rerunError;
@@ -239,7 +254,7 @@ describe('who may spend', () => {
 });
 
 describe('finding the run to re-run', () => {
-  it('asks only for the wix-app gate, the PR trigger, and this head sha', async () => {
+  it('asks for both gates, the PR trigger, and this head sha', async () => {
     const test = harness();
     await test.execute();
 
@@ -250,15 +265,38 @@ describe('finding the run to re-run', () => {
         head_sha: OPEN_PR.head.sha,
         per_page: 1,
       }),
+      expect.objectContaining({
+        workflow_id: YAML_GATE,
+        event: 'pull_request',
+        head_sha: OPEN_PR.head.sha,
+        per_page: 1,
+      }),
     ]);
   });
 
-  it('declines when no gate run exists, naming the wix-manage scope gap', async () => {
+  it('re-runs the wix-manage gate on a PR that only touches that skill', async () => {
+    const test = harness({ runs: [], manageRuns: [MANAGE_RUN] });
+    await test.execute();
+
+    expect(test.rerunIds).toEqual([MANAGE_RUN.id]);
+    expect(test.comments[0]).toContain(YAML_GATE);
+  });
+
+  it('re-runs both gates when a PR touches both skills', async () => {
+    const test = harness({ manageRuns: [MANAGE_RUN] });
+    await test.execute();
+
+    expect(test.rerunIds).toEqual([FAILED_RUN.id, MANAGE_RUN.id]);
+  });
+
+  // A gate only runs on its own paths, so a PR touching neither skill has nothing to re-run.
+  it('declines when no gate run exists, naming the paths that would produce one', async () => {
     const test = harness({ runs: [] });
     await test.execute();
 
-    expect(test.comments[0]).toContain('no wix-app gate run exists');
-    expect(test.comments[0]).toContain('wix-manage');
+    expect(test.comments[0]).toContain('no eval gate run exists');
+    expect(test.comments[0]).toContain('skills/wix-app');
+    expect(test.comments[0]).toContain('yaml/wix-manage-evals');
     expect(test.rerunIds).toEqual([]);
   });
 });

--- a/.github/actions/evalforge-skill-gate/tests/workflow-config.test.ts
+++ b/.github/actions/evalforge-skill-gate/tests/workflow-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as yaml from 'js-yaml';
 
@@ -166,7 +166,21 @@ describe('EvalForge re-eval workflow', () => {
   // a re-run that was already triggered.
   it('neither shares a gate concurrency group nor cancels itself', () => {
     expect(workflow.concurrency.group).not.toContain('evalforge-wix-app-gate-pr');
+    expect(workflow.concurrency.group).not.toContain('evalforge-yaml-gate-pr');
     expect(workflow.concurrency['cancel-in-progress']).toBe(false);
+  });
+
+  // A workflow id that names no file finds no run, and the command then declines as if the gate
+  // had never run for the commit — a silent scope loss no behavioural test can see.
+  it('names gate workflows that exist', () => {
+    const gates = step.with?.script?.match(/const GATES = \[([^\]]*)\]/)?.[1];
+    expect(gates).toBeDefined();
+    const files = [...gates!.matchAll(/'([^']+)'/g)].map(match => match[1]);
+
+    expect(files).toEqual(['evalforge-wix-app-gate.yml', 'evalforge-yaml-gate.yml']);
+    for (const file of files) {
+      expect(existsSync(join(__dirname, '../../../workflows', file))).toBe(true);
+    }
   });
 
   it('grants exactly what it needs and no more', () => {

--- a/.github/workflows/evalforge-re-eval.yml
+++ b/.github/workflows/evalforge-re-eval.yml
@@ -4,7 +4,7 @@ name: EvalForge Re-eval
 # report an unverified result for reasons that have nothing to do with the PR; without this the
 # only remedy is an empty commit.
 #
-# Scoped to the wix-app skill gate for now. See GATES below to extend it.
+# Covers both eval gates. See GATES below to extend it.
 #
 # It re-runs the PR's own `pull_request` run rather than evaluating here, because an issue_comment
 # run is associated with the default branch's commit while required checks are evaluated on the PR
@@ -117,14 +117,11 @@ jobs:
               return decline('only the PR author or a collaborator with write access can trigger this');
             }
 
-            // The wix-app skill gate only, for now.
-            //
-            // The wix-manage YAML gate (`evalforge-yaml-gate.yml`) works exactly the same way and
-            // wants this more, since `EVAL_BLOCK_MERGE` is already true there while wix-app is
-            // still soaking. Adding it is one entry in this array — the loop below re-runs every
-            // gate that has a run for the commit, so a PR touching both skills would re-run both.
-            // Left out deliberately until the wix-app flow has been exercised in anger.
-            const GATES = ['evalforge-wix-app-gate.yml'];
+            // Every gate that re-runs safely: both take their evaluated commit from the PR
+            // payload, so a replayed event evaluates the same thing the original did. The loop
+            // below re-runs each gate that has a run for this commit, so a PR touching both
+            // skills re-runs both and one touching neither is declined.
+            const GATES = ['evalforge-wix-app-gate.yml', 'evalforge-yaml-gate.yml'];
             const notes = [];
             // Counted, not inferred from `notes`: three of the four branches below add a note
             // without having re-run anything, and a heading that claims otherwise is a lie the
@@ -177,12 +174,12 @@ jobs:
             }
 
             if (notes.length === 0) {
-              // Named precisely: on a wix-manage PR a gate run does exist, it is just not one this
-              // command covers yet, and "no gate run exists" would read as a bug.
+              // The gates only run on their own paths, so the likeliest reason is a PR that
+              // touches neither skill. Name the paths rather than leaving the requester to guess.
               return decline(
-                'no wix-app gate run exists for this commit — push a commit touching '
-                + '`skills/wix-app` or `yaml/wix-app-evals` and the gate runs automatically. '
-                + 'This command does not cover the wix-manage gate yet'
+                'no eval gate run exists for this commit — the gates only run on PRs touching '
+                + '`skills/wix-app`, `yaml/wix-app-evals`, `skills/wix-manage/references`, '
+                + '`yaml/wix-manage` or `yaml/wix-manage-evals`'
               );
             }
 

--- a/docs/skill-evaluation.md
+++ b/docs/skill-evaluation.md
@@ -27,6 +27,12 @@ That PR override makes the Wix MCP load skill content from the pull request inst
 
 Use evaluation as a loop, not a one-time check. Review the failures, tighten the skill or the scenario, and rerun until performance is good enough for the target scenarios.
 
+When a run ends without a verdict for reasons that have nothing to do with your change — a
+timeout, a poll failure — comment `/re-eval` on the PR to re-run this gate rather than
+pushing an empty commit. This gate's own comment does not mention the command; the rules
+are the same for both gates and are listed under
+[the wix-app PR eval gate](#wix-app-scenarios-the-pr-eval-gate).
+
 ## wix-app scenarios: the PR eval gate
 
 Every PR touching `skills/wix-app/**` or `yaml/wix-app-evals/**` runs
@@ -98,7 +104,8 @@ cannot see. See [`.github/workflows/evalforge-re-eval.yml`](../.github/workflows
   nothing, so discussing it or quoting someone who used it cannot start a paid run.
 - The **PR author**, or a collaborator with **write access**, may use it. Each scenario is a
   live agent build, and this repo is public, so it is a spend gate.
-- It covers the **wix-app gate only** for now. On a wix-manage PR it refuses and says so.
+- It covers **both gates** — the wix-app gate and the wix-manage YAML gate. A PR touching
+  both skills re-runs both; one touching neither has nothing to re-run and is refused.
 - It cannot help where a re-run would change nothing: a draft or closed PR, a fork branch, a
   commit the gate never ran for, or a gate job that was skipped. Push a commit instead.
 


### PR DESCRIPTION
`/re-eval` was scoped to the wix-app skill gate while that flow soaked. This extends it to the wix-manage YAML gate.

Both gates take their evaluated commit from the PR payload rather than `GITHUB_SHA`, so a replayed `pull_request` event evaluates what the original run did, and both share the same `!draft && !fork` job `if:`. The wix-manage gate also wants this more than wix-app does: `EVAL_BLOCK_MERGE` is already true there, so an unverified run blocks a merge today and the only remedy is an empty commit.

### What changed

- **`evalforge-re-eval.yml`** — `evalforge-yaml-gate.yml` added to `GATES`. The loop already re-runs every gate that has a run for the commit, so a PR touching both skills re-runs both. The refusal when no gate run exists now names the five gated paths instead of announcing the wix-manage scope gap.
- **`re-eval-script.test.ts`** — the harness answers per workflow id (`manageRuns`, empty by default, so the existing single-gate cases are unchanged). New cases: wix-manage alone, both gates on one PR, and the reworded refusal.
- **`workflow-config.test.ts`** — asserts the `GATES` entries name workflow files that exist on disk. A typo'd id finds no run and the command then declines as if the gate had never run for the commit, which no behavioural test can see. Also pins the concurrency group away from the yaml gate's.
- **`docs/skill-evaluation.md`** — the wix-manage section points at the command; the wix-app section's scope bullet updated.

### Deliberately not included

The wix-manage gate's own PR comments still don't mention `/re-eval`. That note lives in `evalforge-core`'s `retryNote()` and only the skill gate's comments use it; adding it to the yaml gate means an action source change and a `dist` rebuild. The doc line is where wix-manage authors learn the command exists for now.

### Verification

`vitest run` on both suites — 67 passed. `tsc --noEmit` clean in `evalforge-skill-gate`. No action source or `dist` changes, so nothing to rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)