### PR TITLE
feat(wix-docs-base44): visitor shape leads with client-only + a prove-the-lane probe

### DIFF
--- a/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
+++ b/skills/wix-docs-base44/references/base44-wix-discovery-execution-loop-guide-disk.md
@@ -18,12 +18,13 @@ exec_tool          ──(admin token)───► wixapis.com   you: ad hoc pro
 ```
 
 **A site for visitors** — storefront, blog, booking. Headless means the Wix site has no pages of
-its own: your app IS its frontend, and it calls Wix from the browser. Every call the visitor token
-can make lives in the client — public reads included (the visitor token queries the catalog
-directly), and `carts/current/*` + checkout act on the CALLER's cart, so only the visitor token
-reaches the visitor's cart. One file carries this path: `src/lib/wixClient.js` (Write the code,
-below). `base44/functions/*` hold the work that needs the owner's identity — elevated-permission
-ops a visitor triggers, webhooks, scheduled jobs — and the app's non-Wix backend.
+its own: your app IS its frontend. **The complete site — catalog, product pages, cart, checkout —
+is browser calls on the visitor token; none of it needs a backend function.** Public reads
+included (the visitor token queries the catalog directly), and `carts/current/*` + checkout act
+on the CALLER's cart, so only the visitor token reaches the visitor's cart. One file carries it
+all: `src/lib/wixClient.js` (Write the code, below). `base44/functions/*` appear only where work
+needs the owner's identity — elevated-permission ops a visitor triggers, webhooks, scheduled
+jobs — and for the app's non-Wix backend.
 
 **An admin tool for the owner** — dashboard, back office. The pages act as the owner, whose token
 is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
@@ -160,4 +161,12 @@ export const wix = (path, opts = {}) => fetch("https://www.wixapis.com" + path, 
   headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } });
 ```
 
-Token contract: `…/headless/authentication/retrieve-tokens`.
+Token contract: `…/headless/authentication/retrieve-tokens`. Prove the lane in one exec before
+writing pages — mint a visitor, make one public read with it:
+
+```js
+const { access_token } = await wx.post("https://www.wixapis.com/oauth2/token",
+  { clientId: WIX_CLIENT_ID, grantType: "anonymous" });   // clientId: from the context report
+return await wx.post("<a public read from Learn Wix>", { query: {} }, access_token);
+// 200 ⇒ every catalog page in the app is this same call, no server between
+```


### PR DESCRIPTION
Run `6a85de9a` — the first run to receive the guide through the connector's `usage_guide` — localized the build flip precisely: agents comply with the visitor token wherever it's *forced* (carts are caller-bound), and flip to admin-token backend fns exactly where both tokens work (catalog reads). The gradient isn't doctrine — at build time the admin call is already proven in hand from research probes, the visitor lane is untested machinery, and `test_backend_function` makes backend fns the only in-loop-verifiable architecture.

Two changes:

- **The headline**: "What are you building?" now opens the visitor shape with — *the complete site — catalog, product pages, cart, checkout — is browser calls on the visitor token; none of it needs a backend function* — with backend fns scoped to owner-identity work and the non-Wix backend.
- **The proof probe**: the visitor client section ends with a one-exec lane test (mint anonymous → one public read on the minted token → `200 ⇒ every catalog page in the app is this same call`), making the client lane as verified-in-hand as the admin lane before any file is written.

8,907 chars — still under the fetch_website wire on every route, and within the connector usage_guide headroom (~12.5K under the 30K cap).

Note: the deployed v9 connector definition holds a frozen copy of the previous edition — after this merges, the definition needs a re-embed to ship as v10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)