### PR TITLE
feat(storefront): headless useVariantOptions hook

### DIFF
--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -29,7 +29,8 @@ so you don't need to open them:**
 | `lib/storeImage.js` | `productImage()` / `productGallery()` / `storeImage()` — normalise Wix image urls |
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
-| `components/VariantPicker.jsx` | option/variant selector used on the PDP — colour options render as real swatches, and picking one moves the gallery to that colour's photo |
+| `hooks/useVariantOptions.js` | headless data layer for options/modifiers — returns `optionGroups` + `modifierGroups` (normalised, render-agnostic); use this to build your own variant UI instead of the shipped `VariantPicker` |
+| `components/VariantPicker.jsx` | default option/variant selector (pills + colour swatches) built on `useVariantOptions` — swap it for your own component if you want a different look; the hook contract stays the same |
 | `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
 | `rest/wix-config.js` | the two ids, written by the install step |
@@ -229,6 +230,36 @@ const { products: inCategory } = await queryProductsByCategory(menu[0].id, { lim
 // product.plainDescription is HTML → render as HTML (the PDP does this):
 <div dangerouslySetInnerHTML={{ __html: product.plainDescription }} />
 // image urls live at: product.media.main.image.url  ·  cart lineItems[].image.url
+```
+
+**Building your own variant/option UI?** Use `useVariantOptions` instead of the shipped `VariantPicker`:
+
+```jsx
+import { useVariantOptions } from "@/hooks/useVariantOptions";
+
+// Inside your PDP component — options/modifiers/selectedOptions/modifierValues come from useProductDetail:
+const { optionGroups, modifierGroups } = useVariantOptions(options, modifiers, selectedOptions, modifierValues);
+
+// optionGroups: [{ id, name, isColor, choices: [{ choiceId, name, colorCode, isColorSwatch, inStock, selected }] }]
+// modifierGroups: [{ key, name, mandatory, type: 'choices'|'text', choices?: [{ key, name, selected }], value?: string }]
+
+// Then render however you want:
+optionGroups.map((group) =>
+  group.choices.map((c) =>
+    c.isColorSwatch
+      ? <MySwatch key={c.choiceId} color={c.colorCode} active={c.selected} disabled={!c.inStock}
+                  onClick={() => selectOption(group.id, c.choiceId)} />
+      : <MyPill  key={c.choiceId} active={c.selected} disabled={!c.inStock}
+                  onClick={() => selectOption(group.id, c.choiceId)}>{c.name}</MyPill>
+  )
+);
+modifierGroups.map((m) =>
+  m.type === "text"
+    ? <MyInput key={m.key} label={m.name} value={m.value} onChange={(v) => setModifier(m.key, v)} />
+    : m.choices.map((c) =>
+        <MyPill key={c.key} active={c.selected} onClick={() => setModifier(m.key, c.key)}>{c.name}</MyPill>
+      )
+);
 ```
 
 Fallback only — when you hit an error or need something not shown here (coupons, members, a field

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -29,8 +29,8 @@ so you don't need to open them:**
 | `lib/storeImage.js` | `productImage()` / `productGallery()` / `storeImage()` — normalise Wix image urls |
 | `components/CartButton.jsx` | header cart **icon** button with a live-count badge |
 | `components/CartDrawer.jsx` | slide-over cart (mount once; opens from `useCart`) |
-| `hooks/useVariantOptions.js` | headless data layer for options/modifiers — returns `optionGroups` + `modifierGroups` (normalised, render-agnostic); use this to build your own variant UI instead of the shipped `VariantPicker` |
-| `components/VariantPicker.jsx` | default option/variant selector (pills + colour swatches) built on `useVariantOptions` — swap it for your own component if you want a different look; the hook contract stays the same |
+| `hooks/useVariantOptions.js` | headless data layer for options/modifiers — returns `optionGroups` + `modifierGroups` (normalised, render-agnostic); **always use this to build your own variant UI on the PDP** |
+| `components/VariantPicker.jsx` | reference implementation of a variant selector built on `useVariantOptions` (pills + colour swatches) — read it for inspiration, but build your own component rather than using it directly |
 | `components/WixManageBanner.jsx` | preview-only manage banner — drop it into your Layout (STEP 3) |
 | `pages/Shop.jsx`, `pages/ProductDetail.jsx` | the two shipped routes (`/shop`, `/product/:slug`) |
 | `rest/wix-config.js` | the two ids, written by the install step |
@@ -232,7 +232,7 @@ const { products: inCategory } = await queryProductsByCategory(menu[0].id, { lim
 // image urls live at: product.media.main.image.url  ·  cart lineItems[].image.url
 ```
 
-**Building your own variant/option UI?** Use `useVariantOptions` instead of the shipped `VariantPicker`:
+**Build your own variant/option UI on the PDP using `useVariantOptions`** — don't use `VariantPicker` directly; it's a reference, not the deliverable:
 
 ```jsx
 import { useVariantOptions } from "@/hooks/useVariantOptions";

--- a/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-vibe-headless/references/storefront/INSTRUCTIONS.md
@@ -71,6 +71,35 @@ replace it.
   banner is dismissed.
 - Routes under the Layout: `/shop` → `Shop`, `/product/:slug` → `ProductDetail` (both shipped, as-is).
   **You add `/` → your own Home** page.
+- **Build your own variant selector on the PDP — this is required, not optional, and it's your chance to be creative.** `ProductDetail.jsx` ships with a `VariantPicker` import — remove it and replace with your own component built on `useVariantOptions`. Design the controls to fit the brief: the business type, the tone, the audience. A fashion brand might want large colour swatches and a size chart link; a tech store might want a compact dropdown. `VariantPicker.jsx` is in `src/` for reference — read it, don't use it:
+
+```jsx
+import { useVariantOptions } from "@/hooks/useVariantOptions";
+
+// options/modifiers/selectedOptions/modifierValues come from useProductDetail:
+const { optionGroups, modifierGroups } = useVariantOptions(options, modifiers, selectedOptions, modifierValues);
+
+// optionGroups: [{ id, name, isColor, choices: [{ choiceId, name, colorCode, isColorSwatch, inStock, selected }] }]
+// modifierGroups: [{ key, name, mandatory, type: 'choices'|'text', choices?: [{ key, name, selected }], value?: string }]
+
+// Then render however you want:
+optionGroups.map((group) =>
+  group.choices.map((c) =>
+    c.isColorSwatch
+      ? <MySwatch key={c.choiceId} color={c.colorCode} active={c.selected} disabled={!c.inStock}
+                  onClick={() => selectOption(group.id, c.choiceId)} />
+      : <MyPill  key={c.choiceId} active={c.selected} disabled={!c.inStock}
+                  onClick={() => selectOption(group.id, c.choiceId)}>{c.name}</MyPill>
+  )
+);
+modifierGroups.map((m) =>
+  m.type === "text"
+    ? <MyInput key={m.key} label={m.name} value={m.value} onChange={(v) => setModifier(m.key, v)} />
+    : m.choices.map((c) =>
+        <MyPill key={c.key} active={c.selected} onClick={() => setModifier(m.key, c.key)}>{c.name}</MyPill>
+      )
+);
+```
 
 ```jsx
 import { useRef, useState, useEffect } from "react";
@@ -230,36 +259,6 @@ const { products: inCategory } = await queryProductsByCategory(menu[0].id, { lim
 // product.plainDescription is HTML → render as HTML (the PDP does this):
 <div dangerouslySetInnerHTML={{ __html: product.plainDescription }} />
 // image urls live at: product.media.main.image.url  ·  cart lineItems[].image.url
-```
-
-**Build your own variant/option UI on the PDP using `useVariantOptions`** — don't use `VariantPicker` directly; it's a reference, not the deliverable:
-
-```jsx
-import { useVariantOptions } from "@/hooks/useVariantOptions";
-
-// Inside your PDP component — options/modifiers/selectedOptions/modifierValues come from useProductDetail:
-const { optionGroups, modifierGroups } = useVariantOptions(options, modifiers, selectedOptions, modifierValues);
-
-// optionGroups: [{ id, name, isColor, choices: [{ choiceId, name, colorCode, isColorSwatch, inStock, selected }] }]
-// modifierGroups: [{ key, name, mandatory, type: 'choices'|'text', choices?: [{ key, name, selected }], value?: string }]
-
-// Then render however you want:
-optionGroups.map((group) =>
-  group.choices.map((c) =>
-    c.isColorSwatch
-      ? <MySwatch key={c.choiceId} color={c.colorCode} active={c.selected} disabled={!c.inStock}
-                  onClick={() => selectOption(group.id, c.choiceId)} />
-      : <MyPill  key={c.choiceId} active={c.selected} disabled={!c.inStock}
-                  onClick={() => selectOption(group.id, c.choiceId)}>{c.name}</MyPill>
-  )
-);
-modifierGroups.map((m) =>
-  m.type === "text"
-    ? <MyInput key={m.key} label={m.name} value={m.value} onChange={(v) => setModifier(m.key, v)} />
-    : m.choices.map((c) =>
-        <MyPill key={c.key} active={c.selected} onClick={() => setModifier(m.key, c.key)}>{c.name}</MyPill>
-      )
-);
 ```
 
 Fallback only — when you hit an error or need something not shown here (coupons, members, a field

--- a/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
+++ b/skills/wix-vibe-headless/references/storefront/app/components/VariantPicker.jsx
@@ -1,118 +1,91 @@
-// PDP choice controls: one OptionSelector per product.options[] (variant choices) and one
-// ModifierSelector per product.modifiers[] (TEXT_CHOICES → buttons, FREE_TEXT → input). Driven by
-// useProductDetail — pass its selection state/handlers in. Styled with base44 design tokens (shadcn Tailwind classes).
+// PDP choice controls built on useVariantOptions — swap this component for your own if you want
+// a different look; the data contract (optionGroups / modifierGroups) stays the same.
+// Styled with base44 design tokens (shadcn Tailwind classes).
+import { useVariantOptions } from "@/hooks/useVariantOptions";
 
 const chipBase = "py-1.5 px-3 cursor-pointer text-sm font-body border rounded-sm";
 const chipIdle = "border-border bg-card text-foreground";
 const chipActive = "border-primary bg-primary text-primary-foreground";
 const label = "block mb-1.5 text-[13px] font-semibold text-muted-foreground";
 
-// A colour/swatch option renders as swatches, a text option as pills — the render type is on the
-// option (`optionRenderType`) and mirrored per choice (`choiceType`: ONE_COLOR vs CHOICE_TEXT).
-// Colour choices carry `colorCode` (hex) and usually `linkedMedia`, so a swatch is real colour, and
-// picking one moves the gallery to that colour's photo.
-const isColorChoice = (option, choice) =>
-  option?.optionRenderType === "COLOR_CHOICES" ||
-  option?.optionRenderType === "SWATCH_CHOICES" ||
-  choice?.choiceType === "ONE_COLOR";
-
-function OptionSelector({ option, selected, onSelect }) {
-  // `visible: false` is a choice the merchant retired — it stays in the payload, so filter it out or
-  // the buyer can pick something the catalogue no longer offers.
-  const choices = (option.choicesSettings?.choices || []).filter((c) => c.visible !== false);
-  if (!choices.length) return null;
-  const swatches = choices.some((c) => isColorChoice(option, c) && c.colorCode);
-
-  return (
-    <div className="mb-4">
-      <label className={label}>
-        {option.name}
-        {/* With swatches the chosen colour's name isn't otherwise on screen — echo it. */}
-        {swatches && selected && (
-          <span className="ml-1.5 font-normal text-foreground">
-            {choices.find((c) => c.choiceId === selected)?.name}
-          </span>
-        )}
-      </label>
-      <div className="flex flex-wrap gap-2">
-        {choices.map((c) => {
-          const active = selected === c.choiceId;
-          const out = c.inStock === false;
-          if (swatches && c.colorCode) {
-            return (
-              <button
-                key={c.choiceId}
-                type="button"
-                disabled={out}
-                onClick={() => onSelect(option.id, c.choiceId)}
-                aria-pressed={active}
-                aria-label={`${c.name}${out ? " (out of stock)" : ""}`}
-                title={c.name}
-                className={`relative w-9 h-9 rounded-full cursor-pointer transition-shadow ring-1 ring-inset ring-black/15 ${
-                  active ? "ring-2 ring-offset-2 ring-offset-background ring-primary" : ""
-                } ${out ? "opacity-40 cursor-not-allowed" : "hover:ring-2 hover:ring-offset-1 hover:ring-offset-background hover:ring-border"}`}
-                style={{ backgroundColor: c.colorCode }}
-              >
-                {/* A struck line reads as "unavailable" without hiding which colour it was. */}
-                {out && (
-                  <span aria-hidden="true" className="absolute inset-0 grid place-items-center">
-                    <span className="w-full h-px bg-destructive rotate-45" />
-                  </span>
-                )}
-              </button>
-            );
-          }
-          return (
-            <button
-              key={c.choiceId}
-              type="button"
-              disabled={out}
-              aria-pressed={active}
-              onClick={() => onSelect(option.id, c.choiceId)}
-              className={`${chipBase} ${active ? chipActive : chipIdle} ${out ? "opacity-40 line-through" : ""}`}
-            >
-              {c.name}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function ModifierSelector({ modifier, value, onChange }) {
-  const key = modifier.modifierRenderType === "FREE_TEXT" ? modifier.freeTextSettings?.key : modifier.key;
-  if (modifier.modifierRenderType === "FREE_TEXT") {
-    return (
-      <div className="mb-4">
-        <label className={label}>{modifier.name}{modifier.mandatory && " *"}</label>
-        <input value={value || ""} onChange={(e) => onChange(key, e.target.value)}
-          className="w-full py-2 px-3 font-body border border-input rounded-sm bg-background text-foreground" />
-      </div>
-    );
-  }
-  return (
-    <div className="mb-4">
-      <label className={label}>{modifier.name}{modifier.mandatory && " *"}</label>
-      <div className="flex flex-wrap gap-2">
-        {modifier.choicesSettings?.choices?.map((c) => (
-          <button key={c.key} aria-pressed={value === c.key} onClick={() => onChange(key, c.key)}
-            className={`${chipBase} ${value === c.key ? chipActive : chipIdle}`}>{c.name}</button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export default function VariantPicker({ options, modifiers, selectedOptions, selectOption, modifierValues, setModifier }) {
+  const { optionGroups, modifierGroups } = useVariantOptions(options, modifiers, selectedOptions, modifierValues);
+
   return (
     <>
-      {options.map((o) => (
-        <OptionSelector key={o.id} option={o} selected={selectedOptions[o.id]} onSelect={selectOption} />
+      {optionGroups.map((group) => (
+        <div key={group.id} className="mb-4">
+          <label className={label}>
+            {group.name}
+            {group.isColor && (
+              <span className="ml-1.5 font-normal text-foreground">
+                {group.choices.find((c) => c.selected)?.name}
+              </span>
+            )}
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {group.choices.map((c) =>
+              c.isColorSwatch ? (
+                <button
+                  key={c.choiceId}
+                  type="button"
+                  disabled={!c.inStock}
+                  onClick={() => selectOption(group.id, c.choiceId)}
+                  aria-pressed={c.selected}
+                  aria-label={`${c.name}${!c.inStock ? " (out of stock)" : ""}`}
+                  title={c.name}
+                  className={`relative w-9 h-9 rounded-full cursor-pointer transition-shadow ring-1 ring-inset ring-black/15 ${
+                    c.selected ? "ring-2 ring-offset-2 ring-offset-background ring-primary" : ""
+                  } ${!c.inStock ? "opacity-40 cursor-not-allowed" : "hover:ring-2 hover:ring-offset-1 hover:ring-offset-background hover:ring-border"}`}
+                  style={{ backgroundColor: c.colorCode }}
+                >
+                  {!c.inStock && (
+                    <span aria-hidden="true" className="absolute inset-0 grid place-items-center">
+                      <span className="w-full h-px bg-destructive rotate-45" />
+                    </span>
+                  )}
+                </button>
+              ) : (
+                <button
+                  key={c.choiceId}
+                  type="button"
+                  disabled={!c.inStock}
+                  aria-pressed={c.selected}
+                  onClick={() => selectOption(group.id, c.choiceId)}
+                  className={`${chipBase} ${c.selected ? chipActive : chipIdle} ${!c.inStock ? "opacity-40 line-through" : ""}`}
+                >
+                  {c.name}
+                </button>
+              )
+            )}
+          </div>
+        </div>
       ))}
-      {modifiers.map((m) => (
-        <ModifierSelector key={m.key || m.freeTextSettings?.key} modifier={m}
-          value={modifierValues[m.key || m.freeTextSettings?.key]} onChange={setModifier} />
+
+      {modifierGroups.map((m) => (
+        <div key={m.key} className="mb-4">
+          <label className={label}>{m.name}{m.mandatory && " *"}</label>
+          {m.type === "text" ? (
+            <input
+              value={m.value}
+              onChange={(e) => setModifier(m.key, e.target.value)}
+              className="w-full py-2 px-3 font-body border border-input rounded-sm bg-background text-foreground"
+            />
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {m.choices.map((c) => (
+                <button
+                  key={c.key}
+                  aria-pressed={c.selected}
+                  onClick={() => setModifier(m.key, c.key)}
+                  className={`${chipBase} ${c.selected ? chipActive : chipIdle}`}
+                >
+                  {c.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       ))}
     </>
   );

--- a/skills/wix-vibe-headless/references/storefront/app/hooks/useVariantOptions.js
+++ b/skills/wix-vibe-headless/references/storefront/app/hooks/useVariantOptions.js
@@ -1,0 +1,76 @@
+// Headless data layer for product option/variant/modifier picking.
+// Normalises raw Wix product options + modifiers into flat, render-agnostic structures so you
+// can build whatever UI you want (pills, radios, dropdowns, swatches) without touching the
+// data-edge-case logic (visible filtering, color detection, modifier key resolution).
+//
+// Usage:
+//   const { optionGroups, modifierGroups } = useVariantOptions(
+//     options, modifiers, selectedOptions, modifierValues
+//   );
+//   // then map over optionGroups/modifierGroups to render your own controls and call
+//   // selectOption(optionId, choiceId) / setModifier(key, value) from useProductDetail.
+
+import { useMemo } from "react";
+
+export function useVariantOptions(options, modifiers, selectedOptions, modifierValues) {
+  const optionGroups = useMemo(() =>
+    (options || []).map((option) => {
+      const rawChoices = option.choicesSettings?.choices || [];
+      // `visible: false` = a choice the merchant retired — filter it so buyers can't select it.
+      const choices = rawChoices
+        .filter((c) => c.visible !== false)
+        .map((c) => ({
+          choiceId:   c.choiceId,
+          name:       c.name,
+          colorCode:  c.colorCode || null,
+          // true when this choice should render as a colour swatch (circle) rather than a pill.
+          isColorSwatch: !!(
+            (option.optionRenderType === "COLOR_CHOICES" ||
+             option.optionRenderType === "SWATCH_CHOICES" ||
+             c.choiceType === "ONE_COLOR") &&
+            c.colorCode
+          ),
+          inStock:  c.inStock !== false,
+          selected: selectedOptions[option.id] === c.choiceId,
+        }));
+      return {
+        id:      option.id,
+        name:    option.name,
+        // true if ANY choice in this group is a colour swatch — lets you branch on group type.
+        isColor: choices.some((c) => c.isColorSwatch),
+        choices,
+      };
+    }),
+    [options, selectedOptions]
+  );
+
+  const modifierGroups = useMemo(() =>
+    (modifiers || []).map((m) => {
+      const isText = m.modifierRenderType === "FREE_TEXT";
+      const key = isText ? m.freeTextSettings?.key : m.key;
+      if (isText) {
+        return {
+          key,
+          name:      m.name,
+          mandatory: !!m.mandatory,
+          type:      "text",
+          value:     modifierValues[key] || "",
+        };
+      }
+      return {
+        key,
+        name:      m.name,
+        mandatory: !!m.mandatory,
+        type:      "choices",
+        choices:   (m.choicesSettings?.choices || []).map((c) => ({
+          key:      c.key,
+          name:     c.name,
+          selected: modifierValues[key] === c.key,
+        })),
+      };
+    }),
+    [modifiers, modifierValues]
+  );
+
+  return { optionGroups, modifierGroups };
+}


### PR DESCRIPTION
## Summary
- New `hooks/useVariantOptions.js` — headless data layer for product options/modifiers. Normalises raw Wix data into render-agnostic `optionGroups` / `modifierGroups`, handling:
  - `visible: false` choice filtering (retired choices)
  - Color/swatch detection (`optionRenderType`, `choiceType`, `colorCode`)
  - Modifier key resolution (free-text vs choice modifiers)
- `VariantPicker.jsx` refactored as a thin wrapper over the hook — UI identical, but now the data logic lives in one place
- `INSTRUCTIONS.md`: hook added to the file table + a "build your own variant UI" snippet showing how to map over `optionGroups`/`modifierGroups`

## Why
`VariantPicker` was the most opinionated shipped component (hardcoded pill/swatch shapes and sizing). Agents can now use `useVariantOptions` to build whatever controls fit the design, while the edge-case data logic stays handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)