### PR TITLE
feat(wix-manage): read-site-context — dynamic context API reference

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -370,6 +370,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Query Sites](references/sites/query-sites.md)
 **Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
 
+### [Read Site Context](references/sites/read-site-context.md)
+**Technical:** One call that returns a site's installed apps (by display name), locale, currency, status, and catalog version. Replaces separate query-sites + list-installed-apps + site-properties calls. Use this first on any unfamiliar site to decide which management recipes to follow.
+
 ### [Site Import](references/sites/site-import.md)
 **Technical:** Drives the autonomous Wix Site Import agent over REST (`/site-import/v1/imports`) to migrate a store/site from another platform (Shopify, WooCommerce, Magento, or any URL) into Wix. Covers Start/Poll/Reply/Cancel, relaying agent questions and progress in plain language, handling `DEPLOYED`/`FAILED`/`AUTH_EXPIRED`/`SESSION_EXPIRED` states, and post-deploy follow-up changes. Use when the user wants to import, migrate, or clone an existing store/site into Wix.
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -370,7 +370,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Query Sites](references/sites/query-sites.md)
 **Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
 
-### [Read Site Context](references/sites/read-site-context.md)
+### [Read Account or Site Context](references/sites/read-site-context.md)
 **Technical:** One call that returns a site's installed apps (by display name), locale, currency, status, and catalog version. Replaces separate query-sites + list-installed-apps + site-properties calls. Use this first on any unfamiliar site to decide which management recipes to follow.
 
 ### [Site Import](references/sites/site-import.md)

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,6 +1,6 @@
 ---
 name: "Read Site Context"
-description: One-call site snapshot — installed apps (by name), locale, currency, and status — using the Dynamic Site Context API. Replaces separate query-sites + list-installed-apps + site-properties calls.
+description: Single-call site snapshot via the Dynamic Site Context API — returns installed apps by display name, locale, currency, timezone, and status. Works with account-level or site-scoped tokens; siteId is optional.
 ---
 # Read Site Context
 
@@ -8,24 +8,13 @@ A single call that returns a site's name, URL, status, locale/region settings, a
 
 Works with both account-level and site-scoped tokens. Passing a `siteId` is optional.
 
