### PR TITLE
🦞 igor-claw: caveat that a clean a11y scan isn't proof of correct rendering

### DIFF
--- a/skills/wix-manage/references/accessibility/scan-site-accessibility.md
+++ b/skills/wix-manage/references/accessibility/scan-site-accessibility.md
@@ -60,6 +60,13 @@ Lead with the scan status and aggregate totals. Then:
 
 - Report failed pages separately. A failed page with zero findings is
   **unknown**, not clean.
+- A page reported as scanned and clear only means it passed the scan's WCAG
+  rule checks against whatever DOM the scan captured. It is **not** proof
+  that every widget/element rendered correctly for a real visitor: a
+  component that fails to load (e.g. an "Element Didn't Load" state) can
+  still be accessible on its own terms and pass every rule. Don't tell the
+  user a page "looks fine" or "is fully working" based on scan results
+  alone — that requires actually loading the live page.
 - Prioritize findings by severity, then page and rule.
 - For each useful finding, include the affected page and element reference,
   what failed, why it matters, WCAG criteria, remediation summary, and the


### PR DESCRIPTION
## Summary
- The "Scan a Wix Site for Accessibility Issues" skill has no caveat distinguishing "passed the accessibility scan" from "renders correctly for visitors."
- A WCAG rule checker validates whatever DOM it captured; a widget that fails to load (e.g. shows an "Element Didn't Load" placeholder) can be a perfectly accessible placeholder and pass every rule, while the page is functionally broken for real visitors.
- Adds one bullet under "Present actionable results" so an agent doesn't tell a user a page "looks fine" based on scan results alone.

## Test plan
- [x] Docs-only change to the skill markdown, no behavior change.

---
Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching Wix MCP feedback. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787115202600489