### PR TITLE
fix(docs skills): API responses stay out of scratch; special APIs section; auth links

### DIFF
--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -43,7 +43,7 @@ this skill into the app via `npx skills add`; after it runs, the path is
 | `docs.sections(slug)` | the outline, with `read_file` coordinates | `{ lines, shown, omitted, rows }` |
 | `await docs.methodsOf("resource-pattern")` | every method of a resource, from the spec index | `{ resources, rows }` |
 | `await docs.methodSchema(docsUrl, slug?)` | one method's exact schema → disk | `{ path, bytes, publicUrl, httpMethod }` |
-| `await docs.callApi({ url, token, body, saveAs? })` | run a call you read the contract for | `{ status, json }` inline, or `{ path, bytes }` if big |
+| `await docs.callApi({ url, token, body })` | run a call you read the contract for | `{ status, json }`, or clipped `text` + `truncated` |
 
 One `exec_tool` call per round, never two. The default timeout is 10s; pass `timeout` (up to 120)
 for a single large fetch. `exec_tool` must never return document text — that is the module's
@@ -166,9 +166,10 @@ URL pattern, from a similar API in another Wix product, or from a search snippet
 
 ## 6. From docs to calls
 
-The docs were the map; `docs.callApi` is the territory. It takes the contract you just read and
-runs it — same invariant as everything else: small responses come back inline, big ones land in
-scratch as `{ path, bytes }`.
+The docs were the map; `docs.callApi` is the territory — it runs the contract you just read.
+API responses are site data, so they stay out of scratch: small ones come back inline, an
+oversized one comes back clipped with `truncated: true` — narrow the call (filters, cursor paging,
+fewer fields) rather than re-request the same size.
 
 Two identities, and which one a call wants is part of what you read:
 
@@ -177,21 +178,16 @@ Two identities, and which one a call wants is part of what you read:
 | **admin** | the app's Wix connector | managing the site — ad hoc from `exec_tool`, or the same fetch inside a backend function |
 | **visitor** | minted in the app's client code | everything the site's end user does — storefront reads, cart, checkout |
 
-**Admin — the connector is the token.** First call: what IS this site? The Dynamic Site Context API
-returns one markdown report — installed apps, status, URL, locale, CMS collections:
+**Admin — the connector is the token.** Any management or read call from its docs contract:
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
 return await docs.callApi({
-  url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  url: "https://www.wixapis.com/stores/v3/products/query",   // from the page you just read
   token: accessToken,
-  body: { siteId: WIX_SITE_ID },
-  saveAs: "site-context",          // the report can approach 1 MB — read it with read_file
+  body: { query: { cursorPaging: { limit: 10 } } },
 });
 ```
-
-A `200` with `{"markdown": ""}` means the token or `siteId` is wrong — the endpoint reports an
-empty context instead of an auth error, so treat empty as "check auth", never as "empty site".
 
 **Visitor — minted from the OAuth app's client id, in the client.** The client id is a public
 value (it lives in a committed config file); the mint is one unauthenticated call, so it belongs
@@ -207,9 +203,48 @@ const res = await fetch("https://www.wixapis.com/oauth2/token", {
 const { access_token } = await res.json();   // bearer for products, cart, checkout
 ```
 