-## Required APIs
-
-- **Get Dynamic Context (markdown)**: [docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown)
-- **Get Dynamic Context (JSON)**: [docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context)
-
-Related:
-
-- [Query Sites](https://dev.wix.com/docs/api-reference/account-level/sites/sites/query-sites) — when you need to page through many sites or filter by field
-- [Get Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/get-installed-apps) — raw app instances; use this if you need fields not in the context snapshot
-- [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) — full properties object including business description, address, social links
-
 ---
 
 ## Markdown endpoint (recommended)
 
 **Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown`
 
-Returns `{ "markdown": "..." }` with human-readable app display names, locale, status, and any app-specific metadata the API injects (e.g. Stores catalog version). Best for reading and routing.
+Returns `{ "markdown": "..." }` with human-readable app display names, locale, status, and any app-specific metadata the API injects. Best for reading and routing.
 
 ### With a site ID — one site
 
@@ -74,7 +63,7 @@ curl -X POST \
   -d '{}'
 ```
 
-- **Account-level token**: returns up to 10 sites on the account. If there are more, the markdown includes: `_Showing 10 sites (more available)_` with a note to call again with a specific `siteId`.
+- **Account-level token**: returns up to 10 sites on the account. If there are more, the markdown includes `_Showing 10 sites (more available)_` with a note to call again with a specific `siteId`.
 - **Site-scoped token** (e.g. the Wix connector in Base44): returns only the site the token is scoped to — useful as a quick way to confirm which site you're operating on before making changes.
 
 ---
@@ -131,20 +120,10 @@ Prefer the markdown endpoint when you just need to read and route — it gives y
 
 ---
 
-## Why use this over separate calls
+## API Reference
 
-| | Dynamic Context | Separate calls |
-|---|---|---|
-| Site name, URL, status | ✓ | [Query Sites](query-sites.md) |
-| Locale + currency | ✓ | [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) |
-| Installed apps (by name) | ✓ | [Get Installed Apps](../app-installation/list-installed-apps.md) + ID lookup |
-| Calls needed | **1** | 3+ |
-
----
-
-## Next Steps
-
-- Found Wix Stores? → [Stores recipes](../../SKILL.md#stores)
-- Found Wix Bookings? → [Bookings recipes](../../SKILL.md#bookings)
-- Found Wix Blog? → [Blog recipes](../../SKILL.md#blog)
-- Need to find the site ID first? → [Query Sites](query-sites.md)
+- [Get Dynamic Context — markdown](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown)
+- [Get Dynamic Context — JSON](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context)
+- [Query Sites](https://dev.wix.com/docs/api-reference/account-level/sites/sites/query-sites) — for paginating or filtering the full site list
+- [Get Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/get-installed-apps) — raw app instances with fields not in the context snapshot
+- [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) — full properties including business description, address, social links

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,6 +1,6 @@
 ---
 name: "Read Site Context"
-description: The recommended first call for any AI agent entering a Wix account or site — returns installed apps by display name, locale, currency, timezone, and status in one shot. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
+description: How AI agents orient themselves on a Wix account or site — one call returns installed apps by display name, locale, currency, timezone, and status. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
 ---
 # Read Site Context
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,6 +1,6 @@
 ---
 name: "Read Site Context"
-description: How AI agents orient themselves on a Wix account or site — one call returns installed apps by display name, locale, currency, timezone, and status. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
+description: Single-call orientation on any Wix site — installed apps by display name, locale, currency, timezone, and status in one shot. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
 ---
 # Read Site Context
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -6,14 +6,18 @@ description: One-call site snapshot — installed apps (by name), locale, curren
 
 A single call that returns a site's name, URL, status, locale/region settings, and all installed apps with human-readable display names. Use this at the start of any management task when you need to understand what a site has installed and how it is configured.
 
-## Prerequisites
-
-- Account-level authentication (the same token used for all other Wix management APIs)
-- Site ID is optional — omit it to get all account sites at once
+Works with both account-level and site-scoped tokens. Passing a `siteId` is optional.
 
 ## Required APIs
 
-- **Dynamic Site Context API**: [Get Dynamic Context Markdown](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md)
+- **Get Dynamic Context (markdown)**: [docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown)
+- **Get Dynamic Context (JSON)**: [docs](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context)
+
+Related:
+
+- [Query Sites](https://dev.wix.com/docs/api-reference/account-level/sites/sites/query-sites) — when you need to page through many sites or filter by field
+- [Get Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/get-installed-apps) — raw app instances; use this if you need fields not in the context snapshot
+- [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) — full properties object including business description, address, social links
 
 ---
 
@@ -21,9 +25,9 @@ A single call that returns a site's name, URL, status, locale/region settings, a
 
 **Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown`
 
-Returns `{ "markdown": "..." }` — human-readable app display names, locale, status, and Wix Stores catalog version. This is the preferred form for reading and routing.
+Returns `{ "markdown": "..." }` with human-readable app display names, locale, status, and any app-specific metadata the API injects (e.g. Stores catalog version). Best for reading and routing.
 
-### With a site ID — single site
+### With a site ID — one site
 
 ```bash
 curl -X POST \
@@ -36,33 +40,31 @@ curl -X POST \
 Response:
 
 ```
-## 1. Harbor and Oak
+## 1. Acme Store
 
-**ID**: `5e0eed94-9982-49da-a980-08fa2cd4a198`
-**URL**: [https://h6s-410bd0d161d8fc-ayalg5.wix-site-host.com/](...)
+**ID**: `<metaSiteId>`
+**URL**: [https://example.wixsite.com/acme](https://example.wixsite.com/acme)
 **Status**: Published
 **Editor Type**: Editorless
-**Created**: Aug 16, 2026, 18:46 · **Updated**: Aug 17, 2026, 13:10
+**Created**: Aug 14, 2026, 05:21 · **Updated**: Aug 17, 2026, 20:44
 **Velo**: Enabled
 
 ### Properties
 
 **Locale & Region**
 - Language: **en**
-- Country: **IE**
-- Timezone: **Europe/Dublin**
-- Currency: **EUR**
+- Country: **US**
+- Timezone: **America/New_York**
+- Currency: **USD**
 
 ### Apps
 
-- **Promote SEO** (ID: `1480c568-...`)
-- **Wix Invoices** (ID: `13ee94c1-...`)
-- **Wix Stores** (ID: `215238eb-...`) — Catalog app version: **V3**
+- **Wix Stores** (ID: `215238eb-22a5-4c36-9e7b-e7c08025e04e`) — Catalog app version: **V3**
+- **Wix Bookings** (ID: `13d21c63-b5ec-5912-8397-c3a5ddb27a97`)
+- **Wix Blog** (ID: `14bcded7-0066-7c35-14d7-466cb3f09103`)
 ```
 
-App names are human-readable display names. Wix Stores entries include the catalog version (V1/V3).
-
-### Without a site ID — all account sites
+### Without a site ID — what you get depends on the token
 
 ```bash
 curl -X POST \
@@ -72,16 +74,8 @@ curl -X POST \
   -d '{}'
 ```
 
-Returns up to 10 sites. If the account has more, the markdown includes a note:
-
-```
-_Showing 10 sites (more available)_
-
-> **This account has more than the 10 sites shown above.** To load context for any
-> site not listed here, call `GetSiteContext` with its `siteName` or `siteId`.
-```
-
-Use this when you have an account-level token and need to discover what sites exist before picking one to act on. Use the single-site form once you have the target `siteId`.
+- **Account-level token**: returns up to 10 sites on the account. If there are more, the markdown includes: `_Showing 10 sites (more available)_` with a note to call again with a specific `siteId`.
+- **Site-scoped token** (e.g. the Wix connector in Base44): returns only the site the token is scoped to — useful as a quick way to confirm which site you're operating on before making changes.
 
 ---
 
@@ -89,7 +83,7 @@ Use this when you have an account-level token and need to discover what sites ex
 
 **Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context`
 
-Same request shape (`{}` or `{"siteId": "..."}`) but returns structured JSON. The `installedApps` array contains raw `appId` UUIDs — most are unrecognizable platform internals. Extract only what you need:
+Same request shape but returns structured JSON. The `installedApps` array contains raw `appId` UUIDs — mostly unrecognizable platform internals. Extract only what you need:
 
 ```javascript
 const res = await fetch(
@@ -103,8 +97,7 @@ const res = await fetch(
 const { sites } = await res.json();
 const site = sites[0];
 
-// Known app IDs worth checking
-const APP_IDS = {
+const KNOWN_APPS = {
   stores:       "215238eb-22a5-4c36-9e7b-e7c08025e04e",
   bookings:     "13d21c63-b5ec-5912-8397-c3a5ddb27a97",
   blog:         "14bcded7-0066-7c35-14d7-466cb3f09103",
@@ -118,24 +111,23 @@ const appById = Object.fromEntries(
 );
 
 const context = {
-  id:       site.id,
-  name:     site.displayName,
-  url:      site.url,
-  currency: site.properties?.paymentCurrency,
-  locale:   `${site.properties?.locale?.languageCode}-${site.properties?.locale?.country}`,
-  timezone: site.properties?.timeZone,
-  // vertical flags
-  hasStores:       !!appById[APP_IDS.stores],
-  storesCatalogV:  appById[APP_IDS.stores]?.catalogVersion ?? null, // "V3" | "V1" | null
-  hasBookings:     !!appById[APP_IDS.bookings],
-  hasBlog:         !!appById[APP_IDS.blog],
-  hasEvents:       !!appById[APP_IDS.events],
-  hasPricingPlans: !!appById[APP_IDS.pricingPlans],
-  hasRestaurants:  !!appById[APP_IDS.restaurants],
+  id:              site.id,
+  name:            site.displayName,
+  url:             site.url,
+  currency:        site.properties?.paymentCurrency,
+  locale:          `${site.properties?.locale?.languageCode}-${site.properties?.locale?.country}`,
+  timezone:        site.properties?.timeZone,
+  hasStores:       !!appById[KNOWN_APPS.stores],
+  storesCatalogV:  appById[KNOWN_APPS.stores]?.catalogVersion ?? null, // "V3" | "V1" | null
+  hasBookings:     !!appById[KNOWN_APPS.bookings],
+  hasBlog:         !!appById[KNOWN_APPS.blog],
+  hasEvents:       !!appById[KNOWN_APPS.events],
+  hasPricingPlans: !!appById[KNOWN_APPS.pricingPlans],
+  hasRestaurants:  !!appById[KNOWN_APPS.restaurants],
 };
 ```
 
-Prefer the markdown endpoint when you just need to read and route — it gives you display names without a lookup table and is easier to reason about.
+Prefer the markdown endpoint when you just need to read and route — it gives you display names without a lookup table.
 
 ---
 
@@ -143,9 +135,9 @@ Prefer the markdown endpoint when you just need to read and route — it gives y
 
 | | Dynamic Context | Separate calls |
 |---|---|---|
-| Site name, URL, status | ✓ | query-sites |
-| Locale + currency | ✓ | site-properties |
-| Installed apps (by name) | ✓ | list-installed-apps + ID lookup |
+| Site name, URL, status | ✓ | [Query Sites](query-sites.md) |
+| Locale + currency | ✓ | [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) |
+| Installed apps (by name) | ✓ | [Get Installed Apps](../app-installation/list-installed-apps.md) + ID lookup |
 | Calls needed | **1** | 3+ |
 
 ---

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,12 +1,10 @@
 ---
 name: "Read Site Context"
-description: Single-call site snapshot via the Dynamic Site Context API — returns installed apps by display name, locale, currency, timezone, and status. Works with account-level or site-scoped tokens; siteId is optional.
+description: Single-call site snapshot via the Dynamic Site Context API — installed apps by display name, locale, currency, timezone, and status. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
 ---
 # Read Site Context
 
-A single call that returns a site's name, URL, status, locale/region settings, and all installed apps with human-readable display names. Use this at the start of any management task when you need to understand what a site has installed and how it is configured.
-
-Works with both account-level and site-scoped tokens. Passing a `siteId` is optional.
+Returns a site's name, URL, status, locale/region, and all installed apps with human-readable display names.
 
 ---
 
@@ -14,9 +12,9 @@ Works with both account-level and site-scoped tokens. Passing a `siteId` is opti
 
 **Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown`
 
-Returns `{ "markdown": "..." }` with human-readable app display names, locale, status, and any app-specific metadata the API injects. Best for reading and routing.
+Returns `{ "markdown": "..." }`.
 
-### With a site ID — one site
+### Account token + siteId — one specific site
 
 ```bash
 curl -X POST \
@@ -53,7 +51,7 @@ Response:
 - **Wix Blog** (ID: `14bcded7-0066-7c35-14d7-466cb3f09103`)
 ```
 
-### Without a site ID — what you get depends on the token
+### Without siteId
 
 ```bash
 curl -X POST \
@@ -63,8 +61,8 @@ curl -X POST \
   -d '{}'
 ```
 
-- **Account-level token**: returns up to 10 sites on the account. If there are more, the markdown includes `_Showing 10 sites (more available)_` with a note to call again with a specific `siteId`.
-- **Site-scoped token** (e.g. the Wix connector in Base44): returns only the site the token is scoped to — useful as a quick way to confirm which site you're operating on before making changes.
+- **Account token**: returns up to 10 sites. If the account has more: `_Showing 10 sites (more available)_` — call again with a specific `siteId`.
+- **Site-scoped token** (e.g. the Wix connector in Base44): returns the one site the token is scoped to.
 
 ---
 
@@ -72,7 +70,7 @@ curl -X POST \
 
 **Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context`
 
-Same request shape but returns structured JSON. The `installedApps` array contains raw `appId` UUIDs — mostly unrecognizable platform internals. Extract only what you need:
+Same request shape. `installedApps` contains raw `appId` UUIDs — extract only what you need:
 
 ```javascript
 const res = await fetch(
@@ -115,8 +113,6 @@ const context = {
   hasRestaurants:  !!appById[KNOWN_APPS.restaurants],
 };
 ```
-
-Prefer the markdown endpoint when you just need to read and route — it gives you display names without a lookup table.
 
 ---
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,6 +1,6 @@
 ---
 name: "Read Site Context"
-description: Single-call site snapshot via the Dynamic Site Context API — installed apps by display name, locale, currency, timezone, and status. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
+description: The recommended first call for any AI agent entering a Wix account or site — returns installed apps by display name, locale, currency, timezone, and status in one shot. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
 ---
 # Read Site Context
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,8 +1,8 @@
 ---
-name: "Read Site Context"
+name: "Read Account or Site Context"
 description: Probe a Wix site or account for full context in one call — installed apps by display name, locale, currency, timezone, and status. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
 ---
-# Read Site Context
+# Read Account or Site Context
 
 Returns a site's name, URL, status, locale/region, and all installed apps with human-readable display names.
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,0 +1,129 @@
+---
+name: "Read Site Context"
+description: One-call site snapshot — installed apps (by name), locale, currency, and status — using the Dynamic Site Context API. Replaces separate query-sites + list-installed-apps + site-properties calls.
+---
+# Read Site Context
+
+A single call that returns a site's name, URL, status, locale/region settings, and all installed apps with human-readable display names. Use this at the start of any management task when you need to understand what a site has installed and how it is configured.
+
+## Prerequisites
+
+- Account-level authentication (the same token used for all other Wix management APIs)
+- Site ID (`metaSiteId`) — typically in your prompt or found via [Query Sites](query-sites.md)
+
+## Required APIs
+
+- **Dynamic Site Context API**: [Get Dynamic Context Markdown](https://dev.wix.com/docs/api-reference/tools/dynamic-site-context/get-dynamic-context-markdown.md)
+
+---
+
+## Call
+
+**Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown`
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{"siteId": "<metaSiteId>"}'
+```
+
+Omit `siteId` to get a snapshot of all sites on the account.
+
+---
+
+## Response
+
+Returns `{ "markdown": "..." }`. The markdown contains:
+
+```
+## 1. Harbor and Oak
+
+**ID**: `5e0eed94-9982-49da-a980-08fa2cd4a198`
+**URL**: [https://h6s-410bd0d161d8fc-ayalg5.wix-site-host.com/](...)
+**Status**: Published
+**Editor Type**: Editorless
+**Created**: Aug 16, 2026, 18:46 · **Updated**: Aug 17, 2026, 13:10
+**Velo**: Enabled
+
+### Properties
+
+**Locale & Region**
+- Language: **en**
+- Country: **IE**
+- Timezone: **Europe/Dublin**
+- Currency: **EUR**
+
+### Apps
+
+- **Promote SEO** (ID: `1480c568-5cbd-9392-5604-1148f5faffa0`)
+- **Wix Invoices** (ID: `13ee94c1-b635-8505-3391-97919052c16f`)
+- **Wix Stores** (ID: `215238eb-22a5-4c36-9e7b-e7c08025e04e`) — Catalog app version: **V3**
+```
+
+App names are display names (not raw UUIDs). Some apps include extra metadata — Wix Stores shows the catalog version (V1/V3), which determines which endpoints to use.
+
+The API also injects global notes at the top of the markdown when relevant — for example, a Wix Stores catalog-version warning when any site has Stores installed.
+
+---
+
+## Why use this over separate calls
+
+| | Dynamic Context | Separate calls |
+|---|---|---|
+| Site name, URL, status | ✓ | query-sites |
+| Locale + currency | ✓ | site-properties |
+| Installed apps (by name) | ✓ | list-installed-apps + ID lookup |
+| Calls needed | **1** | 3+ |
+
+`list-installed-apps` returns raw `appDefId` UUIDs; this endpoint returns human-readable display names.
+
+---
+
+## Use Cases
+
+### Understand an unfamiliar site before acting
+
+```javascript
+const res = await fetch(
+  "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ siteId: metaSiteId }),
+  }
+);
+const { markdown } = await res.json();
+// Read markdown to learn what apps are installed, locale, and site status
+```
+
+### Decide which vertical to manage
+
+If the prompt is vague about what the site does, read the site context first — the installed apps list tells you which Wix Business Solution is active (Stores, Bookings, Blog, Events, etc.) and which management recipes to follow.
+
+### Determine Wix Stores catalog version before any stores call
+
+Check whether Stores shows `Catalog app version: V3` or `V1` before using stores endpoints:
+- V3 sites: use `/stores/v3/` endpoints and V3 catalog recipes
+- V1 sites: use `/stores/v1/` (legacy) endpoints and V1 catalog recipes — never mix
+
+---
+
+## JSON variant
+
+Replace `/markdown` with the bare endpoint to get structured JSON instead:
+
+**Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context`
+
+The JSON response includes an `account` object plus a `sites` array. App entries contain raw `appId` strings (not display names), so the markdown variant is preferred for reading.
+
+---
+
+## Next Steps
+
+- Found Wix Stores? → [Stores recipes](../../SKILL.md#stores)
+- Found Wix Bookings? → [Bookings recipes](../../SKILL.md#bookings)
+- Found Wix Blog? → [Blog recipes](../../SKILL.md#blog)
+- Need to find the site ID first? → [Query Sites](query-sites.md)

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -9,7 +9,7 @@ A single call that returns a site's name, URL, status, locale/region settings, a
 ## Prerequisites
 
 - Account-level authentication (the same token used for all other Wix management APIs)
-- Site ID (`metaSiteId`) — typically in your prompt or found via [Query Sites](query-sites.md)
+- Site ID is optional — omit it to get all account sites at once
 
 ## Required APIs
 
@@ -17,11 +17,14 @@ A single call that returns a site's name, URL, status, locale/region settings, a
 
 ---
 
-## Call
+## Markdown endpoint (recommended)
 
 **Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown`
 
-**Request**:
+Returns `{ "markdown": "..." }` — human-readable app display names, locale, status, and Wix Stores catalog version. This is the preferred form for reading and routing.
+
+### With a site ID — single site
+
 ```bash
 curl -X POST \
   'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
@@ -30,13 +33,7 @@ curl -X POST \
   -d '{"siteId": "<metaSiteId>"}'
 ```
 
-Omit `siteId` to get a snapshot of all sites on the account.
-
----
-
-## Response
-
-Returns `{ "markdown": "..." }`. The markdown contains:
+Response:
 
 ```
 ## 1. Harbor and Oak
@@ -58,14 +55,87 @@ Returns `{ "markdown": "..." }`. The markdown contains:
 
 ### Apps
 
-- **Promote SEO** (ID: `1480c568-5cbd-9392-5604-1148f5faffa0`)
-- **Wix Invoices** (ID: `13ee94c1-b635-8505-3391-97919052c16f`)
-- **Wix Stores** (ID: `215238eb-22a5-4c36-9e7b-e7c08025e04e`) — Catalog app version: **V3**
+- **Promote SEO** (ID: `1480c568-...`)
+- **Wix Invoices** (ID: `13ee94c1-...`)
+- **Wix Stores** (ID: `215238eb-...`) — Catalog app version: **V3**
 ```
 
-App names are display names (not raw UUIDs). Some apps include extra metadata — Wix Stores shows the catalog version (V1/V3), which determines which endpoints to use.
+App names are human-readable display names. Wix Stores entries include the catalog version (V1/V3).
 
-The API also injects global notes at the top of the markdown when relevant — for example, a Wix Stores catalog-version warning when any site has Stores installed.
+### Without a site ID — all account sites
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+Returns up to 10 sites. If the account has more, the markdown includes a note:
+
+```
+_Showing 10 sites (more available)_
+
+> **This account has more than the 10 sites shown above.** To load context for any
+> site not listed here, call `GetSiteContext` with its `siteName` or `siteId`.
+```
+
+Use this when you have an account-level token and need to discover what sites exist before picking one to act on. Use the single-site form once you have the target `siteId`.
+
+---
+
+## JSON endpoint
+
+**Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context`
+
+Same request shape (`{}` or `{"siteId": "..."}`) but returns structured JSON. The `installedApps` array contains raw `appId` UUIDs — most are unrecognizable platform internals. Extract only what you need:
+
+```javascript
+const res = await fetch(
+  "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context",
+  {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ siteId: metaSiteId }),
+  }
+);
+const { sites } = await res.json();
+const site = sites[0];
+
+// Known app IDs worth checking
+const APP_IDS = {
+  stores:       "215238eb-22a5-4c36-9e7b-e7c08025e04e",
+  bookings:     "13d21c63-b5ec-5912-8397-c3a5ddb27a97",
+  blog:         "14bcded7-0066-7c35-14d7-466cb3f09103",
+  events:       "140603ad-af8d-84a5-2c80-a0f60cb47351",
+  pricingPlans: "1522827f-c56c-a5c9-2ac9-00f9e6ae12d3",
+  restaurants:  "13e8d036-5516-6f75-e025-2aca3b5d7930",
+};
+
+const appById = Object.fromEntries(
+  (site.installedApps ?? []).map((a) => [a.appId, a])
+);
+
+const context = {
+  id:       site.id,
+  name:     site.displayName,
+  url:      site.url,
+  currency: site.properties?.paymentCurrency,
+  locale:   `${site.properties?.locale?.languageCode}-${site.properties?.locale?.country}`,
+  timezone: site.properties?.timeZone,
+  // vertical flags
+  hasStores:       !!appById[APP_IDS.stores],
+  storesCatalogV:  appById[APP_IDS.stores]?.catalogVersion ?? null, // "V3" | "V1" | null
+  hasBookings:     !!appById[APP_IDS.bookings],
+  hasBlog:         !!appById[APP_IDS.blog],
+  hasEvents:       !!appById[APP_IDS.events],
+  hasPricingPlans: !!appById[APP_IDS.pricingPlans],
+  hasRestaurants:  !!appById[APP_IDS.restaurants],
+};
+```
+
+Prefer the markdown endpoint when you just need to read and route — it gives you display names without a lookup table and is easier to reason about.
 
 ---
 
@@ -77,47 +147,6 @@ The API also injects global notes at the top of the markdown when relevant — f
 | Locale + currency | ✓ | site-properties |
 | Installed apps (by name) | ✓ | list-installed-apps + ID lookup |
 | Calls needed | **1** | 3+ |
-
-`list-installed-apps` returns raw `appDefId` UUIDs; this endpoint returns human-readable display names.
-
----
-
-## Use Cases
-
-### Understand an unfamiliar site before acting
-
-```javascript
-const res = await fetch(
-  "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
-  {
-    method: "POST",
-    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ siteId: metaSiteId }),
-  }
-);
-const { markdown } = await res.json();
-// Read markdown to learn what apps are installed, locale, and site status
-```
-
-### Decide which vertical to manage
-
-If the prompt is vague about what the site does, read the site context first — the installed apps list tells you which Wix Business Solution is active (Stores, Bookings, Blog, Events, etc.) and which management recipes to follow.
-
-### Determine Wix Stores catalog version before any stores call
-
-Check whether Stores shows `Catalog app version: V3` or `V1` before using stores endpoints:
-- V3 sites: use `/stores/v3/` endpoints and V3 catalog recipes
-- V1 sites: use `/stores/v1/` (legacy) endpoints and V1 catalog recipes — never mix
-
----
-
-## JSON variant
-
-Replace `/markdown` with the bare endpoint to get structured JSON instead:
-
-**Endpoint**: `POST https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context`
-
-The JSON response includes an `account` object plus a `sites` array. App entries contain raw `appId` strings (not display names), so the markdown variant is preferred for reading.
 
 ---
 

--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -1,6 +1,6 @@
 ---
 name: "Read Site Context"
-description: Single-call orientation on any Wix site — installed apps by display name, locale, currency, timezone, and status in one shot. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
+description: Probe a Wix site or account for full context in one call — installed apps by display name, locale, currency, timezone, and status. Account token + siteId targets one site; account token alone returns up to 10; site-scoped token alone returns the site it is scoped to.
 ---
 # Read Site Context
 

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -2,6 +2,10 @@ apiDoc:
   title: Wix Sites Management Recipes
 
   docs:
+    - file: ../../../skills/wix-manage/references/sites/read-site-context.md
+      title: Read Account or Site Context
+      docsEntry: https://dev.wix.com/docs/api-reference/tools/dynamic-site-context
+      tags: [sites]
     - file: ../../../skills/wix-manage/references/sites/query-sites.md
       title: Query Sites
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites


### PR DESCRIPTION
## Summary

- Adds `references/sites/read-site-context.md` — a reference for the Dynamic Site Context API (`POST /dynamic-context/v1/dynamic-context/markdown`)
- Registers it in `SKILL.md` under the Sites section (after Query Sites)

## What it covers

- Single-call site snapshot: installed apps by display name, locale, currency, status, Wix Stores catalog version (V1/V3)
- Replaces three separate calls: query-sites + list-installed-apps + site-properties
- Key use case: read this first on an unfamiliar site to decide which management recipes apply
- JSON variant note (raw UUIDs, not display names → markdown preferred)
- Catalog-version decision guide for Wix Stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)