### PR TITLE
feat(wix-docs-base44): disk.js — native-shaped returns, runnable hints, self-answering dead ends

### DIFF
--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
@@ -44,8 +44,9 @@ under `.agents/skills/wix-docs-base44/scratch/` and returns `{ path, bytes, line
 the outline is the map. Read a saved file with `wx.grep(ref, /term/)` (numbered hits),
 `wx.window(ref, a, b)` (verbatim lines), `wx.fields(ref, a, b)` (a fenced example's field
 vocabulary) — `ref` is the returned path or the original URL. The shell reads the paths too
-(`grep -n 'term' <path>` · `sed -n 'a,bp' <path>` — GNU grep/sed installed, awk is mawk, no rg),
-and read_file takes them with a 45K cap. **API responses are site data and never land in
+(`grep -n 'term' <path>` · `sed -n 'a,bp' <path>` · across everything saved so far:
+`grep -rn 'term' .agents/skills/wix-docs-base44/scratch/` — GNU grep/sed installed, awk is mawk,
+no rg), and read_file takes them with a 45K cap. **API responses are site data and never land in
 scratch** — project them to facts. Fetch every URL inside exec with `fetch()` — website/browser
 tools clip at 10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
@@ -43,10 +43,10 @@ Results ≤ 4,000 chars come back inline (exec results clip at ~5,000); anything
 under `.agents/skills/wix-docs-base44/scratch/` and returns `{ path, bytes, lines, outline }` —
 the outline is the map. Read a saved file with `wx.grep(ref, /term/)` (numbered hits),
 `wx.window(ref, a, b)` (verbatim lines), `wx.fields(ref, a, b)` (a fenced example's field
-vocabulary) — `ref` is the returned path or the original URL. The shell reads the paths too
-(`grep -n 'term' <path>` · `sed -n 'a,bp' <path>` · across everything saved so far:
-`grep -rn 'term' .agents/skills/wix-docs-base44/scratch/` — GNU grep/sed installed, awk is mawk,
-no rg), and read_file takes them with a 45K cap. **API responses are site data and never land in
+vocabulary) — `ref` is the returned path or the original URL. The shell composes over the
+paths too — `wx.bash("grep -n 'term' <path> | head -40")`, `sed -n 'a,bp'`, mawk, and across
+everything saved so far: `wx.bash("grep -rn 'term' .agents/skills/wix-docs-base44/scratch/")`
+(no rg) — and read_file takes them with a 45K cap. **API responses are site data and never land in
 scratch** — project them to facts. Fetch every URL inside exec with `fetch()` — website/browser
 tools clip at 10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
 

--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
@@ -41,12 +41,11 @@ const wx = (() => { const m = { exports: {} };
 
 Results ≤ 4,000 chars come back inline (exec results clip at ~5,000); anything bigger is saved
 under `.agents/skills/wix-docs-base44/scratch/` and returns `{ path, bytes, lines, outline }` —
-the outline is the map. Read a saved file with `wx.grep(ref, /term/)` (numbered hits),
-`wx.window(ref, a, b)` (verbatim lines), `wx.fields(ref, a, b)` (a fenced example's field
-vocabulary) — `ref` is the returned path or the original URL. The shell composes over the
-paths too — `wx.bash("grep -n 'term' <path> | head -40")`, `sed -n 'a,bp'`, mawk, and across
-everything saved so far: `wx.bash("grep -rn 'term' .agents/skills/wix-docs-base44/scratch/")`
-(no rg) — and read_file takes them with a 45K cap. **API responses are site data and never land in
+the outline is the map. Read a saved file the way you already know how:
+`wx.bash("grep -n 'term' <path> | head -40")` to find (GNU grep/sed, awk is mawk, no rg;
+across everything saved: `grep -rn 'term' .agents/skills/wix-docs-base44/scratch/`), and
+`read_file` to quote — a window via `offset`/`limit` at the lines grep named, or the whole
+file when it fits read_file's 45K cap. **API responses are site data and never land in
 scratch** — project them to facts. Fetch every URL inside exec with `fetch()` — website/browser
 tools clip at 10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
 
@@ -82,11 +81,12 @@ Method pages are 100 KB+, twin REST and SDK halves repeating field names at diff
 `page` fetches, saves, and maps in one round; quote only your half:
 
 ```js