-Contract source: `business-management/headless/authentication/retrieve-tokens`. The cart and
-checkout APIs act on the *caller's* identity, so they want the visitor token — the admin token is
-for managing the site, the visitor token is for being on it.
+The cart and checkout APIs act on the *caller's* identity, so they want the visitor token — the
+admin token is for managing the site, the visitor token is for being on it.
+
+The authentication docs, all fetchable with `docs.fetchDoc`:
+
+- `api-reference/articles/authentication/about-identities` — the identity model
+- `api-reference/articles/authentication/rest-api-authentication` — headers, token kinds
+- `business-management/headless/authentication/retrieve-tokens` — the /oauth2/token contract, all grant types
+- `go-headless/authentication/about-authentication` — visitor vs member sessions
+- `go-headless/getting-started/setup/authentication/create-an-oauth-app-for-visitors-and-members` — where the client id comes from
+- `go-headless/authentication/setup/set-up-a-headless-client` — wiring the client
+
+## 7. Special APIs worth knowing
+
+A short list of APIs that answer whole questions, not just single operations:
+
+**Dynamic Site Context — "what IS this site?"** One admin call returns a markdown report of the
+whole site: installed apps, status, URL, locale, CMS collections.
+
+```js
+await docs.callApi({
+  url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  token: accessToken,
+  body: { siteId: WIX_SITE_ID },
+})
+```
+
+The report can be large — expect `truncated: true` on content-rich sites. And a `200` with
+`{"markdown": ""}` means the token or `siteId` is wrong — the endpoint reports an empty context
+instead of an auth error, so treat empty as "check auth", never as "empty site".
+
+**Query OAuth Apps — the site's client ids.** Lists the site's OAuth apps (admin token; needs
+`SCOPE.OAUTH_APP.READ`, which the connector token carries):
+
+```js
+await docs.callApi({
+  url: "https://www.wixapis.com/oauth-app/v1/oauth-apps/query",
+  token: accessToken,
+  body: { query: {} },
+})
+// → each app carries the public client id the visitor mint needs
+```
 
 ## The raw endpoints (what the module wraps)
 

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -43,6 +43,7 @@ this skill into the app via `npx skills add`; after it runs, the path is
 | `docs.sections(slug)` | the outline, with `read_file` coordinates | `{ lines, shown, omitted, rows }` |
 | `await docs.methodsOf("resource-pattern")` | every method of a resource, from the spec index | `{ resources, rows }` |
 | `await docs.methodSchema(docsUrl, slug?)` | one method's exact schema → disk | `{ path, bytes, publicUrl, httpMethod }` |
+| `await docs.callApi({ url, token, body, saveAs? })` | run a call you read the contract for | `{ status, json }` inline, or `{ path, bytes }` if big |
 
 One `exec_tool` call per round, never two. The default timeout is 10s; pass `timeout` (up to 120)
 for a single large fetch. `exec_tool` must never return document text — that is the module's
@@ -162,6 +163,53 @@ Distinguish three outcomes, plainly: the docs show this; the docs show something
 not the same thing; or you enumerated the resource's methods and none of them do this. The third is
 a real answer — give it, and say what you enumerated. Never infer an endpoint, field or enum from a
 URL pattern, from a similar API in another Wix product, or from a search snippet you did not open.
+
+## 6. From docs to calls
+
+The docs were the map; `docs.callApi` is the territory. It takes the contract you just read and
+runs it — same invariant as everything else: small responses come back inline, big ones land in
+scratch as `{ path, bytes }`.
+
+Two identities, and which one a call wants is part of what you read:
+
+| identity | token | for |
+|---|---|---|
+| **admin** | the app's Wix connector | managing the site — ad hoc from `exec_tool`, or the same fetch inside a backend function |
+| **visitor** | minted in the app's client code | everything the site's end user does — storefront reads, cart, checkout |
+
+**Admin — the connector is the token.** First call: what IS this site? The Dynamic Site Context API
+returns one markdown report — installed apps, status, URL, locale, CMS collections:
+
+```js
+const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
+return await docs.callApi({
+  url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  token: accessToken,
+  body: { siteId: WIX_SITE_ID },
+  saveAs: "site-context",          // the report can approach 1 MB — read it with read_file
+});
+```
+
+A `200` with `{"markdown": ""}` means the token or `siteId` is wrong — the endpoint reports an
+empty context instead of an auth error, so treat empty as "check auth", never as "empty site".
+
+**Visitor — minted from the OAuth app's client id, in the client.** The client id is a public
+value (it lives in a committed config file); the mint is one unauthenticated call, so it belongs
+in the app's own frontend code, straight from the docs contract:
+
+```js
+// src/lib/wixClient.js — app code, not exec_tool
+const res = await fetch("https://www.wixapis.com/oauth2/token", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ clientId: WIX_CLIENT_ID, grantType: "anonymous" }),
+});
+const { access_token } = await res.json();   // bearer for products, cart, checkout
+```
+
+Contract source: `business-management/headless/authentication/retrieve-tokens`. The cart and
+checkout APIs act on the *caller's* identity, so they want the visitor token — the admin token is
+for managing the site, the visitor token is for being on it.
 
 ## The raw endpoints (what the module wraps)
 

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -42,8 +42,7 @@ this skill into the app via `npx skills add`; after it runs, the path is
 | `docs.mapTerms(slug, /regex/i)` | line numbers of matches + section headers | `{ lines, shown, omitted, rows }` |
 | `docs.sections(slug)` | the outline, with `read_file` coordinates | `{ lines, shown, omitted, rows }` |
 | `await docs.methodsOf("resource-pattern")` | every method of a resource, from the spec index | `{ resources, rows }` |
