### PR TITLE
DEMO: wix-app Stores versioning note — exercises the EvalForge eval gate

### DIFF
--- a/skills/wix-app/references/STORES_VERSIONING.md
+++ b/skills/wix-app/references/STORES_VERSIONING.md
@@ -130,4 +130,6 @@ Payload changes: V1 `changedFields` → V3 `modifiedFields`. Top-level `entityId
 - [stores/INVENTORY.md](stores/INVENTORY.md) — inventory read and write operations
 - [stores/CATEGORIES.md](stores/CATEGORIES.md) — collections (V1) ↔ categories (V3)
 
+Every snippet in those files branches on `v` — that is the cached `getVersion()` result from [Mandatory: Detect Version First](#mandatory-detect-version-first) above, not a per-file local.
+
 For methods not listed here, use `SearchWixSDKDocumentation` then `ReadFullDocsArticle`. Always return the required permission scopes to the user.

--- a/yaml/wix-app-evals/stores-dual-catalog-product-list.yml
+++ b/yaml/wix-app-evals/stores-dual-catalog-product-list.yml
@@ -1,0 +1,35 @@
+name: stores/dual-catalog-product-list
+description: Dashboard page listing Wix Stores products that must work on both V1 and V3 catalogs — detects the catalog version first and branches per version instead of assuming one shape
+triggerPrompt: |-
+  Build a dashboard page for my app that lists the products of the Wix Stores catalog on the site, showing each product's name and price. It has to work on any site the app gets installed on, including brand new ones, and it must not crash on a site where Wix Stores isn't installed.
+  APP_NAMESPACE: "@mirivo/my-app31ceim", Use this namespace when creating data collections (for idSuffix scoping).
+  CODE_IDENTIFIER: "MirivoMyApp31ceim" When generating editor React component or function library extensions, use this identifier as the type prefix (e.g. type: 'MirivoMyApp31ceim"ComponentName').
+templateId: 33f2cb85-054e-4281-b617-3bc21ac0803f
+tags: [stores-versioning, stores, dashboard-page]
+assertions:
+  - type: skill_was_called
+    negate: false
+    skillNames: [wix-app]
+    referenceFiles:
+      wix-app: [references/STORES_VERSIONING.md]
+  - type: skill_was_called
+    negate: false
+    skillNames: [wix-app]
+    referenceFiles:
+      wix-app: [references/DASHBOARD_PAGE.md]
+  - type: build_passed
+    command: npm run build
+  - type: llm_judge
+    model: claude-sonnet-4-6
+    minScore: 7
+    prompt: |-
+      Evaluate whether the product list correctly supports both Wix Stores catalog versions. Check: (1) `catalogVersioning.getCatalogVersion()` is called before any product read, and its result is reused rather than re-fetched on every call. (2) Both branches exist and use the right module per version — `productsV3` for V3_CATALOG and `products` for V1_CATALOG — rather than one module with the other's field shape. (3) `STORES_NOT_INSTALLED` is handled gracefully (empty result, not a thrown error). (4) A product's name and price are read from the correct fields for each version, not V1 fields applied to a V3 response. Score 0-10.
+  - type: llm_judge
+    model: claude-sonnet-4-6
+    minScore: 7
+    prompt: |-
+      Evaluate the quality of the path the agent took. Check: (1) It read the Stores versioning reference before reaching for SDK doc search, rather than discovering the V1/V3 split by trial and error. (2) It did not hand-write dashboard page scaffolding that `wix generate --params` owns. (3) The page renders a usable table and the code is well-structured, with the dual-catalog branching isolated in one place rather than repeated per call site. (4) It reported the required Stores permission scopes to the user. Score 0-10.
+  - type: time_limit
+    maxDurationMs: 180000
+  - type: cost
+    maxCostUsd: 1


### PR DESCRIPTION
## Purpose

**Dummy PR — do not merge.** Opened to demonstrate the eval GitHub Action end to end, now parked as a draft.

## What changed

1. **`skills/wix-app/references/STORES_VERSIONING.md`** — one line, in the Wix Stores vertical. All five `references/stores/*.md` files branch on `v` (`if (v === 'V3_CATALOG')`) without defining it; only `stores/QUERY.md` carries an inline comment saying where it comes from. This states it once next to the file index in the versioning hub, rather than repeating the comment into the other four.
2. **`yaml/wix-app-evals/stores-dual-catalog-product-list.yml`** — a new scenario tagged `stores-versioning`, added because the gate demanded it (see below).

## What the gate demonstrated

`.github/workflows/evalforge-wix-app-gate.yml` triggers on `pull_request` for `skills/wix-app/**` and `yaml/wix-app-evals/**`. It is the only live eval workflow on skill content — `skill-eval.yml` is disabled (`if: false`), and `skill-eval-ci.yml` only watches the action's own source.

| Push | Change | Gate behavior |
|---|---|---|
| 1 | a bullet in `SKILL.md` | ran the eval — but only because `SKILL.md` is in `DEFAULT_BROAD_IMPACT_GLOBS`, so no tag needs covering |
| 2 | the `STORES_VERSIONING.md` line | **coverage guard failed at 19s** — the path derives tag `stores-versioning`, no scenario carried it, so no EvalForge call was made and no run cost was incurred |
| 3 | + the scenario YAML | guard passed, eval ran, **7/7 assertions, green** |

Two caveats on that green, both of which the gate's own comment states: the comparison arms evaluated identical skill content (the final push only added scenario YAML, and the doc line is non-behavioral), so net impact is 0 by construction; and `blocking` is still `false` during the soak period, so the check was green in push 2 as well *while refusing to run anything* — the comment body, not the check color, is where the verdict lives.

## Scenario notes

`stores/dual-catalog-product-list` follows the three-part shape in `docs/eval-scenarios.md`: `skill_was_called` coverage on `STORES_VERSIONING.md` + `DASHBOARD_PAGE.md`, an `llm_judge` on correctness (version detected and cached first, correct module per version, `STORES_NOT_INSTALLED` handled), a second `llm_judge` on the quality of the path, plus `build_passed` and time/cost ceilings. Seven assertions clears the quality bar (≥3 including an `llm_judge`) — a weak scenario does not count as coverage.

It is tagged `[stores-versioning, stores, dashboard-page]`, so it will also re-run on future changes to `DASHBOARD_PAGE.md` and `references/stores/*.md`. That is the intended many-to-many behavior, but it adds this scenario's runtime to those PRs — drop a tag to keep it narrow.

## Draft status

The gate job is gated on `!github.event.pull_request.draft`, so **it will not re-run while this PR is a draft**. Marking it ready for review re-fires it — `ready_for_review` is in the workflow's `types` list precisely so a draft going ready does not sit unevaluated.

## Cleanup

Close the PR when done — `evalforge-wix-app-gate-cleanup.yml` sweeps the capability versions (including the orphan from the cancelled first run) and the draft scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)