### PR TITLE
🦞 igor-claw: add Set Image Alt Text recipe (Media Manager altText silently no-ops)

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -314,6 +314,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Upload Media to Wix](references/media/upload-media-to-wix.md)
 **Technical:** Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
 
+### [Set Image Alt Text](references/media/set-image-alt-text.md)
+**Technical:** MANDATORY read before attempting to set an image's alt text. The raw Media Manager file has no writable `altText` — `UpdateFileDescriptor` with `media` in its `fieldMask` returns 200 but silently no-ops. Alt text is only writable per-placement: Stores product media (Catalog V3), Blog post `heroImage`, Rich Content image/gallery nodes, and Pro Gallery items. No API exists for a page Image component's alt text. Use for "set alt text for this image", "add accessibility text to my images", or "update image alt attribute".
+
 ---
 
 ## Pricing Plans

--- a/skills/wix-manage/references/media/set-image-alt-text.md
+++ b/skills/wix-manage/references/media/set-image-alt-text.md
@@ -1,0 +1,47 @@
+---
+name: "Set Image Alt Text"
+description: Where alt text for an image actually lives on Wix, and which API to call depending on where the image is used. Covers the Media Manager's raw file (no write path exists), and per-placement alt text on Stores products, Blog posts, Rich Content, and Pro Galleries (all writable).
+---
+# RECIPE: Setting Image Alt Text
+
+Learn where to set an image's alt text depending on where the image is placed. Alt text is **not** a single property of the underlying media file — it's stored per-placement, and different placements use different APIs.
+
+---
+
+## There is no way to set alt text on a raw Media Manager file
+
+`media.image.image.altText` shows up in `GetFileDescriptor`/`UpdateFileDescriptor` response schemas, which makes it look settable. **It isn't.** Calling `UpdateFileDescriptor` with `fieldMask` containing `media` returns `200 OK` but silently makes no change — the alt text is never persisted, `updatedDate` doesn't move.
+
+```bash
+# This "succeeds" but does nothing:
+curl -X PATCH 'https://www.wixapis.com/site-media/v1/files/update-file-descriptor' \
+-H 'Authorization: <AUTH>' \
+-H 'Content-Type: application/json' \
+-d '{
+  "file": { "id": "<fileId>", "media": { "image": { "image": { "altText": "..." } } } },
+  "fieldMask": "media"
+}'
+```
+
+Root cause: the proxy only ever forwards `parentFolderId`, `displayName`, `labels`, and `internalTags` downstream for this endpoint — anything else in the `fieldMask` is dropped before the request leaves the service. A `media` field written by an image's alt text has no code path here at all; the only way `altText` gets populated is Wix's own AI image annotation at import time, which you cannot trigger or override via this API.
+
+**Don't retry this with different `fieldMask` shapes** (array, `{paths: [...]}`, etc.) hoping one will stick — none will, because the field isn't wired downstream regardless of how the mask is encoded.
+
+## Where alt text actually IS writable
+
+Alt text is a property of the *placement* — the specific instance of the image used somewhere — not of the Media Manager file itself. Set it via whichever placement API actually applies:
+
+| Placement | Field | API |
+|---|---|---|
+| Stores product image (Catalog V3) | `product.media.itemsInfo.items[].altText` | [Create Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/create-product) / [Update Product](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/update-product) |
+| Blog post cover image | `heroImage.altText` | [Create Draft Post](https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post) / Update Draft Post |
+| Image inside rich content (blog body, product description, etc.) | the image/gallery node's `altText` | See [Ricos Rich Content recipe](../rich-content/author-ricos-rich-content.md) |
+| Pro Gallery item | `imageInfo.altText` | [Update Gallery Item](https://dev.wix.com/docs/api-reference/assets/pro-gallery/update-gallery-item) |
+
+If the image is placed directly in the Wix Editor as a page Image component (not through one of the business solutions above), there is currently **no API** (REST, SDK, or Velo `$w`) to set its alt text — the Editor SDK's Image element only exposes `src`. That has to be done manually in the Editor's Image Settings panel.
+
+## Practical flow
+
+1. Ask (or infer from context) where the image is actually used — a store product, a blog post, a gallery, or a raw page placement.
+2. If it's one of the business-solution placements above, read that resource first (`GET`/`Get Draft Post`/etc.), set `altText` in the relevant sub-object, and write back the full object per that API's usual partial-update rules.
+3. If it's a page Image component with no covering business API, tell the user this has to be set manually in the Editor — don't attempt `UpdateFileDescriptor`, it will silently no-op.

--- a/yaml/wix-manage/media/documentation.yaml
+++ b/yaml/wix-manage/media/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Upload Media to Wix
       docsEntry: https://dev.wix.com/docs/api-reference/assets/media
       tags: [media]
+
+    - file: ../../../skills/wix-manage/references/media/set-image-alt-text.md
+      title: Set Image Alt Text
+      docsEntry: https://dev.wix.com/docs/api-reference/assets/media/media-manager/files/update-file-descriptor
+      tags: [media, seo, accessibility]


### PR DESCRIPTION
## Problem

A Wix MCP user reported that setting an image's alt text via `UpdateFileDescriptor` returns `200 OK` but the change never persists — confirmed live and root-caused in `wix-private/media-manager-node-services#1585` (the proxy's fieldMask filter silently drops `media`/`altText`, forwarding nothing downstream).

Separately, `WixREADME` has zero mentions of "alt text" anywhere in its index, so an agent hitting this task has no routing guidance at all and has to discover the dead end through repeated trial and error (different fieldMask shapes, different endpoints) before giving up.

## What this adds

A new recipe, `Set Image Alt Text`, indexed in `SKILL.md` and `yaml/wix-manage/media/documentation.yaml`, that:
- Tells the agent up front that the raw Media Manager file has no writable `altText` and not to retry `UpdateFileDescriptor` with different fieldMask encodings.
- Documents where alt text actually **is** writable — confirmed via live schema inspection, not guessed: Stores product media (Catalog V3), Blog `heroImage`, Rich Content image/gallery nodes, and Pro Gallery items.
- Flags that a page's Editor Image component has no alt-text write API anywhere (REST, SDK, or Velo `$w`) — a real capability gap, not something to keep searching for.

---
Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com), researching Wix MCP user feedback.
Report thread: https://wix.slack.com/archives/C08P5DKLJR5/p1786747652147539