### PR TITLE
fix(base44): rename connector string wix-headless → wixheadless

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -64,7 +64,7 @@ shape → the **`wix-docs`** skill.
 access token and send it as a bearer token:
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wixheadless"); // connector name: "wix" or "wixheadless"
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 
@@ -92,7 +92,7 @@ urls are ready by the time you seed.
 When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless");
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wixheadless");
 const res = await fetch("https://www.wixapis.com/<api-path>", {
   method: "POST",
   headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },

--- a/skills/wix-vibe-headless/platforms/base44-ecom-light.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light.md
@@ -62,7 +62,7 @@ rejects the write. Wire routes/imports in with `find_replace`, leave the rest as
 When the user asks for follow-up changes (next iterations), use the already-connected Wix headless connector — get an access token and call the Wix API directly:
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix-headless");
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wixheadless");
 const res = await fetch("https://www.wixapis.com/<api-path>", {
   method: "POST",
   headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },

--- a/skills/wix-vibe-headless/platforms/base44.md
+++ b/skills/wix-vibe-headless/platforms/base44.md
@@ -68,7 +68,7 @@ Only when the business description is vague or missing (else skip to STEP 3). Do
 Business Solution — **read the site in one call** via the connector (exec_tool):
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const res = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
   method: "POST",
   headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
@@ -109,7 +109,7 @@ shape → the **`wix-docs`** skill.
 access token and send it as a bearer token:
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 

--- a/skills/wix-vibe-headless/references/blog/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/blog/seed/SEED.md
@@ -14,7 +14,7 @@ for you (Blog binds the cover by the Wix Media file id, not a url).
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/bookings/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/bookings/seed/SEED.md
@@ -8,7 +8,7 @@ Bookings seed operation. Load it and call **`setupBookings` — the one-call pat
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/cms/INSTRUCTIONS.md
@@ -113,7 +113,7 @@ never carries — a client-side upload answers **403 with an HTML body**. Pick b
 
 **On base44 the elevated route is a backend function** — it holds the credential the client lacks:
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // admin-level; connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");  // admin-level; connector name: "wix" or "wixheadless"
 // → POST /site-media/v1/files/generate-upload-url, PUT the bytes to it, return the file URL
 ```
 That's the same Wix connector the seed step uses, and it's the supported way to reach a Manage-scope

--- a/skills/wix-vibe-headless/references/events/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/events/seed/SEED.md
@@ -13,7 +13,7 @@ after create, and **publishing is one-way**. So per event: create DRAFT → (tic
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/portfolio/seed/SEED.md
@@ -16,7 +16,7 @@ first, then thread their real ids into each project.
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/pricing-plans/seed/SEED.md
@@ -9,7 +9,7 @@ plain data.
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/restaurants/seed/SEED.md
@@ -17,7 +17,7 @@ across exec calls. Online ordering and table reservations run only when the plan
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };

--- a/skills/wix-vibe-headless/references/storefront/seed/SEED.md
+++ b/skills/wix-vibe-headless/references/storefront/seed/SEED.md
@@ -6,7 +6,7 @@ seed operation. Load it and call **`setupStore` — the one-call path** — with
 
 ```js
 // build-time exec_tool
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wix-headless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix"); // connector name: "wix" or "wixheadless"
 const fs = require("fs");
 // exec_tool's require can return EMPTY exports for these build-time modules — load the file itself:
 const seed = (() => { const m = { exports: {} };


### PR DESCRIPTION
## Summary
- All `getConnection("wix-headless")` → `getConnection("wixheadless")` (platforms files)
- All comments `connector name: "wix" or "wix-headless"` → `"wix" or "wixheadless"` (base44.md, all 8 SEED.md files, cms/INSTRUCTIONS.md)
- File path references to `wix-headless/references/...` left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)