-const pg = await wx.page(docsUrl);    // whole text when small; else { path, bytes, lines, outline }
-await wx.grep(pg.path, /refund/);     // headers always + your term, numbered — omitted > 0 ⇒ narrow
-await wx.window(pg.path, 120, 160);   // quote header-to-header — the REST example FIRST:
-                                      // under ### Examples below ## REST API sits a complete request
-await wx.fields(pg.path, 53, 949);    // a giant fenced example → its field vocabulary in one round
+const pg = await wx.page(docsUrl);   // whole text when small; else { path, bytes, lines, outline }
+await wx.bash(`grep -in 'refund' ${pg.path} | head -40`);   // grep -n 'term|^#' keeps the sections visible
+// quote with read_file(pg.path) + offset/limit at the lines grep named — the REST example FIRST:
+// under ### Examples below ## REST API sits a complete working request
+await wx.bash(`sed -n '53,949p' ${pg.path} | grep -oE '"[a-zA-Z]+":' | sort -u | head -60`);
+//  ↑ a giant fenced example → its field vocabulary in one round; read it whole only if you must
 ```
 
 `search` also saves its raw content beside the inline hits — grep its `path` when a hit's six
@@ -116,7 +116,7 @@ await wx.spec(`
 await wx.recipes();           // categories with counts
 await wx.recipes("stores");   // a category's list — or any task word: wx.recipes("coupon")
 await wx.page(url);           // read the chosen recipe — whole when small, saved + outline when
-                              // big; then wx.window / wx.fields by the outline's line numbers
+                              // big; then grep / read_file windows by the outline's line numbers
 ```
 
 A matching recipe beats composing the flow from single endpoints: it carries ordering and

--- a/skills/wix-docs-base44/scripts/disk.js
+++ b/skills/wix-docs-base44/scripts/disk.js
@@ -146,10 +146,14 @@ async function grep(ref, pattern) {
     if (hit) termHits++;
     if (hit || /^#{1,3} /.test(t)) rows.push((i + 1) + ": " + t.trim().slice(0, 100));
   });
-  return { file: p, lines: lines.length, shown: Math.min(rows.length, 40),
-           omitted: Math.max(0, rows.length - 40),
+  // byte-budgeted, not row-capped: a broad first cast (/sort|cursor|paging/) is the right
+  // opening move and must not overflow the exec result
+  const shown = [];
+  let used = 0;
+  for (const r of rows) { if (used + r.length + 1 > BUDGET - 300) break; shown.push(r); used += r.length + 1; }
+  return { file: p, lines: lines.length, shown: shown.length, omitted: rows.length - shown.length,
            ...(termHits === 0 && { note: "the term matched nothing — this is just the outline; try another term, or wx.search across docs" }),
-           hits: rows.slice(0, 40).join("\n") };
+           hits: shown.join("\n") };
 }
 
 // sed -n 'from,top' over a saved file — quote a section verbatim by grep's line numbers.

--- a/skills/wix-docs-base44/scripts/disk.js
+++ b/skills/wix-docs-base44/scripts/disk.js
@@ -8,11 +8,9 @@
 //   const wx = (() => { const m = { exports: {} };
 //     new Function("module", "exports", "require", src)(m, m.exports, require); return m.exports; })();
 //
-// Read a saved file three ways — wx.grep(ref, /term/) numbered hits, wx.window(ref, a, b)
-// verbatim lines, wx.fields(ref, a, b) a fenced example's field vocabulary. `ref` is the
-// returned path OR the original URL (it resolves either). The shell works on the paths
-// too: grep -n 'term' <path> · sed -n 'a,bp' <path> (GNU grep/sed; awk is mawk; no rg),
-// and read_file takes them with a 45K cap.
+// Read a saved file the way you already know how: wx.bash("grep -n 'term' <path> | head -40")
+// to find, read_file(<path>) with offset/limit to window (numbered lines, 45K cap — no exec
+// round needed), pipelines for the rest (GNU grep/sed; awk is mawk; no rg).
 //
 // API responses are site data and stay OUT of scratch (scratch ships with the app):
 // post() never saves — project responses to facts.
@@ -95,7 +93,7 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
   });   // 404 "No menu node found" ⇒ re-orient a level up
   if (content.length <= BUDGET) return content;
   const s = save("browse.md", content);
-  return { ...s, next: `wx.grep("${s.path}", /term/i)   // one line per node — or re-browse with a filter` };
+  return { ...s, next: `wx.bash("grep -in 'term' ${s.path} | head -40")   // one line per node — or re-browse with a filter` };
 }
 
 // Semantic search — ranks, never says "no match". The reduced hits come back inline
