### PR TITLE
feat(wix-base44-connector): in-band notes + effect-shaped examples

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -143,7 +143,9 @@ response or the schema — remembered names are often from older versions. Probe
 const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix");
 const data = await wx.post("https://www.wixapis.com/contacts/v5/contacts/query",   // spec-index publicUrl
   { query: { cursorPaging: { limit: 10 } } }, accessToken);
-return { count: data.contacts?.length, keys: Object.keys(data.contacts?.[0] || {}) };   // project, don't dump
+// let it throw — the thrown message is your result; .catch hides the answer
+return wx.clip({ error: null, count: data.contacts?.length, first: data.contacts?.[0] });
+//  ↑ one real row, whole — the shapes you code against live here, not in key names
 ```
 
 The same call deploys as `base44/functions/*` (work the app does as the owner) — shipped code
@@ -178,4 +180,6 @@ const { access_token } = await wx.post("https://www.wixapis.com/oauth2/token",
   { clientId: WIX_CLIENT_ID, grantType: "anonymous" });   // clientId: from the context report
 return await wx.post("<a public read from Learn Wix>", { query: {} }, access_token);
 // 200 ⇒ every visitor-facing page in the app is this same call, no server between
+// a lean default response isn't the whole shape — contracts often define a fields param
+// that opts INTO heavier parts (formatted prices, media); read the contract for it
 ```

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -33,7 +33,12 @@ const clip = (out) => {
 async function post(url, body, token) {
   const r = await fetch(url, { method: "POST", body: JSON.stringify(body),
     headers: { "Content-Type": "application/json", ...(token && { Authorization: `Bearer ${token}` }) } });
-  if (!r.ok) throw new Error(r.status + " " + (await r.text()).slice(0, 300));
+  if (!r.ok) {
+    const head = (await r.text()).slice(0, 300);
+    throw new Error(r.status + " " + head + (r.status < 500
+      ? " — a 4xx means wrong body or reference: read this endpoint's contract before changing the call"
+      : ""));
+  }
   return r.json();
 }
 
@@ -94,7 +99,7 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
     ...(filter && { name_filter: filter }), ...(depth && { depth }),
   });   // 404 "No menu node found" ⇒ re-orient a level up
   if (content.length <= BUDGET) return content;
-  const s = save("browse.md", content);
+  const s = save("browse-" + (menuUrl.replace(/\/+$/, "").split("/").pop() || "root") + ".md", content);
   return { ...s, next: `wx.bash("grep -in 'term' ${s.path} | head -40")   // one line per node — or re-browse with a filter` };
 }
 
@@ -110,7 +115,7 @@ async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
     gist: ((b.match(/## Method Description:\s*\n([\s\S]{0,400})/) || [])[1] || "")
       .trim().replace(/\s+/g, " ").slice(0, 220),
   })).filter(h => h.docsUrl);
-  const saved = save("search.md", content);
+  const saved = save("search-" + term.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40) + ".md", content);
   if (!hits.length) return clip({ ...saved, head: content.slice(0, 1200),
     note: `no method blocks parsed — raw head above; wx.bash("grep -in 'term' ${saved.path}") for the rest` });
   return clip({ ...saved, hits });
@@ -142,8 +147,9 @@ async function page(url) {
 function bash(cmd) {
   const { execSync } = require("child_process");
   try {
-    return clip(execSync(cmd, { timeout: 15000, encoding: "utf8", maxBuffer: 8 * 1024 * 1024 })
-                || "(no output)");
+    const out = execSync(cmd, { timeout: 15000, encoding: "utf8", maxBuffer: 8 * 1024 * 1024 });
+    return out.trim() ? clip(out)
+      : "(no output — a filter may have swallowed the signal; rerun without the reducer)";
   } catch (e) {
     const exit = e.status ?? null, err = (e.stderr || "").toString().trim();
     return { exit, ...(err && { err: err.slice(0, 300) }),


### PR DESCRIPTION
Approved items 1–3 + 5–6 from the experiment takeaways (same-model evidence: sonnet has the reflexes; Base44 context suppresses them; examples and failure-moment notes are the channels that transfer):

**utils.js**
- `post()` 4xx note: *read this endpoint's contract before changing the call*
- `bash()` empty-output note: *a filter may have swallowed the signal; rerun without the reducer*
- slugged saves: `search-<term>.md`, `browse-<leaf>.md` (no more overwrite amnesia)

**SKILL.md examples**
- admin probe returns `{ error, count, first: <one real row> }` + *let it throw — .catch hides the answer* (keys-only projection taught run 8's shallow probe)
- visitor probe notes `fields` opts INTO heavier response parts (verified live: V3 `fields:["CURRENCY"]` adds `formattedAmount`; the default is the lean view)

All paths verified live before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)