### PR TITLE
feat(wix-manage): read-site-context — dynamic context API reference

### DIFF
--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -6,7 +6,10 @@ description: "Look up Wix API/SDK documentation from inside the Base44 builder s
 # Wix Docs from the Base44 sandbox
 
 Get the exact truth about a Wix API — endpoint, HTTP verb, request/response shape, a field, an enum,
-an error. **Never invent a Wix endpoint, path, body, or enum from memory.**
+an error. **Discover everything: every endpoint, path, doc URL, body and enum comes from this
+skill's tools, never from training, memory, or pattern.** A URL you composed and a path you
+remembered are guesses even when they look right — and a 404 or an empty result means discover,
+not permute.
 
 This is the [`wix-docs`](../wix-docs/SKILL.md) flow — find the right page, then read it — for a
 sandbox with no shell pipeline and a ~5,000-char cap on tool results. Documents therefore live on
@@ -152,11 +155,46 @@ This queries the API spec index and matches the resource's `docsUrl` — `operat
 qualified (`wix.bookings.catalog.v1.…Service.CreateServiceOptionsAndVariants`), so a resource name
 never matches them.
 
-**Reading a schema is `specQuery`.** Schemas are huge (a create method's tree can run past 200 KB),
-so the query returns the slice you need and you **iterate** — each call is one round; refine the
-query instead of returning more. `lightIndex` and `getResourceSchemaByUrl(docsUrl)` are in scope.
+**Reading a schema is `specQuery`.** Two globals are in scope, and knowing their shape is the
+difference between an answer and a silent `[]`:
 
-A method's request fields, names and types only:
+```typescript
+lightIndex: Array<{             // RESOURCES, not methods
+  name: string                  // "Cart"
+  docsUrl: string               // the resource page
+  menuPath: string[]            // ["business-solutions", "e-commerce", "purchase-flow", "cart"]
+  methods: Array<{
+    operationId: string         // fully qualified: "com.wix.ecom…CartService.AddToCurrentCart"
+    summary: string; httpMethod: string
+    path: string                // PARTIAL ("/v1/carts/current/add-to-cart") — never call it
+    publicUrl: string           // "https://www.wixapis.com/ecom/v1/carts/current/add-to-cart" — call THIS
+    docsUrl: string
+  }>
+}>
+getResourceSchemaByUrl(docsUrl)  // full schema; API pages only — skill/article pages have none
+```
+
+`specQuery` is an **inspect** tool, not discovery: arrive with a `docsUrl` from browse or search,
+find the entry **by docsUrl**, then read. Substring-filtering `lightIndex` by name has no ranking
+and misses methods whose resource is named after a different noun — an empty result means the query
+missed the shape, not that the API is absent.
+
+The endpoint to call is always `publicUrl` — `path` is a fragment. When a call 404s, this one
+round replaces guessing path variants:
+
+```js
+await docs.specQuery(`async function(){
+  const r = lightIndex.find(x => x.docsUrl ===
+    "https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/cart");
+  return r.methods.map(m => ({ op: m.operationId.split(".").pop(),
+                               verb: m.httpMethod, call: m.publicUrl }));
+}`)
+// → { op: "AddToCurrentCart", verb: "post",
+//     call: "https://www.wixapis.com/ecom/v1/carts/current/add-to-cart" }
+```
+
+Schemas are huge, so return the slice you need and **iterate** — each call is one round; refine the
+query instead of returning more. A method's request fields, names and types only:
 
 ```js
 await docs.specQuery(`async function(){
@@ -169,22 +207,9 @@ await docs.specQuery(`async function(){
 // → ["draftPost: object", "publish: boolean", "fieldsets: array"]
 ```
 
-Next round, drill into the object you care about:
-
-```js
-  // …same setup…
-  const dp = m.requestBody.content["application/json"].schema.properties.draftPost;
-  return Object.entries(dp.properties).map(([k, v]) => k + ": " + (v.type || v.$circular || "object"));
-// → ["id: string", "title: string", "excerpt: string", "featured: boolean", …]
-```
-
-A field typed as `{ "$circular": "<name>" }` is a repeated type stored once — resolve it by name:
-
-```js
-  // …same setup…
-  const type = s.components.schemas["com.wix.ecom.cart.api.v1.Cart"];
-  return Object.entries(type.properties).map(([k, v]) => k + ": " + (v.type || v.$circular || "object"));
-```
+Next round, drill into the object you care about; a field typed `{ "$circular": "<name>" }` is a
+repeated type stored once — resolve it with `s.components.schemas["<name>"]`, returning only its
+field names and types.
 
 The same door answers anything the canned calls can't — enum values, comparing two methods'
 fields, filtering across every API. Check the *sibling* methods too: a requirement is often

--- a/skills/wix-docs-base44/scripts/docs.js
+++ b/skills/wix-docs-base44/scripts/docs.js
@@ -199,14 +199,23 @@ async function callApi({ url, method = "POST", token, body }) {
   catch { return { status: res.status, text }; }
 }
 
-// THE way to read a schema: write a query over the API spec index — lightIndex and
-// getResourceSchemaByUrl(docsUrl) are in scope, the response arrives wrapped in { result }.
+// THE way to read a schema: write a query over the API spec index. In scope:
+//   lightIndex — Array<{ name, resourceId, docsUrl, menuPath: string[],
+//                        methods: [{ operationId, summary, httpMethod,
+//                                    path,       // PARTIAL — never call it
+//                                    publicUrl,  // the executable wixapis.com URL — call THIS
+//                                    docsUrl, description }] }>
+//   getResourceSchemaByUrl(docsUrl) — the full resource schema: .methods (requestBody at
+//     m.requestBody.content["application/json"].schema; { "$circular": "<name>" } stubs
+//     resolve via .components.schemas["<name>"]). API pages only — skill/article pages
+//     have no schema.
+// This is an INSPECT tool, not discovery: arrive with a docsUrl from browse/search, then
+// find the exact entry by docsUrl. Substring-filtering lightIndex has no ranking, matches
+// only resource names, and returns [] on the wrong field — an empty result means your
+// query missed the shape, not that the API is absent.
 // Schemas are huge; return only the slice you need and ITERATE — each call is one round,
-// refine the query instead of returning more. A method's schema sits at
-// m.requestBody.content["application/json"].schema; repeated types appear as
-// { "$circular": "<name>" } stubs — resolve one with s.components.schemas["<name>"].
-// Small results come back inline; a big one is saved to scratch (public docs — allowed)
-// as { path, bytes } to read with read_file.
+// refine the query instead of returning more. Small results come back inline; a big one is
+// saved to scratch (public docs — allowed) as { path, bytes } to read with read_file.
 async function specQuery(fnBody, { saveAs } = {}) {
   const { result } = await post(SPEC_API, { code: fnBody });
   const text = JSON.stringify(result, null, 1);

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -370,6 +370,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Query Sites](references/sites/query-sites.md)
 **Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
 
+### [Read Site Context](references/sites/read-site-context.md)
+**Technical:** One call that returns a site's installed apps (by display name), locale, currency, status, and catalog version. Replaces separate query-sites + list-installed-apps + site-properties calls. Use this first on any unfamiliar site to decide which management recipes to follow.
+
 ### [Site Import](references/sites/site-import.md)
 **Technical:** Drives the autonomous Wix Site Import agent over REST (`/site-import/v1/imports`) to migrate a store/site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix. Covers Start/Poll/Reply/Cancel, relaying agent questions and progress in plain language, handling `DEPLOYED`/`FAILED`/`AUTH_EXPIRED`/`SESSION_EXPIRED` states, and post-deploy follow-up changes. Use when the user wants to import, migrate, or clone an existing store/site into Wix.
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,0 +1,129 @@
+---
+name: "Read Site Context"
+description: One-call site snapshot — installed apps (by name), locale, currency, and status — using the Dynamic Site Context API. Replaces separate query-sites + list-installed-apps + site-properties calls.
+---
+# Read Site Context
+
+A single call that returns a site's name, URL, status, locale/region settings, and all installed apps with human-readable display names. Use this at the start of any management task when you need to understand what a site has installed and how it is configured.
+
+## Prerequisites
+
+- Account-level authentication (the same token used for all other Wix management APIs)
+- Site ID (`metaSiteId`) — typically in your prompt or found via [Query Sites](query-sites.md)
+
+## Required APIs
+
+- **Dynamic Site Context API**: [Get Dynamic Context Markdown](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md)
+
+---
+
+## Call
+
+**Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown`
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{"siteId": "<metaSiteId>"}'
+```
+
+Omit `siteId` to get a snapshot of all sites on the account.
+
+---
+
+## Response
+
+Returns `{ "markdown": "..." }`. The markdown contains:
+
+```
+## 1. Harbor and Oak
+
+**ID**: `5e0eed94-9982-49da-a980-08fa2cd4a198`
+**URL**: [https://h6s-410bd0d161d8fc-ayalg5.wix-site-host.com/](...)
+**Status**: Published
+**Editor Type**: Editorless
+**Created**: Aug 16, 2026, 18:46 · **Updated**: Aug 17, 2026, 13:10
+**Velo**: Enabled
+
+### Properties
+
+**Locale & Region**
+- Language: **en**
+- Country: **IE**
+- Timezone: **Europe/Dublin**
+- Currency: **EUR**
+
+### Apps
+
+- **Promote SEO** (ID: `1480c568-5cbd-9392-5604-1148f5faffa0`)
+- **Wix Invoices** (ID: `13ee94c1-b635-8505-3391-97919052c16f`)
+- **Wix Stores** (ID: `215238eb-22a5-4c36-9e7b-e7c08025e04e`) — Catalog app version: **V3**
+```
+
+App names are display names (not raw UUIDs). Some apps include extra metadata — Wix Stores shows the catalog version (V1/V3), which determines which endpoints to use.
+
+The API also injects global notes at the top of the markdown when relevant — for example, a Wix Stores catalog-version warning when any site has Stores installed.
+
+---
+
+## Why use this over separate calls
+
+| | Dynamic Context | Separate calls |
+|---|---|---|
+| Site name, URL, status | ✓ | query-sites |
+| Locale + currency | ✓ | site-properties |
+| Installed apps (by name) | ✓ | list-installed-apps + ID lookup |
+| Calls needed | **1** | 3+ |
+
+`list-installed-apps` returns raw `appDefId` UUIDs; this endpoint returns human-readable display names.
+
+---
+
+## Use Cases
+
+### Understand an unfamiliar site before acting
+
+```javascript
+const res = await fetch(
+  "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ siteId: metaSiteId }),
+  }
+);
+const { markdown } = await res.json();
+// Read markdown to learn what apps are installed, locale, and site status
+```
+
+### Decide which vertical to manage
+
+If the prompt is vague about what the site does, read the site context first — the installed apps list tells you which Wix Business Solution is active (Stores, Bookings, Blog, Events, etc.) and which management recipes to follow.
+
+### Determine Wix Stores catalog version before any stores call
+
+Check whether Stores shows `Catalog app version: V3` or `V1` before using stores endpoints:
+- V3 sites: use `/stores/v3/` endpoints and V3 catalog recipes
+- V1 sites: use `/stores/v1/` (legacy) endpoints and V1 catalog recipes — never mix
+
+---
+
+## JSON variant
+
+Replace `/markdown` with the bare endpoint to get structured JSON instead:
+
+**Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context`
+
+The JSON response includes an `account` object plus a `sites` array. App entries contain raw `appId` strings (not display names), so the markdown variant is preferred for reading.
+
+---
+
+## Next Steps
+
+- Found Wix Stores? → [Stores recipes](../../SKILL.md#stores)
+- Found Wix Bookings? → [Bookings recipes](../../SKILL.md#bookings)
+- Found Wix Blog? → [Blog recipes](../../SKILL.md#blog)
+- Need to find the site ID first? → [Query Sites](query-sites.md)


### PR DESCRIPTION
## Summary

- Adds `references/sites/read-site-context.md` — a reference for the Dynamic Site Context API (`POST /dynamic-context/v1/dynamic-context/markdown`)
- Registers it in `SKILL.md` under the Sites section (after Query Sites)

## What it covers

- Single-call site snapshot: installed apps by display name, locale, currency, status, Wix Stores catalog version (V1/V3)
- Replaces three separate calls: query-sites + list-installed-apps + site-properties
- Key use case: read this first on an unfamiliar site to decide which management recipes apply
- JSON variant note (raw UUIDs, not display names → markdown preferred)
- Catalog-version decision guide for Wix Stores

## Background

Explored the API live against several real headless sites (`Harbor and Oak`, `Kintsugi Moomin Ceramics`, `Beatles Plushies`) — all Stores V3. Confirmed response shape and that the markdown variant returns human-readable app names while the JSON variant returns raw `appId` UUIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)