-| `await docs.methodSchema(docsUrl, slug?)` | one method's exact schema, `$circular` types bundled → disk | `{ path, bytes, publicUrl, httpMethod }` |
-| `await docs.specQuery("async function(){…}")` | your own query over the spec index | `{ result }` inline, or `{ path, bytes }` if big |
+| `await docs.specQuery("async function(){…}")` | read schemas: your own query over the spec index | `{ result }` inline, or `{ path, bytes }` if big |
 | `await docs.callApi({ url, token, body })` | run a call you read the contract for | `{ status, json }`, or clipped `text` + `truncated` |
 
 One `exec_tool` call per round, never two. The default timeout is 10s; pass `timeout` (up to 120)
@@ -151,25 +150,45 @@ await docs.methodsOf("bookings-writer-v2")
 
 This queries the API spec index and matches the resource's `docsUrl` — `operationId`s are fully
 qualified (`wix.bookings.catalog.v1.…Service.CreateServiceOptionsAndVariants`), so a resource name
-never matches them. For one method's exact request/response schema or enum values,
-`docs.methodSchema(docsUrl)` writes it to disk as JSON — prefer it over slicing markdown, and check
-the *sibling* methods too: a requirement is often documented on single-create but absent from the
-bulk-create page.
+never matches them.
 
