### PR TITLE
Fix EvalForge new skill limit configuration

### DIFF
--- a/.github/actions/evalforge-yaml-gate/tests/workflow-config.test.ts
+++ b/.github/actions/evalforge-yaml-gate/tests/workflow-config.test.ts
@@ -93,7 +93,7 @@ describe('EvalForge YAML Gate Workflow', () => {
     });
 
     it('passes max new skills from GitHub config with a default', () => {
-      expect(workflowContent).toContain("max-new-skills: ${{ vars.EVAL_MAX_NEW_SKILLS || '1' }}");
+      expect(workflowContent).toContain("max-new-skills: ${{ vars.EVAL_MAX_NEW_SKILL_AREAS || '1' }}");
     });
   });
 });

--- a/.github/workflows/evalforge-yaml-gate.yml
+++ b/.github/workflows/evalforge-yaml-gate.yml
@@ -45,4 +45,4 @@ jobs:
           blocking: ${{ vars.EVAL_BLOCK_MERGE || 'false' }}
           auto-approve: ${{ vars.EVAL_AUTO_APPROVE || 'false' }}
           eval-compare: ${{ vars.TRIGGER_EVAL_COMPARE || 'true' }}
-          max-new-skills: ${{ vars.EVAL_MAX_NEW_SKILLS || '1' }}
+          max-new-skills: ${{ vars.EVAL_MAX_NEW_SKILL_AREAS || '1' }}


### PR DESCRIPTION
## Summary
- read the existing `EVAL_MAX_NEW_SKILL_AREAS` repository variable in the EvalForge YAML gate
- update the workflow regression test to lock the configured variable name

## Testing
- `yarn --cwd .github/actions/evalforge-yaml-gate test` (76 tests passed)