### PR TITLE
feat(docs skills): from docs to calls — identities, dynamic context, visitor mint

### DIFF
--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -43,6 +43,7 @@ this skill into the app via `npx skills add`; after it runs, the path is
 | `docs.sections(slug)` | the outline, with `read_file` coordinates | `{ lines, shown, omitted, rows }` |
 | `await docs.methodsOf("resource-pattern")` | every method of a resource, from the spec index | `{ resources, rows }` |
 | `await docs.methodSchema(docsUrl, slug?)` | one method's exact schema → disk | `{ path, bytes, publicUrl, httpMethod }` |
+| `await docs.callApi({ url, token, body, saveAs? })` | run a call you read the contract for | `{ status, json }` inline, or `{ path, bytes }` if big |
 
 One `exec_tool` call per round, never two. The default timeout is 10s; pass `timeout` (up to 120)
 for a single large fetch. `exec_tool` must never return document text — that is the module's
@@ -162,6 +163,53 @@ Distinguish three outcomes, plainly: the docs show this; the docs show something
 not the same thing; or you enumerated the resource's methods and none of them do this. The third is
 a real answer — give it, and say what you enumerated. Never infer an endpoint, field or enum from a
 URL pattern, from a similar API in another Wix product, or from a search snippet you did not open.
+
+## 6. From docs to calls
+
+The docs were the map; `docs.callApi` is the territory. It takes the contract you just read and
+runs it — same invariant as everything else: small responses come back inline, big ones land in
+scratch as `{ path, bytes }`.
+
+Two identities, and which one a call wants is part of what you read:
+
+| identity | token | for |
+|---|---|---|
+| **admin** | the app's Wix connector | managing the site — ad hoc from `exec_tool`, or the same fetch inside a backend function |
+| **visitor** | minted in the app's client code | everything the site's end user does — storefront reads, cart, checkout |
+
+**Admin — the connector is the token.** First call: what IS this site? The Dynamic Site Context API
+returns one markdown report — installed apps, status, URL, locale, CMS collections:
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+return await docs.callApi({
+  url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  token: accessToken,
+  body: { siteId: WIX_SITE_ID },
+  saveAs: "site-context",          // the report can approach 1 MB — read it with read_file
+});
+```
+
+A `200` with `{"markdown": ""}` means the token or `siteId` is wrong — the endpoint reports an
+empty context instead of an auth error, so treat empty as "check auth", never as "empty site".
+
+**Visitor — minted from the OAuth app's client id, in the client.** The client id is a public
+value (it lives in a committed config file); the mint is one unauthenticated call, so it belongs
+in the app's own frontend code, straight from the docs contract:
+
+```js
+// src/lib/wixClient.js — app code, not exec_tool
+const res = await fetch("https://www.wixapis.com/oauth2/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ clientId: WIX_CLIENT_ID, grantType: "anonymous" }),
+});
+const { access_token } = await res.json();   // bearer for products, cart, checkout
+```
+
+Contract source: `business-management/headless/authentication/retrieve-tokens`. The cart and
+checkout APIs act on the *caller's* identity, so they want the visitor token — the admin token is
+for managing the site, the visitor token is for being on it.
 
 ## The raw endpoints (what the module wraps)
 

--- a/skills/wix-docs-base44/scripts/docs.js
+++ b/skills/wix-docs-base44/scripts/docs.js
@@ -192,4 +192,23 @@ async function methodSchema(docsUrl, slug) {
   return { ...save(name, JSON.stringify(result, null, 1)), publicUrl: result.publicUrl, httpMethod: result.httpMethod };
 }
 
-module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema };
+// ── call (the docs were the map; this is the territory) ─────────────────────
+
+// Call a Wix API whose contract you just read. `token` is a bearer — the connector's
+// (admin) or a visitor's. Responses follow the invariant: big ones go to disk.
+async function callApi({ url, method = "POST", token, body, saveAs }) {
+  const res = await fetch(url, {
+    method,
+    headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) return { status: res.status, error: text.slice(0, 300) };
+  if (saveAs || text.length > BUDGET) {
+    return { ...save((saveAs || "api-response") + ".json", text), status: res.status };
+  }
+  try { return { status: res.status, json: JSON.parse(text) }; }
+  catch { return { status: res.status, text }; }
+}
+
+module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema, callApi };

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -212,6 +212,44 @@ when present, fall back to Lane 1 when not. Optional — skip this lane if the t
 Append `.md` only when `curl`-ing a page directly. The MCP tools and the search endpoint take the
 plain docs URL **without** `.md` — never feed a `.md` URL to an MCP tool.
 
+## From docs to calls
+
+The contract you just read runs under one of two identities — and which one a call wants is part
+of what you read:
+
+| identity | token | for |
+|---|---|---|
+| **admin** | an admin token (API key, connector, or OAuth-app admin grant) | managing the site — ad hoc calls, or the same fetch inside an app's backend function |
+| **visitor** | minted from the site's OAuth app, in frontend code | everything the site's end user does — storefront reads, cart, checkout |
+
+**Admin — first call: what IS this site?** The Dynamic Site Context API returns one markdown
+report — installed apps, status, URL, locale, CMS collections — the same output the Wix MCP's
+site-context tool renders:
+
+```bash
+curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  --data-raw '{"siteId": "<metasite id>"}' | jq -r '.markdown'
+```
+
+A `200` with `"markdown": ""` means the token or `siteId` is wrong — the endpoint reports an empty
+context instead of an auth error, so treat empty as "check auth", never as "empty site".
+
+**Visitor — minted from the OAuth app's client id.** The client id is a public value (it lives in
+a committed config file); the mint is one unauthenticated call, so it belongs in the site's own
+frontend code:
+
+```bash
+curl -sS -X POST 'https://www.wixapis.com/oauth2/token' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"clientId": "<oauth app client id>", "grantType": "anonymous"}'
+# → { "access_token": "OauthNG.JWS.…", … } — bearer for products, cart, checkout
+```
+
+Contract source: `business-management/headless/authentication/retrieve-tokens`. The cart and
+checkout APIs act on the *caller's* identity, so they want the visitor token — the admin token is
+for managing the site, the visitor token is for being on it.
+
 ## Before you write the code
 
 Confirm on the page — not from memory — the endpoint, the HTTP verb, the request body shape,


### PR DESCRIPTION
One new section in each skill (curl-shaped in wix-docs, module-shaped in wix-docs-base44): the two identities a Wix call runs under, the Dynamic Site Context report as the first admin call, and the anonymous visitor mint. Everything live-verified; details in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)