### PR TITLE
fix(wix-base44-connector): clip renders undefined as null

### DIFF
--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -24,8 +24,13 @@ const BUDGET = 4000;
 const SCRATCH = ".agents/skills/wix-base44-connector/scratch";
 
 const clip = (out) => {
-  const s = typeof out === "string" ? out : JSON.stringify(out);
-  return s.length <= BUDGET ? out : { truncated: true, total: s.length, head: s.slice(0, BUDGET) };
+  if (typeof out === "string")
+    return out.length <= BUDGET ? out : { truncated: true, total: out.length, head: out.slice(0, BUDGET) };
+  // absence must be visible: JSON.stringify silently ERASES undefined keys, so a probe like
+  // { lineItems: resp.cart?.lineItems } loses the very field that proves the call failed —
+  // render undefined as null instead
+  const s = JSON.stringify(out, (k, v) => v === undefined ? null : v);
+  return s.length <= BUDGET ? JSON.parse(s) : { truncated: true, total: s.length, head: s.slice(0, BUDGET) };
 };
 
 // One transport for every JSON call — Content-Type, optional Bearer, ok-guard.


### PR DESCRIPTION
Run `6a868522` probed correctly — `return wx.clip({ cartId, lineItems })` — and still shipped the silent-drop bug: `resp.cart?.lineItems` was undefined, and `JSON.stringify` erases undefined keys, so the field that proved the failure simply vanished from the result. False green, then the user's bug report.

`clip()` now uses an `undefined→null` replacer (nested + array values included): the same probe returns `{"cartId":"…","lineItems":null}` — absence visible at the exact moment the agent is looking. The exec-lane equivalent of stderr leaking through a filtered pipe.

Verified: the exact run-9 shape, nesting, arrays, string passthrough, truncation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)