### PR TITLE
🦞 igor-claw: Site Import skill must call site-scoped to target an existing site

### DIFF
--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -24,9 +24,25 @@ and report the final result.
 5. **This API is the only site-creation tool for this task** — never
    substitute other Wix site-builder tools (see Scope).
 
-Base URL: `https://www.wixapis.com/site-import`. All calls use account-level
-scope on the signed-in Wix user's account. A full import typically takes
+Base URL: `https://www.wixapis.com/site-import`. A full import typically takes
 15–60 minutes.
+
+**Destination — new site vs. an existing site.** There is no destination field
+in the request body. The destination is decided entirely by which scope you
+call with, resolved from your own request context:
+- **Account-level scope** (no site context) → the import always **creates a
+  brand-new site**. This is the default and the right choice when the user has
+  no Wix site yet, or explicitly wants a fresh one.
+- **Site-level scope** (called with a specific `siteId`) → the import **writes
+  into that existing site** instead of creating a new one.
+
+**Ask the user which they want before calling Start** — it can't be changed
+after the migration starts. If the user already created (or named) a Wix site
+they want this content imported into — including one they just set up to
+prepare for this import — call Start (and every subsequent call for that
+`importId`) scoped to that site's id, not account-level. Calling account-level
+when the user actually meant an existing site silently creates a second,
+unwanted site and leaves their existing one untouched.
 
 ## Calling the API
 
@@ -46,16 +62,29 @@ nothing useful.
 page, or any client-side code — those fail with CORS. The entire experience
 is plain chat — API calls plus short messages.
 
-Use the Wix account-level REST API tool available in your environment with
-the **full URL**. Start, Send-a-message, and Cancel are mutating (POST);
-Poll is read-only (GET).
+Use the Wix REST API tool available in your environment with the **full
+URL**, scoped per the Destination section above: the account-level tool to
+create a new site, or the site-scoped tool (passing the target `siteId`) to
+import into a site the user already has. Start, Send-a-message, and Cancel
+are mutating (POST); Poll is read-only (GET).
 
-Example — Start:
+Example — Start, creating a new site (account-level call):
 
 ```
 POST https://www.wixapis.com/site-import/v1/imports
 Body: {
   "request": "Import https://example-store.com into a new Wix site",
+  "source_url": "https://example-store.com"
+}
+```
+
+Example — Start, importing into the user's existing site (site-scoped call,
+`siteId` set to that site's id):
+
+```
+POST https://www.wixapis.com/site-import/v1/imports
+Body: {
+  "request": "Import https://example-store.com into my site",
   "source_url": "https://example-store.com"
 }
 ```
@@ -183,9 +212,11 @@ You are the user experience; the API is plumbing. Keep the protocol invisible:
      `request`, and no `fileUrls`, is rejected with `SITE_UNIDENTIFIED`.
    Returns: `importId`, `sourcePlatform`, `sourceConfidence`, `destinationSiteId`.
    `sourcePlatform` comes back as `CSV` for a FILE run (no site was probed, so
-   `sourceConfidence` is meaningless there). `destinationSiteId` is the id of
-   the Wix site being imported into — returned as soon as Start succeeds,
-   even before a source is confirmed.
+   `sourceConfidence` is meaningless there). `destinationSiteId` echoes what the
+   call is about to write into, resolved from your call's scope (see
+   "Destination" above), not from anything in the request body — empty means a
+   new site will be created; set means it's importing into that existing site.
+   Returned as soon as Start succeeds, even before a source is confirmed.
    **One import per store at a time, keyed on `source_url`** (or the file set
    when there's no `source_url`): re-starting with the same identity continues
    the SAME migration (server returns the existing `importId`, no new import


### PR DESCRIPTION
## Problem
`site-import.md` unconditionally told agents to use "the Wix account-level REST API tool" for every `site-import` call. That means Site Import can never write into a site the user already has — it always spins up a brand-new one, even when the user already created a destination site and expects the import to land there.

## Root cause (confirmed in source)
`destinationSiteId` is **not** a request-body field. In `wix-private/replatform-sb`, `packages/bix-site-import/src/shared/identity.ts` (`requireIdentity`, spec 0018), it's resolved purely from the caller's own request context via `ctx.apiGatewayClient.metaSiteId()`:
- Account-level calls carry no site context → `destinationSiteId` is always empty → `startImport` always creates a new site (`service.ts`: `siteStrategy: destinationSiteId ? 'existing' : 'new'`).
- Site-scoped calls (with a `siteId`) → `metaSiteId()` resolves → the import writes into that existing site instead.

The skill's blanket "always account-level" instruction meant this existing-site capability was unreachable no matter what the user asked for.

## Fix
`site-import.md` now:
- Explains the scope/destination tradeoff explicitly (new section "Destination — new site vs. an existing site").
- Tells agents to ask the user whether they want a new site or their existing one, and to call **site-scoped** (with that site's `siteId`) for the latter.
- Clarifies in the Start endpoint docs that `destinationSiteId` in the response reflects the *call's scope*, not anything sent in the body.

## Context
Surfaced while researching a Wix MCP feedback report (healthcare-site migration via Wix Studio) where the user had already created a destination Studio site and uploaded media before attempting Site Import — work that this scoping bug would have discarded even if the (separately tracked, wix-private/replatform-sb#77) `NOT_ENABLED` rollout gate weren't blocking them.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787178008452279

Opened automatically by an AI agent acting on behalf of Ayal (`ayalg@wix.com`) — not written by a human.