### PR TITLE
fix(wix-app-evals): repair the CODE_IDENTIFIER example in the shift-dashboard prompt

### DIFF
--- a/yaml/wix-app-evals/employee-shift-dashboard.yml
+++ b/yaml/wix-app-evals/employee-shift-dashboard.yml
@@ -3,7 +3,7 @@ description: Dashboard page for store owners to manage employee shifts with a ta
 triggerPrompt: |-
   Build a dashboard page that lets store owners manage employee shifts. The page should have a table where each row is a shift with these fields: employee name, date, and hours. The store owner must be able to add new shifts to the table.
   APP_NAMESPACE: "@mirivo/my-app31ceim", Use this namespace when creating data collections (for idSuffix scoping).
-  CODE_IDENTIFIER: "MirivoMyApp31ceim" When generating editor React component or function library extensions, use this identifier as the type prefix (e.g. type: 'MirivoMyApp31ceim"ComponentName').
+  CODE_IDENTIFIER: "MirivoMyApp31ceim", When generating editor React component or function library extensions, use this identifier as the type prefix (e.g. type: 'MirivoMyApp31ceimComponentName').
 templateId: 33f2cb85-054e-4281-b617-3bc21ac0803f
 tags: [dashboard-page, data-collection, auto-patterns-dashboard]
 assertions:


### PR DESCRIPTION
The example type prefix in the shift-dashboard trigger prompt opened with a single quote and closed with a double one mid-token:

```
(e.g. type: 'MirivoMyApp31ceim"ComponentName')
```

So the one concrete illustration of the naming rule was itself malformed. This closes the quote and adds the comma after the identifier that the sibling `APP_NAMESPACE` line already has.

## Also the first live exercise of the AI investigation

#990 added a second `analyze` job that asks EvalForge to investigate a run whose assertions failed and posts the result as its own PR comment. Every part of it has been verified against the live API — the endpoint, the response mapping, the rendering, the comment upsert, the 401/403 path — but **never through the actual CI wiring**, because the gate's job output was supplied by hand.

This PR touches `yaml/wix-app-evals/**`, so it triggers the gate for real. It selects one scenario, which is the floor: 1 scenario × 2 comparison arms × 1 run per scenario.

What to look for:

- the verdict comment appears and its check settles **without** waiting for the analysis
- if any assertion fails, a second collapsed comment follows shortly after, under its own marker
- the `analyze` job is green even when the gate is red
- if everything passes, there should be **no** second comment and no `analyze` job at all

Worth noting the run this scenario produced on 2026-08-12 failed 3 of 7 assertions on a Wix CLI auth error, so a failing run — and therefore an investigation comment — is the likely outcome rather than the exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
