### PR TITLE
feat(evalforge-yaml-gate): merge-tag sweep for wix-manage

### DIFF
--- a/.github/actions/evalforge-yaml-gate/action.yml
+++ b/.github/actions/evalforge-yaml-gate/action.yml
@@ -2,11 +2,11 @@ name: 'EvalForge YAML Gate'
 description: 'Authors YAML scenarios in PRs and runs EvalForge evaluations against PR-version docs'
 inputs:
   mode:
-    description: 'Action mode: "eval" (default) runs the gate on a PR; "promote" applies YAML tags on PR merge; "cleanup" deletes MCP versions and restores or removes draft scenarios on PR close; "run-all" runs all production scenarios on a schedule'
+    description: 'Action mode: "eval" (default) runs the gate on a PR; "promote" applies YAML tags on PR merge; "cleanup" deletes MCP versions and restores or removes draft scenarios on PR close; "run-all" runs all production scenarios on a schedule; "merge-tag-sweep" re-runs tag-matched scenarios after a wix-manage merge'
     required: false
     default: 'eval'
   github-token:
-    description: 'GitHub token for PR comments (required for eval, promote, cleanup modes)'
+    description: 'GitHub token for PR comments (required for eval, promote, cleanup modes) and PR-author lookup (merge-tag-sweep mode)'
     required: false
     default: ''
   evalforge-url:
@@ -16,7 +16,7 @@ inputs:
     description: 'EvalForge project ID'
     required: true
   evalforge-agent-id:
-    description: 'EvalForge agent ID for eval runs (required for eval and run-all modes)'
+    description: 'EvalForge agent ID for eval runs (required for eval, run-all, and merge-tag-sweep modes)'
     required: false
   evalforge-mcp-id:
     description: 'EvalForge MCP capability ID (required for eval, promote, cleanup modes)'
@@ -60,6 +60,10 @@ inputs:
     description: 'Name for the eval run (run-all mode only)'
     required: false
     default: 'scheduled-run'
+  changed-files:
+    description: 'Raw `git diff --name-status` output for this push (required for merge-tag-sweep mode)'
+    required: false
+    default: ''
 outputs:
   status:
     description: 'Eval run terminal status: completed, failed, cancelled, timeout, or skipped (run-all mode only)'
@@ -74,9 +78,27 @@ outputs:
   run-id:
     description: 'EvalForge eval run ID (run-all mode only)'
   run-url:
-    description: 'Link to EvalForge results page (run-all mode only)'
+    description: 'Link to EvalForge results page (run-all and merge-tag-sweep modes)'
   summary:
     description: 'Human-readable one-line summary of the run (run-all mode only)'
+  matched-tags:
+    description: 'Comma-separated tags that triggered this sweep (merge-tag-sweep mode only)'
+  sweep-matched-total:
+    description: 'Total EvalForge scenarios matching the tag(s), before the sampling cap (merge-tag-sweep mode only)'
+  sweep-sampled-count:
+    description: 'Scenarios actually run this sweep, after the cap (merge-tag-sweep mode only)'
+  confirmed-failed-count:
+    description: 'Number of scenarios confirmed failed after confirm-on-fail retries (merge-tag-sweep mode only)'
+  recovered-count:
+    description: 'Number of scenarios that failed once but recovered on retry (merge-tag-sweep mode only)'
+  confirmed-failed-scenarios:
+    description: 'Newline-separated "name (reasons)" for each confirmed-failed scenario (merge-tag-sweep mode only)'
+  merged-by-name:
+    description: 'GitHub handle of the merging PR author, or the raw commit author name if no PR was found (merge-tag-sweep mode only)'
+  merged-by-url:
+    description: 'Link to the merging PR, or to the commit if no PR was found (merge-tag-sweep mode only)'
+  infra-error:
+    description: 'Set when the sweep itself could not run (EvalForge unreachable, run creation failed) — distinct from a confirmed scenario failure (merge-tag-sweep mode only)'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/evalforge-yaml-gate/action.yml
+++ b/.github/actions/evalforge-yaml-gate/action.yml
@@ -97,6 +97,8 @@ outputs:
     description: 'GitHub handle of the merging PR author, or the raw commit author name if no PR was found (merge-tag-sweep mode only)'
   merged-by-url:
     description: 'Link to the merging PR, or to the commit if no PR was found (merge-tag-sweep mode only)'
+  confirm-skip-reason:
+    description: 'Set when retries were skipped, explaining why the verdict rests on a single attempt (merge-tag-sweep mode only)'
   infra-error:
     description: 'Set when the sweep itself could not run (EvalForge unreachable, run creation failed) — distinct from a confirmed scenario failure (merge-tag-sweep mode only)'
 runs:

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -67656,7 +67656,23 @@ function rowsToOutcomes(rows) {
         reasons: outcome.failingAssertionNames ?? [],
     }));
 }
