### PR TITLE
feat(base44): add base44-ecom-light.md and base44-ecom-light-seed.md

### DIFF
--- a/skills/wix-vibe-headless/install/deploy.cjs
+++ b/skills/wix-vibe-headless/install/deploy.cjs
@@ -144,8 +144,7 @@ const finalClientId = onDisk.clientId || clientId;
 const finalMetaSiteId = onDisk.metaSiteId || metaSiteId;
 
 if (!finalClientId || !finalMetaSiteId) {
-  deployed.wixConfig = 'missing_ids — src/rest/wix-config.js is not configured; re-run with '
-    + '--client-id and --metasite-id rather than editing the file by hand';
+  deployed.wixConfig = 'skipped — no ids provided';
 } else if (finalClientId === onDisk.clientId && finalMetaSiteId === onDisk.metaSiteId) {
   deployed.wixConfig = 'already_set';
 } else {

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -1,0 +1,106 @@
+# Wix Managed Headless — Base44 storefront client + seed
+
+You are building a **Wix Managed** headless storefront inside Base44 — the business is described in your
+initial prompt, and the Wix connector is already configured.
+
+Your Wix client id is in your prompt — a public, buyer-facing credential (anonymous visitor tokens
+only), safe in the frontend; use it directly for the Wix client setup.
+
+> **`wix-vibe-headless` and `wix-docs` are the complete build and seed path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).**
+
+Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
+
+## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
+
+Install two skills — they land under `.agents/skills/`:
+- **`wix-vibe-headless`** — the storefront build + seed guide (STEPs 2–3): your main source of truth.
+- **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything `wix-vibe-headless`
+  doesn't cover.
+
+Run this through exec_tool, exactly as written — installs both skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
+
+```js
+const { execSync } = require('child_process');
+const { existsSync, readdirSync } = require('fs');
+const results = {};
+for (const skill of ['wix-vibe-headless', 'wix-docs']) {
+  if (existsSync(`/app/.agents/skills/${skill}/SKILL.md`)) { results[skill] = 'already_installed'; continue; }
+  try {
+    const out = execSync(`CI=1 npx -y skills add wix/skills/skills/${skill} --yes 2>&1`,
+      { cwd: '/app', timeout: 60000, shell: '/bin/bash' }).toString().replace(/\x1b\[[0-9;]*m/g, '');
+    results[skill] = /installed 1 skill|found 1 skill/i.test(out) ? 'success'
+      : out.includes('No valid skills') ? 'not_found' : 'unknown';
+  } catch (e) { results[skill] = 'error: ' + e.message; }
+}
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront`, { cwd: '/app' }).toString();
+const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
+return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
+```
+
+Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
+
+## STEP 2 — Build the client
+
+Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
+
+**REST scaffolds are already in `src/rest/`** (STEP 1 deployed them). The storefront also ships a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
+
+**`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
+(`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
+rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
+
+## STEP 3 — Seed the storefront
+
+**Never delete or clean up anything on the user's site — seeding is additive only.** It's a live
+user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
+cleanup truly seems needed, ask the user first.
+
+Seed by calling the storefront's ready-made seed module — read
+`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.js` via
+its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
+shape → the **`wix-docs`** skill.
+
+**Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its
+access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.
+`getAdminToken()`), install/run the Wix CLI (`@wix/cli`), or device-login (no managed-project auth
+flow applies to Base44):
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless"); // connector name: "wix" or "wix-headless"
+// then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
+```
+
+Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
+`@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
+inline it throws *"Identifier 'base44' has already been declared."*).
+
+**Product images.** Generate with **Base44's built-in image generation**, then attach via the
+storefront seed module's image-attach step — `wix-docs` if the module doesn't cover it.
+
+**Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
+from the **completed** `generate_image` result and pass it straight into your single `setupStore`
+call (images included). A still-generating `/__generating__/<id>.png` placeholder is not a real url
+— Wix can't fetch it. `generate_image` runs in the background while you build the client, so the
+urls are ready by the time you seed.
+
+## STEP 4 — Wrap up
+
+**Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
+
+**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+
+## Later admin requests
+
+When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless");
+const res = await fetch("https://www.wixapis.com/<api-path>", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ /* request body */ }),
+});
+return await res.json();
+```
+
+`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -68,7 +68,7 @@ const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 
-Inline via exec_tool or in backend functions, `base44` is already declared — use it directly; do **not** import
+Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
 `@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
 inline it throws *"Identifier 'base44' has already been declared."*).
 
