### PR TITLE
fix(wix-vibe-headless): trust a wix-config.js the host already wrote

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -74,15 +74,14 @@ function replaceMembersAuthLeftovers() {
 // The two ids arrive as flags so this script writes them once, character-for-character, instead of a
 // later hand-edit of the placeholder file.
 //
-// Precedence differs per id, because the two are not equally trustworthy when a host writes this
-// file itself at app creation:
+// An id already in the file wins; the flags only fill what is unset. A host that writes this file
+// at app creation (Base44) has each id as an exact value rather than a copy read out of a prompt.
+// Per id, so a host that resolved one but not the other still gets the gap filled.
 //
-//   WIX_METASITE_ID — the flag WINS. A host can derive this one indirectly (Base44 resolves it from
-//     the launch instance) and get a different site than the business, and a wrong site id is sent
-//     as the `wix-site-id` header on every catalog read, so the storefront returns nothing. The id
-//     in the prompt is the site the user is looking at, so prefer it and overwrite.
-//   WIX_CLIENT_ID — an existing value wins. It reaches a host as an exact value on the launch
-//     request, so its copy is at least as good as one retyped into a command.
+// This briefly worked the other way round for WIX_METASITE_ID, while Base44 could write a different
+// site than the business: it shared one field between the launch and a metasite it provisions per
+// app, and the launch's id lost. Fixed on that side, and the ids it stores now verify against the
+// site each launch came from, so the file is trusted again.
 function readWixConfig() {
   if (!existsSync(WIX_CONFIG)) return {};
   const src = readFileSync(WIX_CONFIG, 'utf8');
@@ -142,7 +141,7 @@ if (!requested.length) {
 
 const onDisk = readWixConfig();
 const finalClientId = onDisk.clientId || clientId;
-const finalMetaSiteId = metaSiteId || onDisk.metaSiteId;
+const finalMetaSiteId = onDisk.metaSiteId || metaSiteId;
 
 if (!finalClientId || !finalMetaSiteId) {
   deployed.wixConfig = 'missing_ids — src/rest/wix-config.js is not configured; re-run with '
@@ -150,9 +149,8 @@ if (!finalClientId || !finalMetaSiteId) {
 } else if (finalClientId === onDisk.clientId && finalMetaSiteId === onDisk.metaSiteId) {
   deployed.wixConfig = 'already_set';
 } else {
-  const replaced = onDisk.metaSiteId && onDisk.metaSiteId !== finalMetaSiteId;
   writeWixConfig(finalClientId, finalMetaSiteId);
-  deployed.wixConfig = replaced ? 'written — replaced a different WIX_METASITE_ID' : 'written';
+  deployed.wixConfig = 'written';
 }
 
 console.log(JSON.stringify(deployed));

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -21,8 +21,7 @@ Install two skills — they land under `.agents/skills/`:
 Install via the skills CLI — run this through exec_tool, exactly as written. It installs the two
 skills, then runs `deploy.cjs <vertical…> --client-id … --metasite-id …` (lays the shared transport +
 **each** listed vertical's REST scaffolds and UI client into `src/`, writes `wix-config.js` from
-those two ids — the site id from your prompt always wins, so pass both) and `pin-agents-md.cjs`
-(pins the project's AGENTS.md
+those two ids unless it already holds them) and `pin-agents-md.cjs` (pins the project's AGENTS.md
 note so later turns keep the rules).
 
 **Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
@@ -65,8 +64,8 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
       : out.includes('No valid skills') ? 'not_found' : 'unknown';
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-// Deploy the shared transport + each listed vertical's scaffolds/UI into src/, and write
-// wix-config.js. The site id you pass wins over anything already in that file.
+// Deploy the shared transport + each listed vertical's scaffolds/UI into src/, and fill in any
+// id wix-config.js is missing.
 const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')} --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
 // Pin the project's AGENTS.md note (idempotent) so the rules survive after this doc leaves context.
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();


### PR DESCRIPTION
## Why this is going back

#994 made the `--metasite-id` flag override `WIX_METASITE_ID` in an existing config, because Base44 could write a **different site than the business**. The reason it could: Base44 shared one field between the launch link and a metasite it provisions separately per app, and the launch's id lost a race to it.

That is fixed on the platform side — [base44-dev/apper#20145](https://github.com/base44-dev/apper/pull/20145), in production — and the ids it stores now check out. On three real launches since that deploy, each app's stored site id matched the metasite resolved independently from its own Wix connector instance:

| app | stored | resolved from the connector |
|---|---|---|
| `6a7dc147…` | `1a3a0687…` | `1a3a0687…` ✅ |
| `6a7dbf27…` | `ccb94c86…` | `ccb94c86…` ✅ |
| `6a7dc094…` | `c9dbbaa2…` | `c9dbbaa2…` ✅ |

So the file is trustworthy again, and overriding it now does the opposite of what it was for — it replaces an exact value with one retyped out of a prompt.

## The rule

**An id already in the file wins; the flags fill what is unset.** Still evaluated per id, not per file: of those five post-deploy launches, one stored no site id at all (resolution is deliberately fail-soft), so that app's config arrives half-written and needs the flag for the missing half.

## Verified

Ran `deploy.cjs` against a fixture on four paths:

| config on disk | flags | result |
|---|---|---|
| both ids | a **different** site id | `already_set` — file untouched |
| placeholders | both | `written` |
| client id only, site id placeholder | both | `written` — only the missing id filled |
| placeholders | none | `missing_ids`, nothing written |

`base44.md` updated to match: it no longer says the prompt's site id wins.