### PR TITLE
docs(base44-light): drop connector name comment from light mds

### DIFF
--- a/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
+++ b/skills/wix-vibe-headless/platforms/base44-ecom-light-seed.md
@@ -64,7 +64,7 @@ shape → the **`wix-docs`** skill.
 access token and send it as a bearer token:
 
 ```js
-const { accessToken } = await base44.asServiceRole.connectors.getConnection("wixheadless"); // connector name: "wix" or "wixheadless"
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wixheadless");
 // then: fetch(url, { headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" }, ... })
 ```
 


### PR DESCRIPTION
## Summary
Remove the `// connector name: "wix" or "wixheadless"` comment from `base44-ecom-light-seed.md` — the light files shouldn't carry that annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)