@@ -101,4 +101,4 @@ const res = await fetch("https://www.wixapis.com/<api-path>", {
 return await res.json();
 ```
 
-`base44` is already declared inline in exec_tool or in backend functions — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.
+`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -68,7 +68,7 @@ const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 
-Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
+Inline via exec_tool or in backend functions, `base44` is already declared — use it directly; do **not** import
 `@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
 inline it throws *"Identifier 'base44' has already been declared."*).
 
@@ -101,4 +101,4 @@ const res = await fetch("https://www.wixapis.com/<api-path>", {
 return await res.json();
 ```
 
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.
+`base44` is already declared inline in exec_tool or in backend functions — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -61,9 +61,7 @@ its loader snippet (build-time exec_tool); call its functions with your data. Ga
 shape → the **`wix-docs`** skill.
 
 **Auth for these admin calls is the already-configured Wix headless connector — nothing else.** Get its
-access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.
-`getAdminToken()`), install/run the Wix CLI (`@wix/cli`), or device-login (no managed-project auth
-flow applies to Base44):
+access token and send it as a bearer token:
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless"); // connector name: "wix" or "wix-headless"

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -32,7 +32,7 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
       : out.includes('No valid skills') ? 'not_found' : 'unknown';
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront --client-id <client id from prompt> --metasite-id <site id from prompt>`, { cwd: '/app' }).toString();
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront`, { cwd: '/app' }).toString();
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
 ```

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -22,10 +22,6 @@ Run this through exec_tool, exactly as written — installs both skills, deploys
 ```js
 const { execSync } = require('child_process');
 const { existsSync, readdirSync } = require('fs');
-// COPY these two straight from the prompt — deploy writes them into src/rest/wix-config.js, so never
-// retype either one into a file by hand afterwards.
-const WIX_CLIENT_ID = '<client id from the prompt>';
-const WIX_METASITE_ID = '<site id from the prompt>';
 const results = {};
 for (const skill of ['wix-vibe-headless', 'wix-docs']) {
   if (existsSync(`/app/.agents/skills/${skill}/SKILL.md`)) { results[skill] = 'already_installed'; continue; }
@@ -36,7 +32,7 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
       : out.includes('No valid skills') ? 'not_found' : 'unknown';
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront --client-id <client id from prompt> --metasite-id <site id from prompt>`, { cwd: '/app' }).toString();
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
 ```

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -45,10 +45,9 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 ## STEP 2 — Build the client
 
-Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — the single source of
-truth for how the client is built.
+Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**REST scaffolds + `wix-config.js` are already in `src/rest/`** (STEP 1 wrote them). Some verticals also ship a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
+**REST scaffolds + `wix-config.js` are already in `src/rest/`** (STEP 1 wrote them). The storefront also ships a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -10,7 +10,7 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 Follow STEPs 1–3 below exactly.
 
-## STEP 1 — Install and deploy the Wix skills
+## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
 Install two skills — they land under `.agents/skills/`:
 - **`wix-vibe-headless`** — the storefront build guide (STEP 2): your main source of truth.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -71,4 +71,4 @@ const res = await fetch("https://www.wixapis.com/<api-path>", {
 return await res.json();
 ```
 
-`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.
+`base44` is already declared inline in exec_tool or in backend functions — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -59,4 +59,16 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 ## Later admin requests
 
-For any later admin/management request: the storefront seed module first, else `wix-docs` — all over the connector.
+For any later admin/management request, use the Wix connector — get an access token and call the Wix API directly:
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const res = await fetch("https://www.wixapis.com/<api-path>", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ /* request body */ }),
+});
+return await res.json();
+```
+
+`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -8,7 +8,7 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **`wix-vibe-headless` and `wix-docs` are the complete build path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).** **This flow builds the client only — there is no seeding step.**
 
