### PR TITLE
🦞 igor-claw: warn that headless-onto-existing-site rewrites canonical URL

### DIFF
--- a/skills/wix-manage/references/sites/create-headless-site.md
+++ b/skills/wix-manage/references/sites/create-headless-site.md
@@ -45,6 +45,8 @@ Headless sites are not created from templates. One account-level call creates th
 
 To provision headless onto an existing site, pass `"existingMetasite": {}` instead of `newMetasite`. This is a site-level call in the context of that site.
 
+> **Warning:** On a live, published site (e.g. Studio or Classic Editor) this silently changes the site's canonical/serving URL to an internal `wix-site-host.com` host — even if the site only uses its default Wix subdomain, and even more visibly if it has a connected custom domain. Every page published after the call 302-redirects from the site's real URL to the internal host; pages published before the call keep serving on the original URL until republished. **There is no self-service revert**: uninstalling the returned `appId`'s app instance and republishing the site do NOT restore the original canonical URL — this requires Wix support. Before calling this on a site with real traffic or a connected domain, warn the user of this side effect explicitly and confirm they want to proceed.
+
 ## Next Steps
 
 After creating the site:


### PR DESCRIPTION
## What's missing

The "Create Headless Site" recipe's **Existing Sites** section says only:

> To provision headless onto an existing site, pass `"existingMetasite": {}` instead of `newMetasite`.

with no mention of side effects — despite this being a destructive action on a live production site.

## Confirmed by live reproduction

On an owned test site (published Wix Studio site, no custom domain — just its default `wixstudio.com` subdomain):
1. Before: site context / Sites API showed the real `ayalg5.wixstudio.com/...` URL.
2. Called `POST /headless-business-setup/v1/headless-business/provision` with `{"existingMetasite":{},"synchronousSteps":["CONFIGURE_HEADLESS_APP"]}`.
3. After: the same site now reports an internal `https://h6s-<hash>-<user>.wix-site-host.com` URL as canonical, and the original URL returns a live `301` redirect to it.
4. Uninstalled the returned app instance (`apps-installer-service/v1/app-instance/uninstall`) and republished the site (`site-publisher/v1/site/publish`) — the canonical URL stayed on `wix-site-host.com`. **No self-service revert exists.**

This matches a live incident report where the same call broke custom-domain routing on a Partner's production site, requiring Wix support to restore.

## Fix

Add an explicit warning under "Existing Sites" describing the side effect and the lack of a revert path, so an agent warns the user and gets confirmation before running this on a live site — rather than discovering it only after the user's production routing breaks.

---
Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com).
Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1786661971341869