### PR TITLE
sync(editor-react-component): feat(editor-component): enable hat selector for active-item components

### DIFF
--- a/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
+++ b/skills/wix-app/references/EDITOR_REACT_COMPONENT.md
@@ -102,6 +102,11 @@ before writing the code. Triggers, and the only cases that warrant it:
 
 Otherwise, do not reach for a hook at all — data the site owner can type or pick
 belongs in props.
+If the component displays **an array of items where only one body is visible at a
+time** (tabs, slides, steps), follow the
+[active-item rules](editor-react-component/COMPONENT-API.md#active-item-components-one-body-visible-at-a-time)
+in [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) (`ActiveItemIndex<>`,
+`name` on each item, render-all-panels visibility).
 
 Reference: when modifying an _existing_ component, follow
 [`editor-react-component/EDIT-FLOW.md`](editor-react-component/EDIT-FLOW.md).
@@ -117,7 +122,7 @@ Topic-focused references (rules + patterns + common mistakes in one place):
 - [`editor-react-component/DESIGN-STATES.md`](editor-react-component/DESIGN-STATES.md) — Which design states a part supports (heuristic) and how to author them
 - [`editor-react-component/DIRECTIONALITY.md`](editor-react-component/DIRECTIONALITY.md) — RTL/LTR rules and patterns
 - [`editor-react-component/PROPS-VS-CSS.md`](editor-react-component/PROPS-VS-CSS.md) — What should be a React prop vs CSS
-- [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props
+- [`editor-react-component/COMPONENT-API.md`](editor-react-component/COMPONENT-API.md) — Props structure, elementProps, data types, file splitting, containers, array props, active-item components
 - [`editor-react-component/FUNCTION-HANDLERS.md`](editor-react-component/FUNCTION-HANDLERS.md) — Standard SDK event handler props, DOM wiring, custom callbacks
 - [`editor-react-component/ANIMATED-COMPONENTS.md`](editor-react-component/ANIMATED-COMPONENTS.md) — Play/pause control and autoplay for animated/playable components
 - [`editor-react-component/COMPONENT-PREVIEW.md`](editor-react-component/COMPONENT-PREVIEW.md) — Editor-specific entry point (`component.preview.tsx`), `useIsEditMode()`, when to modify

--- a/skills/wix-app/references/editor-react-component/COMPONENT-API.md
+++ b/skills/wix-app/references/editor-react-component/COMPONENT-API.md
@@ -130,6 +130,38 @@ when arithmetic is needed: `price: number`, not `price: string`).
 
 When the parent component defines an array prop (e.g., `items`), child/item components receive a single item directly. They do NOT redeclare the data structure in their own props.
 
+### Active-item components (one body visible at a time)
+
+Apply when the UI shows **one array item body at a time** (tabs, slideshow,
+steps). Skip for always-visible lists, multi-select, or multi-expand accordion.
+
+- Each item needs **`name: string`** — Studio hat labels (not `label` or other keys).
+- Pair the array with **`ActiveItemIndex<'arrayPropName'>`** from
+  `@wix/react-component-utils`; the type param must match the array prop name.
+  Default the index to `0` in `defaultProps`.
+- Render **all** item bodies (`.map`); toggle visibility with `--active` +
+  `display: none` on inactive panels (functional visibility — see
+  [`PROPS-VS-CSS.md`](PROPS-VS-CSS.md)), plus `aria-hidden` and `inert` on
+  inactive bodies.
+- Keyboard navigation between triggers; ARIA roles per
+  [`ACCESSIBILITY.md`](ACCESSIBILITY.md).
+
+```typescript
+import type { ActiveItemIndex } from '@wix/react-component-utils';
+
+export type ItemType = { name: string; body: string };
+
+export type MyComponentProps = {
+  items: Array<ItemType>;
+  activeItem: ActiveItemIndex<'items'>;
+};
+
+export const defaultProps = {
+  items: [{ name: 'Item 1', body: '…' }],
+  activeItem: 0,
+} satisfies Omit<MyComponentProps, 'id' | 'className'>;
+```
+
 ### Array Element Types: Always Objects with Named Keys
 
 Array elements MUST be objects with named keys. This enables stable item identity (each item can carry its own `id`/`key`), non-breaking extension (new fields can be added later without changing the prop signature), and semantic naming (each value has meaning instead of being an opaque scalar).

--- a/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
+++ b/skills/wix-app/references/editor-react-component/DESIGN-STATES.md
@@ -17,6 +17,12 @@ and `.module.css`.
 A custom state may also be driven by a root-level boolean prop (e.g.
 `isFeatured`) instead of by markup or item data — see §5.
 
+For **active-item components** (tabs, slideshow, steps), the `--active` state on
+each item is driven by comparing the item's index to the active-index prop
+(`index === activeItem`), not by a per-item boolean flag — see
+[Active-item components](COMPONENT-API.md#active-item-components-one-body-visible-at-a-time)
+in [`COMPONENT-API.md`](COMPONENT-API.md).
+
 ## 2. Name the state class
 
 Flat: the element's own global class + `--<state>`. Because inner-part


### PR DESCRIPTION
## Automated sync from private repo

Synced from https://github.com/wix-private/editor-react-component-creation-skills/pull/73: feat(editor-component): enable hat selector for active-item components

### What was synced
- Editor React Component entry and references managed by the private source repo
- Editor React Component a11y scanner scripts
- local paths mapped to the public wix/skills layout

Auto-generated by GitHub Actions.