-Follow STEPs 1–3 below exactly.
+Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
@@ -49,9 +49,41 @@ Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` an
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
 rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
 
-## STEP 3 — Wrap up
+## STEP 3 — Seed the storefront
 
-**No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
+**Never delete or clean up anything on the user's site — seeding is additive only.** It's a live
+user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
+cleanup truly seems needed, ask the user first.
+
+Seed by calling the storefront's ready-made seed module — read
+`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.js` via
+its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
+shape → the **`wix-docs`** skill.
+
+**Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
+access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.
+`getAdminToken()`), install/run the Wix CLI (`@wix/cli`), or device-login (no managed-project auth
+flow applies to Base44):
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+// then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
+```
+
+Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
+`@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
+inline it throws *"Identifier 'base44' has already been declared."*).
+
+**Product images.** Generate with **Base44's built-in image generation**, then attach via the
+storefront seed module's image-attach step — `wix-docs` if the module doesn't cover it.
+
+**Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
+from the **completed** `generate_image` result and pass it straight into your single `setupStore`
+call (images included). A still-generating `/__generating__/<id>.png` placeholder is not a real url
+— Wix can't fetch it. `generate_image` runs in the background while you build the client, so the
+urls are ready by the time you seed.
+
+## STEP 4 — Wrap up
 
 **Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
 

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -59,7 +59,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 ## Later admin requests
 
-For any later admin/management request, use the Wix connector — get an access token and call the Wix API directly:
+When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless");

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -1,7 +1,7 @@
-# Wix Managed Headless — Base44 build instructions (client only)
+# Wix Managed Headless — Base44 storefront client
 
-You are building a **Wix Managed** headless site inside Base44 — the business is described in your
-initial prompt, and the Wix connector is already configured; use it for all admin API calls.
+You are building a **Wix Managed** headless storefront inside Base44 — the business is described in your
+initial prompt, and the Wix connector is already configured.
 
 Your Wix client id is in your prompt — a public, buyer-facing credential (anonymous visitor tokens
 only), safe in the frontend; use it directly for the Wix client setup.
@@ -13,7 +13,7 @@ Follow STEPs 1–3 below exactly.
 ## STEP 1 — Install the Wix skills locally
 
 Install two skills — they land under `.agents/skills/`:
-- **`wix-vibe-headless`** — the client build guide (STEP 3): your main source of truth.
+- **`wix-vibe-headless`** — the storefront build guide (STEP 2): your main source of truth.
 - **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything `wix-vibe-headless`
   doesn't cover.
 
@@ -59,4 +59,4 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 
 **Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
 
-**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit, re-seed, or debug image urls.** Leave them and finish.
+**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -62,7 +62,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 For any later admin/management request, use the Wix connector — get an access token and call the Wix API directly:
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless");
 const res = await fetch("https://www.wixapis.com/<api-path>", {
   method: "POST",
   headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -10,7 +10,7 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 Follow STEPs 1–3 below exactly.
 
-## STEP 1 — Install the Wix skills locally
+## STEP 1 — Install and deploy the Wix skills
 
 Install two skills — they land under `.agents/skills/`:
 - **`wix-vibe-headless`** — the storefront build guide (STEP 2): your main source of truth.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -17,29 +17,11 @@ Install two skills — they land under `.agents/skills/`:
 - **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything `wix-vibe-headless`
   doesn't cover.
 
-Run this through exec_tool, exactly as written — installs both skills, deploys REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
-
-**Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
-
-| vertical | pick it when the app needs to |
-|---|---|
-| `storefront` | sell products |
-| `bookings` | take appointments or service bookings |
-| `blog` | publish articles |
-| `events` | publish events with RSVPs or ticket sales |
-| `portfolio` | showcase creative work |
-| `pricing-plans` | sell memberships or subscriptions |
-| `restaurants` | show a menu, take orders, book tables |
-| `members` | let visitors sign in — this is **auth** |
-| `cms` | keep its own structured content — user submissions, galleries, listings, anything the rows above don't already cover |
-
-**List every vertical the app uses.** `cms` for app-stored content, `members` for visitor sign-in — these often join the main vertical. Adding one later: re-run with the extra name.
+Run this through exec_tool, exactly as written — installs both skills, deploys the `storefront` REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
 
 ```js
 const { execSync } = require('child_process');
 const { existsSync, readdirSync } = require('fs');
