### PR TITLE
docs(wix-docs-base44): siteId optional in dynamic site context call

### DIFF
--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -284,7 +284,7 @@ whole site: installed apps, status, URL, locale, CMS collections.
 await docs.callApi({
   url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
   token: accessToken,
-  body: { siteId: WIX_SITE_ID },
+  body: {},            // omit siteId to get all account sites; pass { siteId } to target one
 })
 ```
 

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -284,7 +284,7 @@ whole site: installed apps, status, URL, locale, CMS collections.
 await docs.callApi({
   url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
   token: accessToken,
-  body: {},            // omit siteId to get all account sites; pass { siteId } to target one
+  body: {},            // siteId optional — site token returns that site; account token returns up to 10
 })
 ```
 

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -278,7 +278,7 @@ The authentication docs, all fetchable with `docs.fetchDoc`:
 ## 7. Special APIs worth knowing
 
 **Dynamic Site Context — "what IS this site?"** One admin call returns a markdown report of the
-whole site: installed apps, status, URL, locale, CMS collections.
+whole site: installed apps, status, URL, locale.
 
 ```js
 await docs.callApi({

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -278,14 +278,13 @@ The authentication docs, all fetchable with `docs.fetchDoc`:
 ## 7. Special APIs worth knowing
 
 **Dynamic Site Context — "what IS this site?"** One admin call returns a markdown report of the
-whole site: installed apps, status, URL, locale.
+whole site: site ID, installed apps, status, URL, locale, site properties.
 
 ```js
 await docs.callApi({
   url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
   token: accessToken,
-  body: {},            // siteId optional — site token returns that site; account token returns up to 10,
-                       // each with its ID, so you can call again with { siteId } to target one
+  body: {},            // siteId optional — site token returns that site; account token returns up to 10
 })
 ```
 

--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -284,7 +284,8 @@ whole site: installed apps, status, URL, locale.
 await docs.callApi({
   url: "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
   token: accessToken,
-  body: {},            // siteId optional — site token returns that site; account token returns up to 10
+  body: {},            // siteId optional — site token returns that site; account token returns up to 10,
+                       // each with its ID, so you can call again with { siteId } to target one
 })
 ```
 


### PR DESCRIPTION
siteId is not mandatory — omitting it returns all account sites. Updated the example to reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)