-Large schemas replace repeated types with `{ "$circular": "com.wix.ecom.cart.api.v1.Cart" }` stubs;
-`methodSchema` bundles every referenced type (transitively) into the file's `components`, so the
-saved schema is self-contained — resolve a stub by looking up its name there.
+**Reading a schema is `specQuery`.** Schemas are huge (a create method's tree can run past 200 KB),
+so the query returns the slice you need and you **iterate** — each call is one round; refine the
+query instead of returning more. `lightIndex` and `getResourceSchemaByUrl(docsUrl)` are in scope.
 
-When the canned calls don't fit — expand one enum, compare two methods' fields, filter across every
-API — write the query yourself with `specQuery`. `lightIndex` and `getResourceSchemaByUrl` are in
-scope:
+A method's request fields, names and types only:
 
 ```js
 await docs.specQuery(`async function(){
-  const s = await getResourceSchemaByUrl("…/cart/get-current-cart");
-  return Object.keys(s.components.schemas).filter(n => /LineItem/i.test(n));
+  const u = "https://dev.wix.com/docs/api-reference/business-solutions/blog/draft-posts/create-draft-post";
+  const s = await getResourceSchemaByUrl(u);
+  const m = s.methods.find(x => x.docsUrl === u);
+  const props = m.requestBody.content["application/json"].schema.properties;
+  return Object.entries(props).map(([k, v]) => k + ": " + (v.type || v.$circular || "object"));
 }`)
+// → ["draftPost: object", "publish: boolean", "fieldsets: array"]
 ```
+
+Next round, drill into the object you care about:
+
+```js
+  // …same setup…
+  const dp = m.requestBody.content["application/json"].schema.properties.draftPost;
+  return Object.entries(dp.properties).map(([k, v]) => k + ": " + (v.type || v.$circular || "object"));
+// → ["id: string", "title: string", "excerpt: string", "featured: boolean", …]
+```
+
+A field typed as `{ "$circular": "<name>" }` is a repeated type stored once — resolve it by name:
+
+```js
+  // …same setup…
+  const type = s.components.schemas["com.wix.ecom.cart.api.v1.Cart"];
+  return Object.entries(type.properties).map(([k, v]) => k + ": " + (v.type || v.$circular || "object"));
+```
+
+The same door answers anything the canned calls can't — enum values, comparing two methods'
+fields, filtering across every API. Check the *sibling* methods too: a requirement is often
+documented on single-create but absent from the bulk-create page.
 
 ## 5. Answer
 
@@ -248,8 +267,8 @@ The report can be large — expect `truncated: true` on content-rich sites. And 
 `{"markdown": ""}` means the token or `siteId` is wrong — the endpoint reports an empty context
 instead of an auth error, so treat empty as "check auth", never as "empty site".
 
-For the rest of site management — installing apps, site properties, media, OAuth apps — the
-**`wix-manage`** skill carries per-area recipes. It may already be installed at
+For site management, the **`wix-manage`** skill carries per-area recipes. It may already be
+installed at
 `.agents/skills/wix-manage/`; install it with `npx -y skills add wix/skills/skills/wix-manage`,
 or read it straight off the registry: `https://www.wix.com/skills/wix-manage`.
 
@@ -260,7 +279,7 @@ or read it straight off the registry: `https://www.wix.com/skills/wix-manage`.
 | `POST https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse` | `browse` — body: `menu_url`, `include`, `name_filter`, `depth` (1–6), `deprecated`, `format` |
 | `POST https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown` | `search` — body: `search_term`, `document_type`, `maximum_results` (1–20), `lines_in_each_result` (1–200) |
 | `GET https://dev.wix.com/docs/…?.md` | `fetchDoc` — every docs path has a `.md` twin; `https://dev.wix.com/docs/llms.txt` is the root map; `?apiView=SDK` for the SDK view |
-| `POST https://mcp.wix.com/api/code-mode/search` | `methodsOf` / `methodSchema` — `{ code: "async function(){…}" }` with `lightIndex` and `getResourceSchemaByUrl(docsUrl)` in scope; response wrapped in `{ result }` |
+| `POST https://mcp.wix.com/api/code-mode/search` | `methodsOf` / `specQuery` — `{ code: "async function(){…}" }` with `lightIndex` and `getResourceSchemaByUrl(docsUrl)` in scope; response wrapped in `{ result }` |
 
 There is also a structured search (`POST …/v1/docs/search`, same body → `{ results: [{ title, url,
 relevance_score }] }`) when you want to route on hits programmatically.

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -42,7 +42,8 @@ this skill into the app via `npx skills add`; after it runs, the path is
 | `docs.mapTerms(slug, /regex/i)` | line numbers of matches + section headers | `{ lines, shown, omitted, rows }` |
 | `docs.sections(slug)` | the outline, with `read_file` coordinates | `{ lines, shown, omitted, rows }` |
 | `await docs.methodsOf("resource-pattern")` | every method of a resource, from the spec index | `{ resources, rows }` |
-| `await docs.methodSchema(docsUrl, slug?)` | one method's exact schema → disk | `{ path, bytes, publicUrl, httpMethod }` |
+| `await docs.methodSchema(docsUrl, slug?)` | one method's exact schema, `$circular` types bundled → disk | `{ path, bytes, publicUrl, httpMethod }` |
+| `await docs.specQuery("async function(){…}")` | your own query over the spec index | `{ result }` inline, or `{ path, bytes }` if big |
 | `await docs.callApi({ url, token, body })` | run a call you read the contract for | `{ status, json }`, or clipped `text` + `truncated` |
 
 One `exec_tool` call per round, never two. The default timeout is 10s; pass `timeout` (up to 120)
@@ -155,6 +156,21 @@ never matches them. For one method's exact request/response schema or enum value
 the *sibling* methods too: a requirement is often documented on single-create but absent from the
 bulk-create page.
 
+Large schemas replace repeated types with `{ "$circular": "com.wix.ecom.cart.api.v1.Cart" }` stubs;
+`methodSchema` bundles every referenced type (transitively) into the file's `components`, so the
+saved schema is self-contained — resolve a stub by looking up its name there.
+
+When the canned calls don't fit — expand one enum, compare two methods' fields, filter across every
+API — write the query yourself with `specQuery`. `lightIndex` and `getResourceSchemaByUrl` are in
+scope:
+
+```js
+await docs.specQuery(`async function(){
+  const s = await getResourceSchemaByUrl("…/cart/get-current-cart");
+  return Object.keys(s.components.schemas).filter(n => /LineItem/i.test(n));
+}`)
+```
+
 ## 5. Answer
 
 Cite the file and line for each claim, and name the product the page belongs to.
@@ -217,8 +233,6 @@ The authentication docs, all fetchable with `docs.fetchDoc`:
 
 ## 7. Special APIs worth knowing
 
-A short list of APIs that answer whole questions, not just single operations:
-
 **Dynamic Site Context — "what IS this site?"** One admin call returns a markdown report of the
 whole site: installed apps, status, URL, locale, CMS collections.
 
@@ -234,17 +248,10 @@ The report can be large — expect `truncated: true` on content-rich sites. And 
 `{"markdown": ""}` means the token or `siteId` is wrong — the endpoint reports an empty context
 instead of an auth error, so treat empty as "check auth", never as "empty site".
 
-**Query OAuth Apps — the site's client ids.** Lists the site's OAuth apps (admin token; needs
-`SCOPE.OAUTH_APP.READ`, which the connector token carries):
-
-```js
-await docs.callApi({
-  url: "https://www.wixapis.com/oauth-app/v1/oauth-apps/query",
-  token: accessToken,
-  body: { query: {} },
-})
-// → each app carries the public client id the visitor mint needs
-```
+For the rest of site management — installing apps, site properties, media, OAuth apps — the
+**`wix-manage`** skill carries per-area recipes. It may already be installed at
+`.agents/skills/wix-manage/`; install it with `npx -y skills add wix/skills/skills/wix-manage`,
+or read it straight off the registry: `https://www.wix.com/skills/wix-manage`.
 
 ## The raw endpoints (what the module wraps)
 

--- a/skills/wix-docs-base44/scripts/docs.js
+++ b/skills/wix-docs-base44/scripts/docs.js
@@ -177,39 +177,6 @@ async function methodsOf(resourcePattern) {
     { resources: result.map(r => r.docsUrl) });
 }
 