-const VERTICALS = ['storefront'];        // ← set from the prompt; list every vertical the app uses
-// const VERTICALS = ['members', 'cms']; // ← e.g. visitors sign in AND the app stores what they submit
 // COPY these two straight from the prompt — deploy writes them into src/rest/wix-config.js, so never
 // retype either one into a file by hand afterwards.
 const WIX_CLIENT_ID = '<client id from the prompt>';
@@ -54,7 +36,7 @@ for (const skill of ['wix-vibe-headless', 'wix-docs']) {
       : out.includes('No valid skills') ? 'not_found' : 'unknown';
   } catch (e) { results[skill] = 'error: ' + e.message; }
 }
-const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')} --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs storefront --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
 const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
 return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
 ```

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -17,7 +17,7 @@ Install two skills — they land under `.agents/skills/`:
 - **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything `wix-vibe-headless`
   doesn't cover.
 
-Run this through exec_tool, exactly as written — installs both skills, deploys the `storefront` REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
+Run this through exec_tool, exactly as written — installs both skills, deploys the `storefront` REST scaffolds + UI into `src/`, and pins the AGENTS.md note.
 
 ```js
 const { execSync } = require('child_process');
@@ -43,7 +43,7 @@ Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/s
 
 Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` and follow it **EXACTLY** — the single source of truth for how the storefront client is built.
 
-**REST scaffolds + `wix-config.js` are already in `src/rest/`** (STEP 1 wrote them). The storefront also ships a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
+**REST scaffolds are already in `src/rest/`** (STEP 1 deployed them). The storefront also ships a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
 
 **`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -56,3 +56,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 **Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
 
 **Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit or debug image urls.** Leave them and finish.
+
+## Later admin requests
+
+For any later admin/management request: the storefront seed module first, else `wix-docs` — all over the connector.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -71,4 +71,4 @@ const res = await fetch("https://www.wixapis.com/<api-path>", {
 return await res.json();
 ```
 
-`base44` is already declared inline in exec_tool or in backend functions — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.
+`base44` is already declared inline in exec_tool — use it directly; do **not** import `@base44/sdk` or call `createClient()`. For what to call, check the storefront seed module (`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md`) or look up the endpoint via `wix-docs`.

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -8,7 +8,7 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **`wix-vibe-headless` and `wix-docs` are the complete build path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).** **This flow builds the client only — there is no seeding step.**
 
-Follow STEPs 1–4 below exactly (run STEP 3 in parallel with STEP 2).
+Follow STEPs 1–3 below exactly.
 
 ## STEP 1 — Install the Wix skills and deploy the storefront vertical to the app
 
@@ -49,41 +49,9 @@ Read `.agents/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md` an
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
 rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
 
-## STEP 3 — Seed the storefront
+## STEP 3 — Wrap up
 
-**Never delete or clean up anything on the user's site — seeding is additive only.** It's a live
-user-owned business, so never delete or overwrite existing content, even apparent sample data. If a
-cleanup truly seems needed, ask the user first.
-
-Seed by calling the storefront's ready-made seed module — read
-`.agents/skills/wix-vibe-headless/references/storefront/seed/SEED.md` and load its `seed-*.js` via
-its loader snippet (build-time exec_tool); call its functions with your data. Gaps or an unexpected
-shape → the **`wix-docs`** skill.
-
-**Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
-access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.
-`getAdminToken()`), install/run the Wix CLI (`@wix/cli`), or device-login (no managed-project auth
-flow applies to Base44):
-
-```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-// then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
-```
-
-Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
-`@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
-inline it throws *"Identifier 'base44' has already been declared."*).
-
-**Product images.** Generate with **Base44's built-in image generation**, then attach via the
-storefront seed module's image-attach step — `wix-docs` if the module doesn't cover it.
-
-**Seed images with the FINAL url, in one call.** Use the real `https://media.base44.com/...` url
-from the **completed** `generate_image` result and pass it straight into your single `setupStore`
-call (images included). A still-generating `/__generating__/<id>.png` placeholder is not a real url
-— Wix can't fetch it. `generate_image` runs in the background while you build the client, so the
-urls are ready by the time you seed.
-
-## STEP 4 — Wrap up
+**No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 
 **Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
 

--- a/skills/wix-vibe-headless/platforms/base44-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-light.md
@@ -8,7 +8,7 @@ only), safe in the frontend; use it directly for the Wix client setup.
 
 > **`wix-vibe-headless` and `wix-docs` are the complete build path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).** **This flow builds the client only — there is no seeding step.**
 
