### PR TITLE
rename: scripts/disk.js → scripts/utils.js

### DIFF
--- a/skills/wix-docs-base44/SKILL.md
+++ b/skills/wix-docs-base44/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-docs-base44
-description: "Build on Wix from the Base44 builder sandbox — this file is the complete guide (site context, doc discovery, API contracts, who calls Wix from where), and scripts/disk.js is its helper module, loaded from disk per exec. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, decide frontend vs backend for a Wix call."
+description: "Build on Wix from the Base44 builder sandbox — this file is the complete guide (site context, doc discovery, API contracts, who calls Wix from where), and scripts/utils.js is its helper module, loaded from disk per exec. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, decide frontend vs backend for a Wix call."
 ---
 
 # Building on Wix from Base44
@@ -42,9 +42,9 @@ reload each round; the module lives on disk next to this file, network only as f
 fallback):
 
 ```js
-const fs = require("fs"), P = ".agents/skills/wix-connector/disk.js";
+const fs = require("fs"), P = ".agents/skills/wix-connector/utils.js";
 if (!fs.existsSync(P)) { fs.mkdirSync(".agents/skills/wix-connector", { recursive: true });
-  fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/disk.js")).text()); }
+  fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/utils.js")).text()); }
 const wx = (() => { const m = { exports: {} };
   new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
 ```

--- a/skills/wix-docs-base44/scripts/utils.js
+++ b/skills/wix-docs-base44/scripts/utils.js
@@ -4,9 +4,9 @@
 // pre-pointed at it.
 //
 // Load per exec (execs share no state) — from disk, network only as first-touch fallback:
-//   const fs = require("fs"), P = ".agents/skills/wix-connector/disk.js";
+//   const fs = require("fs"), P = ".agents/skills/wix-connector/utils.js";
 //   if (!fs.existsSync(P)) { fs.mkdirSync(".agents/skills/wix-connector", { recursive: true });
-//     fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/disk.js")).text()); }
+//     fs.writeFileSync(P, await (await fetch("https://www.wix.com/skills/wix-docs-base44/scripts/utils.js")).text()); }
 //   const wx = (() => { const m = { exports: {} };
 //     new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
 //


### PR DESCRIPTION
The module's name leaked an implementation detail of one edition (the disk lane). It's the skill's utils: scripts/utils.js, saved as .agents/skills/wix-connector/utils.js. All references updated (SKILL.md loader + fallback URL, module header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)