-// One method's exact request/response schema, to disk (schemas are large).
-// Large schemas replace repeated types with { "$circular": "<type name>" } stubs; the
-// definitions live in the resource's components — so every referenced one is bundled
-// (transitively) into the saved file under `components`.
-async function methodSchema(docsUrl, slug) {
-  const fn = `async function(){
-    const u = ${JSON.stringify(docsUrl)};
-    const s = await getResourceSchemaByUrl(u);
-    const m = s.methods.find(x => x.docsUrl === u);
-    if (!m) return null;
-    const out = { publicUrl: m.publicUrl, httpMethod: m.httpMethod,
-                  requestBody: m.requestBody, responses: m.responses };
-    const comps = (s.components && s.components.schemas) || {};
-    const need = new Set();
-    const collect = (o) => {
-      if (!o || typeof o !== "object") return;
-      if (o.$circular && comps[o.$circular] && !need.has(o.$circular)) {
-        need.add(o.$circular);
-        collect(comps[o.$circular]);
-      }
-      for (const v of Object.values(o)) collect(v);
-    };
-    collect(out);
-    out.components = {};
-    for (const n of need) out.components[n] = comps[n];
-    return out;
-  }`;
-  const { result } = await post(SPEC_API, { code: fn });
-  if (!result) return { exists: false, hint: "docsUrl did not match a method — copy it from browse/methodsOf output" };
-  const name = (slug || docsUrl.split("/").pop()) + ".schema.json";
-  return { ...save(name, JSON.stringify(result, null, 1)), publicUrl: result.publicUrl, httpMethod: result.httpMethod };
-}
-
 // ── call (the docs were the map; this is the territory) ─────────────────────
 
 // Call a Wix API whose contract you just read. `token` is a bearer — the connector's
@@ -232,10 +199,14 @@ async function callApi({ url, method = "POST", token, body }) {
   catch { return { status: res.status, text }; }
 }
 
-// Your own query over the API spec index — lightIndex and getResourceSchemaByUrl are in
-// scope, the response arrives wrapped in { result }. The escape hatch when the canned calls
-// don't fit: expand an enum, resolve a $circular type, filter across every API. Spec data is
-// public docs, so a big result goes to scratch like any fetched page.
+// THE way to read a schema: write a query over the API spec index — lightIndex and
+// getResourceSchemaByUrl(docsUrl) are in scope, the response arrives wrapped in { result }.
+// Schemas are huge; return only the slice you need and ITERATE — each call is one round,
+// refine the query instead of returning more. A method's schema sits at
+// m.requestBody.content["application/json"].schema; repeated types appear as
+// { "$circular": "<name>" } stubs — resolve one with s.components.schemas["<name>"].
+// Small results come back inline; a big one is saved to scratch (public docs — allowed)
+// as { path, bytes } to read with read_file.
 async function specQuery(fnBody, { saveAs } = {}) {
   const { result } = await post(SPEC_API, { code: fnBody });
   const text = JSON.stringify(result, null, 1);
@@ -243,4 +214,4 @@ async function specQuery(fnBody, { saveAs } = {}) {
   return { result };
 }
 
-module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema, callApi, specQuery };
+module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, callApi, specQuery };

