### PR TITLE
🦞 igor-claw: document Smart Campaign UpdateCampaign's required-fields gap + excludedSearchTerms example

### DIFF
--- a/skills/wix-manage/references/google-ads/manage-campaign-lifecycle.md
+++ b/skills/wix-manage/references/google-ads/manage-campaign-lifecycle.md
@@ -36,7 +36,7 @@ curl -X POST 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}/resum
 
 ## Update (partial) & change budget
 
-`PATCH /v1/campaigns/{id}` — send only the fields you're changing, plus the required `id` and `accountId`. Budget is in **micros** (`20000000` = $20.00/day).
+`PATCH /v1/campaigns/{id}` — always required: `id`, `accountId`, `campaignType`. Budget is in **micros** (`20000000` = $20.00/day).
 
 ```bash
 curl -X PATCH 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}' -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
@@ -44,6 +44,23 @@ curl -X PATCH 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}' -H 
 ```
 
 Changing only the daily budget = the same call with just `id`, `accountId`, and `budget.amountMicros`. Over the account max → `CAMPAIGN_DAILY_BUDGET_TOO_HIGH` (check `GET /v1/campaign/daily-budget-boundaries`, returns min/max in micros).
+
+> **This is not a true field-level partial update for Smart Campaigns yet.** Despite the PATCH semantics, `GET` the campaign first and resend the fields below unchanged — omitting them currently causes a server error (5xx) instead of a clean update or validation message:
+> - `smartCampaign.adGroups` (at least one ad group with its `ads`)
+> - `smartCampaign.url`
+> - `smartCampaign.languageCode`, `smartCampaign.businessName` (and `smartCampaign.phone` if the campaign uses call ads)
+>
+> `budget` itself is optional — omit it to leave the daily budget unchanged.
+>
+> To exclude irrelevant search terms on a Smart Campaign (traffic-quality tuning), `GET` the campaign, then resend it with `smartCampaign.excludedSearchTerms` added/changed alongside the required fields above:
+> ```bash
+> curl -X PATCH 'https://www.wixapis.com/google-ads/v1/campaigns/{campaignId}' -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+>   -d '{ "campaign": { "id": "...", "accountId": "...", "campaignType": "SMART", "smartCampaign": {
+>     "excludedSearchTerms": [ { "freeFormKeywordTheme": "diy", "displayName": "diy" } ],
+>     "adGroups": [ /* from the GET response, unchanged */ ],
+>     "url": "...", "languageCode": "en", "businessName": "..."
+>   } } }'
+> ```
 
 ## Delete & history
 


### PR DESCRIPTION
## Summary

Opened automatically by an AI agent acting on behalf of Ayal (`ayalg@wix.com`), based on an MCP feedback report investigated here: https://wix.slack.com/archives/C08P5DKLJR5/p1786981366779239

**Report:** an agent using the Wix MCP followed this recipe's `manage-campaign-lifecycle.md` guidance ("send only the fields you're changing") to update only a Smart Campaign's `smartCampaign.excludedSearchTerms`. The call failed server-side with no actionable error.

**Root cause** (traced in `wix-private/promote-google-ads`, code fix in a companion PR there): `UpdateCampaign` is PATCH-shaped and documented as a partial update, but the Smart Campaign update handler still unconditionally requires `smartCampaign.adGroups`, `url`, `languageCode`, and `businessName` on every request (throws if omitted), and used to crash the same way when `budget` was omitted too (now fixed to fall back to the saved budget).

**This PR:** updates the recipe so agents don't repeat the same crash while the deeper backend gap is being addressed:
- Tells agents to `GET` the campaign first and resend the still-required fields, instead of inferring "PATCH ⇒ send only the diff" from the HTTP verb alone.
- Adds a concrete `excludedSearchTerms` example, since no recipe showed how to set it and it's the exact field the report needed.

## Test plan
- [ ] N/A — documentation-only change to `skills/wix-manage/references/google-ads/manage-campaign-lifecycle.md`.