-Follow STEPs 1–4 below exactly.
+Follow STEPs 1–3 below exactly.
 
 ## STEP 1 — Install the Wix skills locally
 
@@ -61,27 +61,7 @@ return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.pa
 
 Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
 
-## STEP 2 (optional) — Brief doesn't say what to build? Read the site
-
-Only when the business description is vague or missing (else skip to STEP 3). Don't guess the Wix
-Business Solution — **read the site in one call** via the connector (exec_tool):
-
-```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const res = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
-  method: "POST",
-  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({ siteId: "<metasite id from your prompt>" }),
-});
-return (await res.json()).markdown;
-```
-
-It returns a markdown report — installed apps (by name), status, URL, locale, CMS collections
-([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md)).
-Build for the installed apps' solutions (several → prioritize by the user's words and which holds
-real, non-sample content). If it fails or shows nothing relevant, ask the user what they offer.
-
-## STEP 3 — Build the client
+## STEP 2 — Build the client
 
 Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — the single source of
 truth for how the client is built.
@@ -92,7 +72,7 @@ truth for how the client is built.
 (`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
 rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
 
-## STEP 4 — Wrap up
+## STEP 3 — Wrap up
 
 **No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
 

--- a/skills/wix-vibe-headless/platforms/base44-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-light.md
@@ -1,0 +1,101 @@
+# Wix Managed Headless — Base44 build instructions (client only)
+
+You are building a **Wix Managed** headless site inside Base44 — the business is described in your
+initial prompt, and the Wix connector is already configured; use it for all admin API calls.
+
+Your Wix client id is in your prompt — a public, buyer-facing credential (anonymous visitor tokens
+only), safe in the frontend; use it directly for the Wix client setup.
+
+> **`wix-vibe-headless` and `wix-docs` are the complete build path for this app.** **Do NOT use the Base44 commerce kit (or any Base44 solution kit).** **This flow builds the client only — there is no seeding step.**
+
+Follow STEPs 1–4 below exactly.
+
+## STEP 1 — Install the Wix skills locally
+
+Install two skills — they land under `.agents/skills/`:
+- **`wix-vibe-headless`** — the client build guide (STEP 3): your main source of truth.
+- **`wix-docs`** — a **fallback**: search + read the Wix API docs for anything `wix-vibe-headless`
+  doesn't cover.
+
+Run this through exec_tool, exactly as written — installs both skills, deploys REST scaffolds + UI into `src/`, writes `wix-config.js`, and pins the AGENTS.md note.
+
+**Set `VERTICALS`** to what the prompt asks for (too vague to tell? do STEP 2 first, then set it):
+
+| vertical | pick it when the app needs to |
+|---|---|
+| `storefront` | sell products |
+| `bookings` | take appointments or service bookings |
+| `blog` | publish articles |
+| `events` | publish events with RSVPs or ticket sales |
+| `portfolio` | showcase creative work |
+| `pricing-plans` | sell memberships or subscriptions |
+| `restaurants` | show a menu, take orders, book tables |
+| `members` | let visitors sign in — this is **auth** |
+| `cms` | keep its own structured content — user submissions, galleries, listings, anything the rows above don't already cover |
+
+**List every vertical the app uses.** `cms` for app-stored content, `members` for visitor sign-in — these often join the main vertical. Adding one later: re-run with the extra name.
+
+```js
+const { execSync } = require('child_process');
+const { existsSync, readdirSync } = require('fs');
+const VERTICALS = ['storefront'];        // ← set from the prompt; list every vertical the app uses
+// const VERTICALS = ['members', 'cms']; // ← e.g. visitors sign in AND the app stores what they submit
+// COPY these two straight from the prompt — deploy writes them into src/rest/wix-config.js, so never
+// retype either one into a file by hand afterwards.
+const WIX_CLIENT_ID = '<client id from the prompt>';
+const WIX_METASITE_ID = '<site id from the prompt>';
+const results = {};
+for (const skill of ['wix-vibe-headless', 'wix-docs']) {
+  if (existsSync(`/app/.agents/skills/${skill}/SKILL.md`)) { results[skill] = 'already_installed'; continue; }
+  try {
+    const out = execSync(`CI=1 npx -y skills add wix/skills/skills/${skill} --yes 2>&1`,
+      { cwd: '/app', timeout: 60000, shell: '/bin/bash' }).toString().replace(/\x1b\[[0-9;]*m/g, '');
+    results[skill] = /installed 1 skill|found 1 skill/i.test(out) ? 'success'
+      : out.includes('No valid skills') ? 'not_found' : 'unknown';
+  } catch (e) { results[skill] = 'error: ' + e.message; }
+}
+const deploy = execSync(`node /app/.agents/skills/wix-vibe-headless/install/deploy.cjs ${VERTICALS.join(' ')} --client-id ${WIX_CLIENT_ID} --metasite-id ${WIX_METASITE_ID}`, { cwd: '/app' }).toString();
+const agentsMd = execSync(`node /app/.agents/skills/wix-vibe-headless/install/pin-agents-md.cjs`, { cwd: '/app' }).toString();
+return { results, installed: readdirSync('/app/.agents/skills'), deploy: JSON.parse(deploy), agentsMd: JSON.parse(agentsMd) };
+```
+
+Read skills with **`read_file`** using workspace-relative paths (e.g. `.agents/skills/wix-vibe-headless/SKILL.md`) — absolute `/app/...` fails. Always read from `.agents/skills/` exactly on every turn; ignore stray copies like `agent/skills/`.
+
+## STEP 2 (optional) — Brief doesn't say what to build? Read the site
+
+Only when the business description is vague or missing (else skip to STEP 3). Don't guess the Wix
+Business Solution — **read the site in one call** via the connector (exec_tool):
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const res = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ siteId: "<metasite id from your prompt>" }),
+});
+return (await res.json()).markdown;
+```
+
+It returns a markdown report — installed apps (by name), status, URL, locale, CMS collections
+([docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md)).
+Build for the installed apps' solutions (several → prioritize by the user's words and which holds
+real, non-sample content). If it fails or shows nothing relevant, ask the user what they offer.
+
+## STEP 3 — Build the client
+
+Read `.agents/skills/wix-vibe-headless/SKILL.md` and follow it **EXACTLY** — the single source of
+truth for how the client is built.
+
+**REST scaffolds + `wix-config.js` are already in `src/rest/`** (STEP 1 wrote them). Some verticals also ship a ready UI client in `src/` — theme + wire it per `INSTRUCTIONS.md`, don't rebuild. **Don't `read_file` deployed files** — every field shape is in `INSTRUCTIONS.md`; read one only on a real error or gap.
+
+**`src/App.jsx`: edit surgically, never rewrite.** It carries required platform auth scaffolding
+(`AuthProvider`/`useAuth` from `@/lib/AuthContext`); a full rewrite drops them → the validator
+rejects the write. Wire routes/imports in with `find_replace`, leave the rest as-is.
+
+## STEP 4 — Wrap up
+
+**No seeding in this flow** — the client is the only deliverable. Do not seed, populate, or write data to Wix.
+
+**Do NOT add the `<WixManageBanner/>` component** and do not send the user Wix dashboard links — this flow does not include the manage banner or back-office handoff.
+
+**Preview briefly, don't chase images.** Broken images are expected — `generate_image` returns a `/__generating__/…` placeholder that the platform swaps for the final url automatically at turn end (failures get a stock fallback). **Do NOT edit, re-seed, or debug image urls.** Leave them and finish.

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -68,7 +68,7 @@ Only when the business description is vague or missing (else skip to STEP 3). Do
 Business Solution — **read the site in one call** via the connector (exec_tool):
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const res = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
   method: "POST",
   headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
@@ -111,7 +111,7 @@ access token and send it as a bearer token; do **not** hand-roll a token getter 
 flow applies to Base44):
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -113,7 +113,7 @@ const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 
-Inline via exec_tool or in backend functions, `base44` is already declared — use it directly; do **not** import
+Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
 `@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
 inline it throws *"Identifier 'base44' has already been declared."*).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -113,7 +113,7 @@ const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 
-Inline via exec_tool, `base44` is already declared — use it directly; do **not** import
+Inline via exec_tool or in backend functions, `base44` is already declared — use it directly; do **not** import
 `@base44/sdk`, re-declare it, or call `createClient()` (that's for standalone `.js` files only;
 inline it throws *"Identifier 'base44' has already been declared."*).
 

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -106,9 +106,7 @@ its loader snippet (build-time exec_tool); call its functions with your data. Ga
 shape → the **`wix-docs`** skill.
 
 **Auth for these admin calls is the already-configured Wix connector — nothing else.** Get its
-access token and send it as a bearer token; do **not** hand-roll a token getter (e.g.
-`getAdminToken()`), install/run the Wix CLI (`@wix/cli`), or device-login (no managed-project auth
-flow applies to Base44):
+access token and send it as a bearer token:
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -14,7 +14,7 @@ for you (Blog binds the cover by the Wix Media file id, not a url).
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -8,7 +8,7 @@ Bookings seed operation. Load it and call **`setupBookings` — the one-call pat
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -113,7 +113,7 @@ never carries — a client-side upload answers **403 with an HTML body**. Pick b
 
 **On base44 the elevated route is a backend function** — it holds the credential the client lacks:
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // admin-level
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // admin-level; connector name: "wix" or "wix-headless"
 // → POST /site-media/v1/files/generate-upload-url, PUT the bytes to it, return the file URL
 ```
 That's the same Wix connector the seed step uses, and it's the supported way to reach a Manage-scope

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -13,7 +13,7 @@ after create, and **publishing is one-way**. So per event: create DRAFT → (tic
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -16,7 +16,7 @@ first, then thread their real ids into each project.
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -9,7 +9,7 @@ plain data.
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -17,7 +17,7 @@ across exec calls. Online ordering and table reservations run only when the plan
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -6,7 +6,7 @@ seed operation. Load it and call **`setupStore` — the one-call path** — with
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // Base44 (generic: use $TOKEN)
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };


### PR DESCRIPTION
## Summary

### New files
- **`platforms/base44-ecom-light.md`** — storefront client-only variant (renamed from base44-light.md)
- **`platforms/base44-ecom-light-seed.md`** — storefront client + seed variant

### base44-ecom-light.md
- Hardcoded `storefront` vertical — no vertical selection table
- STEP 1: install skills + deploy storefront to the app
- STEP 2: points directly at `references/storefront/INSTRUCTIONS.md`
- No seeding step
- Do NOT add `<WixManageBanner/>` (opposite of base44.md)
- No Wix dashboard link sent to the user
- Later admin requests section with connector + fetch example using `wix-headless`

### base44-ecom-light-seed.md
- Same as base44-ecom-light but with seeding (STEP 3 — Seed the storefront)
- Storefront-specific seed module path
- Product images via Base44's image generation
- Build + seed run in parallel (STEP 2 ∥ STEP 3)

### deploy.cjs
- Omitting `--client-id`/`--metasite-id` now skips wix-config.js silently (no error)

### All SEED.md files + base44.md + cms/INSTRUCTIONS.md
- Added comment on every `getConnection("wix")` call noting the name can be `"wix"` or `"wix-headless"`

### base44.md
- Dropped verbose auth-method prohibition from the connector auth note

🤖 Generated with [Claude Code](https://claude.com/claude-code)