--- a/skills/wix-docs-base44/scripts/docs.js
+++ b/skills/wix-docs-base44/scripts/docs.js
@@ -195,8 +195,10 @@ async function methodSchema(docsUrl, slug) {
 // ── call (the docs were the map; this is the territory) ─────────────────────
 
 // Call a Wix API whose contract you just read. `token` is a bearer — the connector's
-// (admin) or a visitor's. Responses follow the invariant: big ones go to disk.
-async function callApi({ url, method = "POST", token, body, saveAs }) {
+// (admin) or a visitor's. API responses are site data and stay OUT of scratch (scratch
+// is committed with the app); an oversized response comes back clipped and says so —
+// narrow the call (filters, paging, fields) rather than re-requesting the same size.
+async function callApi({ url, method = "POST", token, body }) {
   const res = await fetch(url, {
     method,
     headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), "Content-Type": "application/json" },
@@ -204,8 +206,9 @@ async function callApi({ url, method = "POST", token, body, saveAs }) {
   });
   const text = await res.text();
   if (!res.ok) return { status: res.status, error: text.slice(0, 300) };
-  if (saveAs || text.length > BUDGET) {
-    return { ...save((saveAs || "api-response") + ".json", text), status: res.status };
+  if (text.length > BUDGET) {
+    return { status: res.status, truncated: true, totalChars: text.length, text: text.slice(0, BUDGET),
+             hint: "narrow the call — filters, cursor paging, or fewer fields" };
   }
   try { return { status: res.status, json: JSON.parse(text) }; }
   catch { return { status: res.status, text }; }

--- a/skills/wix-docs-base44/scripts/docs.js
+++ b/skills/wix-docs-base44/scripts/docs.js
@@ -192,4 +192,23 @@ async function methodSchema(docsUrl, slug) {
   return { ...save(name, JSON.stringify(result, null, 1)), publicUrl: result.publicUrl, httpMethod: result.httpMethod };
 }
 
-module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema };
+// ── call (the docs were the map; this is the territory) ─────────────────────
+
+// Call a Wix API whose contract you just read. `token` is a bearer — the connector's
+// (admin) or a visitor's. Responses follow the invariant: big ones go to disk.
+async function callApi({ url, method = "POST", token, body, saveAs }) {
+  const res = await fetch(url, {
+    method,
+    headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) return { status: res.status, error: text.slice(0, 300) };
+  if (saveAs || text.length > BUDGET) {
+    return { ...save((saveAs || "api-response") + ".json", text), status: res.status };
+  }
+  try { return { status: res.status, json: JSON.parse(text) }; }
+  catch { return { status: res.status, text }; }
+}
+
+module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema, callApi };

--- a/skills/wix-docs-base44/scripts/docs.js
+++ b/skills/wix-docs-base44/scripts/docs.js
@@ -178,13 +178,31 @@ async function methodsOf(resourcePattern) {
 }
 
 // One method's exact request/response schema, to disk (schemas are large).
+// Large schemas replace repeated types with { "$circular": "<type name>" } stubs; the
+// definitions live in the resource's components — so every referenced one is bundled
+// (transitively) into the saved file under `components`.
 async function methodSchema(docsUrl, slug) {
   const fn = `async function(){
     const u = ${JSON.stringify(docsUrl)};
     const s = await getResourceSchemaByUrl(u);
     const m = s.methods.find(x => x.docsUrl === u);
-    return m ? { publicUrl: m.publicUrl, httpMethod: m.httpMethod,
-                 requestBody: m.requestBody, responses: m.responses } : null;
+    if (!m) return null;
+    const out = { publicUrl: m.publicUrl, httpMethod: m.httpMethod,
+                  requestBody: m.requestBody, responses: m.responses };
+    const comps = (s.components && s.components.schemas) || {};
+    const need = new Set();
+    const collect = (o) => {
+      if (!o || typeof o !== "object") return;
+      if (o.$circular && comps[o.$circular] && !need.has(o.$circular)) {
+        need.add(o.$circular);
+        collect(comps[o.$circular]);
+      }
+      for (const v of Object.values(o)) collect(v);
+    };
+    collect(out);
+    out.components = {};
+    for (const n of need) out.components[n] = comps[n];
+    return out;
   }`;
   const { result } = await post(SPEC_API, { code: fn });
   if (!result) return { exists: false, hint: "docsUrl did not match a method — copy it from browse/methodsOf output" };
@@ -214,4 +232,15 @@ async function callApi({ url, method = "POST", token, body }) {
   catch { return { status: res.status, text }; }
 }
 
-module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema, callApi };
+// Your own query over the API spec index — lightIndex and getResourceSchemaByUrl are in
+// scope, the response arrives wrapped in { result }. The escape hatch when the canned calls
+// don't fit: expand an enum, resolve a $circular type, filter across every API. Spec data is
+// public docs, so a big result goes to scratch like any fetched page.
+async function specQuery(fnBody, { saveAs } = {}) {
+  const { result } = await post(SPEC_API, { code: fnBody });
+  const text = JSON.stringify(result, null, 1);
+  if (saveAs || text.length > BUDGET) return save((saveAs || "spec-query") + ".json", text);
+  return { result };
+}
+
+module.exports = { browse, search, fetchDoc, mapTerms, sections, methodsOf, methodSchema, callApi, specQuery };

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -268,8 +268,8 @@ curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-contex
 A `200` with `"markdown": ""` means the token or `siteId` is wrong — the endpoint reports an empty
 context instead of an auth error, so treat empty as "check auth", never as "empty site".
 
-For the rest of site management — installing apps, site properties, media, OAuth apps — the
-**`wix-manage`** skill carries per-area recipes. It may already be installed at
+For site management, the **`wix-manage`** skill carries per-area recipes. It may already be
+installed at
 `.agents/skills/wix-manage/`; install it with `npx -y skills add wix/skills/skills/wix-manage`,
 or read it straight off the registry: `https://www.wix.com/skills/wix-manage`.
 

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -212,6 +212,44 @@ when present, fall back to Lane 1 when not. Optional — skip this lane if the t
 Append `.md` only when `curl`-ing a page directly. The MCP tools and the search endpoint take the
 plain docs URL **without** `.md` — never feed a `.md` URL to an MCP tool.
 
+## From docs to calls
+
+The contract you just read runs under one of two identities — and which one a call wants is part
+of what you read:
+
+| identity | token | for |
+|---|---|---|
+| **admin** | an admin token (API key, connector, or OAuth-app admin grant) | managing the site — ad hoc calls, or the same fetch inside an app's backend function |
+| **visitor** | minted from the site's OAuth app, in frontend code | everything the site's end user does — storefront reads, cart, checkout |
+
+**Admin — first call: what IS this site?** The Dynamic Site Context API returns one markdown
+report — installed apps, status, URL, locale, CMS collections — the same output the Wix MCP's
+site-context tool renders:
+
+```bash
+curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  --data-raw '{"siteId": "<metasite id>"}' | jq -r '.markdown'
+```
+
+A `200` with `"markdown": ""` means the token or `siteId` is wrong — the endpoint reports an empty
+context instead of an auth error, so treat empty as "check auth", never as "empty site".
+
+**Visitor — minted from the OAuth app's client id.** The client id is a public value (it lives in
+a committed config file); the mint is one unauthenticated call, so it belongs in the site's own
+frontend code:
+
+```bash
+curl -sS -X POST 'https://www.wixapis.com/oauth2/token' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{"clientId": "<oauth app client id>", "grantType": "anonymous"}'
+# → { "access_token": "OauthNG.JWS.…", … } — bearer for products, cart, checkout
+```
+
+Contract source: `business-management/headless/authentication/retrieve-tokens`. The cart and
+checkout APIs act on the *caller's* identity, so they want the visitor token — the admin token is
+for managing the site, the visitor token is for being on it.
+
 ## Before you write the code
 
 Confirm on the page — not from memory — the endpoint, the HTTP verb, the request body shape,

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -222,18 +222,13 @@ of what you read:
 | **admin** | an admin token (API key, connector, or OAuth-app admin grant) | managing the site — ad hoc calls, or the same fetch inside an app's backend function |
 | **visitor** | minted from the site's OAuth app, in frontend code | everything the site's end user does — storefront reads, cart, checkout |
 
-**Admin — first call: what IS this site?** The Dynamic Site Context API returns one markdown
-report — installed apps, status, URL, locale, CMS collections — the same output the Wix MCP's
-site-context tool renders:
+**Admin** — any management or read call, straight from its docs contract:
 
 ```bash
-curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+curl -sS -X POST 'https://www.wixapis.com/stores/v3/products/query' \
   -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
-  --data-raw '{"siteId": "<metasite id>"}' | jq -r '.markdown'
+  --data-raw '{"query": {"cursorPaging": {"limit": 10}}}'
 ```
-
-A `200` with `"markdown": ""` means the token or `siteId` is wrong — the endpoint reports an empty
-context instead of an auth error, so treat empty as "check auth", never as "empty site".
 
 **Visitor — minted from the OAuth app's client id.** The client id is a public value (it lives in
 a committed config file); the mint is one unauthenticated call, so it belongs in the site's own