+/**
+ * Wraps the sweep so that anything thrown before the run's own error handling — bad config, a
+ * malformed workspace, an octokit constructor failure — still reaches the `infra-error` output.
+ * Without this the job would only go red, and a red check on a `main` commit is not a signal
+ * anyone is watching for; the Slack message is the whole point of this mode.
+ */
 async function runMergeTagSweep() {
+    try {
+        await sweep();
+    }
+    catch (e) {
+        const message = `Merge-tag sweep failed before it could report a verdict: ${e instanceof Error ? e.message : String(e)}`;
+        core.setOutput('infra-error', message);
+        core.setFailed(message);
+    }
+}
+async function sweep() {
     const config = (0, config_1.getMergeSweepConfig)();
     const workspace = (0, workspace_1.workspaceRoot)();
     const octokit = github.getOctokit(config.githubToken);
@@ -67667,7 +67683,9 @@ async function runMergeTagSweep() {
     }
     const changedFiles = (0, github_1.parseChangedFiles)(config.changedFilesRaw);
     const classified = (0, github_1.classifyChanges)(changedFiles);
-    const { scenarios: headScenarios } = (0, evals_1.loadEvals)(workspace);
+    const { scenarios: headScenarios, errors: loadErrors } = (0, evals_1.loadEvals)(workspace);
+    for (const e of loadErrors)
+        core.warning(`Scenario load issue (${e.path}): ${e.message}`);
     const cov = (0, coverage_1.computeCoverage)(classified.mdFiles, headScenarios, (f) => (0, doc_url_1.canonicalDocUrl)(f, workspace));
     const changedEvalPaths = new Set([
         ...classified.evalsAdded.map(f => f.filename),
@@ -67718,6 +67736,9 @@ async function runMergeTagSweep() {
         core.setFailed(message);
         return;
     }
+    // Set before the completeness check: a run that was created and then failed or was cancelled
+    // is exactly the case where the reader most wants the link.
+    core.setOutput('run-url', (0, evalforge_core_2.evalRunUrl)(config.projectId, initial.id));
     if (initial.status.status !== 'completed' || initial.status.aggregateMetrics.totalAssertions === 0) {
         const reason = initial.status.status !== 'completed'
             ? `the eval run ${initial.status.status === 'cancelled' ? 'was cancelled' : `ended as "${initial.status.status}"`}`
@@ -67727,7 +67748,6 @@ async function runMergeTagSweep() {
         core.setFailed(message);
         return;
     }
-    core.setOutput('run-url', (0, evalforge_core_2.evalRunUrl)(config.projectId, initial.id));
     const initialOutcomes = rowsToOutcomes(initial.status.results);
     const initialFailures = initialOutcomes.filter(o => o.failed);
     if (initialFailures.length === 0) {
@@ -67737,7 +67757,6 @@ async function runMergeTagSweep() {
         return;
     }
     let confirmResult;
-    let retriesFailed = false;
     try {
         confirmResult = await (0, confirm_1.confirmOnFail)(initialOutcomes, async (ids) => {
             const retry = await runOnce(`${runName}-retry`, ids);
@@ -67746,7 +67765,6 @@ async function runMergeTagSweep() {
     }
     catch (e) {
         core.error(`Merge-tag sweep retry failed: ${e instanceof Error ? e.message : String(e)}`);
-        retriesFailed = true;
         confirmResult = {
             verdicts: initialFailures.map(o => ({
                 scenarioId: o.scenarioId, scenarioName: o.scenarioName,
@@ -67758,11 +67776,19 @@ async function runMergeTagSweep() {
     }
     const confirmed = confirmResult.verdicts.filter(v => v.confirmed);
     const recovered = confirmResult.verdicts.filter(v => !v.confirmed);
+    // When retries were skipped, every verdict stands on a single attempt. Saying "confirmed"
+    // without saying that would promise a majority-of-three vote the run never took.
+    const skipNote = confirmResult.skipReason === 'broad-failure'
+        ? `no retries run — ${initialFailures.length} scenarios failed at once, treated as signal rather than noise`
+        : confirmResult.skipReason === 'rerun-error'
+            ? 'no retries run — the retry itself failed, so the first attempt stands'
+            : '';
+    core.setOutput('confirm-skip-reason', skipNote);
     core.setOutput('confirmed-failed-count', String(confirmed.length));
     core.setOutput('recovered-count', String(recovered.length));
     core.setOutput('confirmed-failed-scenarios', confirmed.map(v => `${v.scenarioName} (${v.reasons.join(', ')})`).join('\n'));
-    if (retriesFailed)
-        core.warning('Merge-tag sweep: retry infrastructure failed — first-attempt failures stand');
+    if (skipNote)
+        core.warning(`Merge-tag sweep: ${skipNote}`);
     if (confirmed.length > 0) {
         const fallback = {
             name: github.context.payload.head_commit?.author?.name ?? 'unknown',

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -66306,11 +66306,13 @@ const gate_1 = __nccwpck_require__(2302);
 const promote_1 = __nccwpck_require__(2245);
 const cleanup_1 = __nccwpck_require__(6157);
 const schedule_1 = __nccwpck_require__(6004);
+const merge_tag_sweep_1 = __nccwpck_require__(3821);
 const modes = {
     eval: gate_1.runGate,
     promote: promote_1.runPromote,
     cleanup: cleanup_1.runCleanup,
     'run-all': schedule_1.runSchedule,
+    'merge-tag-sweep': merge_tag_sweep_1.runMergeTagSweep,
 };
 const mode = core.getInput('mode') || 'eval';
 const handler = modes[mode];
@@ -66660,6 +66662,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getSimpleConfig = getSimpleConfig;
 exports.getScheduleConfig = getScheduleConfig;
+exports.getMergeSweepConfig = getMergeSweepConfig;
 exports.getEvalConfig = getEvalConfig;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
@@ -66693,6 +66696,19 @@ function getScheduleConfig() {
         appId: (0, evalforge_core_1.safeGetSecret)(core, 'evalforge-app-id'),
         appSecret: (0, evalforge_core_1.safeGetSecret)(core, 'evalforge-app-secret'),
         runName: core.getInput('run-name') || 'scheduled-run',
+    };
+}
+function getMergeSweepConfig() {
+    return {
+        evalforgeUrl: (0, evalforge_core_1.ensureHttps)(core, core.getInput('evalforge-url', { required: true })),
+        projectId: core.getInput('evalforge-project-id', { required: true }),
+        agentId: core.getInput('evalforge-agent-id', { required: true }),
+        appId: (0, evalforge_core_1.safeGetSecret)(core, 'evalforge-app-id'),
+        appSecret: (0, evalforge_core_1.safeGetSecret)(core, 'evalforge-app-secret'),
+        githubToken: (0, evalforge_core_1.safeGetSecret)(core, 'github-token'),
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        changedFilesRaw: core.getInput('changed-files', { required: true }),
     };
 }
 function getEvalConfig() {
@@ -67386,6 +67402,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.parseChangedFiles = parseChangedFiles;
 exports.classifyChanges = classifyChanges;
 exports.getChangedFiles = getChangedFiles;
 exports.fail = fail;
@@ -67394,6 +67411,40 @@ const core = __importStar(__nccwpck_require__(7484));
 const evalforge_core_1 = __nccwpck_require__(7495);
 const comment_1 = __nccwpck_require__(3116);
 const paths_1 = __nccwpck_require__(6621);
+const GIT_STATUS_MAP = {
+    A: 'added',
+    M: 'modified',
+    D: 'removed',
+    T: 'modified',
+};
+/**
+ * Parses `git diff --name-status <before> <after>` output into `ChangedFile[]`, for the
+ * merge-tag sweep (a push event, not a PR — there's no octokit file-list API to call here).
+ * Copy (C) is treated as added and type-change (T) as modified; renames (R<score>) carry
+ * both paths. Unrecognized status codes are skipped rather than guessed at.
+ */
+function parseChangedFiles(diffOutput) {
+    const files = [];
+    for (const line of diffOutput.split('\n')) {
+        if (!line.trim())
+            continue;
+        const parts = line.split('\t');
+        const letter = parts[0][0];
+        if (letter === 'R') {
+            files.push({ filename: parts[2], status: 'renamed', previousFilename: parts[1] });
+            continue;
+        }
+        if (letter === 'C') {
+            files.push({ filename: parts[2], status: 'added' });
+            continue;
+        }
+        const status = GIT_STATUS_MAP[letter];
+        if (!status)
+            continue;
+        files.push({ filename: parts[1], status });
+    }
+    return files;
+}
 function classifyChanges(files) {
     const classification = { mdFiles: [], evalsAdded: [], evalsModified: [], evalsRemoved: [] };
     for (const file of files) {
@@ -67425,6 +67476,249 @@ function makeCommenter(octokit, owner, repo, prNumber) {
         warn: core.warning,
         writeSummary: async (body) => { await core.summary.addRaw(body).write(); },
     });
+}
+
+
+/***/ }),
+
+/***/ 3821:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.MAX_SWEEP_SCENARIOS = void 0;
+exports.tagsOfDirectlyAffected = tagsOfDirectlyAffected;
+exports.resolveSweepSet = resolveSweepSet;
+exports.rowsToOutcomes = rowsToOutcomes;
+exports.runMergeTagSweep = runMergeTagSweep;
+const evalforge_core_1 = __nccwpck_require__(7495);
+const gate_1 = __nccwpck_require__(2302);
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const evalforge_core_2 = __nccwpck_require__(7495);
+const config_1 = __nccwpck_require__(7799);
+const evals_1 = __nccwpck_require__(1686);
+const doc_url_1 = __nccwpck_require__(8515);
+const coverage_1 = __nccwpck_require__(4035);
+const github_1 = __nccwpck_require__(6246);
+const workspace_1 = __nccwpck_require__(9620);
+const confirm_1 = __nccwpck_require__(1505);
+const merged_by_1 = __nccwpck_require__(5795);
+/** Above this many tag-matched scenarios, the sweep samples rather than running everything —
+ * a broad tag would otherwise mean dozens of scenarios re-running on every merge that touches it. */
+exports.MAX_SWEEP_SCENARIOS = 20;
+/** Only these assertion statuses count as actual failures — `SKIPPED` and `UNKNOWN` are excluded.
+ * See evalforge-core/src/evalforge.ts for the rationale: `UNKNOWN` is a wire value not recognized,
+ * and folding it into a failure would manufacture a failure nothing actually reports as failed. */
+const NOT_PASSED = new Set(['FAILED', 'ERROR']);
+/** Tags carried by whatever the PR-time gate would itself run for this push: scenarios whose
+ * own YAML changed, unioned with scenarios covering a changed doc. */
+function tagsOfDirectlyAffected(headScenarios, changedEvalPaths, coveredBy) {
+    const affected = (0, gate_1.scenariosToRun)({ headScenarios, changedEvalPaths, coveredBy });
+    const tags = new Set();
+    for (const ls of affected.values()) {
+        for (const t of ls.scenario.tags)
+            tags.add(t);
+    }
+    return tags;
+}
+/**
+ * Resolves the sweep set from EvalForge itself, not the local repo — a scenario that exists
+ * only in EvalForge (hand-authored, drafted from traffic mining) is swept in too, as long as
+ * its tag matches. Caps deterministically: sorted by name, so an overflowing tag samples the
+ * same subset every time rather than an unstable truncation.
+ */
+async function resolveSweepSet(client, projectId, tags) {
+    if (tags.size === 0)
+        return { selected: [], excludedCount: 0, totalMatched: 0 };
+    const all = [];
+    for (const tag of tags) {
+        all.push(...await client.listTestScenariosByTag(projectId, tag));
+    }
+    const unique = (0, evalforge_core_1.uniqueRemoteScenarios)(all).sort((a, b) => a.name.localeCompare(b.name));
+    const selected = unique.slice(0, exports.MAX_SWEEP_SCENARIOS);
+    return {
+        selected,
+        excludedCount: Math.max(0, unique.length - exports.MAX_SWEEP_SCENARIOS),
+        totalMatched: unique.length,
+    };
+}
+/** Turns one EvalRun's per-scenario result rows into confirm.ts's generic AttemptOutcome shape.
+ * Sibling to gate.ts's toAttemptOutcomes, not a reuse of it — there's no with/without pair here,
+ * just "did main pass this scenario." */
+function rowsToOutcomes(rows) {
+    return rows.map(row => ({
+        scenarioId: row.scenarioId,
+        scenarioName: row.scenarioName,
+        failed: row.failed > 0,
+        reasons: row.assertions.filter(a => NOT_PASSED.has(a.status)).map(a => a.assertionName),
+    }));
+}
+async function runMergeTagSweep() {
+    const config = (0, config_1.getMergeSweepConfig)();
+    const workspace = (0, workspace_1.workspaceRoot)();
+    const octokit = github.getOctokit(config.githubToken);
+    const evalforge = new evalforge_core_2.EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
+    const changedFiles = (0, github_1.parseChangedFiles)(config.changedFilesRaw);
+    const classified = (0, github_1.classifyChanges)(changedFiles);
+    const { scenarios: headScenarios } = (0, evals_1.loadEvals)(workspace);
+    const cov = (0, coverage_1.computeCoverage)(classified.mdFiles, headScenarios, (f) => (0, doc_url_1.canonicalDocUrl)(f, workspace));
+    const changedEvalPaths = new Set([
+        ...classified.evalsAdded.map(f => f.filename),
+        ...classified.evalsModified.map(f => f.filename),
+    ]);
+    const tags = tagsOfDirectlyAffected(headScenarios, changedEvalPaths, cov.coveredBy);
+    if (tags.size === 0) {
+        core.info('Merge-tag sweep: no eval-relevant tags in this push — nothing to run');
+        return;
+    }
+    const sortedTags = [...tags].sort();
+    core.setOutput('matched-tags', sortedTags.join(', '));
+    const runName = `merge-sweep-${github.context.sha.slice(0, 7)}`;
+    const runOnce = async (name, scenarioIds) => {
+        const created = await evalforge.createAndRunEvalRun(config.projectId, {
+            name,
+            description: `Merge-tag sweep for tags: ${sortedTags.join(', ')}`,
+            projectId: config.projectId,
+            agentId: config.agentId,
+            scenarioIds,
+        });
+        await evalforge.triggerEvalRun(config.projectId, created.id);
+        const status = await (0, evalforge_core_2.pollUntilDone)(evalforge, config.projectId, created.id, { log: core.info, warn: core.warning });
+        return { id: created.id, status };
+    };
+    // Everything from here on talks to EvalForge — wrapped so an infra failure (unreachable,
+    // 5xx, auth) surfaces as a distinct Slack message rather than a bare failed job nobody sees,
+    // same "no silent failure" rule the PR-time gate applies via PR comments.
+    let initial;
+    try {
+        const { selected, excludedCount, totalMatched } = await resolveSweepSet(evalforge, config.projectId, tags);
+        core.setOutput('sweep-matched-total', String(totalMatched));
+        core.setOutput('sweep-sampled-count', String(selected.length));
+        if (excludedCount > 0) {
+            core.warning(`Merge-tag sweep: sampled ${selected.length} of ${totalMatched} tag-matched scenarios (${excludedCount} excluded by the cap)`);
+        }
+        if (selected.length === 0) {
+            core.info('Merge-tag sweep: tag match resolved to zero scenarios — nothing to run');
+            return;
+        }
+        initial = await runOnce(runName, selected.map(s => s.id));
+    }
+    catch (e) {
+        const message = e instanceof evalforge_core_2.EvalRunTimeoutError
+            ? `Merge-tag sweep timed out: ${e.message}`
+            : `Merge-tag sweep could not run: ${e instanceof Error ? e.message : String(e)}`;
+        core.setOutput('infra-error', message);
+        core.setFailed(message);
+        return;
+    }
+    core.setOutput('run-url', (0, evalforge_core_2.evalRunUrl)(config.projectId, initial.id));
+    const initialOutcomes = rowsToOutcomes(initial.status.results);
+    const initialFailures = initialOutcomes.filter(o => o.failed);
+    if (initialFailures.length === 0) {
+        core.info('Merge-tag sweep: all sampled scenarios passed');
+        core.setOutput('confirmed-failed-count', '0');
+        core.setOutput('recovered-count', '0');
+        return;
+    }
+    let confirmResult;
+    let retriesFailed = false;
+    try {
+        confirmResult = await (0, confirm_1.confirmOnFail)(initialOutcomes, async (ids) => {
+            const retry = await runOnce(`${runName}-retry`, ids);
+            return rowsToOutcomes(retry.status.results);
+        });
+    }
+    catch (e) {
+        core.error(`Merge-tag sweep retry failed: ${e instanceof Error ? e.message : String(e)}`);
+        retriesFailed = true;
+        confirmResult = {
+            verdicts: initialFailures.map(o => ({
+                scenarioId: o.scenarioId, scenarioName: o.scenarioName,
+                attempts: 1, failures: 1, confirmed: true, reasons: o.reasons,
+            })),
+            retriesRun: 0,
+            skipReason: 'rerun-error',
+        };
+    }
+    const confirmed = confirmResult.verdicts.filter(v => v.confirmed);
+    const recovered = confirmResult.verdicts.filter(v => !v.confirmed);
+    core.setOutput('confirmed-failed-count', String(confirmed.length));
+    core.setOutput('recovered-count', String(recovered.length));
+    core.setOutput('confirmed-failed-scenarios', confirmed.map(v => `${v.scenarioName} (${v.reasons.join(', ')})`).join('\n'));
+    if (retriesFailed)
+        core.warning('Merge-tag sweep: retry infrastructure failed — first-attempt failures stand');
+    if (confirmed.length > 0) {
+        const fallback = {
+            name: github.context.payload.head_commit?.author?.name ?? 'unknown',
+            url: `https://github.com/${config.owner}/${config.repo}/commit/${github.context.sha}`,
+        };
+        const mergedBy = await (0, merged_by_1.resolveMergedBy)(octokit, config.owner, config.repo, github.context.sha, fallback);
+        core.setOutput('merged-by-name', mergedBy.name);
+        core.setOutput('merged-by-url', mergedBy.url);
+        core.setFailed(`${confirmed.length} scenario(s) confirmed failed in merge-tag sweep (${confirmed.map(v => v.scenarioName).join(', ')})`);
+    }
+}
+
+
+/***/ }),
+
+/***/ 5795:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveMergedBy = resolveMergedBy;
+/**
+ * Attributes a merge commit to a PR author, for the merge-tag sweep's Slack notification.
+ * Works across both squash and rebase merges (a squash-commit-message regex would not) since
+ * it asks GitHub directly which PR(s) a commit belongs to, rather than parsing commit text.
+ * Falls back to the caller-supplied commit author when no PR is associated (e.g. a direct
+ * push bypassing PR flow) or the associated PR's account no longer exists.
+ */
+async function resolveMergedBy(octokit, owner, repo, commitSha, fallback) {
+    const { data } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+        owner, repo, commit_sha: commitSha,
+    });
+    const pr = data[0];
+    if (!pr || !pr.user)
+        return fallback;
+    return { name: pr.user.login, url: pr.html_url };
 }
 
 

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34640,10 +34640,6 @@ const MAX_QUERY_CONCURRENCY = 8;
 // API base (the internal `/_api/evalforge-backend` gateway). The token is minted
 // here, then used as a Bearer credential against the V1 API at `baseUrl`.
 const OAUTH_TOKEN_URL = 'https://www.wixapis.com/oauth2/token';
-const DEFAULT_TIMEOUT_MS = 15_000;
-// The server's own analysis budget is 57s, so the default would abort every analysis client-side
-// moments before it returned.
-const ANALYZE_TIMEOUT_MS = 75_000;
 exports.TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'];
 function contentBody(content) {
     if (content.kind === 'skill')
@@ -34752,30 +34748,6 @@ function toAssertionStatus(rawStatus) {
         : rawStatus;
     return ASSERTION_STATUSES.find(candidate => candidate === unprefixedStatus) ?? 'UNKNOWN';
 }
-const RUN_ANALYSIS_CATEGORIES = [
-    'FAILURE_PATTERN', 'COST_WASTE', 'FLAKINESS', 'INEFFICIENCY', 'POSITIVE',
-    'WRONG_TOOL_CALL', 'TOOL_OUTPUT_ERROR', 'DOCS_ERROR', 'SKILL_MISGUIDANCE',
-];
-const RUN_ANALYSIS_SEVERITIES = ['HIGH', 'MEDIUM', 'LOW'];
-// These are nested proto enums, so unlike AssertionResultStatus their members carry no enum-name
-// prefix and the wire value is bare. proto3 omits a zero-valued enum, making an absent field as
-// ordinary as the explicit UNKNOWN_CATEGORY / UNKNOWN_SEVERITY members — both, and any future or
-// malformed value, land on UNKNOWN so nothing is invented as HIGH.
-function toEnumMember(raw, members) {
-    if (typeof raw !== 'string')
-        return 'UNKNOWN';
-    return members.find(candidate => candidate === raw) ?? 'UNKNOWN';
-}
-function toRunAnalysisFinding(raw) {
-    return {
-        category: toEnumMember(raw?.category, RUN_ANALYSIS_CATEGORIES),
-        severity: toEnumMember(raw?.severity, RUN_ANALYSIS_SEVERITIES),
-        description: raw?.description ?? '',
-        affectedScenarios: toRowArray(raw?.affectedScenarios)
-            .filter((scenario) => typeof scenario === 'string'),
-        ...(raw?.recommendation === undefined ? {} : { recommendation: raw.recommendation }),
-    };
-}
 function toAssertionOutcome(rawAssertionResult) {
     return {
         assertionName: rawAssertionResult?.assertionName ?? '(unnamed)',
@@ -34824,7 +34796,7 @@ class EvalForgeClient {
         // Token is minted at the fixed public endpoint, NOT under `baseUrl`.
         this.tokens = new auth_1.TokenProvider(OAUTH_TOKEN_URL, clientId, clientSecret);
     }
-    send(method, path, body, token, timeoutMs) {
+    send(method, path, body, token) {
         return fetch(`${this.baseUrl}/v1${path}`, {
             method,
             headers: {
@@ -34832,15 +34804,15 @@ class EvalForgeClient {
                 Authorization: `Bearer ${token}`,
             },
             body: body !== undefined ? JSON.stringify(body) : undefined,
-            signal: AbortSignal.timeout(timeoutMs),
+            signal: AbortSignal.timeout(15_000),
         });
     }
-    async request(method, path, body, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    async request(method, path, body) {
         const token = await this.tokens.getToken();
-        let res = await this.send(method, path, body, token, timeoutMs);
+        let res = await this.send(method, path, body, token);
         if (res.status === 401) {
             // Token rejected before its computed expiry — mint a fresh one and retry once.
-            res = await this.send(method, path, body, await this.tokens.forceRefresh(token), timeoutMs);
+            res = await this.send(method, path, body, await this.tokens.forceRefresh(token));
         }
         if (!res.ok) {
             const err = (await res.json().catch(() => ({})));
@@ -34996,17 +34968,6 @@ class EvalForgeClient {
             results: toRowArray(r.results).map(toResultRow),
         };
     }
-    // --- Analysis ---
-    /** Requires a COMPLETED run; anything else is a 400. The result is persisted on the run. */
-    async analyzeEvalRun(projectId, runId) {
-        const res = await this.request('POST', `/projects/${enc(projectId)}/eval-runs/${enc(runId)}/analyze`, {}, ANALYZE_TIMEOUT_MS);
-        const raw = res.runAnalysis ?? {};
-        return {
-            ...(raw.generatedAt === undefined ? {} : { generatedAt: raw.generatedAt }),
-            summary: raw.summary ?? '',
-            findings: toRowArray(raw.findings).map(toRunAnalysisFinding),
-        };
-    }
     async deleteCapabilityVersion(capabilityId, projectId, versionId) {
         await this.request('DELETE', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions/${enc(versionId)}`);
     }
@@ -35124,216 +35085,6 @@ function foldScenarioIterations(rows) {
         });
     }
     return outcomes;
-}
-
-
-/***/ }),
-
-/***/ 9131:
-/***/ ((__unused_webpack_module, exports) => {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.MAX_COMMENT_BODY_LENGTH = exports.ANALYSIS_COMMENT_MARKER = void 0;
-exports.formatAnalysisComment = formatAnalysisComment;
-exports.formatAnalysisUnavailable = formatAnalysisUnavailable;
-exports.formatAnalysisSuperseded = formatAnalysisSuperseded;
-exports.ANALYSIS_COMMENT_MARKER = '<!-- evalforge-skill-analysis-action -->';
-/**
- * Budget for the rendered body. GitHub rejects a comment over 65536 characters with a 422, and
- * `makeCommenter` degrades that to the job summary — so an unbudgeted body does not fail the job,
- * it silently loses the PR comment. The margin absorbs the fixed scaffolding.
- */
-exports.MAX_COMMENT_BODY_LENGTH = 60_000;
-/** One 100k narrative must not be able to crowd out every finding. */
-const MAX_SUMMARY_LENGTH = 12_000;
-const TEASER_LENGTH = 300;
-/**
- * Safety net for the note that explains why no analysis arrived. Its reasons are short mapped
- * sentences, so this bounds only a caller that passes something unbounded through.
- */
-const MAX_REASON_LENGTH = 500;
-/** Room for the omission notice, so trimming findings can never itself overflow the budget. */
-const OMISSION_NOTICE_RESERVE = 160;
-const HEADING = 'EvalForge: AI Investigation';
-const CATEGORY_LABELS = {
-    FAILURE_PATTERN: 'Failure pattern',
-    COST_WASTE: 'Cost waste',
-    FLAKINESS: 'Flakiness',
-    INEFFICIENCY: 'Inefficiency',
-    POSITIVE: 'Strength',
-    WRONG_TOOL_CALL: 'Wrong tool call',
-    TOOL_OUTPUT_ERROR: 'Tool output error',
-    DOCS_ERROR: 'Docs error',
-    SKILL_MISGUIDANCE: 'Skill misguidance',
-    UNKNOWN: 'Uncategorised',
-};
-const SEVERITY_LABELS = {
-    HIGH: '🔴 High',
-    MEDIUM: '🟠 Medium',
-    LOW: '🟡 Low',
-    UNKNOWN: '',
-};
-const SEVERITY_RANK = {
-    HIGH: 0, MEDIUM: 1, LOW: 2, UNKNOWN: 3,
-};
-function render(body) {
-    return [exports.ANALYSIS_COMMENT_MARKER, `## 🔍 ${HEADING}`, '', ...body].join('\n');
-}
-/** `2026-08-12T14:03:22.512Z` → `2026-08-12 14:03 UTC`. Absent for a value the wire mangled. */
-function formatGeneratedAt(generatedAt) {
-    const parsed = new Date(generatedAt);
-    if (Number.isNaN(parsed.getTime()))
-        return undefined;
-    return `${parsed.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
-}
-function runLine(runId, runUrl, generatedAt) {
-    const stamp = generatedAt === undefined ? undefined : formatGeneratedAt(generatedAt);
-    const suffix = stamp === undefined ? '' : ` · ${stamp}`;
-    return `<sub>Generated for <a href="${runUrl}">eval run ${runId}</a>${suffix}</sub>`;
-}
-/**
- * GitHub honours a `</details>` from inside the fold, unfolding every finding after it. Matched
- * loosely because `</DETAILS>` and `</details >` close it just as well as the canonical spelling.
- */
-function neutraliseFoldEnd(text) {
-    return text.replaceAll(/<\/\s*details\s*>/gi, '&lt;/details&gt;');
-}
-/** Positives last: a reader opening this comment is here for what broke. */
-function sortFindings(findings) {
-    return [...findings].sort((left, right) => {
-        const positive = Number(left.category === 'POSITIVE') - Number(right.category === 'POSITIVE');
-        return positive !== 0 ? positive : SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity];
-    });
-}
-function tally(findings) {
-    const problems = findings.filter(candidate => candidate.category !== 'POSITIVE');
-    const counts = [
-        ['high', problems.filter(candidate => candidate.severity === 'HIGH').length],
-        ['medium', problems.filter(candidate => candidate.severity === 'MEDIUM').length],
-        ['low', problems.filter(candidate => candidate.severity === 'LOW').length],
-        ['positive', findings.length - problems.length],
-    ];
-    const parts = counts.filter(([, count]) => count > 0).map(([label, count]) => `${count} ${label}`);
-    const noun = findings.length === 1 ? 'finding' : 'findings';
-    return `**${findings.length} ${noun}**${parts.length > 0 ? ` — ${parts.join(', ')}.` : '.'}`;
-}
-/** Cuts at a word boundary so a truncated string never ends mid-word. */
-function truncateWords(text, limit) {
-    if (text.length <= limit)
-        return text;
-    const cut = text.slice(0, limit);
-    const lastSpace = cut.lastIndexOf(' ');
-    return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
-}
-/** The above-fold extract: the summary's first paragraph, cut to the teaser budget. */
-function teaserText(summary) {
-    const firstParagraph = summary.trim().split('\n\n')[0]?.trim() ?? '';
-    return firstParagraph === '' ? '' : neutraliseFoldEnd(truncateWords(firstParagraph, TEASER_LENGTH));
-}
-function teaserLines(teaser) {
-    return teaser === '' ? [] : ['', teaser];
-}
-function findingBlock(finding) {
-    // A positive finding sits outside the severity counts in the tally, so labelling it "🔴 High"
-    // here would have the heading and the body disagree about the same finding.
-    const severity = finding.category === 'POSITIVE' ? '' : SEVERITY_LABELS[finding.severity];
-    const category = CATEGORY_LABELS[finding.category];
-    const lines = [
-        '',
-        `### ${severity === '' ? category : `${severity} · ${category}`}`,
-        '',
-        neutraliseFoldEnd(finding.description),
-    ];
-    if (finding.affectedScenarios.length > 0) {
-        lines.push('', `**Scenarios:** ${finding.affectedScenarios.map(name => `\`${name}\``).join(', ')}`);
-    }
-    if (finding.recommendation !== undefined && finding.recommendation !== '') {
-        lines.push('', `**Recommendation:** ${neutraliseFoldEnd(finding.recommendation)}`);
-    }
-    return lines;
-}
-/**
- * Drops whole findings from the tail until the body fits. The sort puts the most serious first, so
- * what survives truncation is the material worth reading; the tally and run link sit outside the
- * fold and are never dropped, which is what keeps a truncated comment actionable.
- */
-function foldedDetail(summary, findings, fixedLength, teaser) {
-    const cappedSummary = neutraliseFoldEnd(truncateWords(summary.trim(), MAX_SUMMARY_LENGTH));
-    // A single short paragraph is shown whole by the teaser, so repeating it here reads as a
-    // rendering bug. Compared as rendered strings rather than by re-deriving the two budgets, so the
-    // rule cannot drift if either changes. A truncated teaser still overlaps the full text below,
-    // which is intended — an excerpt, then the narrative.
-    const summaryLines = cappedSummary === teaser ? [] : ['', cappedSummary];
-    // The blank line after `</summary>` is required, or GitHub renders the enclosed markdown
-    // literally. It comes from `summaryLines`, the first finding block, the notice or the footer —
-    // every one of them opens with one.
-    const header = ['', '<details>', '<summary>Full investigation</summary>'];
-    const footer = ['', '</details>'];
-    const lengthOf = (lines) => lines.join('\n').length;
-    let budget = exports.MAX_COMMENT_BODY_LENGTH
-        - fixedLength
-        - lengthOf([...header, ...summaryLines, ...footer])
-        - OMISSION_NOTICE_RESERVE;
-    const kept = [];
-    let dropped = 0;
-    for (const candidate of findings) {
-        const block = findingBlock(candidate);
-        const cost = lengthOf(block) + 1;
-        if (cost > budget) {
-            dropped += 1;
-            continue;
-        }
-        budget -= cost;
-        kept.push(...block);
-    }
-    const notice = dropped === 0 ? [] : [
-        '',
-        `_${dropped} finding${dropped === 1 ? '' : 's'} omitted — `
-            + 'see the full analysis in EvalForge._',
-    ];
-    return [...header, ...summaryLines, ...kept, ...notice, ...footer];
-}
-function formatAnalysisComment(input) {
-    const { analysis, runId, runUrl } = input;
-    const findings = sortFindings(analysis.findings);
-    const footer = ['', runLine(runId, runUrl, analysis.generatedAt)];
-    const teaser = teaserText(analysis.summary);
-    if (findings.length === 0) {
-        return render([
-            'No findings — the investigation surfaced nothing to act on.',
-            ...teaserLines(teaser),
-            ...footer,
-        ]);
-    }
-    const above = [tally(findings), ...teaserLines(teaser)];
-    const fixedLength = render([...above, ...footer]).length;
-    return render([
-        ...above,
-        ...foldedDetail(analysis.summary, findings, fixedLength, teaser),
-        ...footer,
-    ]);
-}
-function formatAnalysisUnavailable(input) {
-    return render([
-        `The AI investigation could not be generated: ${truncateWords(input.reason, MAX_REASON_LENGTH)}.`,
-        '',
-        'This does not affect the gate verdict.',
-        '',
-        runLine(input.runId, input.runUrl),
-    ]);
-}
-/**
- * Retracts an investigation of a run a later push has superseded. Posted by the gate when the run
- * comes back clean, so a green verdict is never left sitting above a stale list of findings.
- */
-function formatAnalysisSuperseded(input) {
-    return render([
-        'The earlier investigation no longer applies — the latest run had no failing assertions.',
-        '',
-        runLine(input.runId, input.runUrl),
-    ]);
 }
 
 
@@ -35776,7 +35527,6 @@ __exportStar(__nccwpck_require__(3308), exports);
 __exportStar(__nccwpck_require__(8833), exports);
 __exportStar(__nccwpck_require__(3460), exports);
 __exportStar(__nccwpck_require__(5970), exports);
-__exportStar(__nccwpck_require__(9131), exports);
 __exportStar(__nccwpck_require__(1985), exports);
 __exportStar(__nccwpck_require__(1372), exports);
 
@@ -36188,12 +35938,8 @@ async function getChangedFiles(octokit, owner, repo, prNumber) {
  * Upserts a single marked PR comment, so repeated runs edit one comment rather than
  * spamming the thread. Never throws: a comment is a report, and losing it must not fail
  * the gate — the body goes to the job summary instead.
- *
- * `createIfMissing: false` makes it update-only: it retracts or rewrites a comment already on the
- * PR and does nothing when there is none, so a body that only makes sense as a replacement cannot
- * introduce itself.
  */
-function makeCommenter(octokit, target, io, options = {}) {
+function makeCommenter(octokit, target, io) {
     let cachedId;
     let resolved = false;
     async function findExistingId() {
@@ -36220,9 +35966,6 @@ function makeCommenter(octokit, target, io, options = {}) {
                 });
             }
             else {
-                if (options.createIfMissing === false) {
-                    return;
-                }
                 const created = await octokit.rest.issues.createComment({
                     owner: target.owner, repo: target.repo, issue_number: target.prNumber, body,
                 });
@@ -66737,6 +66480,78 @@ function getEvalConfig() {
 
 /***/ }),
 
+/***/ 1505:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.MAX_RETRY_SCENARIOS = exports.MAX_CONFIRM_RETRIES = void 0;
+exports.confirmOnFail = confirmOnFail;
+exports.MAX_CONFIRM_RETRIES = 2;
+/** Above this many initial failures, retries are skipped: broad failure is signal, not noise. */
+exports.MAX_RETRY_SCENARIOS = 10;
+async function confirmOnFail(initial, rerun) {
+    const failed = initial.filter(o => o.failed);
+    if (failed.length === 0)
+        return { verdicts: [], retriesRun: 0 };
+    const state = new Map(failed.map(o => [o.scenarioId, {
+            scenarioId: o.scenarioId,
+            scenarioName: o.scenarioName,
+            attempts: 1,
+            failures: 1,
+            reasons: new Set(o.reasons),
+        }]));
+    if (failed.length > exports.MAX_RETRY_SCENARIOS) {
+        return {
+            verdicts: finalize(state, () => true),
+            retriesRun: 0,
+            skipReason: 'broad-failure',
+        };
+    }
+    let pending = [...state.keys()];
+    let retriesRun = 0;
+    for (let retry = 0; retry < exports.MAX_CONFIRM_RETRIES && pending.length > 0; retry++) {
+        const results = new Map((await rerun(pending)).map(o => [o.scenarioId, o]));
+        retriesRun++;
+        const stillTied = [];
+        for (const id of pending) {
+            const s = state.get(id);
+            const outcome = results.get(id);
+            const failedAttempt = outcome ? outcome.failed : true;
+            s.attempts++;
+            if (failedAttempt) {
+                s.failures++;
+                for (const r of outcome?.reasons ?? ['missing-result'])
+                    s.reasons.add(r);
+            }
+            // Majority of 3: 2 failures confirms; a pass after 3 attempts recovers.
+            if (s.failures < 2 && s.attempts <= exports.MAX_CONFIRM_RETRIES)
+                stillTied.push(id);
+        }
+        pending = stillTied;
+    }
+    return {
+        verdicts: finalize(state, s => s.failures >= 2),
+        retriesRun,
+    };
+}
+function finalize(state, isConfirmed) {
+    return [...state.values()]
+        .map(s => ({
+        scenarioId: s.scenarioId,
+        scenarioName: s.scenarioName,
+        attempts: s.attempts,
+        failures: s.failures,
+        confirmed: isConfirmed(s),
+        reasons: [...s.reasons],
+    }))
+        .sort((a, b) => a.scenarioName.localeCompare(b.scenarioName));
+}
+
+
+/***/ }),
+
 /***/ 4035:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -67574,8 +67389,8 @@ async function resolveSweepSet(client, projectId, tags) {
     };
 }
 /** Turns one EvalRun's per-scenario result rows into confirm.ts's generic AttemptOutcome shape.
- * Sibling to gate.ts's toAttemptOutcomes, not a reuse of it — there's no with/without pair here,
- * just "did main pass this scenario." */
+ * There's no with/without pair here as in a PR-time comparison — just "did main pass this
+ * scenario" — so the rows fold straight into an outcome per scenario. */
 function rowsToOutcomes(rows) {
     return (0, evalforge_core_1.foldScenarioIterations)(rows).map(outcome => ({
         scenarioId: outcome.scenarioId,

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -34640,6 +34640,10 @@ const MAX_QUERY_CONCURRENCY = 8;
 // API base (the internal `/_api/evalforge-backend` gateway). The token is minted
 // here, then used as a Bearer credential against the V1 API at `baseUrl`.
 const OAUTH_TOKEN_URL = 'https://www.wixapis.com/oauth2/token';
+const DEFAULT_TIMEOUT_MS = 15_000;
+// The server's own analysis budget is 57s, so the default would abort every analysis client-side
+// moments before it returned.
+const ANALYZE_TIMEOUT_MS = 75_000;
 exports.TERMINAL_RUN_STATUSES = ['completed', 'failed', 'cancelled'];
 function contentBody(content) {
     if (content.kind === 'skill')
@@ -34748,6 +34752,30 @@ function toAssertionStatus(rawStatus) {
         : rawStatus;
     return ASSERTION_STATUSES.find(candidate => candidate === unprefixedStatus) ?? 'UNKNOWN';
 }
+const RUN_ANALYSIS_CATEGORIES = [
+    'FAILURE_PATTERN', 'COST_WASTE', 'FLAKINESS', 'INEFFICIENCY', 'POSITIVE',
+    'WRONG_TOOL_CALL', 'TOOL_OUTPUT_ERROR', 'DOCS_ERROR', 'SKILL_MISGUIDANCE',
+];
+const RUN_ANALYSIS_SEVERITIES = ['HIGH', 'MEDIUM', 'LOW'];
+// These are nested proto enums, so unlike AssertionResultStatus their members carry no enum-name
+// prefix and the wire value is bare. proto3 omits a zero-valued enum, making an absent field as
+// ordinary as the explicit UNKNOWN_CATEGORY / UNKNOWN_SEVERITY members — both, and any future or
+// malformed value, land on UNKNOWN so nothing is invented as HIGH.
+function toEnumMember(raw, members) {
+    if (typeof raw !== 'string')
+        return 'UNKNOWN';
+    return members.find(candidate => candidate === raw) ?? 'UNKNOWN';
+}
+function toRunAnalysisFinding(raw) {
+    return {
+        category: toEnumMember(raw?.category, RUN_ANALYSIS_CATEGORIES),
+        severity: toEnumMember(raw?.severity, RUN_ANALYSIS_SEVERITIES),
+        description: raw?.description ?? '',
+        affectedScenarios: toRowArray(raw?.affectedScenarios)
+            .filter((scenario) => typeof scenario === 'string'),
+        ...(raw?.recommendation === undefined ? {} : { recommendation: raw.recommendation }),
+    };
+}
 function toAssertionOutcome(rawAssertionResult) {
     return {
         assertionName: rawAssertionResult?.assertionName ?? '(unnamed)',
@@ -34796,7 +34824,7 @@ class EvalForgeClient {
         // Token is minted at the fixed public endpoint, NOT under `baseUrl`.
         this.tokens = new auth_1.TokenProvider(OAUTH_TOKEN_URL, clientId, clientSecret);
     }
-    send(method, path, body, token) {
+    send(method, path, body, token, timeoutMs) {
         return fetch(`${this.baseUrl}/v1${path}`, {
             method,
             headers: {
@@ -34804,15 +34832,15 @@ class EvalForgeClient {
                 Authorization: `Bearer ${token}`,
             },
             body: body !== undefined ? JSON.stringify(body) : undefined,
-            signal: AbortSignal.timeout(15_000),
+            signal: AbortSignal.timeout(timeoutMs),
         });
     }
-    async request(method, path, body) {
+    async request(method, path, body, timeoutMs = DEFAULT_TIMEOUT_MS) {
         const token = await this.tokens.getToken();
-        let res = await this.send(method, path, body, token);
+        let res = await this.send(method, path, body, token, timeoutMs);
         if (res.status === 401) {
             // Token rejected before its computed expiry — mint a fresh one and retry once.
-            res = await this.send(method, path, body, await this.tokens.forceRefresh(token));
+            res = await this.send(method, path, body, await this.tokens.forceRefresh(token), timeoutMs);
         }
         if (!res.ok) {
             const err = (await res.json().catch(() => ({})));
@@ -34968,6 +34996,17 @@ class EvalForgeClient {
             results: toRowArray(r.results).map(toResultRow),
         };
     }
+    // --- Analysis ---
+    /** Requires a COMPLETED run; anything else is a 400. The result is persisted on the run. */
+    async analyzeEvalRun(projectId, runId) {
+        const res = await this.request('POST', `/projects/${enc(projectId)}/eval-runs/${enc(runId)}/analyze`, {}, ANALYZE_TIMEOUT_MS);
+        const raw = res.runAnalysis ?? {};
+        return {
+            ...(raw.generatedAt === undefined ? {} : { generatedAt: raw.generatedAt }),
+            summary: raw.summary ?? '',
+            findings: toRowArray(raw.findings).map(toRunAnalysisFinding),
+        };
+    }
     async deleteCapabilityVersion(capabilityId, projectId, versionId) {
         await this.request('DELETE', `/projects/${enc(projectId)}/capabilities/${enc(capabilityId)}/versions/${enc(versionId)}`);
     }
@@ -35085,6 +35124,216 @@ function foldScenarioIterations(rows) {
         });
     }
     return outcomes;
+}
+
+
+/***/ }),
+
+/***/ 9131:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.MAX_COMMENT_BODY_LENGTH = exports.ANALYSIS_COMMENT_MARKER = void 0;
+exports.formatAnalysisComment = formatAnalysisComment;
+exports.formatAnalysisUnavailable = formatAnalysisUnavailable;
+exports.formatAnalysisSuperseded = formatAnalysisSuperseded;
+exports.ANALYSIS_COMMENT_MARKER = '<!-- evalforge-skill-analysis-action -->';
+/**
+ * Budget for the rendered body. GitHub rejects a comment over 65536 characters with a 422, and
+ * `makeCommenter` degrades that to the job summary — so an unbudgeted body does not fail the job,
+ * it silently loses the PR comment. The margin absorbs the fixed scaffolding.
+ */
+exports.MAX_COMMENT_BODY_LENGTH = 60_000;
+/** One 100k narrative must not be able to crowd out every finding. */
+const MAX_SUMMARY_LENGTH = 12_000;
+const TEASER_LENGTH = 300;
+/**
+ * Safety net for the note that explains why no analysis arrived. Its reasons are short mapped
+ * sentences, so this bounds only a caller that passes something unbounded through.
+ */
+const MAX_REASON_LENGTH = 500;
+/** Room for the omission notice, so trimming findings can never itself overflow the budget. */
+const OMISSION_NOTICE_RESERVE = 160;
+const HEADING = 'EvalForge: AI Investigation';
+const CATEGORY_LABELS = {
+    FAILURE_PATTERN: 'Failure pattern',
+    COST_WASTE: 'Cost waste',
+    FLAKINESS: 'Flakiness',
+    INEFFICIENCY: 'Inefficiency',
+    POSITIVE: 'Strength',
+    WRONG_TOOL_CALL: 'Wrong tool call',
+    TOOL_OUTPUT_ERROR: 'Tool output error',
+    DOCS_ERROR: 'Docs error',
+    SKILL_MISGUIDANCE: 'Skill misguidance',
+    UNKNOWN: 'Uncategorised',
+};
+const SEVERITY_LABELS = {
+    HIGH: '🔴 High',
+    MEDIUM: '🟠 Medium',
+    LOW: '🟡 Low',
+    UNKNOWN: '',
+};
+const SEVERITY_RANK = {
+    HIGH: 0, MEDIUM: 1, LOW: 2, UNKNOWN: 3,
+};
+function render(body) {
+    return [exports.ANALYSIS_COMMENT_MARKER, `## 🔍 ${HEADING}`, '', ...body].join('\n');
+}
+/** `2026-08-12T14:03:22.512Z` → `2026-08-12 14:03 UTC`. Absent for a value the wire mangled. */
+function formatGeneratedAt(generatedAt) {
+    const parsed = new Date(generatedAt);
+    if (Number.isNaN(parsed.getTime()))
+        return undefined;
+    return `${parsed.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
+function runLine(runId, runUrl, generatedAt) {
+    const stamp = generatedAt === undefined ? undefined : formatGeneratedAt(generatedAt);
+    const suffix = stamp === undefined ? '' : ` · ${stamp}`;
+    return `<sub>Generated for <a href="${runUrl}">eval run ${runId}</a>${suffix}</sub>`;
+}
+/**
+ * GitHub honours a `</details>` from inside the fold, unfolding every finding after it. Matched
+ * loosely because `</DETAILS>` and `</details >` close it just as well as the canonical spelling.
+ */
+function neutraliseFoldEnd(text) {
+    return text.replaceAll(/<\/\s*details\s*>/gi, '&lt;/details&gt;');
+}
+/** Positives last: a reader opening this comment is here for what broke. */
+function sortFindings(findings) {
+    return [...findings].sort((left, right) => {
+        const positive = Number(left.category === 'POSITIVE') - Number(right.category === 'POSITIVE');
+        return positive !== 0 ? positive : SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity];
+    });
+}
+function tally(findings) {
+    const problems = findings.filter(candidate => candidate.category !== 'POSITIVE');
+    const counts = [
+        ['high', problems.filter(candidate => candidate.severity === 'HIGH').length],
+        ['medium', problems.filter(candidate => candidate.severity === 'MEDIUM').length],
+        ['low', problems.filter(candidate => candidate.severity === 'LOW').length],
+        ['positive', findings.length - problems.length],
+    ];
+    const parts = counts.filter(([, count]) => count > 0).map(([label, count]) => `${count} ${label}`);
+    const noun = findings.length === 1 ? 'finding' : 'findings';
+    return `**${findings.length} ${noun}**${parts.length > 0 ? ` — ${parts.join(', ')}.` : '.'}`;
+}
+/** Cuts at a word boundary so a truncated string never ends mid-word. */
+function truncateWords(text, limit) {
+    if (text.length <= limit)
+        return text;
+    const cut = text.slice(0, limit);
+    const lastSpace = cut.lastIndexOf(' ');
+    return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+/** The above-fold extract: the summary's first paragraph, cut to the teaser budget. */
+function teaserText(summary) {
+    const firstParagraph = summary.trim().split('\n\n')[0]?.trim() ?? '';
+    return firstParagraph === '' ? '' : neutraliseFoldEnd(truncateWords(firstParagraph, TEASER_LENGTH));
+}
+function teaserLines(teaser) {
+    return teaser === '' ? [] : ['', teaser];
+}
+function findingBlock(finding) {
+    // A positive finding sits outside the severity counts in the tally, so labelling it "🔴 High"
+    // here would have the heading and the body disagree about the same finding.
+    const severity = finding.category === 'POSITIVE' ? '' : SEVERITY_LABELS[finding.severity];
+    const category = CATEGORY_LABELS[finding.category];
+    const lines = [
+        '',
+        `### ${severity === '' ? category : `${severity} · ${category}`}`,
+        '',
+        neutraliseFoldEnd(finding.description),
+    ];
+    if (finding.affectedScenarios.length > 0) {
+        lines.push('', `**Scenarios:** ${finding.affectedScenarios.map(name => `\`${name}\``).join(', ')}`);
+    }
+    if (finding.recommendation !== undefined && finding.recommendation !== '') {
+        lines.push('', `**Recommendation:** ${neutraliseFoldEnd(finding.recommendation)}`);
+    }
+    return lines;
+}
+/**
+ * Drops whole findings from the tail until the body fits. The sort puts the most serious first, so
+ * what survives truncation is the material worth reading; the tally and run link sit outside the
+ * fold and are never dropped, which is what keeps a truncated comment actionable.
+ */
+function foldedDetail(summary, findings, fixedLength, teaser) {
+    const cappedSummary = neutraliseFoldEnd(truncateWords(summary.trim(), MAX_SUMMARY_LENGTH));
+    // A single short paragraph is shown whole by the teaser, so repeating it here reads as a
+    // rendering bug. Compared as rendered strings rather than by re-deriving the two budgets, so the
+    // rule cannot drift if either changes. A truncated teaser still overlaps the full text below,
+    // which is intended — an excerpt, then the narrative.
+    const summaryLines = cappedSummary === teaser ? [] : ['', cappedSummary];
+    // The blank line after `</summary>` is required, or GitHub renders the enclosed markdown
+    // literally. It comes from `summaryLines`, the first finding block, the notice or the footer —
+    // every one of them opens with one.
+    const header = ['', '<details>', '<summary>Full investigation</summary>'];
+    const footer = ['', '</details>'];
+    const lengthOf = (lines) => lines.join('\n').length;
+    let budget = exports.MAX_COMMENT_BODY_LENGTH
+        - fixedLength
+        - lengthOf([...header, ...summaryLines, ...footer])
+        - OMISSION_NOTICE_RESERVE;
+    const kept = [];
+    let dropped = 0;
+    for (const candidate of findings) {
+        const block = findingBlock(candidate);
+        const cost = lengthOf(block) + 1;
+        if (cost > budget) {
+            dropped += 1;
+            continue;
+        }
+        budget -= cost;
+        kept.push(...block);
+    }
+    const notice = dropped === 0 ? [] : [
+        '',
+        `_${dropped} finding${dropped === 1 ? '' : 's'} omitted — `
+            + 'see the full analysis in EvalForge._',
+    ];
+    return [...header, ...summaryLines, ...kept, ...notice, ...footer];
+}
+function formatAnalysisComment(input) {
+    const { analysis, runId, runUrl } = input;
+    const findings = sortFindings(analysis.findings);
+    const footer = ['', runLine(runId, runUrl, analysis.generatedAt)];
+    const teaser = teaserText(analysis.summary);
+    if (findings.length === 0) {
+        return render([
+            'No findings — the investigation surfaced nothing to act on.',
+            ...teaserLines(teaser),
+            ...footer,
+        ]);
+    }
+    const above = [tally(findings), ...teaserLines(teaser)];
+    const fixedLength = render([...above, ...footer]).length;
+    return render([
+        ...above,
+        ...foldedDetail(analysis.summary, findings, fixedLength, teaser),
+        ...footer,
+    ]);
+}
+function formatAnalysisUnavailable(input) {
+    return render([
+        `The AI investigation could not be generated: ${truncateWords(input.reason, MAX_REASON_LENGTH)}.`,
+        '',
+        'This does not affect the gate verdict.',
+        '',
+        runLine(input.runId, input.runUrl),
+    ]);
+}
+/**
+ * Retracts an investigation of a run a later push has superseded. Posted by the gate when the run
+ * comes back clean, so a green verdict is never left sitting above a stale list of findings.
+ */
+function formatAnalysisSuperseded(input) {
+    return render([
+        'The earlier investigation no longer applies — the latest run had no failing assertions.',
+        '',
+        runLine(input.runId, input.runUrl),
+    ]);
 }
 
 
@@ -35527,6 +35776,7 @@ __exportStar(__nccwpck_require__(3308), exports);
 __exportStar(__nccwpck_require__(8833), exports);
 __exportStar(__nccwpck_require__(3460), exports);
 __exportStar(__nccwpck_require__(5970), exports);
+__exportStar(__nccwpck_require__(9131), exports);
 __exportStar(__nccwpck_require__(1985), exports);
 __exportStar(__nccwpck_require__(1372), exports);
 
@@ -35938,8 +36188,12 @@ async function getChangedFiles(octokit, owner, repo, prNumber) {
  * Upserts a single marked PR comment, so repeated runs edit one comment rather than
  * spamming the thread. Never throws: a comment is a report, and losing it must not fail
  * the gate — the body goes to the job summary instead.
+ *
+ * `createIfMissing: false` makes it update-only: it retracts or rewrites a comment already on the
+ * PR and does nothing when there is none, so a body that only makes sense as a replacement cannot
+ * introduce itself.
  */
-function makeCommenter(octokit, target, io) {
+function makeCommenter(octokit, target, io, options = {}) {
     let cachedId;
     let resolved = false;
     async function findExistingId() {
@@ -35966,6 +36220,9 @@ function makeCommenter(octokit, target, io) {
                 });
             }
             else {
+                if (options.createIfMissing === false) {
+                    return;
+                }
                 const created = await octokit.rest.issues.createComment({
                     owner: target.owner, repo: target.repo, issue_number: target.prNumber, body,
                 });

--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -66708,7 +66708,7 @@ function getMergeSweepConfig() {
         githubToken: (0, evalforge_core_1.safeGetSecret)(core, 'github-token'),
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
-        changedFilesRaw: core.getInput('changed-files', { required: true }),
+        changedFilesRaw: core.getInput('changed-files'),
     };
 }
 function getEvalConfig() {
@@ -67541,10 +67541,6 @@ const merged_by_1 = __nccwpck_require__(5795);
 /** Above this many tag-matched scenarios, the sweep samples rather than running everything —
  * a broad tag would otherwise mean dozens of scenarios re-running on every merge that touches it. */
 exports.MAX_SWEEP_SCENARIOS = 20;
-/** Only these assertion statuses count as actual failures — `SKIPPED` and `UNKNOWN` are excluded.
- * See evalforge-core/src/evalforge.ts for the rationale: `UNKNOWN` is a wire value not recognized,
- * and folding it into a failure would manufacture a failure nothing actually reports as failed. */
-const NOT_PASSED = new Set(['FAILED', 'ERROR']);
 /** Tags carried by whatever the PR-time gate would itself run for this push: scenarios whose
  * own YAML changed, unioned with scenarios covering a changed doc. */
 function tagsOfDirectlyAffected(headScenarios, changedEvalPaths, coveredBy) {
@@ -67581,11 +67577,11 @@ async function resolveSweepSet(client, projectId, tags) {
  * Sibling to gate.ts's toAttemptOutcomes, not a reuse of it — there's no with/without pair here,
  * just "did main pass this scenario." */
 function rowsToOutcomes(rows) {
-    return rows.map(row => ({
-        scenarioId: row.scenarioId,
-        scenarioName: row.scenarioName,
-        failed: row.failed > 0,
-        reasons: row.assertions.filter(a => NOT_PASSED.has(a.status)).map(a => a.assertionName),
+    return (0, evalforge_core_1.foldScenarioIterations)(rows).map(outcome => ({
+        scenarioId: outcome.scenarioId,
+        scenarioName: outcome.scenarioName,
+        failed: outcome.failed > 0 || outcome.errors > 0,
+        reasons: outcome.failingAssertionNames ?? [],
     }));
 }
 async function runMergeTagSweep() {
@@ -67593,6 +67589,10 @@ async function runMergeTagSweep() {
     const workspace = (0, workspace_1.workspaceRoot)();
     const octokit = github.getOctokit(config.githubToken);
     const evalforge = new evalforge_core_2.EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
+    if (config.changedFilesRaw.trim() === '') {
+        core.info('Merge-tag sweep: no changed files reported for this push (e.g. first push on this ref) — nothing to run');
+        return;
+    }
     const changedFiles = (0, github_1.parseChangedFiles)(config.changedFilesRaw);
     const classified = (0, github_1.classifyChanges)(changedFiles);
     const { scenarios: headScenarios } = (0, evals_1.loadEvals)(workspace);
@@ -67646,6 +67646,15 @@ async function runMergeTagSweep() {
         core.setFailed(message);
         return;
     }
+    if (initial.status.status !== 'completed' || initial.status.aggregateMetrics.totalAssertions === 0) {
+        const reason = initial.status.status !== 'completed'
+            ? `the eval run ${initial.status.status === 'cancelled' ? 'was cancelled' : `ended as "${initial.status.status}"`}`
+            : 'the run produced no assertions, so nothing was verified';
+        const message = `Merge-tag sweep run did not complete reliably: ${reason}`;
+        core.setOutput('infra-error', message);
+        core.setFailed(message);
+        return;
+    }
     core.setOutput('run-url', (0, evalforge_core_2.evalRunUrl)(config.projectId, initial.id));
     const initialOutcomes = rowsToOutcomes(initial.status.results);
     const initialFailures = initialOutcomes.filter(o => o.failed);
@@ -67687,7 +67696,14 @@ async function runMergeTagSweep() {
             name: github.context.payload.head_commit?.author?.name ?? 'unknown',
             url: `https://github.com/${config.owner}/${config.repo}/commit/${github.context.sha}`,
         };
-        const mergedBy = await (0, merged_by_1.resolveMergedBy)(octokit, config.owner, config.repo, github.context.sha, fallback);
+        let mergedBy;
+        try {
+            mergedBy = await (0, merged_by_1.resolveMergedBy)(octokit, config.owner, config.repo, github.context.sha, fallback);
+        }
+        catch (e) {
+            core.warning(`Could not resolve merging PR author, using commit author instead: ${e instanceof Error ? e.message : String(e)}`);
+            mergedBy = fallback;
+        }
         core.setOutput('merged-by-name', mergedBy.name);
         core.setOutput('merged-by-url', mergedBy.url);
         core.setFailed(`${confirmed.length} scenario(s) confirmed failed in merge-tag sweep (${confirmed.map(v => v.scenarioName).join(', ')})`);

--- a/.github/actions/evalforge-yaml-gate/src/index.ts
+++ b/.github/actions/evalforge-yaml-gate/src/index.ts
@@ -3,12 +3,14 @@ import { runGate } from './utils/gate';
 import { runPromote } from './utils/promote';
 import { runCleanup } from './utils/cleanup';
 import { runSchedule } from './utils/schedule';
+import { runMergeTagSweep } from './utils/merge-tag-sweep';
 
 const modes: Record<string, () => Promise<void>> = {
   eval: runGate,
   promote: runPromote,
   cleanup: runCleanup,
   'run-all': runSchedule,
+  'merge-tag-sweep': runMergeTagSweep,
 };
 
 const mode = core.getInput('mode') || 'eval';

--- a/.github/actions/evalforge-yaml-gate/src/utils/config.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/config.ts
@@ -94,7 +94,7 @@ export function getMergeSweepConfig(): MergeSweepConfig {
     githubToken: coreSafeGetSecret(core, 'github-token'),
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    changedFilesRaw: core.getInput('changed-files', { required: true }),
+    changedFilesRaw: core.getInput('changed-files'),
   };
 }
 

--- a/.github/actions/evalforge-yaml-gate/src/utils/config.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/config.ts
@@ -72,6 +72,32 @@ export function getScheduleConfig(): ScheduleConfig {
   };
 }
 
+export type MergeSweepConfig = {
+  evalforgeUrl: string;
+  projectId: string;
+  agentId: string;
+  appId: string;
+  appSecret: string;
+  githubToken: string;
+  owner: string;
+  repo: string;
+  changedFilesRaw: string;
+};
+
+export function getMergeSweepConfig(): MergeSweepConfig {
+  return {
+    evalforgeUrl: coreEnsureHttps(core, core.getInput('evalforge-url', { required: true })),
+    projectId: core.getInput('evalforge-project-id', { required: true }),
+    agentId: core.getInput('evalforge-agent-id', { required: true }),
+    appId: coreSafeGetSecret(core, 'evalforge-app-id'),
+    appSecret: coreSafeGetSecret(core, 'evalforge-app-secret'),
+    githubToken: coreSafeGetSecret(core, 'github-token'),
+    owner: github.context.repo.owner,
+    repo: github.context.repo.repo,
+    changedFilesRaw: core.getInput('changed-files', { required: true }),
+  };
+}
+
 export function getEvalConfig(): Config {
   const pr = github.context.payload.pull_request!;
   const headSha = (pr.head as { sha?: string } | undefined)?.sha;

--- a/.github/actions/evalforge-yaml-gate/src/utils/confirm.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/confirm.ts
@@ -1,0 +1,91 @@
+/** One scenario's pass/fail outcome for one eval attempt. */
+export type AttemptOutcome = { scenarioId: string; scenarioName: string; failed: boolean; reasons: string[] };
+
+export type ConfirmVerdict = {
+  scenarioId: string;
+  scenarioName: string;
+  attempts: number;
+  failures: number;
+  confirmed: boolean;
+  reasons: string[];
+};
+
+/**
+ * 'broad-failure': more scenarios failed initially than MAX_RETRY_SCENARIOS allows to
+ * rerun, so the failures are treated as a real regression rather than noise.
+ * 'rerun-error': the retry infrastructure itself failed; first-attempt failures stand.
+ * Absent: retries ran normally (there may still be zero of them, e.g. nothing failed).
+ */
+export type ConfirmResult = { verdicts: ConfirmVerdict[]; retriesRun: number; skipReason?: 'broad-failure' | 'rerun-error' };
+
+export const MAX_CONFIRM_RETRIES = 2;
+
+/** Above this many initial failures, retries are skipped: broad failure is signal, not noise. */
+export const MAX_RETRY_SCENARIOS = 10;
+
+export async function confirmOnFail(
+  initial: AttemptOutcome[],
+  rerun: (scenarioIds: string[]) => Promise<AttemptOutcome[]>,
+): Promise<ConfirmResult> {
+  const failed = initial.filter(o => o.failed);
+  if (failed.length === 0) return { verdicts: [], retriesRun: 0 };
+
+  const state = new Map(failed.map(o => [o.scenarioId, {
+    scenarioId: o.scenarioId,
+    scenarioName: o.scenarioName,
+    attempts: 1,
+    failures: 1,
+    reasons: new Set(o.reasons),
+  }]));
+
+  if (failed.length > MAX_RETRY_SCENARIOS) {
+    return {
+      verdicts: finalize(state, () => true),
+      retriesRun: 0,
+      skipReason: 'broad-failure',
+    };
+  }
+
+  let pending = [...state.keys()];
+  let retriesRun = 0;
+
+  for (let retry = 0; retry < MAX_CONFIRM_RETRIES && pending.length > 0; retry++) {
+    const results = new Map((await rerun(pending)).map(o => [o.scenarioId, o]));
+    retriesRun++;
+    const stillTied: string[] = [];
+    for (const id of pending) {
+      const s = state.get(id)!;
+      const outcome = results.get(id);
+      const failedAttempt = outcome ? outcome.failed : true;
+      s.attempts++;
+      if (failedAttempt) {
+        s.failures++;
+        for (const r of outcome?.reasons ?? ['missing-result']) s.reasons.add(r);
+      }
+      // Majority of 3: 2 failures confirms; a pass after 3 attempts recovers.
+      if (s.failures < 2 && s.attempts <= MAX_CONFIRM_RETRIES) stillTied.push(id);
+    }
+    pending = stillTied;
+  }
+
+  return {
+    verdicts: finalize(state, s => s.failures >= 2),
+    retriesRun,
+  };
+}
+
+function finalize(
+  state: Map<string, { scenarioId: string; scenarioName: string; attempts: number; failures: number; reasons: Set<string> }>,
+  isConfirmed: (s: { failures: number }) => boolean,
+): ConfirmVerdict[] {
+  return [...state.values()]
+    .map(s => ({
+      scenarioId: s.scenarioId,
+      scenarioName: s.scenarioName,
+      attempts: s.attempts,
+      failures: s.failures,
+      confirmed: isConfirmed(s),
+      reasons: [...s.reasons],
+    }))
+    .sort((a, b) => a.scenarioName.localeCompare(b.scenarioName));
+}

--- a/.github/actions/evalforge-yaml-gate/src/utils/github.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/github.ts
@@ -19,6 +19,40 @@ export type Classification = {
   evalsRemoved: ChangedFile[];
 };
 
+const GIT_STATUS_MAP: Record<string, string> = {
+  A: 'added',
+  M: 'modified',
+  D: 'removed',
+  T: 'modified',
+};
+
+/**
+ * Parses `git diff --name-status <before> <after>` output into `ChangedFile[]`, for the
+ * merge-tag sweep (a push event, not a PR — there's no octokit file-list API to call here).
+ * Copy (C) is treated as added and type-change (T) as modified; renames (R<score>) carry
+ * both paths. Unrecognized status codes are skipped rather than guessed at.
+ */
+export function parseChangedFiles(diffOutput: string): ChangedFile[] {
+  const files: ChangedFile[] = [];
+  for (const line of diffOutput.split('\n')) {
+    if (!line.trim()) continue;
+    const parts = line.split('\t');
+    const letter = parts[0][0];
+    if (letter === 'R') {
+      files.push({ filename: parts[2], status: 'renamed', previousFilename: parts[1] });
+      continue;
+    }
+    if (letter === 'C') {
+      files.push({ filename: parts[2], status: 'added' });
+      continue;
+    }
+    const status = GIT_STATUS_MAP[letter];
+    if (!status) continue;
+    files.push({ filename: parts[1], status });
+  }
+  return files;
+}
+
 export function classifyChanges(files: ChangedFile[]): Classification {
   const classification: Classification = { mdFiles: [], evalsAdded: [], evalsModified: [], evalsRemoved: [] };
   for (const file of files) {

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -1,0 +1,65 @@
+import { uniqueRemoteScenarios, type RemoteScenario, type EvalRunResultRow } from '@wix/evalforge-core';
+import type { LoadedScenario } from './evals';
+import { scenariosToRun } from './gate';
+import type { AttemptOutcome } from './confirm';
+
+/** Above this many tag-matched scenarios, the sweep samples rather than running everything —
+ * a broad tag would otherwise mean dozens of scenarios re-running on every merge that touches it. */
+export const MAX_SWEEP_SCENARIOS = 20;
+
+/** Tags carried by whatever the PR-time gate would itself run for this push: scenarios whose
+ * own YAML changed, unioned with scenarios covering a changed doc. */
+export function tagsOfDirectlyAffected(
+  headScenarios: Map<string, LoadedScenario>,
+  changedEvalPaths: Set<string>,
+  coveredBy: Map<string, string[]>,
+): Set<string> {
+  const affected = scenariosToRun({ headScenarios, changedEvalPaths, coveredBy });
+  const tags = new Set<string>();
+  for (const ls of affected.values()) {
+    for (const t of ls.scenario.tags) tags.add(t);
+  }
+  return tags;
+}
+
+/** The slice of EvalForgeClient this module needs — declared structurally so tests need no client. */
+export type SweepSetClient = {
+  listTestScenariosByTag(projectId: string, tag: string): Promise<RemoteScenario[]>;
+};
+
+/**
+ * Resolves the sweep set from EvalForge itself, not the local repo — a scenario that exists
+ * only in EvalForge (hand-authored, drafted from traffic mining) is swept in too, as long as
+ * its tag matches. Caps deterministically: sorted by name, so an overflowing tag samples the
+ * same subset every time rather than an unstable truncation.
+ */
+export async function resolveSweepSet(
+  client: SweepSetClient,
+  projectId: string,
+  tags: Set<string>,
+): Promise<{ selected: RemoteScenario[]; excludedCount: number; totalMatched: number }> {
+  if (tags.size === 0) return { selected: [], excludedCount: 0, totalMatched: 0 };
+  const all: RemoteScenario[] = [];
+  for (const tag of tags) {
+    all.push(...await client.listTestScenariosByTag(projectId, tag));
+  }
+  const unique = uniqueRemoteScenarios(all).sort((a, b) => a.name.localeCompare(b.name));
+  const selected = unique.slice(0, MAX_SWEEP_SCENARIOS);
+  return {
+    selected,
+    excludedCount: Math.max(0, unique.length - MAX_SWEEP_SCENARIOS),
+    totalMatched: unique.length,
+  };
+}
+
+/** Turns one EvalRun's per-scenario result rows into confirm.ts's generic AttemptOutcome shape.
+ * Sibling to gate.ts's toAttemptOutcomes, not a reuse of it — there's no with/without pair here,
+ * just "did main pass this scenario." */
+export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
+  return rows.map(row => ({
+    scenarioId: row.scenarioId,
+    scenarioName: row.scenarioName,
+    failed: row.failed > 0,
+    reasons: row.assertions.filter(a => a.status !== 'PASSED').map(a => a.assertionName),
+  }));
+}

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -75,7 +75,23 @@ export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
   }));
 }
 
+/**
+ * Wraps the sweep so that anything thrown before the run's own error handling — bad config, a
+ * malformed workspace, an octokit constructor failure — still reaches the `infra-error` output.
+ * Without this the job would only go red, and a red check on a `main` commit is not a signal
+ * anyone is watching for; the Slack message is the whole point of this mode.
+ */
 export async function runMergeTagSweep(): Promise<void> {
+  try {
+    await sweep();
+  } catch (e) {
+    const message = `Merge-tag sweep failed before it could report a verdict: ${e instanceof Error ? e.message : String(e)}`;
+    core.setOutput('infra-error', message);
+    core.setFailed(message);
+  }
+}
+
+async function sweep(): Promise<void> {
   const config = getMergeSweepConfig();
   const workspace = workspaceRoot();
   const octokit = github.getOctokit(config.githubToken);
@@ -88,7 +104,8 @@ export async function runMergeTagSweep(): Promise<void> {
 
   const changedFiles = parseChangedFiles(config.changedFilesRaw);
   const classified = classifyChanges(changedFiles);
-  const { scenarios: headScenarios } = loadEvals(workspace);
+  const { scenarios: headScenarios, errors: loadErrors } = loadEvals(workspace);
+  for (const e of loadErrors) core.warning(`Scenario load issue (${e.path}): ${e.message}`);
   const cov = computeCoverage(classified.mdFiles, headScenarios, (f) => canonicalDocUrl(f, workspace));
   const changedEvalPaths = new Set<string>([
     ...classified.evalsAdded.map(f => f.filename),
@@ -141,6 +158,10 @@ export async function runMergeTagSweep(): Promise<void> {
     core.setFailed(message);
     return;
   }
+  // Set before the completeness check: a run that was created and then failed or was cancelled
+  // is exactly the case where the reader most wants the link.
+  core.setOutput('run-url', evalRunUrl(config.projectId, initial.id));
+
   if (initial.status.status !== 'completed' || initial.status.aggregateMetrics.totalAssertions === 0) {
     const reason = initial.status.status !== 'completed'
       ? `the eval run ${initial.status.status === 'cancelled' ? 'was cancelled' : `ended as "${initial.status.status}"`}`
@@ -150,8 +171,6 @@ export async function runMergeTagSweep(): Promise<void> {
     core.setFailed(message);
     return;
   }
-
-  core.setOutput('run-url', evalRunUrl(config.projectId, initial.id));
 
   const initialOutcomes = rowsToOutcomes(initial.status.results);
   const initialFailures = initialOutcomes.filter(o => o.failed);
@@ -163,7 +182,6 @@ export async function runMergeTagSweep(): Promise<void> {
   }
 
   let confirmResult: ConfirmResult;
-  let retriesFailed = false;
   try {
     confirmResult = await confirmOnFail(initialOutcomes, async (ids) => {
       const retry = await runOnce(`${runName}-retry`, ids);
@@ -171,7 +189,6 @@ export async function runMergeTagSweep(): Promise<void> {
     });
   } catch (e) {
     core.error(`Merge-tag sweep retry failed: ${e instanceof Error ? e.message : String(e)}`);
-    retriesFailed = true;
     confirmResult = {
       verdicts: initialFailures.map(o => ({
         scenarioId: o.scenarioId, scenarioName: o.scenarioName,
@@ -184,13 +201,22 @@ export async function runMergeTagSweep(): Promise<void> {
 
   const confirmed = confirmResult.verdicts.filter(v => v.confirmed);
   const recovered = confirmResult.verdicts.filter(v => !v.confirmed);
+
+  // When retries were skipped, every verdict stands on a single attempt. Saying "confirmed"
+  // without saying that would promise a majority-of-three vote the run never took.
+  const skipNote = confirmResult.skipReason === 'broad-failure'
+    ? `no retries run — ${initialFailures.length} scenarios failed at once, treated as signal rather than noise`
+    : confirmResult.skipReason === 'rerun-error'
+      ? 'no retries run — the retry itself failed, so the first attempt stands'
+      : '';
+  core.setOutput('confirm-skip-reason', skipNote);
   core.setOutput('confirmed-failed-count', String(confirmed.length));
   core.setOutput('recovered-count', String(recovered.length));
   core.setOutput(
     'confirmed-failed-scenarios',
     confirmed.map(v => `${v.scenarioName} (${v.reasons.join(', ')})`).join('\n'),
   );
-  if (retriesFailed) core.warning('Merge-tag sweep: retry infrastructure failed — first-attempt failures stand');
+  if (skipNote) core.warning(`Merge-tag sweep: ${skipNote}`);
 
   if (confirmed.length > 0) {
     const fallback: MergedBy = {

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -2,6 +2,17 @@ import { uniqueRemoteScenarios, type RemoteScenario, type EvalRunResultRow } fro
 import type { LoadedScenario } from './evals';
 import { scenariosToRun } from './gate';
 import type { AttemptOutcome } from './confirm';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { EvalForgeClient, pollUntilDone, EvalRunTimeoutError, evalRunUrl } from '@wix/evalforge-core';
+import { getMergeSweepConfig } from './config';
+import { loadEvals } from './evals';
+import { canonicalDocUrl } from './doc-url';
+import { computeCoverage } from './coverage';
+import { classifyChanges, parseChangedFiles } from './github';
+import { workspaceRoot } from './workspace';
+import { confirmOnFail, type ConfirmResult } from './confirm';
+import { resolveMergedBy, type MergedBy } from './merged-by';
 
 /** Above this many tag-matched scenarios, the sweep samples rather than running everything —
  * a broad tag would otherwise mean dozens of scenarios re-running on every merge that touches it. */
@@ -67,4 +78,118 @@ export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
     failed: row.failed > 0,
     reasons: row.assertions.filter(a => NOT_PASSED.has(a.status)).map(a => a.assertionName),
   }));
+}
+
+export async function runMergeTagSweep(): Promise<void> {
+  const config = getMergeSweepConfig();
+  const workspace = workspaceRoot();
+  const octokit = github.getOctokit(config.githubToken);
+  const evalforge = new EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
+
+  const changedFiles = parseChangedFiles(config.changedFilesRaw);
+  const classified = classifyChanges(changedFiles);
+  const { scenarios: headScenarios } = loadEvals(workspace);
+  const cov = computeCoverage(classified.mdFiles, headScenarios, (f) => canonicalDocUrl(f, workspace));
+  const changedEvalPaths = new Set<string>([
+    ...classified.evalsAdded.map(f => f.filename),
+    ...classified.evalsModified.map(f => f.filename),
+  ]);
+  const tags = tagsOfDirectlyAffected(headScenarios, changedEvalPaths, cov.coveredBy);
+
+  if (tags.size === 0) {
+    core.info('Merge-tag sweep: no eval-relevant tags in this push — nothing to run');
+    return;
+  }
+  const sortedTags = [...tags].sort();
+  core.setOutput('matched-tags', sortedTags.join(', '));
+
+  const runName = `merge-sweep-${github.context.sha.slice(0, 7)}`;
+  const runOnce = async (name: string, scenarioIds: string[]) => {
+    const created = await evalforge.createAndRunEvalRun(config.projectId, {
+      name,
+      description: `Merge-tag sweep for tags: ${sortedTags.join(', ')}`,
+      projectId: config.projectId,
+      agentId: config.agentId,
+      scenarioIds,
+    });
+    await evalforge.triggerEvalRun(config.projectId, created.id);
+    const status = await pollUntilDone(evalforge, config.projectId, created.id, { log: core.info, warn: core.warning });
+    return { id: created.id, status };
+  };
+
+  // Everything from here on talks to EvalForge — wrapped so an infra failure (unreachable,
+  // 5xx, auth) surfaces as a distinct Slack message rather than a bare failed job nobody sees,
+  // same "no silent failure" rule the PR-time gate applies via PR comments.
+  let initial: Awaited<ReturnType<typeof runOnce>> | undefined;
+  try {
+    const { selected, excludedCount, totalMatched } = await resolveSweepSet(evalforge, config.projectId, tags);
+    core.setOutput('sweep-matched-total', String(totalMatched));
+    core.setOutput('sweep-sampled-count', String(selected.length));
+    if (excludedCount > 0) {
+      core.warning(`Merge-tag sweep: sampled ${selected.length} of ${totalMatched} tag-matched scenarios (${excludedCount} excluded by the cap)`);
+    }
+    if (selected.length === 0) {
+      core.info('Merge-tag sweep: tag match resolved to zero scenarios — nothing to run');
+      return;
+    }
+    initial = await runOnce(runName, selected.map(s => s.id));
+  } catch (e) {
+    const message = e instanceof EvalRunTimeoutError
+      ? `Merge-tag sweep timed out: ${e.message}`
+      : `Merge-tag sweep could not run: ${e instanceof Error ? e.message : String(e)}`;
+    core.setOutput('infra-error', message);
+    core.setFailed(message);
+    return;
+  }
+  core.setOutput('run-url', evalRunUrl(config.projectId, initial.id));
+
+  const initialOutcomes = rowsToOutcomes(initial.status.results);
+  const initialFailures = initialOutcomes.filter(o => o.failed);
+  if (initialFailures.length === 0) {
+    core.info('Merge-tag sweep: all sampled scenarios passed');
+    core.setOutput('confirmed-failed-count', '0');
+    core.setOutput('recovered-count', '0');
+    return;
+  }
+
+  let confirmResult: ConfirmResult;
+  let retriesFailed = false;
+  try {
+    confirmResult = await confirmOnFail(initialOutcomes, async (ids) => {
+      const retry = await runOnce(`${runName}-retry`, ids);
+      return rowsToOutcomes(retry.status.results);
+    });
+  } catch (e) {
+    core.error(`Merge-tag sweep retry failed: ${e instanceof Error ? e.message : String(e)}`);
+    retriesFailed = true;
+    confirmResult = {
+      verdicts: initialFailures.map(o => ({
+        scenarioId: o.scenarioId, scenarioName: o.scenarioName,
+        attempts: 1, failures: 1, confirmed: true, reasons: o.reasons,
+      })),
+      retriesRun: 0,
+      skipReason: 'rerun-error',
+    };
+  }
+
+  const confirmed = confirmResult.verdicts.filter(v => v.confirmed);
+  const recovered = confirmResult.verdicts.filter(v => !v.confirmed);
+  core.setOutput('confirmed-failed-count', String(confirmed.length));
+  core.setOutput('recovered-count', String(recovered.length));
+  core.setOutput(
+    'confirmed-failed-scenarios',
+    confirmed.map(v => `${v.scenarioName} (${v.reasons.join(', ')})`).join('\n'),
+  );
+  if (retriesFailed) core.warning('Merge-tag sweep: retry infrastructure failed — first-attempt failures stand');
+
+  if (confirmed.length > 0) {
+    const fallback: MergedBy = {
+      name: github.context.payload.head_commit?.author?.name ?? 'unknown',
+      url: `https://github.com/${config.owner}/${config.repo}/commit/${github.context.sha}`,
+    };
+    const mergedBy = await resolveMergedBy(octokit, config.owner, config.repo, github.context.sha, fallback);
+    core.setOutput('merged-by-name', mergedBy.name);
+    core.setOutput('merged-by-url', mergedBy.url);
+    core.setFailed(`${confirmed.length} scenario(s) confirmed failed in merge-tag sweep (${confirmed.map(v => v.scenarioName).join(', ')})`);
+  }
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -7,6 +7,11 @@ import type { AttemptOutcome } from './confirm';
  * a broad tag would otherwise mean dozens of scenarios re-running on every merge that touches it. */
 export const MAX_SWEEP_SCENARIOS = 20;
 
+/** Only these assertion statuses count as actual failures — `SKIPPED` and `UNKNOWN` are excluded.
+ * See evalforge-core/src/evalforge.ts for the rationale: `UNKNOWN` is a wire value not recognized,
+ * and folding it into a failure would manufacture a failure nothing actually reports as failed. */
+const NOT_PASSED = new Set(['FAILED', 'ERROR']);
+
 /** Tags carried by whatever the PR-time gate would itself run for this push: scenarios whose
  * own YAML changed, unioned with scenarios covering a changed doc. */
 export function tagsOfDirectlyAffected(
@@ -60,6 +65,6 @@ export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
     scenarioId: row.scenarioId,
     scenarioName: row.scenarioName,
     failed: row.failed > 0,
-    reasons: row.assertions.filter(a => a.status !== 'PASSED').map(a => a.assertionName),
+    reasons: row.assertions.filter(a => NOT_PASSED.has(a.status)).map(a => a.assertionName),
   }));
 }

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -1,4 +1,4 @@
-import { uniqueRemoteScenarios, type RemoteScenario, type EvalRunResultRow } from '@wix/evalforge-core';
+import { uniqueRemoteScenarios, foldScenarioIterations, type RemoteScenario, type EvalRunResultRow } from '@wix/evalforge-core';
 import type { LoadedScenario } from './evals';
 import { scenariosToRun } from './gate';
 import type { AttemptOutcome } from './confirm';
@@ -17,11 +17,6 @@ import { resolveMergedBy, type MergedBy } from './merged-by';
 /** Above this many tag-matched scenarios, the sweep samples rather than running everything —
  * a broad tag would otherwise mean dozens of scenarios re-running on every merge that touches it. */
 export const MAX_SWEEP_SCENARIOS = 20;
-
-/** Only these assertion statuses count as actual failures — `SKIPPED` and `UNKNOWN` are excluded.
- * See evalforge-core/src/evalforge.ts for the rationale: `UNKNOWN` is a wire value not recognized,
- * and folding it into a failure would manufacture a failure nothing actually reports as failed. */
-const NOT_PASSED = new Set(['FAILED', 'ERROR']);
 
 /** Tags carried by whatever the PR-time gate would itself run for this push: scenarios whose
  * own YAML changed, unioned with scenarios covering a changed doc. */
@@ -72,11 +67,11 @@ export async function resolveSweepSet(
  * Sibling to gate.ts's toAttemptOutcomes, not a reuse of it — there's no with/without pair here,
  * just "did main pass this scenario." */
 export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
-  return rows.map(row => ({
-    scenarioId: row.scenarioId,
-    scenarioName: row.scenarioName,
-    failed: row.failed > 0,
-    reasons: row.assertions.filter(a => NOT_PASSED.has(a.status)).map(a => a.assertionName),
+  return foldScenarioIterations(rows).map(outcome => ({
+    scenarioId: outcome.scenarioId,
+    scenarioName: outcome.scenarioName,
+    failed: outcome.failed > 0 || outcome.errors > 0,
+    reasons: outcome.failingAssertionNames ?? [],
   }));
 }
 
@@ -85,6 +80,11 @@ export async function runMergeTagSweep(): Promise<void> {
   const workspace = workspaceRoot();
   const octokit = github.getOctokit(config.githubToken);
   const evalforge = new EvalForgeClient(config.evalforgeUrl, config.appId, config.appSecret);
+
+  if (config.changedFilesRaw.trim() === '') {
+    core.info('Merge-tag sweep: no changed files reported for this push (e.g. first push on this ref) — nothing to run');
+    return;
+  }
 
   const changedFiles = parseChangedFiles(config.changedFilesRaw);
   const classified = classifyChanges(changedFiles);
@@ -141,6 +141,16 @@ export async function runMergeTagSweep(): Promise<void> {
     core.setFailed(message);
     return;
   }
+  if (initial.status.status !== 'completed' || initial.status.aggregateMetrics.totalAssertions === 0) {
+    const reason = initial.status.status !== 'completed'
+      ? `the eval run ${initial.status.status === 'cancelled' ? 'was cancelled' : `ended as "${initial.status.status}"`}`
+      : 'the run produced no assertions, so nothing was verified';
+    const message = `Merge-tag sweep run did not complete reliably: ${reason}`;
+    core.setOutput('infra-error', message);
+    core.setFailed(message);
+    return;
+  }
+
   core.setOutput('run-url', evalRunUrl(config.projectId, initial.id));
 
   const initialOutcomes = rowsToOutcomes(initial.status.results);
@@ -187,7 +197,13 @@ export async function runMergeTagSweep(): Promise<void> {
       name: github.context.payload.head_commit?.author?.name ?? 'unknown',
       url: `https://github.com/${config.owner}/${config.repo}/commit/${github.context.sha}`,
     };
-    const mergedBy = await resolveMergedBy(octokit, config.owner, config.repo, github.context.sha, fallback);
+    let mergedBy: MergedBy;
+    try {
+      mergedBy = await resolveMergedBy(octokit, config.owner, config.repo, github.context.sha, fallback);
+    } catch (e) {
+      core.warning(`Could not resolve merging PR author, using commit author instead: ${e instanceof Error ? e.message : String(e)}`);
+      mergedBy = fallback;
+    }
     core.setOutput('merged-by-name', mergedBy.name);
     core.setOutput('merged-by-url', mergedBy.url);
     core.setFailed(`${confirmed.length} scenario(s) confirmed failed in merge-tag sweep (${confirmed.map(v => v.scenarioName).join(', ')})`);

--- a/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merge-tag-sweep.ts
@@ -64,8 +64,8 @@ export async function resolveSweepSet(
 }
 
 /** Turns one EvalRun's per-scenario result rows into confirm.ts's generic AttemptOutcome shape.
- * Sibling to gate.ts's toAttemptOutcomes, not a reuse of it — there's no with/without pair here,
- * just "did main pass this scenario." */
+ * There's no with/without pair here as in a PR-time comparison — just "did main pass this
+ * scenario" — so the rows fold straight into an outcome per scenario. */
 export function rowsToOutcomes(rows: EvalRunResultRow[]): AttemptOutcome[] {
   return foldScenarioIterations(rows).map(outcome => ({
     scenarioId: outcome.scenarioId,

--- a/.github/actions/evalforge-yaml-gate/src/utils/merged-by.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/merged-by.ts
@@ -1,0 +1,36 @@
+export type MergedBy = { name: string; url: string };
+
+/** The slice of Octokit this module needs — declared structurally so tests need no client. */
+export type PullRequestLookupClient = {
+  rest: {
+    repos: {
+      listPullRequestsAssociatedWithCommit(params: {
+        owner: string;
+        repo: string;
+        commit_sha: string;
+      }): Promise<{ data: Array<{ html_url: string; user: { login: string } | null }> }>;
+    };
+  };
+};
+
+/**
+ * Attributes a merge commit to a PR author, for the merge-tag sweep's Slack notification.
+ * Works across both squash and rebase merges (a squash-commit-message regex would not) since
+ * it asks GitHub directly which PR(s) a commit belongs to, rather than parsing commit text.
+ * Falls back to the caller-supplied commit author when no PR is associated (e.g. a direct
+ * push bypassing PR flow) or the associated PR's account no longer exists.
+ */
+export async function resolveMergedBy(
+  octokit: PullRequestLookupClient,
+  owner: string,
+  repo: string,
+  commitSha: string,
+  fallback: MergedBy,
+): Promise<MergedBy> {
+  const { data } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+    owner, repo, commit_sha: commitSha,
+  });
+  const pr = data[0];
+  if (!pr || !pr.user) return fallback;
+  return { name: pr.user.login, url: pr.html_url };
+}

--- a/.github/actions/evalforge-yaml-gate/tests/confirm.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/confirm.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { confirmOnFail, MAX_RETRY_SCENARIOS, type AttemptOutcome } from '../src/utils/confirm';
+
+const fail = (id: string, reasons = ['llm-judge']): AttemptOutcome =>
+  ({ scenarioId: id, scenarioName: `name-${id}`, failed: true, reasons });
+const pass = (id: string): AttemptOutcome =>
+  ({ scenarioId: id, scenarioName: `name-${id}`, failed: false, reasons: [] });
+
+describe('confirmOnFail', () => {
+  it('makes no reruns when nothing failed initially', async () => {
+    const rerun = vi.fn();
+    const out = await confirmOnFail([pass('a'), pass('b')], rerun);
+    expect(rerun).not.toHaveBeenCalled();
+    expect(out.verdicts).toEqual([]);
+    expect(out.retriesRun).toBe(0);
+  });
+
+  it('confirms a scenario that fails the first retry, without a third run', async () => {
+    const rerun = vi.fn().mockResolvedValueOnce([fail('a')]);
+    const out = await confirmOnFail([fail('a'), pass('b')], rerun);
+    expect(rerun).toHaveBeenCalledTimes(1);
+    expect(rerun).toHaveBeenCalledWith(['a']);
+    expect(out.verdicts).toEqual([
+      { scenarioId: 'a', scenarioName: 'name-a', attempts: 2, failures: 2, confirmed: true, reasons: ['llm-judge'] },
+    ]);
+  });
+
+  it('recovers a scenario that passes both retries', async () => {
+    const rerun = vi.fn()
+      .mockResolvedValueOnce([pass('a')])
+      .mockResolvedValueOnce([pass('a')]);
+    const out = await confirmOnFail([fail('a')], rerun);
+    expect(rerun).toHaveBeenCalledTimes(2);
+    expect(out.verdicts[0]).toMatchObject({ scenarioId: 'a', attempts: 3, failures: 1, confirmed: false });
+  });
+
+  it('confirms a scenario that passes retry 1 but fails the tiebreak', async () => {
+    const rerun = vi.fn()
+      .mockResolvedValueOnce([pass('a')])
+      .mockResolvedValueOnce([fail('a', ['token-budget'])]);
+    const out = await confirmOnFail([fail('a')], rerun);
+    expect(out.verdicts[0]).toMatchObject({ attempts: 3, failures: 2, confirmed: true });
+    expect(out.verdicts[0].reasons.sort()).toEqual(['llm-judge', 'token-budget']);
+  });
+
+  it('retries only the still-tied ids on the tiebreak', async () => {
+    const rerun = vi.fn()
+      .mockResolvedValueOnce([fail('a'), pass('b')])   // a confirmed at 2/2, b tied 1-1
+      .mockResolvedValueOnce([pass('b')]);
+    const out = await confirmOnFail([fail('a'), fail('b')], rerun);
+    expect(rerun).toHaveBeenNthCalledWith(1, ['a', 'b']);
+    expect(rerun).toHaveBeenNthCalledWith(2, ['b']);
+    const byId = Object.fromEntries(out.verdicts.map(v => [v.scenarioId, v]));
+    expect(byId['a'].confirmed).toBe(true);
+    expect(byId['b'].confirmed).toBe(false);
+  });
+
+  it('skips retries above the scenario cap and confirms everything', async () => {
+    const rerun = vi.fn();
+    const many = Array.from({ length: MAX_RETRY_SCENARIOS + 1 }, (_, i) => fail(`s${i}`));
+    const out = await confirmOnFail(many, rerun);
+    expect(rerun).not.toHaveBeenCalled();
+    expect(out.skipReason).toBe('broad-failure');
+    expect(out.verdicts.every(v => v.confirmed && v.attempts === 1)).toBe(true);
+  });
+
+  it('treats an id missing from a rerun result as a failed attempt', async () => {
+    const rerun = vi.fn().mockResolvedValueOnce([]);
+    const out = await confirmOnFail([fail('a')], rerun);
+    expect(out.verdicts[0].confirmed).toBe(true);
+    expect(out.verdicts[0].reasons).toContain('missing-result');
+  });
+});

--- a/.github/actions/evalforge-yaml-gate/tests/github.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyChanges } from '../src/utils/github';
+import { classifyChanges, parseChangedFiles } from '../src/utils/github';
 
 const f = (filename: string, status: 'added' | 'modified' | 'removed' | 'renamed') => ({ filename, status });
 
@@ -37,5 +37,47 @@ describe('classifyChanges', () => {
     expect(out.evalsAdded).toEqual([]);
     expect(out.evalsModified).toEqual([]);
     expect(out.evalsRemoved).toEqual([]);
+  });
+});
+
+describe('parseChangedFiles', () => {
+  it('parses added, modified, and deleted files', () => {
+    const out = parseChangedFiles(
+      'A\tyaml/wix-manage-evals/blog/new.yml\n' +
+      'M\tskills/wix-manage/references/blog/x.md\n' +
+      'D\tyaml/wix-manage-evals/blog/old.yml\n',
+    );
+    expect(out).toEqual([
+      { filename: 'yaml/wix-manage-evals/blog/new.yml', status: 'added' },
+      { filename: 'skills/wix-manage/references/blog/x.md', status: 'modified' },
+      { filename: 'yaml/wix-manage-evals/blog/old.yml', status: 'removed' },
+    ]);
+  });
+
+  it('parses a rename with its similarity-score suffix', () => {
+    const out = parseChangedFiles('R100\told/path.yml\tnew/path.yml\n');
+    expect(out).toEqual([
+      { filename: 'new/path.yml', status: 'renamed', previousFilename: 'old/path.yml' },
+    ]);
+  });
+
+  it('maps a type-change (T) to modified and a copy (C) to added', () => {
+    const out = parseChangedFiles(
+      'T\tyaml/wix-manage-evals/blog/x.yml\n' +
+      'C100\tsrc.yml\tdst.yml\n',
+    );
+    expect(out).toEqual([
+      { filename: 'yaml/wix-manage-evals/blog/x.yml', status: 'modified' },
+      { filename: 'dst.yml', status: 'added' },
+    ]);
+  });
+
+  it('ignores blank lines', () => {
+    const out = parseChangedFiles('\nA\ta.yml\n\n');
+    expect(out).toEqual([{ filename: 'a.yml', status: 'added' }]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseChangedFiles('')).toEqual([]);
   });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -56,4 +56,9 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
   it('reuses the existing Slack webhook secret', () => {
     expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}');
   });
+
+  it('guards both Slack steps with always(), since the sweep step itself reports failure on a confirmed regression or infra error', () => {
+    expect(workflowContent).toContain("if: always() && steps.sweep.outputs.confirmed-failed-count");
+    expect(workflowContent).toContain("if: always() && steps.sweep.outputs.infra-error");
+  });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -57,6 +57,31 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
     expect(workflowContent).toContain("if: vars.MERGE_TAG_SWEEP_ENABLED != 'false'");
   });
 
+  it('allows a job budget above the worst-case three sequential 30-minute polls', () => {
+    const match = workflowContent.match(/timeout-minutes:\s*(\d+)/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThanOrEqual(95);
+  });
+
+  it('notifies even when the sweep step reports no verdict at all', () => {
+    expect(workflowContent).toContain('Post Slack notification (job failed with no verdict)');
+    expect(workflowContent).toContain('failure()');
+  });
+
+  it('surfaces the skipped-retries caveat so a single-attempt verdict is not read as a majority', () => {
+    expect(workflowContent).toContain('confirm-skip-reason');
+    expect(workflowContent).toContain('$skip_reason');
+  });
+
+  it('fails loudly when Slack rejects a payload, rather than dropping the alert', () => {
+    expect(workflowContent).not.toMatch(/curl -s -X POST/);
+    expect(workflowContent).toContain('--fail-with-body');
+  });
+
+  it('does not let git quote non-ASCII paths out of matching the doc and scenario patterns', () => {
+    expect(workflowContent).toContain('core.quotePath=false');
+  });
+
   it('reuses the existing Slack webhook secret', () => {
     expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}');
   });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -84,9 +84,8 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
     expect(workflowContent).toContain('core.quotePath=false');
   });
 
-  it('posts through its own webhook secret, not the one the weekly run shares', () => {
-    expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}');
-    expect(workflowContent).not.toContain('secrets.SLACK_WEBHOOK_URL }}');
+  it('reuses the existing Slack webhook secret', () => {
+    expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}');
   });
 
   it('guards both Slack steps with always(), since the sweep step itself reports failure on a confirmed regression or infra error', () => {

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('EvalForge Merge-Tag Sweep Workflow', () => {
+  let workflowContent: string;
+
+  beforeAll(() => {
+    const workflowPath = join(__dirname, '../../../workflows/evalforge-merge-tag-sweep.yml');
+    workflowContent = readFileSync(workflowPath, 'utf-8');
+  });
+
+  it('triggers on push events', () => {
+    expect(workflowContent).toContain('on:\n  push:');
+  });
+
+  it('targets main branch', () => {
+    expect(workflowContent).toContain('branches: [main]');
+  });
+
+  it('watches all three wix-manage paths', () => {
+    expect(workflowContent).toContain("'skills/wix-manage/references/**'");
+    expect(workflowContent).toContain("'yaml/wix-manage/**'");
+    expect(workflowContent).toContain("'yaml/wix-manage-evals/**'");
+  });
+
+  it('has no cancel-in-progress concurrency rule', () => {
+    expect(workflowContent).not.toContain('cancel-in-progress: true');
+  });
+
+  it('checks out with full history for git diff', () => {
+    expect(workflowContent).toContain('fetch-depth: 0');
+  });
+
+  it('invokes the evalforge-yaml-gate action in merge-tag-sweep mode', () => {
+    expect(workflowContent).toContain('./.github/actions/evalforge-yaml-gate');
+    expect(workflowContent).toContain('mode: merge-tag-sweep');
+  });
+
+  it('passes the diffed changed-files output to the action', () => {
+    expect(workflowContent).toContain('changed-files:');
+  });
+
+  it('guards the confirmed-failure Slack step on a confirmed failure', () => {
+    expect(workflowContent).toContain('confirmed-failed-count');
+  });
+
+  it('has a separate Slack step for infra errors, distinct from confirmed failures', () => {
+    expect(workflowContent).toContain('infra-error');
+  });
+
+  it('reuses the existing Slack webhook secret', () => {
+    expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}');
+  });
+});

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -65,7 +65,9 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
 
   it('notifies even when the sweep step reports no verdict at all', () => {
     expect(workflowContent).toContain('Post Slack notification (job failed with no verdict)');
-    expect(workflowContent).toContain('failure()');
+    // Cancellation, not just failure: a job killed by timeout-minutes reports the cancelled
+    // conclusion, so guarding on failure() alone would miss the case the step exists for.
+    expect(workflowContent).toContain('(failure() || cancelled())');
   });
 
   it('surfaces the skipped-retries caveat so a single-attempt verdict is not read as a majority', () => {

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -53,6 +53,10 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
     expect(workflowContent).toContain('infra-error');
   });
 
+  it('has a repo-variable kill switch so the sweep can be stopped without a code change', () => {
+    expect(workflowContent).toContain("if: vars.MERGE_TAG_SWEEP_ENABLED != 'false'");
+  });
+
   it('reuses the existing Slack webhook secret', () => {
     expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}');
   });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -28,6 +28,10 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
     expect(workflowContent).not.toContain('cancel-in-progress: true');
   });
 
+  it('has no concurrency block at all', () => {
+    expect(workflowContent).not.toContain('concurrency:');
+  });
+
   it('checks out with full history for git diff', () => {
     expect(workflowContent).toContain('fetch-depth: 0');
   });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep-workflow-config.test.ts
@@ -84,8 +84,9 @@ describe('EvalForge Merge-Tag Sweep Workflow', () => {
     expect(workflowContent).toContain('core.quotePath=false');
   });
 
-  it('reuses the existing Slack webhook secret', () => {
-    expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}');
+  it('posts through its own webhook secret, not the one the weekly run shares', () => {
+    expect(workflowContent).toContain('SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}');
+    expect(workflowContent).not.toContain('secrets.SLACK_WEBHOOK_URL }}');
   });
 
   it('guards both Slack steps with always(), since the sweep step itself reports failure on a confirmed regression or infra error', () => {

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep.test.ts
@@ -88,4 +88,27 @@ describe('rowsToOutcomes', () => {
     }]);
     expect(out).toEqual([{ scenarioId: '1', scenarioName: 'a', failed: true, reasons: ['correctness'] }]);
   });
+
+  it('includes ERROR assertions in reasons but excludes SKIPPED', () => {
+    const out = rowsToOutcomes([{
+      scenarioId: '1', scenarioName: 'a', passed: 1, failed: 1, partial: false, iterationIndex: 0,
+      assertions: [
+        { assertionName: 'api_call', assertionType: 'tool_called', status: 'ERROR' },
+        { assertionName: 'validation', assertionType: 'tool_output_check', status: 'SKIPPED' },
+        { assertionName: 'check', assertionType: 'llm_judge', status: 'PASSED' },
+      ],
+    }]);
+    expect(out).toEqual([{ scenarioId: '1', scenarioName: 'a', failed: true, reasons: ['api_call'] }]);
+  });
+
+  it('excludes UNKNOWN from reasons', () => {
+    const out = rowsToOutcomes([{
+      scenarioId: '1', scenarioName: 'a', passed: 1, failed: 1, partial: false, iterationIndex: 0,
+      assertions: [
+        { assertionName: 'actual_fail', assertionType: 'llm_judge', status: 'FAILED' },
+        { assertionName: 'unknown_status', assertionType: 'unknown_type', status: 'UNKNOWN' },
+      ],
+    }]);
+    expect(out).toEqual([{ scenarioId: '1', scenarioName: 'a', failed: true, reasons: ['actual_fail'] }]);
+  });
 });

--- a/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merge-tag-sweep.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MAX_SWEEP_SCENARIOS, tagsOfDirectlyAffected, resolveSweepSet, rowsToOutcomes,
+} from '../src/utils/merge-tag-sweep';
+import type { LoadedScenario } from '../src/utils/evals';
+import type { Scenario } from '@wix/evalforge-core';
+
+const scenario = (name: string, tags: string[]): LoadedScenario => ({
+  path: `yaml/wix-manage-evals/${name}.yml`,
+  scenario: {
+    name, description: '', triggerPrompt: '0123456789', tags,
+    assertions: [{ tool: 'T', params: { url: `https://x.com/${name}` } }],
+  } satisfies Scenario,
+});
+
+describe('tagsOfDirectlyAffected', () => {
+  it('unions tags across changed-YAML and doc-covered scenarios', () => {
+    const head = new Map([
+      ['blog/changed', scenario('blog/changed', ['blog', 'bookings'])],
+      ['marketing/social', scenario('marketing/social', ['marketing'])],
+      ['blog/unrelated', scenario('blog/unrelated', ['unrelated'])],
+    ]);
+    const tags = tagsOfDirectlyAffected(
+      head,
+      new Set(['yaml/wix-manage-evals/blog/changed.yml']),
+      new Map([['skills/wix-manage/references/marketing/social.md', ['marketing/social']]]),
+    );
+    expect([...tags].sort()).toEqual(['blog', 'bookings', 'marketing']);
+  });
+
+  it('returns an empty set when nothing is directly affected', () => {
+    const tags = tagsOfDirectlyAffected(new Map(), new Set(), new Map());
+    expect(tags.size).toBe(0);
+  });
+});
+
+describe('resolveSweepSet', () => {
+  it('resolves and dedupes scenarios across multiple tags', async () => {
+    const client = {
+      listTestScenariosByTag: vi.fn()
+        .mockImplementation(async (_projectId: string, tag: string) => {
+          if (tag === 'bookings') return [{ id: '1', name: 'a', tags: ['bookings'] }, { id: '2', name: 'b', tags: ['bookings', 'stores'] }];
+          if (tag === 'stores') return [{ id: '2', name: 'b', tags: ['bookings', 'stores'] }, { id: '3', name: 'c', tags: ['stores'] }];
+          return [];
+        }),
+    };
+    const out = await resolveSweepSet(client, 'proj-1', new Set(['bookings', 'stores']));
+    expect(out.selected.map(s => s.id).sort()).toEqual(['1', '2', '3']);
+    expect(out.totalMatched).toBe(3);
+    expect(out.excludedCount).toBe(0);
+  });
+
+  it('caps the sampled set deterministically (sorted by name) and reports the excluded count', async () => {
+    const many = Array.from({ length: MAX_SWEEP_SCENARIOS + 5 }, (_, i) => ({
+      id: `id-${i}`, name: `scenario-${String(i).padStart(2, '0')}`, tags: ['big'],
+    }));
+    const client = { listTestScenariosByTag: vi.fn().mockResolvedValue(many) };
+    const out = await resolveSweepSet(client, 'proj-1', new Set(['big']));
+    expect(out.selected).toHaveLength(MAX_SWEEP_SCENARIOS);
+    expect(out.selected[0].name).toBe('scenario-00');
+    expect(out.totalMatched).toBe(MAX_SWEEP_SCENARIOS + 5);
+    expect(out.excludedCount).toBe(5);
+  });
+
+  it('resolves to an empty set for an empty tag set', async () => {
+    const client = { listTestScenariosByTag: vi.fn() };
+    const out = await resolveSweepSet(client, 'proj-1', new Set());
+    expect(out.selected).toEqual([]);
+    expect(client.listTestScenariosByTag).not.toHaveBeenCalled();
+  });
+});
+
+describe('rowsToOutcomes', () => {
+  it('marks a clean row as passed', () => {
+    const out = rowsToOutcomes([
+      { scenarioId: '1', scenarioName: 'a', passed: 3, failed: 0, partial: false, iterationIndex: 0, assertions: [] },
+    ]);
+    expect(out).toEqual([{ scenarioId: '1', scenarioName: 'a', failed: false, reasons: [] }]);
+  });
+
+  it('marks a failing row as failed, naming the failed assertions', () => {
+    const out = rowsToOutcomes([{
+      scenarioId: '1', scenarioName: 'a', passed: 1, failed: 1, partial: false, iterationIndex: 0,
+      assertions: [
+        { assertionName: 'correctness', assertionType: 'llm_judge', status: 'FAILED' },
+        { assertionName: 'coverage', assertionType: 'tool_called_with_param', status: 'PASSED' },
+      ],
+    }]);
+    expect(out).toEqual([{ scenarioId: '1', scenarioName: 'a', failed: true, reasons: ['correctness'] }]);
+  });
+});

--- a/.github/actions/evalforge-yaml-gate/tests/merged-by.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/merged-by.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveMergedBy } from '../src/utils/merged-by';
+
+const FALLBACK = { name: 'jane-doe', url: 'https://github.com/wix/skills/commit/abc123' };
+
+function octokitWith(data: Array<{ html_url: string; user: { login: string } | null }>) {
+  return {
+    rest: {
+      repos: {
+        listPullRequestsAssociatedWithCommit: vi.fn().mockResolvedValue({ data }),
+      },
+    },
+  };
+}
+
+describe('resolveMergedBy', () => {
+  it('returns the associated PR author and PR link when one is found', async () => {
+    const octokit = octokitWith([
+      { html_url: 'https://github.com/wix/skills/pull/1000', user: { login: 'alice' } },
+    ]);
+    const out = await resolveMergedBy(octokit, 'wix', 'skills', 'abc123', FALLBACK);
+    expect(out).toEqual({ name: 'alice', url: 'https://github.com/wix/skills/pull/1000' });
+    expect(octokit.rest.repos.listPullRequestsAssociatedWithCommit).toHaveBeenCalledWith({
+      owner: 'wix', repo: 'skills', commit_sha: 'abc123',
+    });
+  });
+
+  it('takes the first associated PR when more than one is returned', async () => {
+    const octokit = octokitWith([
+      { html_url: 'https://github.com/wix/skills/pull/1000', user: { login: 'alice' } },
+      { html_url: 'https://github.com/wix/skills/pull/999', user: { login: 'bob' } },
+    ]);
+    const out = await resolveMergedBy(octokit, 'wix', 'skills', 'abc123', FALLBACK);
+    expect(out.name).toBe('alice');
+  });
+
+  it('falls back to the commit author when no PR is associated', async () => {
+    const octokit = octokitWith([]);
+    const out = await resolveMergedBy(octokit, 'wix', 'skills', 'abc123', FALLBACK);
+    expect(out).toEqual(FALLBACK);
+  });
+
+  it('falls back when the associated PR has no user (e.g. a deleted account)', async () => {
+    const octokit = octokitWith([{ html_url: 'https://github.com/wix/skills/pull/1000', user: null }]);
+    const out = await resolveMergedBy(octokit, 'wix', 'skills', 'abc123', FALLBACK);
+    expect(out).toEqual(FALLBACK);
+  });
+});

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'skills/wix-manage/references/**'
+      # documentation.yaml changes cannot contribute a tag on their own (classifyChanges matches
+      # only skill docs and scenario YAML), but the path is kept so this trigger stays in step
+      # with the PR-time gate's.
       - 'yaml/wix-manage/**'
       - 'yaml/wix-manage-evals/**'
 
@@ -23,7 +26,10 @@ jobs:
     # Slack, so it needs a dial that does not require a PR to turn.
     if: vars.MERGE_TAG_SWEEP_ENABLED != 'false'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Three sequential eval runs are possible (initial + two retries) and each may poll for up
+    # to 30 minutes, so a 60-minute budget could kill the job mid-retry — with no notification,
+    # since the sweep would never reach its reporting step.
+    timeout-minutes: 105
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
@@ -44,7 +50,7 @@ jobs:
           fi
           {
             echo 'files<<EOF'
-            git diff --name-status "$BEFORE_SHA" "$AFTER_SHA"
+            git -c core.quotePath=false diff --name-status "$BEFORE_SHA" "$AFTER_SHA"
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
@@ -73,9 +79,11 @@ jobs:
           MERGED_BY_NAME: ${{ steps.sweep.outputs.merged-by-name }}
           MERGED_BY_URL: ${{ steps.sweep.outputs.merged-by-url }}
           RUN_URL: ${{ steps.sweep.outputs.run-url }}
+          SKIP_REASON: ${{ steps.sweep.outputs.confirm-skip-reason }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           jq -n \
+            --arg skip_reason "$SKIP_REASON" \
             --arg confirmed "$CONFIRMED_COUNT" \
             --arg recovered "$RECOVERED_COUNT" \
             --arg scenarios "$CONFIRMED_SCENARIOS" \
@@ -88,7 +96,7 @@ jobs:
             --arg wf_url "$WORKFLOW_URL" \
             '{
               text: (":warning: *EvalForge Merge-Tag Sweep* — " + $confirmed + " confirmed failure(s) for tag(s): " + $tags),
-              blocks: [
+              blocks: ([
                 {
                   type: "header",
                   text: { type: "plain_text", text: ":warning: EvalForge Merge-Tag Sweep", emoji: true }
@@ -105,8 +113,14 @@ jobs:
                 },
                 {
                   type: "section",
-                  text: { type: "mrkdwn", text: ("*Confirmed failures:*\n```" + $scenarios + "```") }
-                },
+                  text: { type: "mrkdwn", text: ("*Confirmed failures:*\n```" + $scenarios[0:2600] + "```") }
+                }
+              ]
+              + (if $skip_reason != "" then [{
+                  type: "context",
+                  elements: [{ type: "mrkdwn", text: (":information_source: " + $skip_reason) }]
+                }] else [] end)
+              + [
                 {
                   type: "actions",
                   elements: (
@@ -114,9 +128,9 @@ jobs:
                     + (if $run_url != "" then [{ type: "button", text: { type: "plain_text", text: "EvalForge Results" }, url: $run_url }] else [] end)
                   )
                 }
-              ]
+              ])
             }' \
-          | curl -s -X POST \
+          | curl -sS --fail-with-body -X POST \
               -H "Content-Type: application/json" \
               -d @- "$SLACK_WEBHOOK_URL"
 
@@ -147,6 +161,44 @@ jobs:
                 }
               ]
             }' \
-          | curl -s -X POST \
+          | curl -sS --fail-with-body -X POST \
+              -H "Content-Type: application/json" \
+              -d @- "$SLACK_WEBHOOK_URL"
+
+      # Last resort. The two steps above both key off an output of the sweep step, so anything
+      # that stops the job before an output is written — a failure in the diff step, a throw
+      # while reading config, the job hitting its timeout mid-retry — would otherwise be
+      # reported only as a red check on a main commit, which nobody is watching.
+      - name: Post Slack notification (job failed with no verdict)
+        if: >-
+          failure()
+          && steps.sweep.outputs.infra-error == ''
+          && (steps.sweep.outputs.confirmed-failed-count == '' || steps.sweep.outputs.confirmed-failed-count == '0')
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          jq -n \
+            --arg wf_url "$WORKFLOW_URL" \
+            --arg sha "$COMMIT_SHA" \
+            '{
+              text: (":x: *EvalForge Merge-Tag Sweep* failed without reporting a verdict (commit " + $sha[0:7] + ")"),
+              blocks: [
+                {
+                  type: "header",
+                  text: { type: "plain_text", text: ":x: EvalForge Merge-Tag Sweep — no verdict", emoji: true }
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: ("The sweep job for commit `" + $sha[0:7] + "` failed before it could report whether the tagged scenarios still pass. Nothing was verified for this merge — check the job log.") }
+                },
+                {
+                  type: "actions",
+                  elements: [{ type: "button", text: { type: "plain_text", text: "GitHub Run" }, url: $wf_url }]
+                }
+              ]
+            }' \
+          | curl -sS --fail-with-body -X POST \
               -H "Content-Type: application/json" \
               -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Post Slack notification
         if: always() && steps.sweep.outputs.confirmed-failed-count != '' && steps.sweep.outputs.confirmed-failed-count != '0'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}
           CONFIRMED_COUNT: ${{ steps.sweep.outputs.confirmed-failed-count }}
           RECOVERED_COUNT: ${{ steps.sweep.outputs.recovered-count }}
           CONFIRMED_SCENARIOS: ${{ steps.sweep.outputs.confirmed-failed-scenarios }}
@@ -137,7 +137,7 @@ jobs:
       - name: Post Slack notification (infra error)
         if: always() && steps.sweep.outputs.infra-error != ''
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}
           ERROR_MESSAGE: ${{ steps.sweep.outputs.infra-error }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -178,7 +178,7 @@ jobs:
           && steps.sweep.outputs.infra-error == ''
           && (steps.sweep.outputs.confirmed-failed-count == '' || steps.sweep.outputs.confirmed-failed-count == '0')
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
         run: |

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -1,0 +1,147 @@
+name: EvalForge Merge-Tag Sweep
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/wix-manage/references/**'
+      - 'yaml/wix-manage/**'
+      - 'yaml/wix-manage-evals/**'
+
+# Deliberately no concurrency block: every push is a distinct, permanent commit on main.
+# Cancelling one sweep because another push landed would mean that commit's regression
+# is never checked.
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0  # need full history to diff before/after
+
+      - name: Diff before/after
+        id: diff
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "First push on this ref — nothing to diff, skipping."
+            { echo 'files<<EOF'; echo EOF; } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo 'files<<EOF'
+            git diff --name-status "$BEFORE_SHA" "$AFTER_SHA"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/evalforge-yaml-gate
+        id: sweep
+        with:
+          mode: merge-tag-sweep
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          evalforge-url: ${{ vars.EVALFORGE_URL }}
+          evalforge-project-id: ${{ vars.AUTO_SKILLS_PIPELINE_PROJECT_ID }}
+          evalforge-agent-id: ${{ vars.AUTO_SKILLS_PIPELINE_AGENT_ID }}
+          evalforge-app-id: ${{ secrets.AUTO_SKILLS_PIPELINE_APP_ID }}
+          evalforge-app-secret: ${{ secrets.AUTO_SKILLS_PIPELINE_APP_SECRET }}
+          changed-files: ${{ steps.diff.outputs.files }}
+
+      - name: Post Slack notification
+        if: steps.sweep.outputs.confirmed-failed-count != '' && steps.sweep.outputs.confirmed-failed-count != '0'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CONFIRMED_COUNT: ${{ steps.sweep.outputs.confirmed-failed-count }}
+          RECOVERED_COUNT: ${{ steps.sweep.outputs.recovered-count }}
+          CONFIRMED_SCENARIOS: ${{ steps.sweep.outputs.confirmed-failed-scenarios }}
+          MATCHED_TAGS: ${{ steps.sweep.outputs.matched-tags }}
+          SAMPLED_COUNT: ${{ steps.sweep.outputs.sweep-sampled-count }}
+          MATCHED_TOTAL: ${{ steps.sweep.outputs.sweep-matched-total }}
+          MERGED_BY_NAME: ${{ steps.sweep.outputs.merged-by-name }}
+          MERGED_BY_URL: ${{ steps.sweep.outputs.merged-by-url }}
+          RUN_URL: ${{ steps.sweep.outputs.run-url }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg confirmed "$CONFIRMED_COUNT" \
+            --arg recovered "$RECOVERED_COUNT" \
+            --arg scenarios "$CONFIRMED_SCENARIOS" \
+            --arg tags "$MATCHED_TAGS" \
+            --arg sampled "$SAMPLED_COUNT" \
+            --arg total "$MATCHED_TOTAL" \
+            --arg merged_by "$MERGED_BY_NAME" \
+            --arg merged_by_url "$MERGED_BY_URL" \
+            --arg run_url "$RUN_URL" \
+            --arg wf_url "$WORKFLOW_URL" \
+            '{
+              text: (":warning: *EvalForge Merge-Tag Sweep* — " + $confirmed + " confirmed failure(s) for tag(s): " + $tags),
+              blocks: [
+                {
+                  type: "header",
+                  text: { type: "plain_text", text: ":warning: EvalForge Merge-Tag Sweep", emoji: true }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    { type: "mrkdwn", text: ("*Tags:* " + $tags) },
+                    { type: "mrkdwn", text: ("*Sampled:* " + $sampled + " / " + $total + " matched") },
+                    { type: "mrkdwn", text: ("*Confirmed failed:* " + $confirmed) },
+                    { type: "mrkdwn", text: ("*Recovered (flaky):* " + $recovered) },
+                    { type: "mrkdwn", text: ("*Merged by:* <" + $merged_by_url + "|" + $merged_by + ">") }
+                  ]
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: ("*Confirmed failures:*\n```" + $scenarios + "```") }
+                },
+                {
+                  type: "actions",
+                  elements: (
+                    [{ type: "button", text: { type: "plain_text", text: "GitHub Run" }, url: $wf_url }]
+                    + (if $run_url != "" then [{ type: "button", text: { type: "plain_text", text: "EvalForge Results" }, url: $run_url }] else [] end)
+                  )
+                }
+              ]
+            }' \
+          | curl -s -X POST \
+              -H "Content-Type: application/json" \
+              -d @- "$SLACK_WEBHOOK_URL"
+
+      - name: Post Slack notification (infra error)
+        if: steps.sweep.outputs.infra-error != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ERROR_MESSAGE: ${{ steps.sweep.outputs.infra-error }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg error "$ERROR_MESSAGE" \
+            --arg wf_url "$WORKFLOW_URL" \
+            '{
+              text: (":x: *EvalForge Merge-Tag Sweep* could not run — " + $error),
+              blocks: [
+                {
+                  type: "header",
+                  text: { type: "plain_text", text: ":x: EvalForge Merge-Tag Sweep — infra error", emoji: true }
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: $error }
+                },
+                {
+                  type: "actions",
+                  elements: [{ type: "button", text: { type: "plain_text", text: "GitHub Run" }, url: $wf_url }]
+                }
+              ]
+            }' \
+          | curl -s -X POST \
+              -H "Content-Type: application/json" \
+              -d @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -57,7 +57,7 @@ jobs:
           changed-files: ${{ steps.diff.outputs.files }}
 
       - name: Post Slack notification
-        if: steps.sweep.outputs.confirmed-failed-count != '' && steps.sweep.outputs.confirmed-failed-count != '0'
+        if: always() && steps.sweep.outputs.confirmed-failed-count != '' && steps.sweep.outputs.confirmed-failed-count != '0'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CONFIRMED_COUNT: ${{ steps.sweep.outputs.confirmed-failed-count }}
@@ -117,7 +117,7 @@ jobs:
               -d @- "$SLACK_WEBHOOK_URL"
 
       - name: Post Slack notification (infra error)
-        if: steps.sweep.outputs.infra-error != ''
+        if: always() && steps.sweep.outputs.infra-error != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ERROR_MESSAGE: ${{ steps.sweep.outputs.infra-error }}

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -170,8 +170,11 @@ jobs:
       # while reading config, the job hitting its timeout mid-retry — would otherwise be
       # reported only as a red check on a main commit, which nobody is watching.
       - name: Post Slack notification (job failed with no verdict)
+        # `cancelled()` as well as `failure()`: a job killed by `timeout-minutes` reports the
+        # cancelled conclusion, not a failed one, and the timeout is precisely one of the cases
+        # this step exists to catch.
         if: >-
-          failure()
+          (failure() || cancelled())
           && steps.sweep.outputs.infra-error == ''
           && (steps.sweep.outputs.confirmed-failed-count == '' || steps.sweep.outputs.confirmed-failed-count == '0')
         env:

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -18,6 +18,10 @@ permissions:
 
 jobs:
   sweep:
+    # Kill switch: set the MERGE_TAG_SWEEP_ENABLED repo variable to 'false' to stop the
+    # sweep without shipping a code change. It spends real eval budget and posts to
+    # Slack, so it needs a dial that does not require a PR to turn.
+    if: vars.MERGE_TAG_SWEEP_ENABLED != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Post Slack notification
         if: always() && steps.sweep.outputs.confirmed-failed-count != '' && steps.sweep.outputs.confirmed-failed-count != '0'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CONFIRMED_COUNT: ${{ steps.sweep.outputs.confirmed-failed-count }}
           RECOVERED_COUNT: ${{ steps.sweep.outputs.recovered-count }}
           CONFIRMED_SCENARIOS: ${{ steps.sweep.outputs.confirmed-failed-scenarios }}
@@ -137,7 +137,7 @@ jobs:
       - name: Post Slack notification (infra error)
         if: always() && steps.sweep.outputs.infra-error != ''
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ERROR_MESSAGE: ${{ steps.sweep.outputs.infra-error }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -178,7 +178,7 @@ jobs:
           && steps.sweep.outputs.infra-error == ''
           && (steps.sweep.outputs.confirmed-failed-count == '' || steps.sweep.outputs.confirmed-failed-count == '0')
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
         run: |

--- a/.github/workflows/evalforge-merge-tag-sweep.yml
+++ b/.github/workflows/evalforge-merge-tag-sweep.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   sweep:

--- a/docs/skill-evaluation.md
+++ b/docs/skill-evaluation.md
@@ -42,7 +42,9 @@ already on `main` by the time it runs. Eval runs are not fully deterministic, so
 scenario is rerun (up to two retries) and only counts as a regression when a majority of the
 attempts fail; only a confirmed regression posts to Slack, naming the merging PR's author. A
 tag matching more than 20 scenarios samples rather than running everything, to keep a broad tag
-from re-running dozens of scenarios on every merge that touches it.
+from re-running dozens of scenarios on every merge that touches it. Setting the
+`MERGE_TAG_SWEEP_ENABLED` repository variable to `false` turns the sweep off without a code
+change.
 
 ## wix-app scenarios: the PR eval gate
 

--- a/docs/skill-evaluation.md
+++ b/docs/skill-evaluation.md
@@ -33,6 +33,17 @@ pushing an empty commit. This gate's own comment does not mention the command; t
 are the same for both gates and are listed under
 [the wix-app PR eval gate](#wix-app-scenarios-the-pr-eval-gate).
 
+### Merge-tag sweep
+
+After a wix-manage PR merges to `main`, [`evalforge-merge-tag-sweep.yml`](../.github/workflows/evalforge-merge-tag-sweep.yml)
+re-runs every EvalForge scenario sharing a tag with whatever changed — catching regressions in
+other areas that a PR's own scenarios can't see. It's reactive, not blocking: the commit is
+already on `main` by the time it runs. Eval runs are not fully deterministic, so a failing
+scenario is rerun (up to two retries) and only counts as a regression when a majority of the
+attempts fail; only a confirmed regression posts to Slack, naming the merging PR's author. A
+tag matching more than 20 scenarios samples rather than running everything, to keep a broad tag
+from re-running dozens of scenarios on every merge that touches it.
+
 ## wix-app scenarios: the PR eval gate
 
 Every PR touching `skills/wix-app/**` or `yaml/wix-app-evals/**` runs

--- a/docs/skill-evaluation.md
+++ b/docs/skill-evaluation.md
@@ -42,9 +42,10 @@ already on `main` by the time it runs. Eval runs are not fully deterministic, so
 scenario is rerun (up to two retries) and only counts as a regression when a majority of the
 attempts fail; only a confirmed regression posts to Slack, naming the merging PR's author. A
 tag matching more than 20 scenarios samples rather than running everything, to keep a broad tag
-from re-running dozens of scenarios on every merge that touches it. Setting the
-`MERGE_TAG_SWEEP_ENABLED` repository variable to `false` turns the sweep off without a code
-change.
+from re-running dozens of scenarios on every merge that touches it. It posts through its own
+`MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL` secret, so its alerts land in a dedicated channel rather
+than alongside the weekly run's summaries. Setting the `MERGE_TAG_SWEEP_ENABLED` repository
+variable to `false` turns the sweep off without a code change.
 
 ## wix-app scenarios: the PR eval gate
 

--- a/docs/skill-evaluation.md
+++ b/docs/skill-evaluation.md
@@ -42,10 +42,9 @@ already on `main` by the time it runs. Eval runs are not fully deterministic, so
 scenario is rerun (up to two retries) and only counts as a regression when a majority of the
 attempts fail; only a confirmed regression posts to Slack, naming the merging PR's author. A
 tag matching more than 20 scenarios samples rather than running everything, to keep a broad tag
-from re-running dozens of scenarios on every merge that touches it. It posts through its own
-`MERGE_TAG_SWEEP_SLACK_WEBHOOK_URL` secret, so its alerts land in a dedicated channel rather
-than alongside the weekly run's summaries. Setting the `MERGE_TAG_SWEEP_ENABLED` repository
-variable to `false` turns the sweep off without a code change.
+from re-running dozens of scenarios on every merge that touches it. Setting the
+`MERGE_TAG_SWEEP_ENABLED` repository variable to `false` turns the sweep off without a code
+change.
 
 ## wix-app scenarios: the PR eval gate
 


### PR DESCRIPTION
Adds a reactive, post-merge check for wix-manage skills: after a PR touching
`skills/wix-manage/references/**`, `yaml/wix-manage/**`, or `yaml/wix-manage-evals/**`
merges to `main`, every EvalForge scenario sharing a tag with whatever changed
re-runs. Confirmed failures post to Slack, naming the merging PR's author.
It never blocks anything — the commit is already on `main` by the time it runs.

Explicitly not GitHub's merge queue: that's branch-wide (no native way to scope
which PRs use it by path touched) and needs a repo-settings change. This is
reactive instead of preventive, and scoped through the existing scenario tags
rather than a curated sentinel list.

## Mechanism

- New `mode: merge-tag-sweep` in the existing evalforge-yaml-gate action,
  triggered by a new `push`-to-`main` workflow, path-filtered to the three
  wix-manage paths.
- Diffs the push's before/after SHAs, reuses the existing
  `scenariosToRun`/`computeCoverage` logic to find directly-affected scenarios,
  unions their tags, then resolves the sweep set from **EvalForge itself** via
  `listTestScenariosByTag` — a scenario that exists only in EvalForge, with no
  local YAML, is swept in too, as long as its tag matches.
- Capped at 20 scenarios per sweep (deterministic, sorted by name) so a broad
  tag can't re-run dozens of scenarios on every merge that touches it. When the
  cap truncates, the Slack message says so rather than looking like full coverage.
- A failing scenario is rerun (up to two retries) and only counts as a regression
  when a majority of attempts fail — eval runs aren't deterministic, and an
  alerting system that names a person on a single flake is worse than no alert.
- No comparison pipeline, no draft tags, no MCP-version lifecycle: this just
  asks "does `main` still pass".
- **Kill switch:** set the `MERGE_TAG_SWEEP_ENABLED` repo variable to `false` to
  stop the sweep without shipping a PR. It spends real eval budget and posts to a
  shared channel, so it needs a dial that doesn't require a code change to turn.
- Reuses the existing `SLACK_WEBHOOK_URL` secret. Posts only on a confirmed
  failure, attributing via `listPullRequestsAssociatedWithCommit` (robust across
  squash and rebase merges) with a commit-author fallback.

## Testing

- 117/117 tests passing, `tsc --noEmit` clean, `dist` rebuilt against this tree.
  New coverage across `parseChangedFiles`, `resolveMergedBy`,
  `tagsOfDirectlyAffected`/`resolveSweepSet`/`rowsToOutcomes`, and the workflow config.
- Reviewed per-task during implementation, plus a whole-branch review that caught
  four cross-task integration bugs — most seriously that both Slack steps' `if:`
  conditions needed `always()`, since the sweep step itself reports `setFailed`
  in exactly the two cases those steps exist to fire on. Without it the feature
  would have been silently inert.
- **Verified live.** On a disposable branch with the trigger widened and the Slack
  steps swapped to print rather than post, a trivial edit to a real `blog`-tagged
  scenario exercised the full path: tag resolved against EvalForge (4 scenarios,
  two of which exist only in EvalForge), real runs executed, the retry fired and
  confirmed, and every output was set correctly — including the commit-author
  fallback, since a direct push has no associated PR. The `always()` fix was
  confirmed working: the sweep step failed as designed and the Slack step still ran.

## Before turning it on

All four `blog`-tagged scenarios currently fail in production, unrelated to this
change. Whoever merges a blog-related doc change first will get a red check and a
Slack ping naming them for a pre-existing breakage. Consider landing with
`MERGE_TAG_SWEEP_ENABLED=false` and flipping it on once production is green.

Worth confirming separately: the sweep pins no capability version, so it evaluates
whatever the production MCP currently serves. If `main` content doesn't propagate
before the sweep fires, it would be testing pre-merge state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)