### PR TITLE
feat(wix-docs-base44): lite.js — fetch+eval helpers replace inline snippets in the light guide

### DIFF
--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -30,14 +30,23 @@ is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.
 
 ## Gather context — the dynamic context report
 
+Every JSON call in this guide shares one shape — this helper opens each exec (execs share no
+state, so redeclare it):
+
+```js
+const post = async (url, body, token) => {
+  const r = await fetch(url, { method: "POST", body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", ...(token && { Authorization: `Bearer ${token}` }) } });
+  if (!r.ok) throw new Error(r.status + " " + (await r.text()).slice(0, 300));
+  return r.json();
+};
+```
+
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const r = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
-  method: "POST",
-  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({}),   // the connector token is site-bound; siteId filter is optional
-});
-const { markdown } = await r.json();   // big? extract a section, don't page blind:
+const { markdown } = await post("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
+  {}, accessToken);   // the connector token is site-bound; siteId filter is optional
+// big? extract a section, don't page blind:
 const apps = (markdown.match(/### Apps[\s\S]*?(?=\n### |$)/) || [markdown.slice(0, 3500)])[0];
 return { total: markdown.length, apps: apps.slice(0, 3500) };
 ```
@@ -61,27 +70,21 @@ out. One exec per round; timeout 10s, up to 120 via `{timeout}`. Clip guard for 
 listings clip:
 
 ```js
-const r = await fetch("https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse", {
-  method: "POST", headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({
-    menu_url: "https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
-    include: ["METHOD"], name_filter: "resched", depth: 4,   // orient first: menu_url alone
-  }),
+const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse", {
+  menu_url: "https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
+  include: ["METHOD"], name_filter: "resched", depth: 4,   // orient first: menu_url alone
 });
-return (await r.json()).content;   // null/404 ⇒ not a docs node — re-orient a level up
+return content;   // 404 "No menu node found" ⇒ re-orient a level up
 ```
 
 **Don't know where it lives? Search (ranks, never matches).** Each hit is a condensed method
 doc. Reduce per hit, keeping the riches:
 
 ```js
-const r = await fetch("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown", {
-  method: "POST", headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ search_term: "pause a pricing plan subscription and resume it",
+const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
+  { search_term: "pause a pricing plan subscription and resume it",
     document_type: "REST",   // or SDK | WIX_HEADLESS | VELO | CLI
-    maximum_results: 5, lines_in_each_result: 6 }),
-});
-const { content } = await r.json();
+    maximum_results: 5, lines_in_each_result: 6 });
 const hits = content.split(/\n---\n+(?=#### )/).map(b => ({
   method:   (b.match(/^# Method: (.+)$/m) || [])[1],
   endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // callable
@@ -140,17 +143,14 @@ The index answers questions about pages you already found — arrive with a `doc
 A resource's methods with callable URLs — also the only proof an API does NOT exist:
 
 ```js
-const r = await fetch("https://mcp.wix.com/api/code-mode/search", {
-  method: "POST", headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ code: `async function(){
-    const r = lightIndex.find(x => x.docsUrl ===
-      "https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5");
-    return r.methods.filter(m => /query/i.test(m.summary))
-                    .map(m => ({ op: m.operationId.split(".").pop(),
-                                 verb: m.httpMethod, call: m.publicUrl }));
-  }` }),
-});
-return (await r.json()).result;
+const { result } = await post("https://mcp.wix.com/api/code-mode/search", { code: `async function(){
+  const r = lightIndex.find(x => x.docsUrl ===
+    "https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5");
+  return r.methods.filter(m => /query/i.test(m.summary))
+                  .map(m => ({ op: m.operationId.split(".").pop(),
+                               verb: m.httpMethod, call: m.publicUrl }));
+}` });
+return result;
 ```
 
 Request fields: same wrapper, `getResourceSchemaByUrl(methodDocsUrl)` → schema at
@@ -208,14 +208,9 @@ deployed `base44/functions/*` (work the app does as the owner). Project the resp
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const r = await fetch("https://www.wixapis.com/contacts/v5/contacts/query", {   // spec-index publicUrl
-  method: "POST",
-  headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({ query: { cursorPaging: { limit: 10 } } }),
-});
-if (!r.ok) return { status: r.status, error: (await r.text()).slice(0, 300) };
-const data = await r.json();   // project, don't dump:
-return { count: data.contacts?.length, keys: Object.keys(data.contacts?.[0] || {}) };
+const data = await post("https://www.wixapis.com/contacts/v5/contacts/query",   // spec-index publicUrl
+  { query: { cursorPaging: { limit: 10 } } }, accessToken);
+return { count: data.contacts?.length, keys: Object.keys(data.contacts?.[0] || {}) };   // project, don't dump
 ```
 
 ### A visitor client — src/lib/wixClient.js

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -1,16 +1,9 @@
-# Wix APIs from Base44 — zero-disk
+# Building on Wix from Base44
 
-**Discover everything.** Endpoints, paths, doc URLs, request and response fields — all from the
-calls below, never from memory or pattern. 404 or empty ⇒ discover, not permute. Examples teach
-mechanics and go stale — verify before relying.
-
-**Every call: fetch → reduce in memory → return ≤ 4,000 chars.** Results clip at ~5,000. Nothing
-is written to disk; state between rounds = re-fetching (~1s). **Fetch every URL inside exec with
-`fetch()`** — website/browser tools clip at 10,000 chars silently. Return facts, not documents; a
-big result returns a count of what was left out. One exec per round; timeout 10s, up to 120 via
-`{timeout}`.
-
-Clip guard: `const s = JSON.stringify(out); return s.length > 4000 ? { truncated: true, total: s.length, head: s.slice(0, 4000) } : out;`
+The Wix connector is connected; this is how the app gets built on it — gather the site's context,
+learn the APIs from the docs, write the code. **Discover everything**: endpoints, paths, doc URLs,
+request and response fields all come from the calls below, never from memory or pattern. 404 or
+empty ⇒ discover, not permute. Examples teach mechanics and go stale — verify before relying.
 
 ## What are you building?
 
@@ -25,38 +18,22 @@ exec_tool          ──(admin token)───► wixapis.com   you: ad hoc pro
 ```
 
 **A site for visitors** — storefront, blog, booking. Headless means the Wix site has no pages of
-its own: your app IS its frontend, and it calls Wix from the browser. Every call the visitor
-token can make lives in the client:
-
-```js
-// src/lib/wixClient.js — the visitor path; pages import it
-const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, { ...opts,
-  headers: { Authorization: `Bearer ${visitorToken}`, "Content-Type": "application/json" } });
-
-wix("/stores/v3/products/query", { method: "POST", body: JSON.stringify({ query: {} }) });
-//  ↑ public reads included — the visitor token queries catalog directly
-wix("/ecom/v1/carts/current");
-wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
-//  ↑ carts/current/* and checkout act on the CALLER's cart — only the visitor token
-//    reaches the visitor's cart
-```
-
+its own: your app IS its frontend, and it calls Wix from the browser. Every call the visitor token
+can make lives in the client — one file, `src/lib/wixClient.js` (Write the code, below).
 `base44/functions/*` hold the work that needs the owner's identity — elevated-permission ops a
 visitor triggers, webhooks, scheduled jobs — and the app's non-Wix backend.
 
 **An admin tool for the owner** — dashboard, back office. The pages act as the owner, whose token
 is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
 
-## Gather context
-
-### The dynamic context report
+## Gather context — the dynamic context report
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
 const r = await fetch("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {
   method: "POST",
   headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-  body: JSON.stringify({ siteId: WIX_SITE_ID }),
+  body: JSON.stringify({}),   // the connector token is site-bound; siteId filter is optional
 });
 const { markdown } = await r.json();   // big? extract a section, don't page blind:
 const apps = (markdown.match(/### Apps[\s\S]*?(?=\n### |$)/) || [markdown.slice(0, 3500)])[0];
@@ -65,9 +42,16 @@ return { total: markdown.length, apps: apps.slice(0, 3500) };
 
 One report: installed apps **with ids** (incl. Stores' catalog version — V1 vs V3 decides its
 endpoints), the OAuth app id (**also the visitor `clientId`**), locale, currency, CMS collections.
-`markdown: ""` = bad token or siteId, never an empty site.
+`markdown: ""` = bad token, never an empty site.
 
 ## Learn Wix — discover APIs in the docs
+
+Research runs in exec_tool, and every research call is **fetch → reduce in memory → return
+≤ 4,000 chars** (results clip at ~5,000). Nothing is written to disk; state between rounds =
+re-fetching (~1s). **Fetch every URL inside exec with `fetch()`** — website/browser tools clip at
+10,000 chars silently. Return facts, not documents; a big result returns a count of what was left
+out. One exec per round; timeout 10s, up to 120 via `{timeout}`. Clip guard for any big return:
+`const s = JSON.stringify(out); return s.length > 4000 ? { truncated: true, total: s.length, head: s.slice(0, 4000) } : out;`
 
 ### Find what to read
 
@@ -150,8 +134,8 @@ lightIndex: Array<{   // RESOURCES, not methods
 getResourceSchemaByUrl(docsUrl)   // full schema; API method pages only
 ```
 
-Inspect, don't discover: arrive with a `docsUrl`, match by it. A resource's methods with
-callable URLs — also the only proof an API does NOT exist:
+The index answers questions about pages you already found — arrive with a `docsUrl`, match by it.
+A resource's methods with callable URLs — also the only proof an API does NOT exist:
 
 ```js
 const r = await fetch("https://mcp.wix.com/api/code-mode/search", {
@@ -173,8 +157,8 @@ round; `$circular` stubs resolve via `s.components.schemas["<name>"]`.
 
 ### Management recipes — check before composing admin flows
 
-~100 curated multi-step recipes (install apps, seed catalogs, set up whole verticals), each with a
-name and description written for searching:
+~100 curated multi-step recipes (install apps, seed catalogs, set up whole verticals) from the
+`wix-manage` skill, each named and described for searching:
 
 ```js
 const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
@@ -186,11 +170,51 @@ return files.filter(f => q.test(f.name + " " + (f.description || "")))
 A recipe is a doc page — fetch + map it like any other. A matching recipe beats composing the flow
 from single endpoints: it carries ordering and cross-step gotchas no method page mentions.
 
-## Write code on the APIs
+## Write the code
 
-### Ad hoc management, from exec
+**Response shapes obey the discover rule in every lane**: code against fields you saw in a live
+response or the schema — remembered names are often from older versions. Probe one real row first.
 
-The admin token is the connector's. Project the response to facts:
+### The visitor client — src/lib/wixClient.js
+
+One file carries the whole visitor path; pages import it. Neither `clientId` (from the context
+report) nor the minted token is a secret — together they are "an anonymous visitor", safe in
+shipped code:
+
+```js
+// src/lib/wixClient.js
+let visitorToken;
+async function mint(body) {
+  const res = await fetch("https://www.wixapis.com/oauth2/token", {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const { access_token, refresh_token } = await res.json();   // expires_in: 14400s = 4h
+  visitorToken = access_token;
+  sessionStorage.setItem("wixRefresh", refresh_token);
+}
+// first visit:                 mint({ clientId: WIX_CLIENT_ID, grantType: "anonymous" });
+// on expiry — same visitor:    mint({ refreshToken: sessionStorage.getItem("wixRefresh"),
+//                                     grantType: "refresh_token" });
+// (a fresh anonymous mint is a NEW visitor — the old one's cart goes with it)
+
+const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, { ...opts,
+  headers: { Authorization: `Bearer ${visitorToken}`, "Content-Type": "application/json" } });
+
+wix("/stores/v3/products/query", { method: "POST", body: JSON.stringify({ query: {} }) });
+//  ↑ public reads included — the visitor token queries catalog directly
+wix("/ecom/v1/carts/current");
+wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
+//  ↑ carts/current/* and checkout act on the CALLER's cart — only the visitor token
+//    reaches the visitor's cart
+```
+
+Token contract: `…/headless/authentication/retrieve-tokens`.
+
+### Admin calls — exec ad hoc, backend functions deployed
+
+The admin token is the connector's; the same call works from exec (probing, managing) and from a
+deployed `base44/functions/*` (work the app does as the owner). Project the response to facts:
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
@@ -203,28 +227,3 @@ if (!r.ok) return { status: r.status, error: (await r.text()).slice(0, 300) };
 const data = await r.json();   // project, don't dump:
 return { count: data.contacts?.length, keys: Object.keys(data.contacts?.[0] || {}) };
 ```
-
-Backend functions are this lane, deployed: same token, same calls. **Response shapes obey the
-discover rule too**: code against fields you saw in a live response or the schema — remembered
-names are often from older versions. Probe one real row first.
-
-### The visitor token — client code
-
-Neither `clientId` nor the minted token is a secret — together they are "an anonymous visitor",
-safe in shipped code:
-
-```js
-// src/lib/wixClient.js — ships with the app
-const res = await fetch("https://www.wixapis.com/oauth2/token", {
-  method: "POST", headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ clientId: WIX_CLIENT_ID, grantType: "anonymous" }),
-});
-const { access_token, refresh_token, expires_in } = await res.json();   // 14400s = 4h
-```
-
-On expiry exchange `refresh_token` (`grantType: "refresh_token"`) — a fresh mint is a NEW visitor
-and the old one's cart goes with it. Contract: `…/headless/authentication/retrieve-tokens`.
-
-## More
-
-Site management: `wix-manage` — `wix.com/skills/wix-manage`.

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -28,169 +28,87 @@ ops a visitor triggers, webhooks, scheduled jobs — and the app's non-Wix backe
 **An admin tool for the owner** — dashboard, back office. The pages act as the owner, whose token
 is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
 
-## Gather context — the dynamic context report
+## The helpers
 
-Every JSON call in this guide shares one shape — this helper opens each exec (execs share no
-state, so redeclare it):
+Research and probing run in exec_tool, and one loader opens every exec (execs share no state —
+reload each round, ~1s):
 
 ```js
-const post = async (url, body, token) => {
-  const r = await fetch(url, { method: "POST", body: JSON.stringify(body),
-    headers: { "Content-Type": "application/json", ...(token && { Authorization: `Bearer ${token}` }) } });
-  if (!r.ok) throw new Error(r.status + " " + (await r.text()).slice(0, 300));
-  return r.json();
-};
+const src = await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/lite.js")).text();
+const wx = (() => { const m = { exports: {} };
+  new Function("module", "exports", src)(m, m.exports); return m.exports; })();
 ```
+
+Every helper is fetch → reduce in memory → return ≤ 4,000 chars (exec results clip at ~5,000);
+nothing touches disk. A big return comes back `{ truncated, total, head }` — narrow the query,
+don't page the blob. Fetch every URL inside exec with `fetch()` — website/browser tools clip at
+10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`. A surprising
+shape? Read the script itself — the functions are thin.
+
+## Gather context — the dynamic context report
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const { markdown } = await post("https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown",
-  {}, accessToken);   // the connector token is site-bound; siteId filter is optional
-// big? extract a section, don't page blind:
-const apps = (markdown.match(/### Apps[\s\S]*?(?=\n### |$)/) || [markdown.slice(0, 3500)])[0];
-return { total: markdown.length, apps: apps.slice(0, 3500) };
+return await wx.context(accessToken, "Apps");   // no section arg → the report's outline
 ```
 
 One report: installed apps **with ids** (incl. Stores' catalog version — V1 vs V3 decides its
 endpoints), the OAuth app id (**also the visitor `clientId`**), locale, currency, CMS collections.
-`markdown: ""` = bad token, never an empty site.
+An empty report = bad token, never an empty site.
 
 ## Learn Wix — find the APIs, learn their contracts
 
-Research runs in exec_tool, and every research call is **fetch → reduce in memory → return
-≤ 4,000 chars** (results clip at ~5,000). Nothing is written to disk; state between rounds =
-re-fetching (~1s). **Fetch every URL inside exec with `fetch()`** — website/browser tools clip at
-10,000 chars silently. Return facts, not documents; a big result returns a count of what was left
-out. One exec per round; timeout 10s, up to 120 via `{timeout}`. Clip guard for any big return:
-`const s = JSON.stringify(out); return s.length > 4000 ? { truncated: true, total: s.length, head: s.slice(0, 4000) } : out;`
+```js
+// know the product? browse is deterministic — menuUrl alone orients (children + counts);
+// filter before listing methods, unfiltered listings clip
+await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
+                { include: ["METHOD"], filter: "resched", depth: 4 });
 
-### Find what to read
+// don't know where it lives? search ranks, never says "no match" — drop wrong-product hits
+await wx.search("pause a pricing plan subscription and resume it");
+// → { hits: [{ method, endpoint /* callable */, docsUrl, gist }] } — hits often ARE the answer
+```
 
-**Know the product? Browse (deterministic).** Orient with counts, then filter — unfiltered
-listings clip:
+Go deeper for fields, enums, or absence — only the spec index proves absence.
+
+### Read a doc page
+
+Method pages are 100 KB+, twin REST and SDK halves repeating field names at different types — map,
+then quote only your half:
 
 ```js
