### PR TITLE
🦞 igor-claw: add Delete Sites recipe for cleaning up duplicate/orphan Harmony-built sites

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -367,6 +367,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Create Headless Site](references/sites/create-headless-site.md)
 **Technical:** Creates a Wix Headless site (headless business) with one account-level API call — site, Wix Business Solution apps, and a configured OAuth client.
 
+### [Delete Sites](references/sites/delete-sites.md)
+**Technical:** Moves one or more account-owned sites to the trash bin (recoverable, not permanent) via the Bulk Delete Site API. Use to clean up duplicate/orphan sites left by a retried, declined, or timed-out site-creation call instead of leaving the user to find and delete them manually.
+
 ### [Manage OAuth Apps](references/sites/manage-oauth-apps.md)
 **Technical:** Create, read, update, and query OAuth apps for a Wix headless site. Each OAuth app's `id` is the `client_id` for frontends connecting to the site's Wix APIs. Secret and rotation are dashboard-only.
 

--- a/skills/wix-manage/references/sites/delete-sites.md
+++ b/skills/wix-manage/references/sites/delete-sites.md
@@ -1,0 +1,89 @@
+---
+name: "Delete Sites"
+description: Deletes one or more sites from a Wix account using the Bulk Delete Site API. Use this to clean up unwanted duplicate/orphan sites (e.g. leftover from a declined, timed-out, or retried site-creation call) instead of leaving them for the user to find and delete manually.
+---
+# Delete Sites
+
+This recipe deletes one or more sites owned by the account. It's the cleanup step to pair with
+[Query Sites](query-sites.md) whenever a site-creation flow (e.g. `WixSiteBuilder`/Wix Harmony AI
+generation) leaves behind duplicate or unwanted sites — for example when a build call was retried,
+or when a user declined/the client timed out on a tool-call approval but the backend build had
+already started and a real site was created anyway.
+
+## Prerequisites
+
+- Account-level API access (authenticated as a Wix user or using an account-level API key)
+- Permission `my-account.delete-site`
+
+## Required APIs
+
+- **Bulk Delete Site API**: [REST](https://dev.wix.com/docs/api-reference/account-level/sites/site-actions/bulk-delete-site)
+
+> This is **not a permanent delete** — sites are moved to the trash bin and can be restored by a
+> site collaborator. Safe to use for cleaning up accidental/duplicate sites without risk of
+> permanent data loss.
+
+## When to use this
+
+1. A site-creation tool (e.g. `WixSiteBuilder`) was called more than once for what was meant to be
+   one site — each call creates a fully independent new site, with no de-duplication.
+2. A site-creation tool call was declined or timed out client-side, but the site was already
+   created server-side by the time of the decline/timeout.
+3. The user asks to clean up test/duplicate/unwanted sites in their account.
+
+Identify the sites to delete first — with [Query Sites](query-sites.md) or `ListWixSites`, matching
+on name, `createdDate`, or `updatedDate` around the time of the duplicate calls. **Confirm with the
+user which sites are unwanted before deleting** — deletion (even to trash) should not be assumed
+silently for sites the user might still want.
+
+## Delete Sites
+
+**Endpoint**: `POST https://www.wixapis.com/site-actions/v1/bulk/sites/delete`
+
+Up to 20 site IDs per call.
+
+**Request Body**:
+```json
+{
+  "ids": [
+    "9f023696-c821-4e09-b1d0-55357272ff2a",
+    "da0c7663-e375-48a9-b273-f0bd45c933a9"
+  ]
+}
+```
+
+**Request**:
+```bash
+curl -X POST \
+  'https://www.wixapis.com/site-actions/v1/bulk/sites/delete' \
+  -H 'Authorization: <AUTH>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "ids": ["9f023696-c821-4e09-b1d0-55357272ff2a"]
+  }'
+```
+
+## Response Structure
+
+```json
+{
+  "results": [
+    { "itemMetadata": { "id": "9f023696-c821-4e09-b1d0-55357272ff2a", "originalIndex": 0, "success": true } }
+  ],
+  "bulkActionMetadata": {
+    "totalSuccesses": 1,
+    "totalFailures": 0
+  }
+}
+```
+
+Check `results[].itemMetadata.success` per site — a non-zero `totalFailures` doesn't mean the whole
+call failed, just that some of the requested IDs didn't delete (e.g. already trashed, or not owned
+by this account).
+
+## Next Steps
+
+- Deleted sites go to the trash bin, not permanent deletion — see
+  [Moving a site to trash](https://support.wix.com/en/article/moving-a-site-to-trash) for how a
+  collaborator restores one.
+- To find sites to clean up in the first place, see [Query Sites](query-sites.md).

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -195,3 +195,4 @@ After finding a site:
 - Use the site `id` for site-level API calls
 - Create new sites using [Create Site from Template](create-site-from-template.md)
 - Manage site settings and content
+- Found duplicate/unwanted sites (e.g. from a retried or declined site-creation call)? See [Delete Sites](delete-sites.md)


### PR DESCRIPTION
## Summary
Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching a piece of Wix MCP user feedback: https://wix.slack.com/archives/C08P5DKLJR5/p1787055639423569

- Reporter's session made several `WixSiteBuilder` calls that were declined/timed out client-side during an approval step; each still created a real, persisted site server-side (the tool starts the Harmony build the instant it's invoked — a client-side decline/timeout can't unwind that). Result: 4 leftover sites, 3 unwanted duplicates.
- **Gap:** there was no documented way for an agent to clean these up. The user had to manually find and delete the duplicates via the dashboard themselves; the MCP/skills had no recipe pointing at the account-level `Bulk Delete Site` API (`POST site-actions/v1/bulk/sites/delete`).
- Live-verified this endpoint is reachable via `ManageWixSite` in the MCP's normal account-auth context — tested against an owned placeholder test site (moved to trash, recoverable, not a permanent delete).

## Fix (this PR)
- New recipe `skills/wix-manage/references/sites/delete-sites.md`: how/when to bulk-delete sites, paired with `Query Sites` to find candidates first, with an explicit "confirm with the user before deleting" note.
- Indexed in `SKILL.md` under `## Sites`.
- Cross-linked from `query-sites.md`'s "Next Steps".

Companion fix on the harness side: [igor-tools#1563](https://github.com/wix-private/igor-tools/pull/1563) (the existing PR covering `WixSiteBuilder`'s no-dedup behavior) got a follow-up commit pointing agents at this same cleanup path directly from the tool description.