### PR TITLE
feat(wix-manage): restaurants-reservations-setup recipe

### DIFF
--- a/skills/wix-manage/references/restaurants/restaurants-reservations-setup.md
+++ b/skills/wix-manage/references/restaurants/restaurants-reservations-setup.md
@@ -69,7 +69,6 @@ Everything a merchant means by "our booking rules" lives on the reservation loca
     "revision": "4",
     "configuration": {
       "onlineReservations": {
-        "onlineReservationsEnabled": true,
         "partySize": { "min": 1, "max": 10 },
         "defaultTurnoverTime": 90,
         "approval": { "mode": "MANUAL" }
@@ -80,6 +79,8 @@ Everything a merchant means by "our booking rules" lives on the reservation loca
 ```
 
 `defaultTurnoverTime` is minutes and applies to every party; `turnoverTimeRules` overrides it per party size, which is what "90 minutes for a table of four" means. Pacing reads `timeSlotInterval` (15 by default), so party and seat pacing are per 15-minute slot. `minimumReservationNotice` is `{ number, unit }`, e.g. 30 `MINUTES`.
+
+**Do not echo `onlineReservationsEnabled` back unless the merchant is asking to turn online reservations on or off.** Writing `true` to it is gated on a Premium plan — on a non-premium site it returns `428 PREMIUM_ONLY` (`"Can't turn on online reservation for a non-premium website"`), even when the field already reads `true` on a `GET`. A `GET` returns the flag; sending it straight back re-triggers the premium check and fails the whole `PATCH`, so the rule fields never get written. Patch only the rules the merchant asked for (party size, turnover, approval, pacing, schedule) and leave `onlineReservationsEnabled` at its existing value. If the merchant explicitly wants online reservations turned on and the call comes back `PREMIUM_ONLY`, say plainly that a Premium plan is required and stop — do not retry the same body.
 
 ### Step 3: Check Availability Before Booking
 
@@ -139,6 +140,7 @@ Read field shapes from the [Reservations API docs](https://dev.wix.com/docs/api-
 | Error changing a `HELD` reservation's status | Normal updates cannot move a reservation out of `HELD`, and it expires after 10 minutes | Use the reserve call, or start again if it expired |
 | Reservation rejected on create | Non walk-in bookings require the guest's first name and phone | Collect both before creating |
 | Slot looks open but booking fails | Party or seat pacing, not table availability | Check the slot first — it reports pacing conflicts explicitly |
+| `428 PREMIUM_ONLY` — "Can't turn on online reservation for a non-premium website" | `onlineReservationsEnabled` was written (`true` or `false`) on a non-premium site, usually echoed back from a `GET` | Drop `onlineReservationsEnabled` from the body and re-send only the rule fields the merchant asked for. If the merchant specifically wants online reservations on, tell them a Premium plan is required and stop |
 
 ## What This Skill Does NOT Cover
 

--- a/skills/wix-manage/references/restaurants/restaurants-reservations-setup.md
+++ b/skills/wix-manage/references/restaurants/restaurants-reservations-setup.md
@@ -1,0 +1,151 @@
+---
+name: "Restaurants Reservations Setup"
+description: "Configures Wix Table Reservations: party size limits, party and seat pacing, turnover times per party size, manual approval of online requests, the reservation business schedule, and creating or managing individual reservations through their lifecycle. Use when a merchant wants to accept table bookings, change how many guests they seat, set how long a table is held, require approval before a booking is confirmed, block a night, or when asked to create, seat, cancel or mark a reservation as a no-show. Reservations are a separate app from online ordering — menus and pickup or delivery hours are not configured here."
+---
+
+# Restaurants Reservations Setup
+
+Table bookings live in the **Wix Table Reservations** app, separate from Menus and Orders. This recipe covers reservation settings and the reservation lifecycle. For online ordering see [Restaurants Orders Settings](restaurants-orders-settings.md); for the menu itself see [Restaurants Menus Setup](restaurants-menus-setup.md).
+
+## When to Use
+
+- Setting minimum and maximum party size, or how long a table is held
+- Limiting how many parties or guests can be seated in the same 15 minutes
+- Requiring staff approval before an online booking is confirmed
+- Setting the hours reservations can be booked for
+- Creating a booking, seating a party, cancelling, or marking a no-show
+- Unsure which app owns the request? Start from [Configure Restaurants from Prompt](configure-restaurants-from-prompt.md)
+
+## Prerequisites
+
+1. Wix Table Reservations installed on the site (`f9c07de2-5341-40c6-b096-8eb39de391fb`) — it is independent of the ordering apps, so a site that takes online orders may not have it
+2. **At least one location configured in Business Info.** Every other call depends on it
+3. API access with reservations permissions
+
+## Two Rules That Decide Whether This Works
+
+### Rule 1: reservation locations are not created here
+
+A reservation location represents one physical restaurant and holds its calendar, pacing, and table rules. It can only be **created or archived through the Dashboard or the Locations API** — never through the Reservations APIs. Read the existing ones and update them.
+
+The same call also refuses to change a location's `location` object. Address changes belong to the Locations API.
+
+If listing returns nothing, the site has no location configured in Business Info yet. Say so rather than trying to create one.
+
+### Rule 2: several settings have two spellings, and sending both fails
+
+The server keeps a newer and a deprecated field in sync, and a `GET` returns **both** spellings:
+
+| Use this | Not this |
+|---|---|
+| `partySize` | `partiesSize` |
+| `turnoverTimeRules` | `turnoverRules` |
+
+Echoing the whole object back therefore sends both, and if their values disagree the request is rejected. Send only the newer field, and strip the deprecated twin from anything you read before writing it back. Manual approval is a third shape rather than a twin — `approval.mode`, either `"AUTOMATIC"` or `"MANUAL"`.
+
+## Flow
+
+### Step 1: Find the Reservation Location
+
+List or query reservation locations and pick one. Sites with several restaurants have one per physical location, so match on the location before changing anything.
+
+### Step 2: Update Its Configuration
+
+Everything a merchant means by "our booking rules" lives on the reservation location under `configuration.onlineReservations`:
+
+- **Party size** — minimum and maximum guests bookable online.
+- **Turnover time** — how long a table is held, usually varying by party size. "90 minutes for a table of four" is a turnover rule, not a global setting.
+- **Party pacing** — how many parties may *start* within any 15-minute window. Stops the kitchen being hit by ten bookings at 19:00.
+- **Seat pacing** — the same cap expressed in guests rather than parties.
+- **Manual approval** — when on, online bookings arrive as `REQUESTED` and staff confirm them. When off, they are confirmed immediately.
+- **Business schedule** — the hours bookings can be made for.
+
+`PATCH /table-reservations/reservation-locations/v1/reservation-locations/{id}`, body wrapped in `reservationLocation` with `id` and the current `revision`. Party of 10 max, 90-minute turnover, staff approval:
+
+```json
+{
+  "reservationLocation": {
+    "id": "<RESERVATION_LOCATION_ID>",
+    "revision": "4",
+    "configuration": {
+      "onlineReservations": {
+        "onlineReservationsEnabled": true,
+        "partySize": { "min": 1, "max": 10 },
+        "defaultTurnoverTime": 90,
+        "approval": { "mode": "MANUAL" }
+      }
+    }
+  }
+}
+```
+
+`defaultTurnoverTime` is minutes and applies to every party; `turnoverTimeRules` overrides it per party size, which is what "90 minutes for a table of four" means. Pacing reads `timeSlotInterval` (15 by default), so party and seat pacing are per 15-minute slot. `minimumReservationNotice` is `{ number, unit }`, e.g. 30 `MINUTES`.
+
+### Step 3: Check Availability Before Booking
+
+Time slot availability is computed from party size, pacing rules, the business schedule, and existing bookings — never assume a time is free. Get time slots for a date and party size, or check one specific slot, which also reports which table combinations fit and flags pacing conflicts.
+
+### Step 4: Create the Reservation
+
+Two shapes, and picking the wrong one strands guests:
+
+- **Direct** — create the reservation with all details at once via `Create Reservation`, bypassing `HELD` entirely. It lands in `RESERVED` (or `REQUESTED` for an online-source reservation when the location requires manual approval). Use it for staff taking a booking over the phone or entering one from the dashboard — that is the offline/staff path, and offline bookings are `RESERVED` regardless of the manual-approval setting. With the `MANAGE RESERVATIONS (FULL)` scope you can set the status explicitly and override online-availability and table rules.
+- **Held, then reserved** — hold the slot, collect the guest's details, then convert it. Right for a guest-facing flow, because it stops two people taking the same table while one is still typing. A held reservation **expires after 10 minutes**, and it cannot be moved out of `HELD` with a normal update — it has to be converted with the dedicated reserve call.
+
+Any reservation not made as a walk-in requires the guest's first name and phone number. The hold takes only the slot; the reserve call adds the guest:
+
+```json
+POST .../reservations/hold
+{ "reservationDetails": { "reservationLocationId": "<ID>", "startDate": "2026-09-04T19:00:00Z", "partySize": 4 } }
+
+POST .../reservations/{reservationId}/reserve
+{ "reservee": { "firstName": "Dana", "phone": "+15555550123" }, "revision": "1" }
+```
+
+`startDate` is an ISO timestamp, `partySize` an integer. `reservee` and `revision` are both required on reserve — that `revision` is the held reservation's, from the hold response.
+
+### Step 5: Move It Through the Lifecycle
+
+`HELD → REQUESTED → RESERVED → SEATED → FINISHED`, with `DECLINED`, `CANCELED` and `NO_SHOW` as exits. `PAYMENT_INFORMATION_PENDING` appears when the location requires payment, and clears to `RESERVED` on its own once paid — do not try to force it.
+
+A reservation's `source` records how it was made and decides which statuses it can start in: `ONLINE` (made through the site or app — the only path that begins in `HELD`), `OFFLINE` (made by staff, e.g. a phone booking entered in the dashboard — starts in `RESERVED` or `REQUESTED` via `Create Reservation`, skipping `HELD`), or `WALK_IN` (a guest who arrived without a booking). `source` is set on creation, not updated later.
+
+**Reservations that require payment create an eCommerce order.** When a reservation location charges a per-guest or per-reservation fee, takes a deposit, or holds a card as a guarantee, the reservation is backed by an eCommerce order whose line item carries `catalogReference.appId` `f9c07de2-5341-40c6-b096-8eb39de391fb` (the Table Reservations app) and `catalogItemId` equal to the reservation ID. The reservation's `paymentStatus` mirrors that order — `FREE` (no charge), `NOT_PAID`, `PAID`, `PARTIALLY_PAID`, `PARTIALLY_REFUNDED`, `FULLY_REFUNDED`. A no-show or late cancellation fee, where the location's policy applies one, is charged and refunded against the same order. Free reservations have no order.
+
+Report the outcome in the merchant's words: which party, what time, how many guests.
+
+## Endpoints
+
+Under `https://www.wixapis.com` with an `Authorization` header:
+
+| Purpose | Call |
+|---|---|
+| List, read, update a reservation location | `GET` `/table-reservations/reservation-locations/v1/reservation-locations[/{id}]`, `POST` `.../query`, `PATCH` `.../{id}` |
+| Get time slots for a date and party size | `POST /table-reservations/reservations/v1/time-slots` |
+| Check one time slot | `POST /table-reservations/reservations/v1/check-time-slot` |
+| Create a reservation | `POST /table-reservations/reservations/v1/reservations` |
+| Hold a slot for 10 minutes, then convert it | `POST /table-reservations/reservations/v1/reservations/hold`, `POST .../{reservationId}/reserve` |
+| Find reservations, cancel one | `POST /table-reservations/reservations/v1/reservations/query`, `POST .../{reservationId}/cancel` |
+
+Read field shapes from the [Reservations API docs](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/reservations/introduction) rather than from this table.
+
+## Error Handling
+
+| Error | Cause | Action |
+|---|---|---|
+| Validation error naming two fields that mean the same thing | Both the current and deprecated spelling were sent with different values, usually from echoing a GET | Send only `partySize`, `turnoverTimeRules`, `approval` |
+| Application error changing a location's `location` | That object is owned by the Locations API | Change the address there instead |
+| Listing reservation locations returns nothing | No location configured in Business Info | Tell the merchant to add one; it cannot be created from here |
+| Error changing a `HELD` reservation's status | Normal updates cannot move a reservation out of `HELD`, and it expires after 10 minutes | Use the reserve call, or start again if it expired |
+| Reservation rejected on create | Non walk-in bookings require the guest's first name and phone | Collect both before creating |
+| Slot looks open but booking fails | Party or seat pacing, not table availability | Check the slot first — it reports pacing conflicts explicitly |
+
+## What This Skill Does NOT Cover
+
+- **Online ordering — hours, pickup, delivery** — a different app; see [Restaurants Orders Settings](restaurants-orders-settings.md)
+- **Menus, sections, items, prices** — see [Restaurants Menus Setup](restaurants-menus-setup.md)
+- **Orders customers placed online** — see [Restaurants Orders Management](restaurants-orders-management.md)
+- **Floor plans and table definitions** — dashboard only, see [Restaurants Dashboard Navigation](restaurants-dashboard-navigation.md)
+- **Experiences** (wine tastings, chef's tables) — a separate Reservations API, not covered here yet
+
+If you cannot complete a change, say plainly that it was not applied and hand back the dashboard page — the reservations pages are listed in [Restaurants Dashboard Navigation](restaurants-dashboard-navigation.md). Never report a setting as saved, noted, or configured without a successful call behind it.

--- a/yaml/wix-manage-evals/restaurants/restaurants-set-reservation-rules.yml
+++ b/yaml/wix-manage-evals/restaurants/restaurants-set-reservation-rules.yml
@@ -2,8 +2,10 @@ name: restaurants/set-reservation-rules
 description: >-
   Verifies the agent reads the reservations-setup recipe and configures an
   existing reservation location's party size and turnover time, without trying
-  to create a reservation location and without sending both the current and
-  deprecated spelling of a setting.
+  to create a reservation location, without sending both the current and
+  deprecated spelling of a setting, and without echoing `onlineReservationsEnabled`
+  (a Free-plan/PREMIUM_ONLY-gated flag the merchant never asked to toggle) into
+  the PATCH body.
 triggerPrompt: >-
   For table bookings at my restaurant: biggest party we'll take online is 10
   people, and hold each table for 90 minutes. Also I want to approve bookings
@@ -58,12 +60,21 @@ assertions:
         4. Only the current field spellings were sent — not the deprecated twin
            of the same setting in the same request.
         5. The update carried the location's current revision.
+        6. The agent did NOT send `onlineReservationsEnabled` in the PATCH body.
+           The merchant asked for party size, turnover, and approval only — not
+           to turn online reservations on or off. The provisioned site is on a
+           Free plan, and writing `onlineReservationsEnabled` (even echoing the
+           `true` a GET returns) triggers `428 PREMIUM_ONLY` and fails the whole
+           PATCH, so the rule fields never land. Patch only the requested rules.
 
       Fail if ANY of these hold:
         - A create call was attempted against the Reservations APIs for a
           reservation location.
         - Both a current and a deprecated spelling of the same setting were sent
           together.
+        - `onlineReservationsEnabled` was sent in the PATCH body and the call
+          returned `PREMIUM_ONLY`, especially after echoing a GET response —
+          or the same failing body was retried unchanged.
         - The 90 minutes was written as something other than a turnover rule —
           for example as a preparation time or an ordering setting.
         - The agent confused reservations with online ordering and touched
@@ -78,9 +89,12 @@ assertions:
       Penalize and LIST any of: a non-2xx error even if recovered; attempting to
       create a reservation location and being rejected; a validation error from
       sending a deprecated field alongside its replacement, especially after
-      echoing back a GET response wholesale; hunting through the ordering APIs
-      before finding the reservations ones; updating without first reading the
-      revision; redundant or probing calls clearer docs would avoid. For each,
-      name the likely MCP/docs gap.
+      echoing back a GET response wholesale; sending `onlineReservationsEnabled`
+      in the PATCH and hitting `428 PREMIUM_ONLY` on a Free plan — the flag is
+      premium-gated and the merchant never asked to toggle it, so it should be
+      omitted entirely; retrying the same failing PATCH body unchanged; hunting
+      through the ordering APIs before finding the reservations ones; updating
+      without first reading the revision; redundant or probing calls clearer
+      docs would avoid. For each, name the likely MCP/docs gap.
       Return ONLY {"score":<0-10>,"reason":"<terse list of frictions +
       suspected MCP/docs gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage-evals/restaurants/restaurants-set-reservation-rules.yml
+++ b/yaml/wix-manage-evals/restaurants/restaurants-set-reservation-rules.yml
@@ -1,0 +1,86 @@
+name: restaurants/set-reservation-rules
+description: >-
+  Verifies the agent reads the reservations-setup recipe and configures an
+  existing reservation location's party size and turnover time, without trying
+  to create a reservation location and without sending both the current and
+  deprecated spelling of a setting.
+triggerPrompt: >-
+  For table bookings at my restaurant: biggest party we'll take online is 10
+  people, and hold each table for 90 minutes. Also I want to approve bookings
+  myself before they're confirmed.
+tags: [restaurants]
+maxTokens: 600000
+siteSetup:
+  mode: template
+  templateId: restaurants-editor
+  bootstrap:
+    steps:
+      # The restaurants template ships the ordering apps; Table Reservations is a separate
+      # app and reservation locations only exist once it is installed. Without this the
+      # scenario would test "the agent correctly reports there is nothing to configure".
+      - label: Install Wix Table Reservations so the site has a reservation location
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: f9c07de2-5341-40c6-b096-8eb39de391fb
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/restaurants-reservations-setup
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The merchant asked for three reservation settings: maximum online party
+      size 10, a 90-minute turnover, and manual approval of bookings.
+
+      All three live on an existing reservation location's configuration.
+      A reservation location cannot be created through the Reservations APIs —
+      only through the dashboard or the Locations API — so the agent must read
+      the existing one and update it. Three settings also have a deprecated
+      twin field (`partySize`/`partiesSize`, `turnoverTimeRules`/`turnoverRules`,
+      `approval`/`manualApproval`) that the server keeps in sync; a GET returns
+      both, and sending both with conflicting values is rejected.
+
+      Examine the tool-call trace, not just the final prose.
+
+      Pass only if ALL of these hold:
+        1. The agent listed or queried reservation locations and updated an
+           existing one, rather than attempting to create one.
+        2. Maximum party size 10 and a 90-minute turnover were written to that
+           location's configuration.
+        3. Manual approval was enabled, so online bookings arrive requiring
+           confirmation.
+        4. Only the current field spellings were sent — not the deprecated twin
+           of the same setting in the same request.
+        5. The update carried the location's current revision.
+
+      Fail if ANY of these hold:
+        - A create call was attempted against the Reservations APIs for a
+          reservation location.
+        - Both a current and a deprecated spelling of the same setting were sent
+          together.
+        - The 90 minutes was written as something other than a turnover rule —
+          for example as a preparation time or an ordering setting.
+        - The agent confused reservations with online ordering and touched
+          fulfillment methods or operations.
+        - The agent only described the steps without executing them.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: >
+      Rate how smoothly the Wix MCP let the agent fulfill this request. Examine
+      the tool-call trace. Score 0-10 (10 = direct: no wasted calls, no errors).
+      Penalize and LIST any of: a non-2xx error even if recovered; attempting to
+      create a reservation location and being rejected; a validation error from
+      sending a deprecated field alongside its replacement, especially after
+      echoing back a GET response wholesale; hunting through the ordering APIs
+      before finding the reservations ones; updating without first reading the
+      revision; redundant or probing calls clearer docs would avoid. For each,
+      name the likely MCP/docs gap.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions +
+      suspected MCP/docs gap, or 'clean path' if none>"}.

--- a/yaml/wix-manage/restaurants/documentation.yaml
+++ b/yaml/wix-manage/restaurants/documentation.yaml
@@ -11,3 +11,8 @@ apiDoc:
       title: Restaurants Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/restaurants
       tags: [restaurants]
+
+    - file: ../../../skills/wix-manage/references/restaurants/restaurants-reservations-setup.md
+      title: Restaurants Reservations Setup
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/restaurants
+      tags: [restaurants]


### PR DESCRIPTION
Adds a dedicated recipe for the **Wix Table Reservations** app (`f9c07de2`), which is independent of the Menus and Orders apps and had no recipe coverage.

## What it covers
- Party size limits, party and seat pacing, turnover times per party size
- Manual approval of online requests
- The reservation business schedule
- Creating reservations through their lifecycle — `HELD → REQUESTED → RESERVED → SEATED → FINISHED`, exits `DECLINED`/`CANCELED`/`NO_SHOW`, `source` (`ONLINE`/`OFFLINE`/`WALK_IN`) deciding the starting status
- The eCommerce-order link for payment-required reservations (per-guest fee, deposit, card guarantee) and the no-show / late-cancellation fee path

## Why a separate PR
The Table Reservations app is self-contained, so this recipe can land independently. It is also part of a larger Restaurants recipe split (#1044), but isolated here as a single new skill so it can be reviewed and merged on its own. The cross-links to other recipes in #1044 resolve once that PR lands; until then they are relative paths to files not yet on `main`.

## Eval
Adds `restaurants/set-reservation-rules` — configures an existing reservation location's party size, turnover, and manual approval, without creating a reservation location and without sending deprecated field spellings (`partySize`/`partiesSize`, `turnoverTimeRules`/`turnoverRules`).

## Premium-gate fix (second commit)
The original Step 2 PATCH example sent `onlineReservationsEnabled: true` unconditionally. On a Free-plan site that write is gated — `428 PREMIUM_ONLY` ("Can't turn on online reservation for a non-premium website") — even when a `GET` already returns `true`, and echoing it back re-triggers the premium check so the rule fields never land. The merchant asked for party size, turnover, and approval only, never to toggle online reservations on/off.

- **Recipe**: dropped the flag from the example, added a premium-gate note, and added a `PREMIUM_ONLY` error-handling row (re-send only the rule fields, or stop and report a Premium plan is required when the merchant explicitly wants online reservations on).
- **Eval**: added a pass criterion that the agent must not send `onlineReservationsEnabled`, a matching fail criterion (flag echo / unchanged retry), and a smoothness-judge penalty for the `PREMIUM_ONLY` 428.

General lesson surfaced: patch only the fields the merchant asked for — do not echo the whole `GET` object back, since re-sending a premium-gated flag fails the entire `PATCH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)