@@ -112,67 +110,26 @@ async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
   })).filter(h => h.docsUrl);
   const saved = save("search.md", content);
   if (!hits.length) return clip({ ...saved, head: content.slice(0, 1200),
-    note: `no method blocks parsed — raw head above; wx.grep("${saved.path}", /term/i) for the rest` });
+    note: `no method blocks parsed — raw head above; wx.bash("grep -in 'term' ${saved.path}") for the rest` });
   return clip({ ...saved, hits });
 }
 
 // ── read a page (docs pages and recipes alike) ────────────────────────────────
 
 // Fetch + save + map in one round: whole text inline when small, else
-// { path, bytes, lines, outline } — the outline's line numbers feed grep/window/fields.
+// { path, bytes, lines, outline } — the outline's line numbers feed grep and read_file windows.
 async function page(url) {
   const { path: p, lines } = await resolveRef(url);
   const text = lines.join("\n");
   if (text.length <= BUDGET) return text;
   const o = outlineOf(lines);
-  const [h1, h2] = o.outline;
   const bytes = Buffer.byteLength(text);
   return { path: p, bytes, lines: lines.length, ...o,
            next: [
-             `wx.grep("${p}", /term/i)`,
-             h1 && h2 ? `wx.window("${p}", ${h1.line}, ${h2.line - 1})   // first section` : `wx.window("${p}", 1, 40)`,
-             ...(bytes <= 45000 ? [`read_file("${p}")   // fits whole — 45K cap`] : []),
+             `wx.bash("grep -in 'term' ${p} | head -40")`,
+             bytes <= 45000 ? `read_file ${p}   // whole (fits the 45K cap), or a window via offset/limit`
+                            : `read_file ${p} with offset/limit   // window a section by the outline's lines`,
            ] };
-}
-
-// grep -n over a saved file: headers always match, plus your term — numbered for window().
-async function grep(ref, pattern) {
-  const { path: p, lines } = await resolveRef(ref);
-  const re = pattern instanceof RegExp ? pattern : new RegExp(pattern, "i");
-  const rows = [];
-  let termHits = 0;
-  lines.forEach((t, i) => {
-    const hit = re.test(t);
-    if (hit) termHits++;
-    if (hit || /^#{1,3} /.test(t)) rows.push((i + 1) + ": " + t.trim().slice(0, 100));
-  });
-  // byte-budgeted, not row-capped: a broad first cast (/sort|cursor|paging/) is the right
-  // opening move and must not overflow the exec result
-  const shown = [];
-  let used = 0;
-  for (const r of rows) { if (used + r.length + 1 > BUDGET - 300) break; shown.push(r); used += r.length + 1; }
-  return { file: p, lines: lines.length, shown: shown.length, omitted: rows.length - shown.length,
-           ...(termHits === 0 && { note: "the term matched nothing — this is just the outline; try another term, or wx.search across docs" }),
-           hits: shown.join("\n") };
-}
-
-// sed -n 'from,top' over a saved file — quote a section verbatim by grep's line numbers.
-async function window(ref, from, to) {
-  const { path: p, lines } = await resolveRef(ref);
-  const end = Math.min(to, lines.length), start = Math.max(1, Math.min(from, end));
-  return clip({ file: p,
-                ...(to > lines.length && { note: `file ends at line ${lines.length}` }),
-                text: lines.slice(start - 1, end).map((t, i) => (start + i) + ": " + t.slice(0, 110)).join("\n") });
-}
-
-// A big section is usually ONE fenced example — reduce it to its field vocabulary
-// instead of paging it; window() only where exact values matter.
-async function fields(ref, from, to) {
-  const { path: p, lines } = await resolveRef(ref);
-  const sec = lines.slice(from - 1, to).join("\n");
-  const names = [...new Set(sec.match(/"([a-zA-Z][a-zA-Z0-9]*)":/g) || [])].map(s => s.slice(1, -2));
-  return clip({ file: p, sectionLines: to - from + 1, fields: names,
-                ...(names.length === 0 && { note: `no JSON fields in this range — wx.window("${p}", ${from}, ${to}) to see it` }) });
 }
 
 // ── shell ─────────────────────────────────────────────────────────────────────
@@ -239,4 +196,4 @@ async function recipes(q) {
   return clip(m.map(row));
 }
 
-module.exports = { post, clip, context, browse, search, page, grep, window, fields, bash, spec, recipes };
+module.exports = { post, clip, context, browse, search, page, bash, spec, recipes };

--- a/skills/wix-docs-base44/scripts/disk.js
+++ b/skills/wix-docs-base44/scripts/disk.js
@@ -94,8 +94,8 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
     ...(filter && { name_filter: filter }), ...(depth && { depth }),
   });   // 404 "No menu node found" ⇒ re-orient a level up
   if (content.length <= BUDGET) return content;