-const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse", {
-  menu_url: "https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
-  include: ["METHOD"], name_filter: "resched", depth: 4,   // orient first: menu_url alone
-});
-return content;   // 404 "No menu node found" ⇒ re-orient a level up
+const map = await wx.page(docsUrl, "refund");   // headers + your term, with line numbers;
+                                                // no term = the outline; omitted > 0 ⇒ narrow
+await wx.window(docsUrl, 120, 160);   // quote header-to-header — the REST example FIRST:
+                                      // under ### Examples below ## REST API sits a complete request
+await wx.fields(docsUrl, 53, 949);    // a giant fenced example → its field vocabulary in one round
 ```
 
-**Don't know where it lives? Search (ranks, never matches).** Each hit is a condensed method
-doc. Reduce per hit, keeping the riches:
+### The spec index
+
+Answers questions about pages you already found — arrive with a `docsUrl`, match by it. Also the
+only proof an API does NOT exist:
 
 ```js
-const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
-  { search_term: "pause a pricing plan subscription and resume it",
-    document_type: "REST",   // or SDK | WIX_HEADLESS | VELO | CLI
-    maximum_results: 5, lines_in_each_result: 6 });
-const hits = content.split(/\n---\n+(?=#### )/).map(b => ({
-  method:   (b.match(/^# Method: (.+)$/m) || [])[1],
-  endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // callable
-  docsUrl:  (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
-  gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "").trim().replace(/\s+/g, " ").slice(0, 220),
-})).filter(h => h.docsUrl);
-return { total: content.length, hits };   // hits often ARE the answer
+await wx.spec(`
+  const r = lightIndex.find(x => x.docsUrl === "<docsUrl from browse/search>");
+  return r.methods.map(m => ({ op: m.operationId.split(".").pop(), verb: m.httpMethod,
+                               call: m.publicUrl }));   // publicUrl is callable — path is PARTIAL
+`);
+// request fields next round: getResourceSchemaByUrl(docsUrl) →
+//   m.requestBody.content["application/json"].schema.properties — names and types, drill deeper
+//   per round; $circular stubs resolve via s.components.schemas["<name>"]
 ```
-
-Go deeper for fields, enums, or absence — only the spec index proves absence. Drop
-wrong-product hits.
-
-### Read a doc page — fetch + map in one exec
-
-Always append **`.md`** (without it: a multi-MB HTML shell). Method pages are 100 KB+, twin REST
-and SDK halves repeating field names at different types — never return the page, map it:
-
-```js
-const url = "https://dev.wix.com/docs/…/cancel-booking";   // from browse/search output
-const res = await fetch(url.replace(/\.md$/, "") + ".md");
-if (!res.ok) return { status: res.status, hint: "not a docs page — take URLs from output, don't compose" };
-const lines = (await res.text()).split("\n");
-const hits = [];
-lines.forEach((text, i) => {
-  if (/^#{1,3} /.test(text) || /refund/i.test(text))   // headers always; term of interest
-    hits.push({ line: i + 1, text: text.trim().slice(0, 100) });
-});
-return { lines: lines.length, shown: Math.min(hits.length, 40),
-         omitted: Math.max(0, hits.length - 40), hits: hits.slice(0, 40) };
-```
-
-`omitted > 0` ⇒ narrow, map again. Headers say which `##` half each hit is in — quote only yours.
-No term = the outline; header-to-header = section windows.
-
-**Window the REST example FIRST** — under `### Examples` below `## REST API` sits a complete
-working request (URL, headers, body): usually all you need. Window it with the same
-fetch, sliced to the map's line numbers: `lines.slice(a, b).map((t, i) => (a + 1 + i) + ": " + t.slice(0, 110)).join("\n")`.
-
-### The spec index — endpoints, exact schemas
-
-`POST https://mcp.wix.com/api/code-mode/search` with `{ code: "async function(){…}" }` → `{ result }`.
-In scope:
-
-```typescript
-lightIndex: Array<{   // RESOURCES, not methods
-  name; docsUrl; menuPath: string[]
-  methods: Array<{ operationId,   // fully qualified — never filter by resource name on it
-    summary, httpMethod,
-    path,        // PARTIAL — never call it
-    publicUrl,   // the callable https://www.wixapis.com/… URL — call THIS
-    docsUrl }> }>
-getResourceSchemaByUrl(docsUrl)   // full schema; API method pages only
-```
-
-The index answers questions about pages you already found — arrive with a `docsUrl`, match by it.
-A resource's methods with callable URLs — also the only proof an API does NOT exist:
-
-```js
-const { result } = await post("https://mcp.wix.com/api/code-mode/search", { code: `async function(){
-  const r = lightIndex.find(x => x.docsUrl ===
-    "https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/contacts-v5");
-  return r.methods.filter(m => /query/i.test(m.summary))
-                  .map(m => ({ op: m.operationId.split(".").pop(),
-                               verb: m.httpMethod, call: m.publicUrl }));
-}` });
-return result;
-```
-
-Request fields: same wrapper, `getResourceSchemaByUrl(methodDocsUrl)` → schema at
-`m.requestBody.content["application/json"].schema.properties` — names and types only, drill next
-round; `$circular` stubs resolve via `s.components.schemas["<name>"]`.
 
 ### Management recipes — check before composing admin flows
 
-~100 curated multi-step recipes (install apps, seed catalogs, set up whole verticals) from the
-`wix-manage` skill. Drill in three steps — categories, a category's recipes, one recipe:
+~100 curated multi-step recipes (install apps, seed catalogs, set up whole verticals):
 
 ```js
-// 1. what categories exist
-const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
-const cats = {};
-for (const f of files) { const m = f.path.match(/^references\/([^/]+)\//); if (m) cats[m[1]] = (cats[m[1]] || 0) + 1; }
-return cats;   // { stores: 9, bookings: 13, ecommerce: 24, cms: 7, "app-installation": 3, … }
-```
-
-```js
-// 2. one category's recipes — names and descriptions are written for choosing
-return files.filter(f => f.path.startsWith("references/stores/"))
-            .map(f => ({ name: f.name, gist: (f.description || "").slice(0, 120), url: base + f.path, kb: Math.round(f.size / 1024) }));
-```
-
-```js
-// 3. read the chosen recipe — whole when small, outline first when big
-const text = await (await fetch(url)).text();   // url from step 2
-if (text.length <= 4000) return text;
-const lines = text.split("\n");
-return { total: text.length, outline: lines.map((t, i) => /^#{1,3} /.test(t)
-  ? { line: i + 1, text: t.slice(0, 80) } : null).filter(Boolean) };
-```
-
-```js
-// 4. a big section is usually ONE fenced example (bulk-create's STEP 1: 897 lines, one fence) —
-//    reduce it to its shape, window verbatim only where exact values matter
-const sec = lines.slice(from - 1, to);   // bounds: this header's line → the next header's
-const fields = [...new Set(sec.join("\n").match(/"([a-zA-Z][a-zA-Z0-9]*)":/g) || [])].map(s => s.slice(1, -2));
-return { sectionLines: sec.length, fields };   // the request vocabulary in one round
+await wx.recipes();           // categories with counts
+await wx.recipes("stores");   // a category's list — or any task word: wx.recipes("coupon")
+await wx.recipe(url);         // whole when small; { total, outline } when big —
+                              // then wx.window / wx.fields by the outline's line numbers
 ```
 
 A matching recipe beats composing the flow from single endpoints: it carries ordering and
@@ -203,15 +121,15 @@ response or the schema — remembered names are often from older versions. Probe
 
 ### Admin calls — exec ad hoc, backend functions deployed
 
-The admin token is the connector's; the same call works from exec (probing, managing) and from a
-deployed `base44/functions/*` (work the app does as the owner). Project the response to facts:
-
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
-const data = await post("https://www.wixapis.com/contacts/v5/contacts/query",   // spec-index publicUrl
+const data = await wx.post("https://www.wixapis.com/contacts/v5/contacts/query",   // spec-index publicUrl
   { query: { cursorPaging: { limit: 10 } } }, accessToken);
 return { count: data.contacts?.length, keys: Object.keys(data.contacts?.[0] || {}) };   // project, don't dump
 ```
+
+The same call deploys as `base44/functions/*` (work the app does as the owner) — shipped code
+carries its own four-line fetch; the helpers are a build tool, not a runtime dependency.
 
 ### A visitor client — src/lib/wixClient.js
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -14,43 +14,38 @@ Clip guard: `const s = JSON.stringify(out); return s.length > 4000 ? { truncated
 
 ## What are you building?
 
-The app's audience picks its architecture, because it picks the token — and the two tokens have
-opposite rules: the **visitor token is public** (mintable by anyone from the site's `clientId`),
-the **admin token is a secret** (the connector's; never ships to a browser).
+The app's audience picks the token, and the token picks the architecture: the **visitor token is
+public** — anyone can mint it from the site's `clientId` — and the **admin token is a secret**,
+the connector's, server-side only.
 
-**A site for visitors** — storefront, blog, booking page. Headless means the Wix site has no
-pages of its own: your app IS its frontend, and it calls Wix like any frontend calls its backend —
-from the browser, on the visitor token:
+```
+browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
+base44/functions/* ──(admin token)───► wixapis.com   work that needs the owner's identity
+exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
+```
+
+**A site for visitors** — storefront, blog, booking. Headless means the Wix site has no pages of
+its own: your app IS its frontend, and it calls Wix from the browser. Every call the visitor
+token can make lives in the client:
 
 ```js
-// src/lib/wixClient.js — the ENTIRE visitor path lives here; pages import it
+// src/lib/wixClient.js — the visitor path; pages import it
 const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, { ...opts,
   headers: { Authorization: `Bearer ${visitorToken}`, "Content-Type": "application/json" } });
 
 wix("/stores/v3/products/query", { method: "POST", body: JSON.stringify({ query: {} }) });
-//  ↑ public reads too — the visitor token queries catalog directly; no "admin read" backend fn
+//  ↑ public reads included — the visitor token queries catalog directly
 wix("/ecom/v1/carts/current");
 wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
-//  ↑ carts/current/* and checkout are CALLER-BOUND: on the admin token they act on the
-//    ADMIN's cart — a checkout proxied through a backend function comes up empty
+//  ↑ carts/current/* and checkout act on the CALLER's cart — only the visitor token
+//    reaches the visitor's cart
 ```
 
-The rule is not "no backend functions" — it is: **a call the visitor token can make belongs in
-the client.** A visitor site still has `base44/functions/*` for its non-Wix backend, and for Wix
-ops that genuinely need the ADMIN identity — elevated-permission work a visitor may *trigger* but
-must never hold the token for — plus the app's own owner-side work (webhooks, scheduled jobs).
+`base44/functions/*` hold the work that needs the owner's identity — elevated-permission ops a
+visitor triggers, webhooks, scheduled jobs — and the app's non-Wix backend.
 
-**An admin tool for the owner** — dashboard, back office, ops. Now the pages act *as the owner*,
-and the owner's token is a secret — so the shape inverts, correctly:
-`pages → base44/functions/* ──(admin token)──► wixapis.com`.
-
-The three lanes, whatever you build:
-
-```
-browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
-base44/functions/* ──(admin token)───► wixapis.com   ops that truly need the owner's identity
-exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
-```
+**An admin tool for the owner** — dashboard, back office. The pages act as the owner, whose token
+is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
 
 ## Gather context
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -19,9 +19,11 @@ exec_tool          ──(admin token)───► wixapis.com   you: ad hoc pro
 
 **A site for visitors** — storefront, blog, booking. Headless means the Wix site has no pages of
 its own: your app IS its frontend, and it calls Wix from the browser. Every call the visitor token
-can make lives in the client — one file, `src/lib/wixClient.js` (Write the code, below).
-`base44/functions/*` hold the work that needs the owner's identity — elevated-permission ops a
-visitor triggers, webhooks, scheduled jobs — and the app's non-Wix backend.
+can make lives in the client — public reads included (the visitor token queries the catalog
+directly), and `carts/current/*` + checkout act on the CALLER's cart, so only the visitor token
+reaches the visitor's cart. One file carries this path: `src/lib/wixClient.js` (Write the code,
+below). `base44/functions/*` hold the work that needs the owner's identity — elevated-permission
+ops a visitor triggers, webhooks, scheduled jobs — and the app's non-Wix backend.
 
 **An admin tool for the owner** — dashboard, back office. The pages act as the owner, whose token
 is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
@@ -199,42 +201,6 @@ cross-step gotchas no method page mentions.
 **Response shapes obey the discover rule in every lane**: code against fields you saw in a live
 response or the schema — remembered names are often from older versions. Probe one real row first.
 
-### The visitor client — src/lib/wixClient.js
-
-One file carries the whole visitor path; pages import it. Neither `clientId` (from the context
-report) nor the minted token is a secret — together they are "an anonymous visitor", safe in
-shipped code:
-
-```js
-// src/lib/wixClient.js
-let visitorToken;
-async function mint(body) {
-  const res = await fetch("https://www.wixapis.com/oauth2/token", {
-    method: "POST", headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  const { access_token, refresh_token } = await res.json();   // expires_in: 14400s = 4h
-  visitorToken = access_token;
-  sessionStorage.setItem("wixRefresh", refresh_token);
-}
-// first visit:                 mint({ clientId: WIX_CLIENT_ID, grantType: "anonymous" });
-// on expiry — same visitor:    mint({ refreshToken: sessionStorage.getItem("wixRefresh"),
-//                                     grantType: "refresh_token" });
-// (a fresh anonymous mint is a NEW visitor — the old one's cart goes with it)
-
-const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, { ...opts,
-  headers: { Authorization: `Bearer ${visitorToken}`, "Content-Type": "application/json" } });
-
-wix("/stores/v3/products/query", { method: "POST", body: JSON.stringify({ query: {} }) });
-//  ↑ public reads included — the visitor token queries catalog directly
-wix("/ecom/v1/carts/current");
-wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
-//  ↑ carts/current/* and checkout act on the CALLER's cart — only the visitor token
-//    reaches the visitor's cart
-```
-
-Token contract: `…/headless/authentication/retrieve-tokens`.
-
 ### Admin calls — exec ad hoc, backend functions deployed
 
 The admin token is the connector's; the same call works from exec (probing, managing) and from a
@@ -251,3 +217,26 @@ if (!r.ok) return { status: r.status, error: (await r.text()).slice(0, 300) };
 const data = await r.json();   // project, don't dump:
 return { count: data.contacts?.length, keys: Object.keys(data.contacts?.[0] || {}) };
 ```
+
+### A visitor client — src/lib/wixClient.js
+
+The "site for visitors" shape (What are you building?), in code — one file pages import. Neither
+`clientId` (from the context report) nor the minted token is a secret; together they are "an
+anonymous visitor", safe in shipped code:
+
+```js
+// src/lib/wixClient.js
+let token;
+const mint = async (body) => {
+  const r = await (await fetch("https://www.wixapis.com/oauth2/token", { method: "POST",
+    headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) })).json();
+  token = r.access_token; sessionStorage.setItem("wixRefresh", r.refresh_token);   // expires_in: 14400s = 4h
+};
+// first visit:  mint({ clientId: WIX_CLIENT_ID, grantType: "anonymous" });
+// on expiry:    mint({ refreshToken: sessionStorage.getItem("wixRefresh"), grantType: "refresh_token" });
+//               a fresh anonymous mint is a NEW visitor — the old one's cart goes with it
+export const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, { ...opts,
+  headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } });
+```
+
+Token contract: `…/headless/authentication/retrieve-tokens`.

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -49,7 +49,7 @@ is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.
 
 ## Gather context
 
-### What IS this site — one call answers it
+### The dynamic context report
 
 ```js
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
@@ -108,7 +108,7 @@ return { total: content.length, hits };   // hits often ARE the answer
 Go deeper for fields, enums, or absence — only the spec index proves absence. Drop
 wrong-product hits.
 
-### Read a doc page — fetch + map in ONE call
+### Read a doc page — fetch + map in one exec
 
 Always append **`.md`** (without it: a multi-MB HTML shell). Method pages are 100 KB+, twin REST
 and SDK halves repeating field names at different types — never return the page, map it:

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -12,20 +12,15 @@ big result returns a count of what was left out. One exec per round; timeout 10s
 
 Clip guard: `const s = JSON.stringify(out); return s.length > 4000 ? { truncated: true, total: s.length, head: s.slice(0, 4000) } : out;`
 
-## Who calls Wix
+## What are you building?
 
-```
-end user's browser ──(visitor token)─► wixapis.com   the app, at runtime
-exec_tool          ──(admin token)───► wixapis.com   you: probing/managing while building
-backend function   ──(admin token)───► wixapis.com   admin work the app does at runtime
-```
+The app's audience picks its architecture, because it picks the token — and the two tokens have
+opposite rules: the **visitor token is public** (mintable by anyone from the site's `clientId`),
+the **admin token is a secret** (the connector's; never ships to a browser).
 
-Headless means the Wix site has no pages of its own — **your app IS its frontend**, and a
-frontend calls its backend from the browser. Tokens: visitor minted in client code; admin via
-`getConnection("wix")`.
-
-The visitor-facing shape, as files (`base44/functions/*` carry only owner-side work — for a
-management dashboard, that's most of the app):
+**A site for visitors** — storefront, blog, booking page. Headless means the Wix site has no
+pages of its own: your app IS its frontend, and it calls Wix like any frontend calls its backend —
+from the browser, on the visitor token:
 
 ```js
 // src/lib/wixClient.js — the ENTIRE visitor path lives here; pages import it
@@ -39,6 +34,16 @@ wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
 //  ↑ carts/current/* and checkout are CALLER-BOUND: on the admin token they act on the
 //    ADMIN's cart — a checkout proxied through a backend function comes up empty
 ```
+
+Zero `base44/functions/*` on this path — they exist here only for work the app does on its own
+as the site's owner (webhooks, scheduled jobs).
+
+**An admin tool for the owner** — dashboard, back office, ops. Now the pages act *as the owner*,
+and the owner's token is a secret — so the shape inverts, correctly:
+`pages → base44/functions/* ──(admin token)──► wixapis.com`.
+
+**Either way, you, while building**: probe and manage ad hoc from `exec_tool` on the admin token
+(next section).
 
 ## Gather context
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -24,11 +24,21 @@ Headless means the Wix site has no pages of its own — **your app IS its fronte
 frontend calls its backend from the browser. Tokens: visitor minted in client code; admin via
 `getConnection("wix")`.
 
-Litmus, in file paths: a visitor-facing site is `src/lib/wixClient.js` (mint + call helpers) and
-pages that call it — **zero `base44/functions/*` on the visitor path**; those carry only what the
-app does *as the site's owner* (for a management dashboard, that's most of the app). Writing a
-backend function a page calls to reach Wix? If the page serves visitors, that call belongs in the
-browser.
+The visitor-facing shape, as files (`base44/functions/*` carry only owner-side work — for a
+management dashboard, that's most of the app):
+
+```js
+// src/lib/wixClient.js — the ENTIRE visitor path lives here; pages import it
+const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, { ...opts,
+  headers: { Authorization: `Bearer ${visitorToken}`, "Content-Type": "application/json" } });
+
+wix("/stores/v3/products/query", { method: "POST", body: JSON.stringify({ query: {} }) });
+//  ↑ public reads too — the visitor token queries catalog directly; no "admin read" backend fn
+wix("/ecom/v1/carts/current");
+wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
+//  ↑ carts/current/* and checkout are CALLER-BOUND: on the admin token they act on the
+//    ADMIN's cart — a checkout proxied through a backend function comes up empty
+```
 
 ## Gather context
 
@@ -153,6 +163,21 @@ return (await r.json()).result;
 Request fields: same wrapper, `getResourceSchemaByUrl(methodDocsUrl)` → schema at
 `m.requestBody.content["application/json"].schema.properties` — names and types only, drill next
 round; `$circular` stubs resolve via `s.components.schemas["<name>"]`.
+
+### Management recipes — check before composing admin flows
+
+~100 curated multi-step recipes (install apps, seed catalogs, set up whole verticals), each with a
+name and description written for searching:
+
+```js
+const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
+const q = /install|app/i;   // your task's words
+return files.filter(f => q.test(f.name + " " + (f.description || "")))
+            .map(f => ({ name: f.name, url: base + f.path, kb: Math.round(f.size / 1024) }));
+```
+
+A recipe is a doc page — fetch + map it like any other. A matching recipe beats composing the flow
+from single endpoints: it carries ordering and cross-step gotchas no method page mentions.
 
 ## Write code on the APIs
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -1,7 +1,7 @@
 # Building on Wix from Base44
 
 The Wix connector is connected; this is how the app gets built on it — gather the site's context,
-learn the APIs from the docs, write the code. **Discover everything**: endpoints, paths, doc URLs,
+find the APIs and learn their contracts from the docs, write the code. **Discover everything**: endpoints, paths, doc URLs,
 request and response fields all come from the calls below, never from memory or pattern. 404 or
 empty ⇒ discover, not permute. Examples teach mechanics and go stale — verify before relying.
 
@@ -44,7 +44,7 @@ One report: installed apps **with ids** (incl. Stores' catalog version — V1 vs
 endpoints), the OAuth app id (**also the visitor `clientId`**), locale, currency, CMS collections.
 `markdown: ""` = bad token, never an empty site.
 
-## Learn Wix — discover APIs in the docs
+## Learn Wix — find the APIs, learn their contracts
 
 Research runs in exec_tool, and every research call is **fetch → reduce in memory → return
 ≤ 4,000 chars** (results clip at ~5,000). Nothing is written to disk; state between rounds =
@@ -158,17 +158,34 @@ round; `$circular` stubs resolve via `s.components.schemas["<name>"]`.
 ### Management recipes — check before composing admin flows
 
 ~100 curated multi-step recipes (install apps, seed catalogs, set up whole verticals) from the
-`wix-manage` skill, each named and described for searching:
+`wix-manage` skill. Drill in three steps — categories, a category's recipes, one recipe:
 
 ```js
+// 1. what categories exist
 const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
-const q = /install|app/i;   // your task's words
-return files.filter(f => q.test(f.name + " " + (f.description || "")))
-            .map(f => ({ name: f.name, url: base + f.path, kb: Math.round(f.size / 1024) }));
+const cats = {};
+for (const f of files) { const m = f.path.match(/^references\/([^/]+)\//); if (m) cats[m[1]] = (cats[m[1]] || 0) + 1; }
+return cats;   // { stores: 9, bookings: 13, ecommerce: 24, cms: 7, "app-installation": 3, … }
 ```
 
-A recipe is a doc page — fetch + map it like any other. A matching recipe beats composing the flow
-from single endpoints: it carries ordering and cross-step gotchas no method page mentions.
+```js
+// 2. one category's recipes — names and descriptions are written for choosing
+return files.filter(f => f.path.startsWith("references/stores/"))
+            .map(f => ({ name: f.name, gist: (f.description || "").slice(0, 120), url: base + f.path, kb: Math.round(f.size / 1024) }));
+```
+
+```js
+// 3. read the chosen recipe — whole when small, outline first when big
+const text = await (await fetch(url)).text();   // url from step 2
+if (text.length <= 4000) return text;
+const lines = text.split("\n");
+return { total: text.length, outline: lines.map((t, i) => /^#{1,3} /.test(t)
+  ? { line: i + 1, text: t.slice(0, 80) } : null).filter(Boolean) };
+// recipes are structured (Overview → Prerequisites → Steps) — window sections like any doc page
+```
+
+A matching recipe beats composing the flow from single endpoints: it carries ordering and
+cross-step gotchas no method page mentions.
 
 ## Write the code
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -35,15 +35,22 @@ wix("/ecom/v1/carts/current/create-checkout", { method: "POST", body: "{}" });
 //    ADMIN's cart — a checkout proxied through a backend function comes up empty
 ```
 
-Zero `base44/functions/*` on this path — they exist here only for work the app does on its own
-as the site's owner (webhooks, scheduled jobs).
+The rule is not "no backend functions" — it is: **a call the visitor token can make belongs in
+the client.** A visitor site still has `base44/functions/*` for its non-Wix backend, and for Wix
+ops that genuinely need the ADMIN identity — elevated-permission work a visitor may *trigger* but
+must never hold the token for — plus the app's own owner-side work (webhooks, scheduled jobs).
 
 **An admin tool for the owner** — dashboard, back office, ops. Now the pages act *as the owner*,
 and the owner's token is a secret — so the shape inverts, correctly:
 `pages → base44/functions/* ──(admin token)──► wixapis.com`.
 
-**Either way, you, while building**: probe and manage ad hoc from `exec_tool` on the admin token
-(next section).
+The three lanes, whatever you build:
+
+```
+browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
+base44/functions/* ──(admin token)───► wixapis.com   ops that truly need the owner's identity
+exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
+```
 
 ## Gather context
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-light.md
@@ -181,7 +181,14 @@ if (text.length <= 4000) return text;
 const lines = text.split("\n");
 return { total: text.length, outline: lines.map((t, i) => /^#{1,3} /.test(t)
   ? { line: i + 1, text: t.slice(0, 80) } : null).filter(Boolean) };
-// recipes are structured (Overview → Prerequisites → Steps) — window sections like any doc page
+```
+
+```js
+// 4. a big section is usually ONE fenced example (bulk-create's STEP 1: 897 lines, one fence) —
+//    reduce it to its shape, window verbatim only where exact values matter
+const sec = lines.slice(from - 1, to);   // bounds: this header's line → the next header's
+const fields = [...new Set(sec.join("\n").match(/"([a-zA-Z][a-zA-Z0-9]*)":/g) || [])].map(s => s.slice(1, -2));
+return { sectionLines: sec.length, fields };   // the request vocabulary in one round
 ```
 
 A matching recipe beats composing the flow from single endpoints: it carries ordering and

--- a/skills/wix-docs-base44/scripts/lite.js
+++ b/skills/wix-docs-base44/scripts/lite.js
@@ -1,0 +1,145 @@
+// Wix docs helpers for the Base44 sandbox — the zero-disk set, matching the
+// "Building on Wix from Base44" guide: every helper is fetch → reduce in memory →
+// return ≤ 4,000 chars (exec results clip at ~5,000). Nothing touches disk; state
+// between rounds = re-fetching (~1s). Oversized returns come back as
+// { truncated, total, head } — narrow and re-run.
+//
+// Load per exec (execs share no state) — needs only global fetch, no require:
+//   const src = await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/lite.js")).text();
+//   const wx = (() => { const m = { exports: {} };
+//     new Function("module", "exports", src)(m, m.exports); return m.exports; })();
+//
+//   return await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
+//                          { filter: "resched", include: ["METHOD"], depth: 4 });
+//
+// If a response shape surprises you, read this file and hand-roll the call — the
+// functions are thin. Never guess an API from memory.
+
+const BUDGET = 4000;
+
+// Cap any return; { truncated } means narrow the query, not page the blob.
+function clip(out) {
+  const s = typeof out === "string" ? out : JSON.stringify(out);
+  return s.length <= BUDGET ? out : { truncated: true, total: s.length, head: s.slice(0, BUDGET) };
+}
+
+// One transport for every JSON call — Content-Type, optional Bearer, ok-guard.
+// Admin calls are this with the connector token: post(publicUrl, body, accessToken).
+async function post(url, body, token) {
+  const r = await fetch(url, { method: "POST", body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", ...(token && { Authorization: `Bearer ${token}` }) } });
+  if (!r.ok) throw new Error(r.status + " " + (await r.text()).slice(0, 300));
+  return r.json();
+}
+
+// ── gather context ────────────────────────────────────────────────────────────
+
+// The dynamic context report. No section → its header outline; with one → that
+// section's text. `markdown: ""` = bad token, never an empty site.
+async function context(token, section) {
+  const { markdown } = await post(
+    "https://www.wixapis.com/_api/dynamic-context/v1/dynamic-context/markdown", {}, token);
+  if (!section) {
+    const sections = markdown.split("\n")
+      .map((t, i) => (/^#{1,3} /.test(t) ? { line: i + 1, text: t.slice(0, 80) } : null))
+      .filter(Boolean);
+    return clip({ total: markdown.length, sections });
+  }
+  const m = markdown.match(new RegExp("^#{1,3} .*" + section + "[\\s\\S]*?(?=\\n#{1,3} |$)", "im"));
+  return clip({ total: markdown.length, section: m ? m[0] : "not found — call context(token) for the outline" });
+}
+
+// ── find what to read ─────────────────────────────────────────────────────────
+
+// Browse the docs tree — deterministic. menuUrl alone orients (children + counts);
+// filter before listing methods, unfiltered listings clip.
+async function browse(menuUrl, { include, filter, depth } = {}) {
+  const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/menu/browse", {
+    menu_url: menuUrl, ...(include && { include }),
+    ...(filter && { name_filter: filter }), ...(depth && { depth }),
+  });   // 404 "No menu node found" ⇒ re-orient a level up
+  return clip(content);
+}
+
+// Semantic search — ranks, never says "no match". Each hit reduced to the riches;
+// hits often ARE the answer. type: REST | SDK | WIX_HEADLESS | VELO | CLI.
+async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
+  const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
+    { search_term: term, document_type: type, maximum_results: max, lines_in_each_result: lines });
+  const hits = content.split(/\n---\n+(?=#### )/).map(b => ({
+    method:   (b.match(/^# Method: (.+)$/m) || [])[1],
+    endpoint: (b.match(/^# Method API Endpoint: (.+)$/m) || [])[1],   // callable
+    docsUrl:  (b.match(/#### \[[^\]]+\]\((https:[^)]+)\)/) || [])[1],
+    gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "")
+      .trim().replace(/\s+/g, " ").slice(0, 220),
+  })).filter(h => h.docsUrl);
+  return clip({ total: content.length, hits });
+}
+
+// ── read a doc page ───────────────────────────────────────────────────────────
+
+// Map a page (docs pages AND recipes): headers always, plus lines matching `term`.
+// No term = the outline; header-to-header = window bounds. omitted > 0 ⇒ narrow.
+async function page(url, term) {
+  const res = await fetch(url.replace(/\.md$/, "") + ".md");
+  if (!res.ok) return { status: res.status, hint: "not a docs page — take URLs from output, don't compose" };
+  const all = (await res.text()).split("\n");
+  const re = term && new RegExp(term, "i");
+  const hits = [];
+  all.forEach((text, i) => {
+    if (/^#{1,3} /.test(text) || (re && re.test(text)))
+      hits.push({ line: i + 1, text: text.trim().slice(0, 100) });
+  });
+  return { lines: all.length, shown: Math.min(hits.length, 40),
+           omitted: Math.max(0, hits.length - 40), hits: hits.slice(0, 40) };
+}
+
+// Quote a section verbatim by the map's line numbers (REST examples live under
+// ### Examples below ## REST API — usually all you need).
+async function window(url, from, to) {
+  const all = (await (await fetch(url.replace(/\.md$/, "") + ".md")).text()).split("\n");
+  return clip(all.slice(from - 1, to).map((t, i) => (from + i) + ": " + t.slice(0, 110)).join("\n"));
+}
+
+// A big section is usually ONE fenced example — reduce it to its field vocabulary
+// instead of paging it; window() only where exact values matter.
+async function fields(url, from, to) {
+  const all = (await (await fetch(url.replace(/\.md$/, "") + ".md")).text()).split("\n");
+  const sec = all.slice(from - 1, to).join("\n");
+  const names = [...new Set(sec.match(/"([a-zA-Z][a-zA-Z0-9]*)":/g) || [])].map(s => s.slice(1, -2));
+  return clip({ sectionLines: to - from + 1, fields: names });
+}
+
+// ── the spec index ────────────────────────────────────────────────────────────
+
+// Run a query over the API spec index. In scope: lightIndex (RESOURCES with
+// .methods — operationId, summary, httpMethod, path [PARTIAL — never call it],
+// publicUrl [callable], docsUrl) and getResourceSchemaByUrl(docsUrl). Arrive with
+// a docsUrl and match by it — also the only proof an API does NOT exist.
+async function spec(code) {
+  if (!/^\s*async function/.test(code)) code = `async function(){ ${code} }`;
+  const { result } = await post("https://mcp.wix.com/api/code-mode/search", { code });
+  return clip(result);
+}
+
+// ── management recipes ────────────────────────────────────────────────────────
+
+// ~100 curated multi-step admin flows. No arg → categories with counts; with one →
+// that category's recipes (names and gists are written for choosing). Read the
+// chosen url with page(url) / window(url, a, b) / fields(url, a, b).
+async function recipes(cat) {
+  const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
+  if (!cat) {
+    const cats = {};
+    for (const f of files) {
+      const m = f.path.match(/^references\/([^/]+)\//);
+      if (m) cats[m[1]] = (cats[m[1]] || 0) + 1;
+    }
+    return cats;
+  }
+  return clip(files.filter(f => f.path.startsWith(`references/${cat}/`))
+    .map(f => ({ name: f.name, gist: (f.description || "").slice(0, 120),
+                 url: base + f.path, kb: Math.round(f.size / 1024) })));
+}
+
+module.exports = { post, clip, context, browse, search, page, window, fields, spec, recipes };

--- a/skills/wix-docs-base44/scripts/lite.js
+++ b/skills/wix-docs-base44/scripts/lite.js
@@ -124,22 +124,35 @@ async function spec(code) {
 
 // ── management recipes ────────────────────────────────────────────────────────
 
-// ~100 curated multi-step admin flows. No arg → categories with counts; with one →
-// that category's recipes (names and gists are written for choosing). Read the
-// chosen url with page(url) / window(url, a, b) / fields(url, a, b).
-async function recipes(cat) {
+// ~100 curated multi-step admin flows. No arg → categories with counts; a category
+// name → its recipes; any other term → search every recipe's name + gist for it
+// (names and gists are written for choosing).
+async function recipes(q) {
   const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
-  if (!cat) {
+  const cat = f => (f.path.match(/^references\/([^/]+)\//) || [])[1];
+  const row = f => ({ name: f.name, cat: cat(f), gist: (f.description || "").slice(0, 120),
+                      url: base + f.path, kb: Math.round(f.size / 1024) });
+  if (!q) {
     const cats = {};
-    for (const f of files) {
-      const m = f.path.match(/^references\/([^/]+)\//);
-      if (m) cats[m[1]] = (cats[m[1]] || 0) + 1;
-    }
+    for (const f of files) { const c = cat(f); if (c) cats[c] = (cats[c] || 0) + 1; }
     return cats;
   }
-  return clip(files.filter(f => f.path.startsWith(`references/${cat}/`))
-    .map(f => ({ name: f.name, gist: (f.description || "").slice(0, 120),
-                 url: base + f.path, kb: Math.round(f.size / 1024) })));
+  const inCat = files.filter(f => cat(f) === q);
+  if (inCat.length) return clip(inCat.map(row));
+  const re = new RegExp(q, "i");
+  return clip(files.filter(f => re.test(f.name + " " + (f.description || ""))).map(row));
 }
 
-module.exports = { post, clip, context, browse, search, page, window, fields, spec, recipes };
+// Read a chosen recipe — whole when small, outline first when big; then quote or
+// reduce sections by the outline's line numbers with window(url, a, b) /
+// fields(url, a, b). A matching recipe beats composing the flow from single
+// endpoints: it carries ordering and cross-step gotchas no method page mentions.
+async function recipe(url) {
+  const text = await (await fetch(url)).text();
+  if (text.length <= BUDGET) return text;
+  const outline = text.split("\n").map((t, i) => /^#{1,3} /.test(t)
+    ? { line: i + 1, text: t.slice(0, 80) } : null).filter(Boolean);
+  return clip({ total: text.length, outline });
+}
+
+module.exports = { post, clip, context, browse, search, page, window, fields, spec, recipes, recipe };


### PR DESCRIPTION
## What

Two pieces that ship together:

**`scripts/lite.js`** — a zero-disk helper module for the Base44 sandbox, loadable straight off this registry with fetch + eval (no install, no `require`, no `fs`):

```js
const src = await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/lite.js")).text();
const wx = (() => { const m = { exports: {} };
  new Function("module", "exports", src)(m, m.exports); return m.exports; })();
```

Eleven helpers named for the guide's sections — `post`/`clip` (transport + return cap), `context` (dynamic-context report: outline or one section), `browse`/`search` (find what to read), `page`/`window`/`fields` (map a page, quote a section, reduce a giant fenced example to its field vocabulary — doc pages and recipes alike), `spec` (spec-index queries, wraps bare bodies), `recipes`/`recipe` (categories → category list → term search → whole-when-small/outline-when-big).

**The light guide rewritten around it** — doctrine stays in prose (What are you building?, token secrecy, the discover rule, response shapes, the visitor client); the mechanics sections collapse to the 3-line loader + one-liner catalog. 12,235 → **7,753 chars**: back under the 10,000-char fetch_website wire on every route including the worst injected header.

## Why fetch+eval works

Sandbox diagnostic run `6a857c85`: exec fetched `scripts/docs.js` off this registry (served raw, byte-identical, `text/javascript`), eval'd it, and ran live helpers — all steps verified in the real environment, no truncation.

## Verification

Every helper exercised live except `context` (needs a connector token; endpoint + reduction proven in builder runs): browse orients (1,793 chars at root) and filters; search reduces 6–7K raw to ~800; `page` maps a 458-line doc to 33 hits; `fields` reduces bulk-create's 897-line example to 44 field names; `recipes("coupon")` finds cross-category term hits; the clip guard fires on a 33.5 KB unfiltered listing.

Raw payloads behind the helpers (why the reductions are load-bearing): doc pages ~52 KB, recipes manifest 52 KB, big recipes 43 KB, unfiltered listings 33 KB, searches 6–7K — all past the ~5K exec result cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)