### PR TITLE
🦞 igor-claw: Add recovery guidance when wix login fails

### DIFF
--- a/skills/wix-headless/references/managed/AUTHENTICATION.md
+++ b/skills/wix-headless/references/managed/AUTHENTICATION.md
@@ -14,6 +14,7 @@ If it's non-zero, **log in yourself** — don't punt to the user and stop:
 2. Poll that file for the first JSON event: `{"event":"awaiting_user","userCode":"…","verificationUri":"…"}`.
 3. Surface it to the user in plain prose: *"Open `<verificationUri>` and enter the code `<userCode>` — I'll continue once you've logged in."* **Send the message; do not re-invoke login.**
 4. Wait for the harness `task-notification` with `<status>completed</status>` (not a sleep loop). On exit 0, run `whoami` once to confirm, then proceed.
+5. **If the background task exits non-zero, or the user reports they approved the code but `whoami` still shows logged out** — don't loop with a fresh code; `wix login` (with or without `--api-key`) needs outbound access to `manage.wix.com` for every login method, so a repeat attempt fails the same way. Stop and tell the user this looks like a network-policy block in the current execution environment, and that authenticating the Wix CLI here requires `manage.wix.com` (and `www.wixapis.com` for calls after login) to be reachable.
 
 ## 2 · Mint the token
 


### PR DESCRIPTION
## What's broken

`managed/AUTHENTICATION.md` §1 tells the agent to run `wix login` in the background, wait for the harness `task-notification`, and on exit 0 proceed — but has no branch for the task *not* exiting 0, or for the user reporting they approved the code while `whoami` still shows logged out. There's nothing telling the agent to stop; the only documented path is the happy one.

## Root cause (from real feedback)

An agent (ChatGPT Work/Codex) building a Wix Headless project hit exactly this: `wix login`'s device-code flow reached the awaiting-user step, the user approved it in the browser, but the CLI's callback to `manage.wix.com` was blocked by the execution sandbox's network policy — so the session never persisted and `whoami` stayed unauthenticated. The agent retried the whole login flow with a fresh user code, hit the identical block, and only then gave up. Confirmed in `@wix/cli` source: both the device-code flow and `--api-key` route through `createHttpClient({ type: "backoffice" })` → `manage.wix.com` — a fresh code doesn't route around a `manage.wix.com` network block, so retrying was never going to help.

## Fix

Added a step 5 to §1: if the background login task fails, or the user says they approved the code but `whoami` still shows logged out, stop instead of retrying with a new code, and tell the user this looks like the execution environment blocking `manage.wix.com` (and that `www.wixapis.com` is needed after login too).

---
Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`).
Report thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787173008813849