-  return { ...save("browse.md", content),
-           next: "one line per node — wx.grep(path, /term/) it, or re-browse with a filter" };
+  const s = save("browse.md", content);
+  return { ...s, next: `wx.grep("${s.path}", /term/i)   // one line per node — or re-browse with a filter` };
 }
 
 // Semantic search — ranks, never says "no match". The reduced hits come back inline
@@ -111,6 +111,8 @@ async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
       .trim().replace(/\s+/g, " ").slice(0, 220),
   })).filter(h => h.docsUrl);
   const saved = save("search.md", content);
+  if (!hits.length) return clip({ ...saved, head: content.slice(0, 1200),
+    note: `no method blocks parsed — raw head above; wx.grep("${saved.path}", /term/i) for the rest` });
   return clip({ ...saved, hits });
 }
 
@@ -122,24 +124,41 @@ async function page(url) {
   const { path: p, lines } = await resolveRef(url);
   const text = lines.join("\n");
   if (text.length <= BUDGET) return text;
-  return { path: p, bytes: Buffer.byteLength(text), lines: lines.length, ...outlineOf(lines),
-           next: "wx.grep(path, /term/) · wx.window(path, a, b) · wx.fields(path, a, b) — or shell grep -n / sed -n" };
+  const o = outlineOf(lines);
+  const [h1, h2] = o.outline;
+  const bytes = Buffer.byteLength(text);
+  return { path: p, bytes, lines: lines.length, ...o,
+           next: [
+             `wx.grep("${p}", /term/i)`,
+             h1 && h2 ? `wx.window("${p}", ${h1.line}, ${h2.line - 1})   // first section` : `wx.window("${p}", 1, 40)`,
+             ...(bytes <= 45000 ? [`read_file("${p}")   // fits whole — 45K cap`] : []),
+           ] };
 }
 
 // grep -n over a saved file: headers always match, plus your term — numbered for window().
 async function grep(ref, pattern) {
   const { path: p, lines } = await resolveRef(ref);
   const re = pattern instanceof RegExp ? pattern : new RegExp(pattern, "i");
-  const hits = [];
-  lines.forEach((t, i) => { if (/^#{1,3} /.test(t) || re.test(t)) hits.push({ line: i + 1, text: t.trim().slice(0, 100) }); });
-  return { file: p, lines: lines.length, shown: Math.min(hits.length, 40),
-           omitted: Math.max(0, hits.length - 40), hits: hits.slice(0, 40) };
+  const rows = [];
+  let termHits = 0;
+  lines.forEach((t, i) => {
+    const hit = re.test(t);
+    if (hit) termHits++;
+    if (hit || /^#{1,3} /.test(t)) rows.push((i + 1) + ": " + t.trim().slice(0, 100));
+  });
+  return { file: p, lines: lines.length, shown: Math.min(rows.length, 40),
+           omitted: Math.max(0, rows.length - 40),
+           ...(termHits === 0 && { note: "the term matched nothing — this is just the outline; try another term, or wx.search across docs" }),
+           hits: rows.slice(0, 40).join("\n") };
 }
 
 // sed -n 'from,top' over a saved file — quote a section verbatim by grep's line numbers.
 async function window(ref, from, to) {
   const { path: p, lines } = await resolveRef(ref);
-  return clip({ file: p, text: lines.slice(from - 1, to).map((t, i) => (from + i) + ": " + t.slice(0, 110)).join("\n") });
+  const end = Math.min(to, lines.length), start = Math.max(1, Math.min(from, end));
+  return clip({ file: p,
+                ...(to > lines.length && { note: `file ends at line ${lines.length}` }),
+                text: lines.slice(start - 1, end).map((t, i) => (start + i) + ": " + t.slice(0, 110)).join("\n") });
 }
 
 // A big section is usually ONE fenced example — reduce it to its field vocabulary
@@ -148,7 +167,8 @@ async function fields(ref, from, to) {
   const { path: p, lines } = await resolveRef(ref);
   const sec = lines.slice(from - 1, to).join("\n");
   const names = [...new Set(sec.match(/"([a-zA-Z][a-zA-Z0-9]*)":/g) || [])].map(s => s.slice(1, -2));
-  return clip({ file: p, sectionLines: to - from + 1, fields: names });
+  return clip({ file: p, sectionLines: to - from + 1, fields: names,
+                ...(names.length === 0 && { note: `no JSON fields in this range — wx.window("${p}", ${from}, ${to}) to see it` }) });
 }
 
 // ── the spec index ────────────────────────────────────────────────────────────
@@ -161,6 +181,8 @@ async function fields(ref, from, to) {
 async function spec(code) {
   if (!/^\s*async function/.test(code)) code = `async function(){ ${code} }`;
   const { result } = await post("https://mcp.wix.com/api/code-mode/search", { code });
+  if (result == null || (Array.isArray(result) && !result.length))
+    return { result, note: "empty — the query missed the shape, not proof of absence; find the resource by docsUrl on lightIndex" };
   const text = JSON.stringify(result, null, 1);
   if (text.length <= BUDGET) return result;
   return { ...save("spec.json", text),
@@ -186,7 +208,13 @@ async function recipes(q) {
   const inCat = files.filter(f => cat(f) === q);
   if (inCat.length) return clip(inCat.map(row));
   const re = new RegExp(q, "i");
-  return clip(files.filter(f => re.test(f.name + " " + (f.description || ""))).map(row));
+  const m = files.filter(f => re.test(f.name + " " + (f.description || "")));
+  if (!m.length) {
+    const cats = {};
+    for (const f of files) { const c = cat(f); if (c) cats[c] = (cats[c] || 0) + 1; }
+    return { note: `nothing matches "${q}" — the categories:`, categories: cats };
+  }
+  return clip(m.map(row));
 }
 
 module.exports = { post, clip, context, browse, search, page, grep, window, fields, spec, recipes };

--- a/skills/wix-docs-base44/scripts/disk.js
+++ b/skills/wix-docs-base44/scripts/disk.js
@@ -175,6 +175,24 @@ async function fields(ref, from, to) {
                 ...(names.length === 0 && { note: `no JSON fields in this range — wx.window("${p}", ${from}, ${to}) to see it` }) });
 }
 
+// ── shell ─────────────────────────────────────────────────────────────────────
+
+// Compose native pipelines over scratch — grep -n, sed -n, mawk, sort, uniq, wc
+// (GNU grep/sed; awk is mawk; no rg). Cap your own output (| head -40); the return
+// clips regardless. grep's exit 1 means no match, not failure — the return says so.
+function bash(cmd) {
+  const { execSync } = require("child_process");
+  try {
+    return clip(execSync(cmd, { timeout: 15000, encoding: "utf8", maxBuffer: 8 * 1024 * 1024 })
+                || "(no output)");
+  } catch (e) {
+    const exit = e.status ?? null, err = (e.stderr || "").toString().trim();
+    return { exit, ...(err && { err: err.slice(0, 300) }),
+             out: clip((e.stdout || "").toString()),
+             ...(exit === 1 && !err && { note: "exit 1 with no stderr — a no-match, not a failure" }) };
+  }
+}
+
 // ── the spec index ────────────────────────────────────────────────────────────
 
 // Run a query over the API spec index. In scope: lightIndex (RESOURCES with
@@ -221,4 +239,4 @@ async function recipes(q) {
   return clip(m.map(row));
 }
 
-module.exports = { post, clip, context, browse, search, page, grep, window, fields, spec, recipes };
+module.exports = { post, clip, context, browse, search, page, grep, window, fields, bash, spec, recipes };


### PR DESCRIPTION
Disk is now the canonical edition; this applies the two improvement tracks to it.

**Quieter, not smarter** (a fresh `claude -p` given the same 52K file did size → grep → window unprompted — native-looking tools need no teaching):
- `grep` hits are one `"N: text"` block — `grep -n`'s own output shape (fewer tokens too)
- `page.next` is paste-able calls with the real path + first-section coordinates substituted, and `read_file(path)` appears exactly when the file fits its 45K cap (verified: 43.6K recipe gets it, 52K doc doesn't)

**Dead ends answer in-band** (the `context()` fix pattern as an audit — each of these previously cost a run ~5 execs to discover):
- `grep`: term matched nothing → "this is just the outline; try another term, or wx.search"
- `window` past EOF → clamps + "file ends at line 458"
- `fields` on a prose range → points back at the exact `wx.window` call
- `spec` returning `[]` → "missed the shape, not proof of absence"
- `recipes("nonsense")` → the categories ride along with the note
- `search` parsing zero hits → raw head rides along

Every path exercised live. `lite.js` is frozen as-is (in-flight loaders keep working); the prompt path now points at the disk guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)