@@ -246,9 +241,43 @@ curl -sS -X POST 'https://www.wixapis.com/oauth2/token' \
 # → { "access_token": "OauthNG.JWS.…", … } — bearer for products, cart, checkout
 ```
 
-Contract source: `business-management/headless/authentication/retrieve-tokens`. The cart and
-checkout APIs act on the *caller's* identity, so they want the visitor token — the admin token is
-for managing the site, the visitor token is for being on it.
+The cart and checkout APIs act on the *caller's* identity, so they want the visitor token — the
+admin token is for managing the site, the visitor token is for being on it.
+
+The authentication docs (append `.md` to read):
+
+- [`about-identities`](https://dev.wix.com/docs/api-reference/articles/authentication/about-identities) — the identity model
+- [`rest-api-authentication`](https://dev.wix.com/docs/api-reference/articles/authentication/rest-api-authentication) — headers, token kinds
+- [`retrieve-tokens`](https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens) — the `/oauth2/token` contract, all grant types
+- [`about-authentication`](https://dev.wix.com/docs/go-headless/authentication/about-authentication) — visitor vs member sessions
+- [`create-an-oauth-app-for-visitors-and-members`](https://dev.wix.com/docs/go-headless/getting-started/setup/authentication/create-an-oauth-app-for-visitors-and-members) — where the client id comes from
+- [`set-up-a-headless-client`](https://dev.wix.com/docs/go-headless/authentication/setup/set-up-a-headless-client) — wiring the client
+
+## Special APIs worth knowing
+
+APIs that answer whole questions, not just single operations:
+
+**Dynamic Site Context — "what IS this site?"** One admin call returns a markdown report of the
+whole site — installed apps, status, URL, locale, CMS collections — the same output the Wix MCP's
+site-context tool renders:
+
+```bash
+curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  --data-raw '{"siteId": "<metasite id>"}' | jq -r '.markdown'
+```
+
+A `200` with `"markdown": ""` means the token or `siteId` is wrong — the endpoint reports an empty
+context instead of an auth error, so treat empty as "check auth", never as "empty site".
+
+**Query OAuth Apps — the site's client ids.** Lists the site's OAuth apps (admin token; needs
+`SCOPE.OAUTH_APP.READ`) — each app carries the public client id the visitor mint needs:
+
+```bash
+curl -sS -X POST 'https://www.wixapis.com/oauth-app/v1/oauth-apps/query' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  --data-raw '{"query": {}}'
+```
 
 ## Before you write the code
 

--- a/skills/wix-docs/SKILL.md
+++ b/skills/wix-docs/SKILL.md
@@ -255,8 +255,6 @@ The authentication docs (append `.md` to read):
 
 ## Special APIs worth knowing
 
-APIs that answer whole questions, not just single operations:
-
 **Dynamic Site Context — "what IS this site?"** One admin call returns a markdown report of the
 whole site — installed apps, status, URL, locale, CMS collections — the same output the Wix MCP's
 site-context tool renders:
@@ -270,14 +268,10 @@ curl -sS -X POST 'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-contex
 A `200` with `"markdown": ""` means the token or `siteId` is wrong — the endpoint reports an empty
 context instead of an auth error, so treat empty as "check auth", never as "empty site".
 
-**Query OAuth Apps — the site's client ids.** Lists the site's OAuth apps (admin token; needs
-`SCOPE.OAUTH_APP.READ`) — each app carries the public client id the visitor mint needs:
-
-```bash
-curl -sS -X POST 'https://www.wixapis.com/oauth-app/v1/oauth-apps/query' \
-  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
-  --data-raw '{"query": {}}'
-```
+For the rest of site management — installing apps, site properties, media, OAuth apps — the
+**`wix-manage`** skill carries per-area recipes. It may already be installed at
+`.agents/skills/wix-manage/`; install it with `npx -y skills add wix/skills/skills/wix-manage`,
+or read it straight off the registry: `https://www.wix.com/skills/wix-manage`.
 
 ## Before you write the code
 


### PR DESCRIPTION
Rework of the docs-to-calls sections in both skills: callApi clips oversized responses instead of writing site data into the committed scratch dir; the admin example is a general products query; Dynamic Site Context and Query OAuth Apps move to a dedicated 'Special APIs worth knowing' section built to grow; six authentication doc links added to both skills. Clip path live-verified (4,000 of 56,314 chars, nothing on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)