### PR TITLE
fix(evalforge-gate): allow the comparison poll more time and flag partial results

### DIFF
--- a/.github/actions/evalforge-yaml-gate/dist/index.js
+++ b/.github/actions/evalforge-yaml-gate/dist/index.js
@@ -66546,18 +66546,24 @@ function winnerLabel(s) {
     return `${winnerIcon} ${s.pairwiseJudgement.winner} (${s.pairwiseJudgement.confidence})`;
 }
 function formatComparisonResult(result, projectId) {
-    const { verdict, tag, scenarios } = result.result;
+    const { verdict, tag, scenarios, judgeCoverage } = result.result;
     const hasNoWinner = comparisonHasNoWinner(result.result);
-    const verdictIcon = verdict === 'not-required' && !hasNoWinner ? '✅' : '⚠️';
+    // Partial judging never gets a green tick: `not-required` is what the pipeline
+    // returns when a judge yields nothing, so a throttled pass looks identical to
+    // a genuine "no difference" unless coverage is taken into account.
+    const isFullyJudged = !judgeCoverage || judgeCoverage.judged === judgeCoverage.total;
+    const verdictIcon = verdict === 'not-required' && !hasNoWinner && isFullyJudged ? '✅' : '⚠️';
     const lines = [
         exports.COMMENT_MARKER,
         `## ${verdictIcon} ${HEADING}: Eval Comparison`,
         '',
         `**Verdict:** \`${verdict}\` | **Tag:** \`${tag}\``,
         '',
-        '| Scenario | Required | Winner | Cost (PR / prod) | Tokens (PR / prod) | Time (PR / prod) | Runs (PR / prod) |',
-        '|---|---|---|---|---|---|---|',
     ];
+    if (!isFullyJudged && judgeCoverage) {
+        lines.push(`> ⚠️ **Only ${judgeCoverage.judged}/${judgeCoverage.total} scenarios were judged.** The verdict above rests on the`, '> remaining scenarios\' assertion results alone, so treat it as provisional rather than', '> as evidence the skill makes no difference. Re-run to get full coverage.', '');
+    }
+    lines.push('| Scenario | Required | Winner | Cost (PR / prod) | Tokens (PR / prod) | Time (PR / prod) | Runs (PR / prod) |', '|---|---|---|---|---|---|---|');
     for (const s of (scenarios ?? [])) {
         const costWith = s.with.totalCostUsd.toFixed(3);
         const costWithout = s.without.totalCostUsd.toFixed(3);
@@ -66943,6 +66949,18 @@ const POLL_INTERVAL_MS = 2 * 60_000;
 const POLL_TIMEOUT_MS = 30 * 60 * 1_000;
 const RETRY_LIMIT = 5;
 const RETRY_DELAY_MS = 10_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * The completion poll does substantially more work server-side than the
+ * intermediate "still running" polls, so it can legitimately take much longer
+ * than a normal call.
+ *
+ * Deliberately longer than any deadline the server side applies to itself, so
+ * that the client is the last participant to give up. Aborting locally first
+ * loses the real error and, because an abort counts as retriable, re-issues a
+ * request whose work had already succeeded.
+ */
+const COMPARE_GROUP_TIMEOUT_MS = 65_000;
 function delay(ms) {
     return new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
 }
@@ -66964,7 +66982,7 @@ class EvalPipelineClient {
         // headers no longer resolve the app identity once the app is public.
         this.tokens = new evalforge_core_1.TokenProvider(OAUTH_TOKEN_URL, appId, appSecret);
     }
-    async post(path, body) {
+    async post(path, body, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
         // No 401 refresh-retry: /run-comparison is non-idempotent (it queues eval runs)
         // and getToken() re-mints proactively before expiry, so a 401 here is a
         // permission denial, not a stale token — retrying would only double-fire.
@@ -66976,7 +66994,7 @@ class EvalPipelineClient {
                 Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify(body),
-            signal: AbortSignal.timeout(30_000),
+            signal: AbortSignal.timeout(timeoutMs),
         });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
@@ -66988,7 +67006,7 @@ class EvalPipelineClient {
         return this.post('/run-comparison', { tags, agentName, commitSha, skillsRepo, scenarioIds });
     }
     async compareGroup(comparisonGroupId) {
-        return this.post('/compare-group', { comparisonGroupId });
+        return this.post('/compare-group', { comparisonGroupId }, COMPARE_GROUP_TIMEOUT_MS);
     }
 }
 exports.EvalPipelineClient = EvalPipelineClient;

--- a/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/comment.ts
@@ -130,18 +130,34 @@ function winnerLabel(s: ScenarioComparison): string {
 }
 
 export function formatComparisonResult(result: CompareGroupComplete, projectId?: string): string {
-  const { verdict, tag, scenarios } = result.result;
+  const { verdict, tag, scenarios, judgeCoverage } = result.result;
   const hasNoWinner = comparisonHasNoWinner(result.result);
-  const verdictIcon = verdict === 'not-required' && !hasNoWinner ? '✅' : '⚠️';
+  // Partial judging never gets a green tick: `not-required` is what the pipeline
+  // returns when a judge yields nothing, so a throttled pass looks identical to
+  // a genuine "no difference" unless coverage is taken into account.
+  const isFullyJudged = !judgeCoverage || judgeCoverage.judged === judgeCoverage.total;
+  const verdictIcon = verdict === 'not-required' && !hasNoWinner && isFullyJudged ? '✅' : '⚠️';
   const lines: string[] = [
     COMMENT_MARKER,
     `## ${verdictIcon} ${HEADING}: Eval Comparison`,
     '',
     `**Verdict:** \`${verdict}\` | **Tag:** \`${tag}\``,
     '',
+  ];
+
+  if (!isFullyJudged && judgeCoverage) {
+    lines.push(
+      `> ⚠️ **Only ${judgeCoverage.judged}/${judgeCoverage.total} scenarios were judged.** The verdict above rests on the`,
+      '> remaining scenarios\' assertion results alone, so treat it as provisional rather than',
+      '> as evidence the skill makes no difference. Re-run to get full coverage.',
+      '',
+    );
+  }
+
+  lines.push(
     '| Scenario | Required | Winner | Cost (PR / prod) | Tokens (PR / prod) | Time (PR / prod) | Runs (PR / prod) |',
     '|---|---|---|---|---|---|---|',
-  ];
+  );
 
   for (const s of (scenarios ?? [])) {
     const costWith = s.with.totalCostUsd.toFixed(3);

--- a/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
+++ b/.github/actions/evalforge-yaml-gate/src/utils/eval-pipeline.ts
@@ -47,6 +47,10 @@ export type ComparisonGroupResult = {
   verdict: string;
   tag: string;
   scenarios: ScenarioComparison[];
+  // How many scenarios actually obtained a pairwise judgement. A verdict built
+  // from partial judging is a weaker claim than one built from all of it, and
+  // `verdict` alone cannot express that. Absent when the pipeline ran no judge.
+  judgeCoverage?: { judged: number; total: number };
 };
 
 export type CompareGroupComplete = {
@@ -64,6 +68,20 @@ const POLL_INTERVAL_MS = 2 * 60_000;
 const POLL_TIMEOUT_MS = 30 * 60 * 1_000;
 const RETRY_LIMIT = 5;
 const RETRY_DELAY_MS = 10_000;
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * The completion poll does substantially more work server-side than the
+ * intermediate "still running" polls, so it can legitimately take much longer
+ * than a normal call.
+ *
+ * Deliberately longer than any deadline the server side applies to itself, so
+ * that the client is the last participant to give up. Aborting locally first
+ * loses the real error and, because an abort counts as retriable, re-issues a
+ * request whose work had already succeeded.
+ */
+const COMPARE_GROUP_TIMEOUT_MS = 65_000;
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
@@ -90,7 +108,7 @@ export class EvalPipelineClient {
     this.tokens = new TokenProvider(OAUTH_TOKEN_URL, appId, appSecret);
   }
 
-  private async post<T>(path: string, body: unknown): Promise<T> {
+  private async post<T>(path: string, body: unknown, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<T> {
     // No 401 refresh-retry: /run-comparison is non-idempotent (it queues eval runs)
     // and getToken() re-mints proactively before expiry, so a 401 here is a
     // permission denial, not a stale token — retrying would only double-fire.
@@ -102,7 +120,7 @@ export class EvalPipelineClient {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({})) as { error?: string };
@@ -119,7 +137,7 @@ export class EvalPipelineClient {
   }
 
   async compareGroup(comparisonGroupId: string): Promise<CompareGroupStatus> {
-    return this.post<CompareGroupStatus>('/compare-group', { comparisonGroupId });
+    return this.post<CompareGroupStatus>('/compare-group', { comparisonGroupId }, COMPARE_GROUP_TIMEOUT_MS);
   }
 }
 

--- a/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/comment.test.ts
@@ -29,12 +29,15 @@ function scenario(over: Partial<ScenarioComparison> = {}): ScenarioComparison {
   };
 }
 
-function group(scenarios: ScenarioComparison[]): CompareGroupComplete {
+function group(
+  scenarios: ScenarioComparison[],
+  resultOver: Partial<CompareGroupComplete['result']> = {},
+): CompareGroupComplete {
   return {
     status: 'complete',
     completedRuns: scenarios.length,
     totalRuns: scenarios.length,
-    result: { comparisonGroupId: 'cg1', verdict: 'not-required', tag: 'draft:wix/skills#1', scenarios },
+    result: { comparisonGroupId: 'cg1', verdict: 'not-required', tag: 'draft:wix/skills#1', scenarios, ...resultOver },
   };
 }
 
@@ -88,6 +91,37 @@ describe('comment formatters', () => {
 
   it('formatNoChanges signals success', () => {
     expect(c.formatNoChanges()).toContain('No Gated Changes');
+  });
+
+  it('formatComparisonResult warns and drops the green tick when judging was partial', () => {
+    const tie = scenario({ pairwiseJudgement: undefined, required: false });
+    const out = c.formatComparisonResult(group([tie], { judgeCoverage: { judged: 1, total: 3 } }), 'proj-1');
+
+    // A not-required verdict from partial judging must not read as a pass.
+    // Scoped to the heading, since ✅/⚠️ also appear in the scenario rows.
+    const heading = out.split('\n').find(l => l.startsWith('## '))!;
+    expect(out).toContain('Only 1/3 scenarios were judged');
+    expect(heading).toContain('⚠️');
+    expect(heading).not.toContain('✅');
+  });
+
+  it('formatComparisonResult keeps the green tick at full coverage', () => {
+    const tie = scenario({ pairwiseJudgement: { winner: 'tie', confidence: 'high', reasoning: 'same' }, required: false });
+    const out = c.formatComparisonResult(group([tie], { judgeCoverage: { judged: 1, total: 1 } }), 'proj-1');
+    const heading = out.split('\n').find(l => l.startsWith('## '))!;
+
+    expect(out).not.toContain('scenarios were judged');
+    expect(heading).toContain('✅');
+  });
+
+  it('formatComparisonResult is unchanged when the pipeline reports no coverage', () => {
+    const tie = scenario({ pairwiseJudgement: { winner: 'tie', confidence: 'high', reasoning: 'same' }, required: false });
+    const out = c.formatComparisonResult(group([tie]), 'proj-1');
+
+    // Older pipeline builds omit the field; absent must not mean degraded.
+    const heading = out.split('\n').find(l => l.startsWith('## '))!;
+    expect(out).not.toContain('scenarios were judged');
+    expect(heading).toContain('✅');
   });
 
   it('formatComparisonResult adds a Runs column with PR + prod run links', () => {


### PR DESCRIPTION
## Why

The gate polls the eval comparison service until a comparison finishes. The final poll — the one that returns the result — does considerably more work server-side than the intermediate "still running" polls, and could take longer than the 30s the HTTP client allowed for every request.

When the client timed out first, two things went wrong:

- The real error was replaced by a generic abort, so failures reported `The operation was aborted due to timeout` instead of what actually happened.
- An abort counts as retriable, so the request was re-issued — repeating work that had already completed successfully.

The visible effect was a failing gate on comparisons that had in fact finished, with every retry hitting the same wall.

## What changed

**Per-request timeouts.** `post()` now accepts a timeout rather than hardcoding one. The default is unchanged at 30s; only the completion poll gets a longer one, chosen to exceed any deadline the server applies to itself so that the client is the last participant to give up and a real response is what we act on.

`/run-comparison` deliberately keeps the 30s default: it returns quickly and is non-idempotent (it queues eval runs), so failing fast is safer than widening the window for a duplicate.

**A partially judged comparison is no longer presented as a pass.** The service can report how many scenarios actually produced a pairwise judgement. When that is fewer than the total, the PR comment now carries a warning and the heading drops its ✅. This matters because `not-required` is also the verdict produced when judging yields nothing — so a degraded comparison and a genuine "this skill makes no difference" were previously indistinguishable in the comment. The field is optional; when absent, rendering is unchanged.

**`dist/` rebuilt**, since the committed bundle is what the action runs.

## Testing

`yarn typecheck` clean. `yarn test` — 79 passed / 10 files.

Three new tests in `tests/comment.test.ts`: partial coverage warns and downgrades the heading icon, full coverage keeps ✅, and a missing field keeps ✅ so existing responses render as before. The icon behaviour is mutation-checked — removing the coverage condition fails the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
