### PR TITLE
feat(wix-manage): manage-oauth-apps reference

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -367,6 +367,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Create Headless Site](references/sites/create-headless-site.md)
 **Technical:** Creates a Wix Headless site (headless business) with one account-level API call — site, Wix Business Solution apps, and a configured OAuth client.
 
+### [Manage OAuth Apps](references/sites/manage-oauth-apps.md)
+**Technical:** Create, read, update, and query OAuth apps for a Wix headless site. Each OAuth app's `id` is the `client_id` for frontends connecting to the site's Wix APIs. Secret and rotation are dashboard-only.
+
 ### [Query Sites](references/sites/query-sites.md)
 **Technical:** Lists and queries all sites associated with a Wix account using Sites API. Covers pagination with cursor-based navigation.
 

--- a/skills/wix-manage/references/sites/create-headless-site.md
+++ b/skills/wix-manage/references/sites/create-headless-site.md
@@ -50,3 +50,4 @@ To provision headless onto an existing site, pass `"existingMetasite": {}` inste
 After creating the site:
 - Install additional apps using [Install Wix Apps](../app-installation/install-wix-apps.md)
 - Add content (products, services, blog posts, etc.)
+- Use the `appId` as the `client_id` to mint visitor tokens and make buyer-facing API calls — see [Manage OAuth Apps](manage-oauth-apps.md)

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -12,12 +12,6 @@ When a headless site is provisioned it gets one OAuth app automatically (see [Cr
 
 ---
 
-## Prerequisites
-
-- Site-level authentication with `SCOPE.OAUTH_APP.MANAGE` permission
-
----
-
 ## Create an OAuth App
 
 **Endpoint**: `POST https://www.wixapis.com/oauth-app/v1/oauth-apps`

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -146,7 +146,7 @@ curl -X POST 'https://www.wixapis.com/oauth2/token' \
   -d '{ "clientId": "<clientId>", "grantType": "refresh_token", "refreshToken": "<refreshToken>" }'
 ```
 
-Use the `access_token` as the `Authorization` header on subsequent API calls — Wix expects the raw token value, **not** `Bearer <token>`.
+Use the `access_token` as the `Authorization` header on subsequent API calls.
 
 > **Never re-mint anonymous on every load.** The visitor token is the cart/session identity — a fresh anonymous mint creates a new visitor and silently empties the cart. Persist the `refresh_token` and use it to renew.
 

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -15,7 +15,6 @@ When a headless site is provisioned it gets one OAuth app automatically (see [Cr
 ## Prerequisites
 
 - Site-level authentication with `SCOPE.OAUTH_APP.MANAGE` permission
-- The site must be a headless site (OAuth apps are headless-only)
 
 ---
 

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -1,6 +1,6 @@
 ---
 name: "Manage OAuth Apps"
-description: Create, read, update, and query OAuth apps for a Wix headless site. Each OAuth app is the credential holder (client_id) for a frontend or external client connecting to the site's Wix APIs.
+description: Create, read, update, and query OAuth apps for a Wix headless site. Each OAuth app's id is the client_id a frontend uses to mint anonymous visitor tokens and call Wix APIs.
 ---
 # Manage OAuth Apps
 
@@ -119,6 +119,34 @@ curl -X PATCH \
 | `allowedRedirectUris` | Exact-match URIs for post-authentication redirect. Max 20. |
 | `allowedRedirectDomains` | Domain-level allow-list for non-auth redirects (e.g. checkout). Max 20. |
 | `applicationType` | `WEB_APP`, `MOBILE`, `OTHER` |
+
+---
+
+## Minting a Visitor Token
+
+Once you have a `client_id`, frontends use it to mint an anonymous visitor token for buyer-facing API calls.
+
+**Endpoint**: `POST https://www.wixapis.com/oauth2/token`
+
+```bash
+# Initial anonymous mint
+curl -X POST 'https://www.wixapis.com/oauth2/token' \
+  -H 'Content-Type: application/json' \
+  -d '{ "clientId": "<clientId>", "grantType": "anonymous" }'
+
+# Response: { "access_token": "...", "refresh_token": "...", "expires_in": 14400 }
+```
+
+```bash
+# Refresh (use this instead of re-minting)
+curl -X POST 'https://www.wixapis.com/oauth2/token' \
+  -H 'Content-Type: application/json' \
+  -d '{ "clientId": "<clientId>", "grantType": "refresh_token", "refreshToken": "<refreshToken>" }'
+```
+
+Use the `access_token` as the `Authorization` header on subsequent API calls — Wix expects the raw token value, **not** `Bearer <token>`.
+
+> **Never re-mint anonymous on every load.** The visitor token is the cart/session identity — a fresh anonymous mint creates a new visitor and silently empties the cart. Persist the `refresh_token` and use it to renew.
 
 ---
 

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -4,9 +4,11 @@ description: Create, read, update, and query OAuth apps for a Wix headless site.
 ---
 # Manage OAuth Apps
 
-An OAuth app is a site-level credential holder — its `id` is the `client_id` used in OAuth 2.0 flows by any frontend or external client connecting to the site. When a headless site is provisioned, Wix creates one automatically; use this recipe to create additional apps, inspect existing ones, or update their redirect configuration.
+An OAuth app is a site-level credential holder. Its `id` is the `client_id` (the two terms are interchangeable — Wix uses `appId` in provisioning responses, `clientId` in token requests, and `id` in the OAuth Apps API; they all refer to the same value).
 
-> **Secret is dashboard-only.** The `client_secret` is shown once in the Headless Settings dashboard and never returned by the API. Rotation is also dashboard-only — there is no programmatic rotate-secret endpoint.
+When a headless site is provisioned it gets one OAuth app automatically (see [Create Headless Site](create-headless-site.md)); use this recipe to create additional apps, inspect existing ones, or update their redirect configuration.
+
+> **`client_id` is not a secret** — it is a public identifier safe to embed in frontend code. The visitor token it mints is also non-privileged: it represents an anonymous visitor, not an admin. The `client_secret` is different — shown once in the Headless Settings dashboard, never returned by the API, and rotation is dashboard-only.
 
 ---
 

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -158,3 +158,4 @@ Use the `access_token` as the `Authorization` header on subsequent API calls —
 - [OAuth Apps — Get](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/get-o-auth-app)
 - [OAuth Apps — Query](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/query-o-auth-apps)
 - [OAuth Apps — Update](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/update-o-auth-app)
+- [Retrieve Tokens — `/oauth2/token` contract, all grant types](https://dev.wix.com/docs/api-reference/business-management/headless/authentication/retrieve-tokens)

--- a/skills/wix-manage/references/sites/manage-oauth-apps.md
+++ b/skills/wix-manage/references/sites/manage-oauth-apps.md
@@ -1,0 +1,130 @@
+---
+name: "Manage OAuth Apps"
+description: Create, read, update, and query OAuth apps for a Wix headless site. Each OAuth app is the credential holder (client_id) for a frontend or external client connecting to the site's Wix APIs.
+---
+# Manage OAuth Apps
+
+An OAuth app is a site-level credential holder — its `id` is the `client_id` used in OAuth 2.0 flows by any frontend or external client connecting to the site. When a headless site is provisioned, Wix creates one automatically; use this recipe to create additional apps, inspect existing ones, or update their redirect configuration.
+
+> **Secret is dashboard-only.** The `client_secret` is shown once in the Headless Settings dashboard and never returned by the API. Rotation is also dashboard-only — there is no programmatic rotate-secret endpoint.
+
+---
+
+## Prerequisites
+
+- Site-level authentication with `SCOPE.OAUTH_APP.MANAGE` permission
+- The site must be a headless site (OAuth apps are headless-only)
+
+---
+
+## Create an OAuth App
+
+**Endpoint**: `POST https://www.wixapis.com/oauth-app/v1/oauth-apps`
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/oauth-app/v1/oauth-apps' \
+  -H 'Authorization: <AUTH>' \
+  -H 'wix-site-id: <metaSiteId>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "oAuthApp": {
+      "name": "My Storefront",
+      "loginUrl": "https://example.com/login",
+      "allowedRedirectUris": ["https://example.com/callback"],
+      "allowedRedirectDomains": ["example.com"]
+    }
+  }'
+```
+
+**Response**:
+```json
+{
+  "oAuthApp": {
+    "id": "<clientId>",
+    "name": "My Storefront",
+    "loginUrl": "https://example.com/login",
+    "allowedRedirectUris": ["https://example.com/callback"],
+    "allowedRedirectDomains": ["example.com"],
+    "createdDate": "2026-08-18T10:00:00Z"
+  }
+}
+```
+
+`id` is the OAuth `client_id`. After creating the app, retrieve the `client_secret` from the Headless Settings dashboard.
+
+---
+
+## Get an OAuth App
+
+**Endpoint**: `GET https://www.wixapis.com/oauth-app/v1/oauth-apps/{id}`
+
+```bash
+curl 'https://www.wixapis.com/oauth-app/v1/oauth-apps/<clientId>' \
+  -H 'Authorization: <AUTH>' \
+  -H 'wix-site-id: <metaSiteId>'
+```
+
+---
+
+## Query OAuth Apps
+
+**Endpoint**: `POST https://www.wixapis.com/oauth-app/v1/oauth-apps/query`
+
+```bash
+curl -X POST \
+  'https://www.wixapis.com/oauth-app/v1/oauth-apps/query' \
+  -H 'Authorization: <AUTH>' \
+  -H 'wix-site-id: <metaSiteId>' \
+  -H 'Content-Type: application/json' \
+  -d '{ "query": {} }'
+```
+
+Returns all OAuth apps for the site.
+
+---
+
+## Update an OAuth App
+
+**Endpoint**: `PATCH https://www.wixapis.com/oauth-app/v1/oauth-apps/{id}`
+
+Update requires an explicit `mask.paths` — omitting it silently updates nothing.
+
+Updatable fields: `name`, `description`, `loginUrl`, `logoutUrl`, `allowedRedirectUris`, `allowedRedirectDomains`, `technology`.
+
+```bash
+curl -X PATCH \
+  'https://www.wixapis.com/oauth-app/v1/oauth-apps/<clientId>' \
+  -H 'Authorization: <AUTH>' \
+  -H 'wix-site-id: <metaSiteId>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "oAuthApp": {
+      "allowedRedirectUris": ["https://example.com/callback", "https://example.com/auth"]
+    },
+    "mask": { "paths": ["allowedRedirectUris"] }
+  }'
+```
+
+---
+
+## Key Fields
+
+| Field | Notes |
+|---|---|
+| `id` | The OAuth `client_id`. Read-only. |
+| `name` | Required on create. 2–256 chars. |
+| `loginUrl` | External login redirect. Defaults to Wix login if omitted. |
+| `logoutUrl` | Called when the user logs out at Wix. |
+| `allowedRedirectUris` | Exact-match URIs for post-authentication redirect. Max 20. |
+| `allowedRedirectDomains` | Domain-level allow-list for non-auth redirects (e.g. checkout). Max 20. |
+| `applicationType` | `WEB_APP`, `MOBILE`, `OTHER` |
+
+---
+
+## API Reference
+
+- [OAuth Apps — Create](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/create-o-auth-app)
+- [OAuth Apps — Get](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/get-o-auth-app)
+- [OAuth Apps — Query](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/query-o-auth-apps)
+- [OAuth Apps — Update](https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps/update-o-auth-app)

--- a/yaml/wix-manage-evals/sites/manage-oauth-apps.yml
+++ b/yaml/wix-manage-evals/sites/manage-oauth-apps.yml
@@ -1,0 +1,30 @@
+name: sites/manage-oauth-apps
+description: >-
+  Verifies the agent reads the manage-oauth-apps skill and uses the OAuth Apps API to create or
+  update an OAuth app for a headless site, correctly setting allowedRedirectUris and using a
+  mask.paths on update.
+triggerPrompt: >-
+  I have a Wix headless site and I want to add a second OAuth app for a new frontend I'm building
+  at https://shop.example.com. The post-login callback will be https://shop.example.com/callback.
+  Show me the API call to create the OAuth app and how to get its client_id.
+tags: [sites]
+assertions:
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user wants to create a second OAuth app for their Wix headless site, with a redirect URI
+      of https://shop.example.com/callback, and wants the client_id.
+
+      Pass if the response:
+      - calls POST https://www.wixapis.com/oauth-app/v1/oauth-apps with a wix-site-id header, AND
+      - includes allowedRedirectUris containing the callback URL in the request body, AND
+      - states that the response id field is the OAuth client_id, AND
+      - mentions that the client_secret is only available from the Headless Settings dashboard
+        (not returned by the API).
+
+      Fail if the response:
+      - uses the headless-business-setup provision endpoint to create a new site instead of a new
+        OAuth app on the existing site, OR
+      - claims the client_secret is returned by the create API, OR
+      - omits the endpoint or the allowedRedirectUris field.

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -18,6 +18,10 @@ apiDoc:
       title: Create Headless Site
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites
       tags: [sites]
+    - file: ../../../skills/wix-manage/references/sites/manage-oauth-apps.md
+      title: Manage OAuth Apps
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/headless/oauth-apps
+      tags: [sites]
     - file: ../../../skills/wix-manage/references/sites/site-import.md
       title: Site Import
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/sites


### PR DESCRIPTION
## Summary

- Adds `references/sites/manage-oauth-apps.md` — CRUD for headless site OAuth apps
- Registers in `SKILL.md` under Sites (after Create Headless Site)
- Adds `yaml/wix-manage/sites/documentation.yaml` entry
- Adds `yaml/wix-manage-evals/sites/manage-oauth-apps.yml` eval scenario

## What it covers

- Create, Get, Query, Update via `/oauth-app/v1/oauth-apps`
- `id` = OAuth `client_id` — no separate step needed
- Update requires explicit `mask.paths` (silent no-op without it)
- Secret and rotation are dashboard-only — called out as a gotcha upfront

🤖 Generated with [Claude Code](https://claude.com/claude-code)