### PR TITLE
fix(wix-vibe-headless): seed HTML descriptions as rich text; the prompt's site id wins

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -74,12 +74,23 @@ function replaceMembersAuthLeftovers() {
 // The two ids arrive as flags so this script writes them once, character-for-character, instead of a
 // later hand-edit of the placeholder file.
 //
-// Only ever writes a config that still holds the placeholders. A file already carrying values is
-// left exactly as it is: on hosts that write it themselves at app creation (Base44) those values
-// came straight from the host and never passed through a prompt, and elsewhere they are the agent's
-// own edit. Either way this script has nothing better to put there.
-function wixConfigHasValues() {
-  return existsSync(WIX_CONFIG) && !readFileSync(WIX_CONFIG, 'utf8').includes('<YOUR-');
+// Precedence differs per id, because the two are not equally trustworthy when a host writes this
+// file itself at app creation:
+//
+//   WIX_METASITE_ID — the flag WINS. A host can derive this one indirectly (Base44 resolves it from
+//     the launch instance) and get a different site than the business, and a wrong site id is sent
+//     as the `wix-site-id` header on every catalog read, so the storefront returns nothing. The id
+//     in the prompt is the site the user is looking at, so prefer it and overwrite.
+//   WIX_CLIENT_ID — an existing value wins. It reaches a host as an exact value on the launch
+//     request, so its copy is at least as good as one retyped into a command.
+function readWixConfig() {
+  if (!existsSync(WIX_CONFIG)) return {};
+  const src = readFileSync(WIX_CONFIG, 'utf8');
+  const pick = (name) => {
+    const v = (src.match(new RegExp(`${name}\\s*=\\s*["']([^"']*)["']`)) || [])[1] || '';
+    return v.startsWith('<') ? '' : v;   // the shipped file's `<YOUR-…>` placeholders count as unset
+  };
+  return { clientId: pick('WIX_CLIENT_ID'), metaSiteId: pick('WIX_METASITE_ID') };
 }
 
 function writeWixConfig(clientId, metaSiteId) {
@@ -129,14 +140,19 @@ if (!requested.length) {
   deployed.note = 'no vertical given — deployed the shared transport only; re-run: node deploy.cjs <vertical> [<vertical> …]';
 }
 
-if (wixConfigHasValues()) {
-  deployed.wixConfig = 'already_set';
-} else if (clientId && metaSiteId) {
-  writeWixConfig(clientId, metaSiteId);
-  deployed.wixConfig = 'written';
-} else {
-  deployed.wixConfig = 'no_ids_given — src/rest/wix-config.js still holds placeholders; re-run with '
+const onDisk = readWixConfig();
+const finalClientId = onDisk.clientId || clientId;
+const finalMetaSiteId = metaSiteId || onDisk.metaSiteId;
+
+if (!finalClientId || !finalMetaSiteId) {
+  deployed.wixConfig = 'missing_ids — src/rest/wix-config.js is not configured; re-run with '
     + '--client-id and --metasite-id rather than editing the file by hand';
+} else if (finalClientId === onDisk.clientId && finalMetaSiteId === onDisk.metaSiteId) {
+  deployed.wixConfig = 'already_set';
+} else {
+  const replaced = onDisk.metaSiteId && onDisk.metaSiteId !== finalMetaSiteId;
+  writeWixConfig(finalClientId, finalMetaSiteId);
+  deployed.wixConfig = replaced ? 'written — replaced a different WIX_METASITE_ID' : 'written';
 }
 
 console.log(JSON.stringify(deployed));

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -21,7 +21,8 @@ Install two skills — they land under `.agents/skills/`:
 Install via the skills CLI — run this through exec_tool, exactly as written. It installs the two
 skills, then runs `deploy.cjs <vertical…> --client-id … --metasite-id …` (lays the shared transport +
 **each** listed vertical's REST scaffolds and UI client into `src/`, writes `wix-config.js` from
-those two ids unless it already holds values) and `pin-agents-md.cjs` (pins the project's AGENTS.md
+those two ids — the site id from your prompt always wins, so pass both) and `pin-agents-md.cjs`
+(pins the project's AGENTS.md
 note so later turns keep the rules).
 
 **Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
@@ -65,7 +66,7 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
 // Deploy the shared transport + each listed vertical's scaffolds/UI into src/, and write
-// wix-config.js unless it already holds values.
+// wix-config.js. The site id you pass wins over anything already in that file.
 const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')} --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
 // Pin the project's AGENTS.md note (idempotent) so the rules survive after this doc leaves context.
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();

--- a/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
+++ b/skills/wix-vibe-headless/references/storefront/seed/seed-store.js
@@ -82,14 +82,51 @@ async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
   }
 }
 
-// plain string -> Wix rich-text description node tree (plainDescription is HTML/nodes, not text)
+// description string -> Wix rich-text node tree.
+//
+// Descriptions arrive as HTML as often as not: asked to describe a product, a model writes
+// <p>…</p><strong>Care:</strong><br/>. The writable field is `description` (Ricos nodes) — the HTML
+// `plainDescription` the storefront renders is read-only, derived from them. So markup dropped into
+// a single TEXT node is stored as literal text, comes back escaped, and the PDP shows the tags to
+// the buyer. Convert the tags a model actually emits; a string with no tags stays one paragraph.
+const HTML_ENTITIES = { "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;": "'", "&nbsp;": " " };
+
+function decodeEntities(s) {
+  return s.replace(/&(?:amp|lt|gt|quot|#39|nbsp);/g, (m) => HTML_ENTITIES[m] ?? m);
+}
+
+// One paragraph's inner HTML -> TEXT nodes, carrying bold/italic as Ricos decorations.
+function mkTextNodes(html) {
+  const nodes = [];
+  let bold = 0, italic = 0, last = 0, m;
+  const tag = /<(\/?)(strong|b|em|i)\s*\/?>/gi;
+  const push = (raw) => {
+    const text = decodeEntities(raw.replace(/<[^>]*>/g, ""));
+    if (!text) return;
+    const decorations = [];
+    if (bold > 0) decorations.push({ type: "BOLD" });
+    if (italic > 0) decorations.push({ type: "ITALIC" });
+    nodes.push({ type: "TEXT", textData: { text, decorations } });
+  };
+  while ((m = tag.exec(html)) !== null) {
+    push(html.slice(last, m.index));
+    const step = m[1] ? -1 : 1;
+    if (/^(strong|b)$/i.test(m[2])) bold = Math.max(0, bold + step);
+    else italic = Math.max(0, italic + step);
+    last = tag.lastIndex;
+  }
+  push(html.slice(last));
+  return nodes.length ? nodes : [{ type: "TEXT", textData: { text: "", decorations: [] } }];
+}
+
 function mkDesc(text, i) {
+  const blocks = String(text ?? "").split(/<\/p\s*>|<br\s*\/?>/i).map((b) => b.trim()).filter(Boolean);
   return {
-    nodes: [{
-      type: "PARAGRAPH", id: `desc-${i}`,
-      nodes: [{ type: "TEXT", textData: { text: text || "" } }],
+    nodes: (blocks.length ? blocks : [""]).map((block, n) => ({
+      type: "PARAGRAPH", id: `desc-${i}-${n}`,
+      nodes: mkTextNodes(block),
       paragraphData: { textStyle: { textAlignment: "AUTO" } },
-    }],
+    })),
     metadata: { version: 1, id: `desc-meta-${i}` },
   };
 }
@@ -157,6 +194,8 @@ async function listProducts(ctx) {
  * Bulk-create products.
  * @param products [{ name, description, price, compareAtPrice?, quantity,
  *   options?: [{ name, type?:"text"|"color", choices:["8","9"] | [{name,colorCode}] }] }]
+ *   description: plain text, or simple HTML (`<p>`, `<br/>`, `<strong>`, `<em>`) — converted to
+ *   Wix rich text here, so the storefront renders paragraphs and bold rather than tag text.
  *   options = ONLY things the buyer selects-and-buys (Size, Color) -> become variants.
  *   Display-only attributes go in name/category/description, NOT options. Default: no options.
  *   visible/physicalProperties/variant-expansion handled here. `quantity` is the stock created.


### PR DESCRIPTION
Two fixes from one live build (`Kintsugi Moomin Ceramics`).

---

## 1. HTML descriptions shipped as visible tags

The product page showed the markup to buyers:

> `<p>A pair of dinner plates celebrating the steadfast love of Moominpappa and Moominmamma.</p><strong>Dimensions:</strong> 26cm diameter each…`

Every description in that build was HTML — which is what a model writes when asked to describe a product.

**Why.** `mkDesc` put the whole string into a single Ricos `TEXT` node. Wix stores a text node as text, so the markup came back escaped and the PDP's `dangerouslySetInnerHTML` rendered exactly what it was handed.

Confirmed against Catalog V3 on a live site:

- **`plainDescription` is read-only** — sent on create, it is silently dropped.
- **`description` (Ricos nodes) is the writable field**, and `plainDescription` is Wix's HTML rendering of it.
- It is **only returned when requested** (`?fields=PLAIN_DESCRIPTION`). Our reader already does this.

**Fix.** `mkDesc` converts the markup a model emits: `</p>` and `<br/>` become paragraph breaks, `<strong>`/`<b>` and `<em>`/`<i>` become BOLD/ITALIC decorations, other tags are dropped, entities decoded. A description with no tags still becomes one paragraph, so plain-text callers are unchanged.

**Verified** by round-tripping that store's own description through the live API — Wix now returns real `<p>` blocks with `<span style="font-weight: 700">Dimensions:</span>`. Edge cases: plain text, empty, `null`/`undefined`, entities, unclosed `<strong>`, nested bold+italic, unknown tags, `<br/>`-only. Probe product deleted afterwards.

---

## 2. `WIX_METASITE_ID` — the id in the prompt now wins

The same build hit this mid-flight and corrected it by hand:

> *"I notice the WIX_METASITE_ID doesn't match the one from the prompt. Let me fix that."*

Base44 writes `wix-config.js` at app creation and derives the site id **indirectly**, from the launch instance. For that app it resolved `2d657ea9-3863-4393-83b5-57a69093e545`, while the business was `7e66fd88-5ca4-4ccf-b6a8-1f0fe56f110b` — the id in the prompt, and the one the build's own seeding used successfully.

That value is sent as the `wix-site-id` header on **every** catalog read, so a wrong one means a storefront that returns nothing while the build reports success. An agent that doesn't happen to notice ships it.

**Fix.** Precedence is now per id instead of per file:

| id | wins |
|---|---|
| `WIX_METASITE_ID` | **the flag** — overwrites a different value |
| `WIX_CLIENT_ID` | an existing value — a host receives it verbatim on the launch request, so its copy beats one retyped into a command |

**Verified** on five combinations, including that app's exact mismatch: the prompt's site id replaces the resolved one (`written — replaced a different WIX_METASITE_ID`), a correct config is untouched, placeholders get filled, and no-flags-with-placeholders reports instead of writing.

This is the quick fix. The root cause — why Base44's resolution returns a different site — is being investigated separately on the platform side.

---

## Not changed

`blog/seed/seed-blog.js` has the same one-line risk in its `mkText`, but its interface takes typed blocks (`{type:"heading", text}`) rather than an HTML string, so callers are steered away from markup. Worth hardening if we see it happen.