### PR TITLE
[test] verify /re-eval reaches the wix-manage gate

### DIFF
--- a/skills/wix-manage/references/analytics/analytics-dashboard-navigation.md
+++ b/skills/wix-manage/references/analytics/analytics-dashboard-navigation.md
@@ -31,7 +31,7 @@ Per-business-solution overviews also exist at `analytics/overviews/{solution}` (
 
 ## Pairing Data with Its Read API
 
-Answer the question with the [Query Site Analytics](../analytics/query-site-analytics.md) recipe (Semantic Model API — `GET /analytics/semantic-model/v3/semantic-models`, `POST .../semantic-models/query-data`), then link the matching overview page.
+Answer the question with the [Query Site Analytics](./query-site-analytics.md) recipe (Semantic Model API — `GET /analytics/semantic-model/v3/semantic-models`, `POST .../semantic-models/query-data`), then link the matching overview page.
 
 Example:
 


### PR DESCRIPTION
**Throwaway PR — will be closed, not merged.** Do not review.

#988 extended `/re-eval` to `evalforge-yaml-gate.yml`. That was verified by unit tests and by a live refusal on a PR with no gate run, but the actual re-run of a wix-manage gate has never been exercised. This PR exists to produce one gate run to re-run.

The diff is a one-character-class link fix in `analytics/analytics-dashboard-navigation.md` (`../analytics/x.md` → `./x.md`, same target). The analytics area was chosen because no other open PR touches it, so the draft-scenario lock this run takes cannot block anyone.

Sequence: let the gate run → comment `/re-eval` → confirm a second gate run starts for the same head sha and the check updates in place → close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)