### PR TITLE
feat(seo): add SEO tags management recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -36,10 +36,8 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## SEO
 
-> **Routing rule (READ FIRST).** For every request to read or change a site's SEO tags — titles, meta descriptions, social share tags, canonical links, structured data, indexing directives, or SEO patterns — call `ReadFullDocsArticle` on `https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/skills/manage-a-wix-site-s-seo-tags` BEFORE making any API calls or searching schemas. The recipe contains the exact request shapes, field masks, and tag structures needed — do not construct requests without loading it first.
-
 ### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
-**Technical:** Reads and writes a site's SEO tags at three levels — site-wide tags, page-type patterns, and a single item's tags — choosing the level that matches the change. Discovers item IDs and pattern variables instead of hardcoding them, reads before every full-replace write, handles bulk writes with per-item results, and reports resolved tags with the source each one came from.
+**Technical:** Reads and writes SEO tags (titles, descriptions, social tags, structured data, indexing) at three levels: site-wide, page-type patterns, and individual items. Always read before write — every Set replaces in full.
 
 ### [Manage URL Redirects on a Wix Site](references/seo/manage-url-redirects.md)
 **Technical:** Reads, creates, and deletes URL redirects through the public SEO Redirects API. Distinguishes exact from group redirects, handles language-scoped redirects on multilingual sites, reads per-item results from bulk responses, and confirms before writes, because creating a redirect can permanently delete an existing one.

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -36,7 +36,7 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## SEO
 
-> **Routing rule (READ FIRST).** For every request to read or change a site's SEO tags — titles, meta descriptions, social share tags, canonical links, structured data, indexing directives, or SEO patterns — use the available full-documentation reading capability to retrieve and read the canonical [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md) recipe before using API schema search. Every SEO write replaces the target's tags in full, so the recipe's read-before-write sequence has to be loaded before the first call.
+> **Routing rule (READ FIRST).** For every request to read or change a site's SEO tags — titles, meta descriptions, social share tags, canonical links, structured data, indexing directives, or SEO patterns — call `ReadFullDocsArticle` on `https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/skills/manage-a-wix-site-s-seo-tags` BEFORE making any API calls or searching schemas. The recipe contains the exact request shapes, field masks, and tag structures needed — do not construct requests without loading it first.
 
 ### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
 **Technical:** Reads and writes a site's SEO tags at three levels — site-wide tags, page-type patterns, and a single item's tags — choosing the level that matches the change. Discovers item IDs and pattern variables instead of hardcoding them, reads before every full-replace write, handles bulk writes with per-item results, and reports resolved tags with the source each one came from.

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -36,6 +36,11 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## SEO
 
+> **Routing rule (READ FIRST).** For every request to read or change a site's SEO tags — titles, meta descriptions, social share tags, canonical links, structured data, indexing directives, or SEO patterns — use the available full-documentation reading capability to retrieve and read the canonical [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md) recipe before using API schema search. Every SEO write replaces the target's tags in full, so the recipe's read-before-write sequence has to be loaded before the first call.
+
+### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
+**Technical:** Reads and writes a site's SEO tags at three levels — site-wide tags, page-type patterns, and a single item's tags — choosing the level that matches the change. Discovers item IDs and pattern variables instead of hardcoding them, reads before every full-replace write, handles bulk writes with per-item results, and reports resolved tags with the source each one came from.
+
 ### [Manage URL Redirects on a Wix Site](references/seo/manage-url-redirects.md)
 **Technical:** Reads, creates, and deletes URL redirects through the public SEO Redirects API. Distinguishes exact from group redirects, handles language-scoped redirects on multilingual sites, reads per-item results from bulk responses, and confirms before writes, because creating a redirect can permanently delete an existing one.
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, SEO, dashboard-navigation."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, seo, dashboard-navigation."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -355,6 +355,13 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Author Ricos Rich Content](references/rich-content/author-ricos-rich-content.md)
 **Technical:** Required first source for every request to hand-author, output, or return Ricos / `richContent` JSON (`nodes` tree) for Blog, Stores, Events, or CMS. Retrieve and read this full article before API schema search or constructing the JSON. Covers node shapes — paragraphs, headings, lists, blockquotes, dividers, tables with cell fills, code blocks, images, buttons, audio, video, galleries, collapsible lists, HTML embeds — plus inline text decorations (including spoiler) and nesting rules.
+
+---
+
+## SEO
+
+### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
+**Technical:** Reads and writes a site's SEO tags at three levels — site-wide tags, page-type patterns, and a single item's tags — choosing the level that matches the change. Discovers item IDs and pattern variables instead of hardcoding them, reads before every full-replace write, handles bulk writes with per-item results, and reports resolved tags with the source each one came from.
 
 ---
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -360,6 +360,8 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## SEO
 
+> **Routing rule (READ FIRST).** For every request to read or change a site's SEO tags — titles, meta descriptions, social share tags, canonical links, structured data, indexing directives, or SEO patterns — use the available full-documentation reading capability to retrieve and read the canonical [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md) recipe before using API schema search. Every SEO write replaces the target's tags in full, so the recipe's read-before-write sequence has to be loaded before the first call.
+
 ### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
 **Technical:** Reads and writes a site's SEO tags at three levels — site-wide tags, page-type patterns, and a single item's tags — choosing the level that matches the change. Discovers item IDs and pattern variables instead of hardcoding them, reads before every full-replace write, handles bulk writes with per-item results, and reports resolved tags with the source each one came from.
 

--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -363,15 +363,6 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ---
 
-## SEO
-
-> **Routing rule (READ FIRST).** For every request to read or change a site's SEO tags — titles, meta descriptions, social share tags, canonical links, structured data, indexing directives, or SEO patterns — use the available full-documentation reading capability to retrieve and read the canonical [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md) recipe before using API schema search. Every SEO write replaces the target's tags in full, so the recipe's read-before-write sequence has to be loaded before the first call.
-
-### [Manage a Wix Site's SEO Tags](references/seo/manage-seo-tags.md)
-**Technical:** Reads and writes a site's SEO tags at three levels — site-wide tags, page-type patterns, and a single item's tags — choosing the level that matches the change. Discovers item IDs and pattern variables instead of hardcoding them, reads before every full-replace write, handles bulk writes with per-item results, and reports resolved tags with the source each one came from.
-
----
-
 ## Site Properties
 
 ### [Change Payment Currency](references/site-properties/change-payment-currency-site-properties.md)

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -174,6 +174,67 @@ To remove an item's own tags so it inherits again, call **Reset Item SEO Tags To
 Default** (or **Reset SEO Pattern To Default**) — never set an empty list to
 mean "reset".
 
+## Worked example: set a product's SEO title and description
+
+The user asks: *"Set the SEO title of my product 'Handmade Mug' to 'Handmade
+Ceramic Mug | Studio Shop' and its description to 'A stoneware mug.'"*
+
+**Step 1 — find the product ID.** Query the Stores API by name, not the SEO API:
+
+```
+POST https://www.wixapis.com/stores/v1/products/query
+{ "query": { "filter": { "name": "Handmade Mug" } } }
+```
+
+Take the product's `id` from the response. The item type is `STORES_PRODUCT`.
+
+**Step 2 — read the current tags.**
+
+```
+GET https://www.wixapis.com/promote/seo/v1/item-seo-tags/STORES_PRODUCT/{productId}
+```
+
+The response carries `itemSeoTags.tags` (the item's own tags) and
+`resolvedTags` (what the page renders with, each with a source).
+
+**Step 3 — merge and write.** Take the full `tags` array from step 2, replace
+or add the title and description, and send the complete set back:
+
+```json
+PATCH /item-seo-tags/STORES_PRODUCT/{productId}
+{
+  "itemSeoTags": {
+    "tags": [
+      { "type": "title", "children": "Handmade Ceramic Mug | Studio Shop" },
+      { "type": "meta", "props": { "name": "description", "content": "A stoneware mug." } }
+    ]
+  },
+  "fieldMask": "tags"
+}
+```
+
+**Step 4 — report from the response.** The Set response returns the updated
+`tags` and `resolvedTags`. Report each resolved tag with its source. Do not
+issue another Get — the write response is the confirmation.
+
+## Common agent mistakes — do not make these
+
+- **Searching the API schemas or reading the reference article before the first
+  call.** The request shapes are in this recipe. Read the reference article only
+  after a 400 you cannot explain from the shapes here.
+- **Using `searchWixAPISpec` or `searchWixAPIs` to find the SEO endpoints.**
+  The method table and shapes are above; spec search wastes a turn.
+- **Sending `fieldMask` as an array over REST.** Over REST it is a
+  comma-separated string: `"fieldMask": "tags"`. The SDK's `["tags"]` array
+  returns `INVALID_FIELD_MASK`.
+- **Guessing the item type.** Use the values in the Discover section. A store
+  product is `STORES_PRODUCT`, not `StoresProduct`, `product`, or `Product`.
+- **Calling List Item SEO Tags to find a product by name.** List returns IDs
+  and tags, not product names. Query the vertical's own API (e.g. Stores) by
+  name first, then use the ID.
+- **Issuing a verification Get after a successful Set.** The Set response
+  already carries `resolvedTags`. A second read is redundant.
+
 Tags can currently be written only for the site's primary language: leave
 `language` unset on every write. There is no revision checking — the last write
 wins and dashboard edits write to the same data, so read immediately before

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -58,6 +58,8 @@ reference article URLs follow this pattern (for edge cases not covered here):
 
 ## REST request and response shapes
 
+Use these shapes directly — do not go looking for them in the docs first.
+
 Build requests from the shapes below. Do not search the API schemas or read
 the reference article to construct them.
 
@@ -128,9 +130,7 @@ returns `INVALID_FIELD_MASK`. `publish` is a boolean.
 `TAG_SOURCE_ITEM`, or `TAG_SOURCE_UNSPECIFIED`. `inheritedTag` appears only when
 this source replaced a value a lower source had set.
 
-All paths are relative to the service base. The reference documents two bases
-(`promote/seo/v1` in schemas, `seo-metatags-server/v1` in curl examples); both
-are routed and work.
+All paths are relative to `https://www.wixapis.com/promote/seo/v1`.
 
 ## Discover, never invent
 
@@ -139,7 +139,7 @@ are routed and work.
   `BLOG_POST`, `BLOG_CATEGORY`, `BOOKINGS_SERVICE`, `EVENTS_PAGE`,
   `PORTFOLIO_PROJECTS`, `PORTFOLIO_COLLECTIONS`, `RESTAURANTS_MENU_PAGE`.
 - To find an item's ID when the user refers to it by name (e.g. a product
-  name), find the item through the MCP's search tools or the vertical's own API
+  name), use Search Products v3: `POST /stores/v3/products/search`
   to get the product ID, then use that ID as the `itemId` with item type
   `STORES_PRODUCT`. Do not call List Item SEO Tags and scan through all items
   to match by name — use the vertical API.
@@ -178,16 +178,19 @@ mean "reset".
 The user asks: *"Set the SEO title of my product 'Handmade Mug' to 'Handmade
 Ceramic Mug | Studio Shop' and its description to 'A stoneware mug.'"*
 
-**Step 1 — find the product ID.** Use the Wix MCP's product search to find the
-product by name. The `name` field is **not filterable** on the Query Products
-endpoint (it returns 400), so search instead:
+**Step 1 — find the product ID.** Search Products v3 by name:
 
-- Through the MCP: search for "Stores" products, then filter results by name.
-- Or call **List Item SEO Tags** for item type `STORES_PRODUCT` — this returns
-  all product IDs on the site. On a site with few products (like this one),
-  it's the fastest path.
+```
+POST https://www.wixapis.com/stores/v3/products/search
+{ "search": { "search": { "expression": "Handmade Mug" } } }
+```
 
-Take the product's `id` from the response. The item type is `STORES_PRODUCT`.
+```json
+{ "products": [{ "id": "a1b2c3d4-...", "name": "Handmade Mug", ... }] }
+```
+
+Take `products[0].id`. The item type is `STORES_PRODUCT`. Do not use Query
+Products with a `name` filter — `name` is not filterable and returns 400.
 
 **Step 2 — read the current tags.**
 
@@ -195,8 +198,21 @@ Take the product's `id` from the response. The item type is `STORES_PRODUCT`.
 GET https://www.wixapis.com/promote/seo/v1/item-seo-tags/STORES_PRODUCT/{productId}
 ```
 
-The response carries `itemSeoTags.tags` (the item's own tags) and
-`resolvedTags` (what the page renders with, each with a source).
+```json
+{
+  "itemSeoTags": {
+    "tags": [],
+    "hasOverride": false,
+    "resolvedTags": [
+      { "tag": { "type": "title", "children": "Handmade Mug | My Site" },
+        "source": "TAG_SOURCE_DEFAULT_PATTERN" }
+    ]
+  }
+}
+```
+
+`tags` is empty because the item has no overrides yet. `resolvedTags` shows
+what the page currently renders with and where each tag comes from.
 
 **Step 3 — merge and write.** Take the full `tags` array from step 2, replace
 or add the title and description, and send the complete set back:
@@ -223,22 +239,21 @@ issue another Get — the write response is the confirmation.
 - **Searching the API schemas or reading the reference article before the first
   call.** The request shapes are in this recipe. If you get a 400, compare your
   request against the shapes in this recipe — do not go to the docs.
-- **Using `searchWixAPISpec` or `searchWixAPIs` to find the SEO endpoints.**
-  The method table and shapes are above; spec search wastes a turn.
+- **Searching for the SEO endpoints through API spec tools.** The shapes are
+  above; searching wastes a turn.
 - **Sending `fieldMask` as an array over REST.** Over REST it is a
   comma-separated string: `"fieldMask": "tags"`. The SDK's `["tags"]` array
   returns `INVALID_FIELD_MASK`.
 - **Guessing the item type.** Use the values in the Discover section. A store
   product is `STORES_PRODUCT`, not `StoresProduct`, `product`, or `Product`.
-- **Calling List Item SEO Tags expecting product names.** List returns IDs
-  and tags, not product names. However, on a site with few products, listing
-  all `STORES_PRODUCT` items and matching the ID from context is acceptable.
+
 - **Issuing a verification Get after a successful Set.** The Set response
   already carries `resolvedTags`. A second read is redundant.
-- **Using the Products v1 API or filtering by `name` on Query Products.** v1
-  is deprecated (returns 400), and `name` is not a filterable field on v3
-  Query Products (also returns 400). Use the MCP's product search or List
-  Item SEO Tags for `STORES_PRODUCT` instead.
+- **Using Products v1 or filtering by `name` on Query Products.** Both return
+  400. Use Search Products v3: `POST /stores/v3/products/search` with
+  `{"search":{"search":{"expression":"..."}}}`.
+- **Calling List Item SEO Tags expecting product names.** List returns IDs
+  and tags, not names. Use Search Products to find the ID by name first.
 - **Retrying a 400 with a different request shape without checking why.** A 400
   means the shape was wrong. Compare against the shapes in this recipe, fix the
   mismatch, send once. Three retries with guessed shapes is three wasted calls.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -24,6 +24,16 @@ Match the user's request to the level that owns the change:
 | "All my product/blog/event pages should be titled like X" — a convention for every item of a page type | Pattern | **SEO Patterns** |
 | "Change the title of this page/product/post" — one specific item | Item | **Item SEO Tags** |
 
+All three APIs live under the **SEO** category of the Wix REST API reference.
+Read the chosen method's own reference article directly rather than searching
+schemas; these are the methods each level has:
+
+| Level | Methods |
+|---|---|
+| Site | Get Site SEO Tags, Set Site SEO Tags |
+| Pattern | Get SEO Pattern, List SEO Patterns, List SEO Pattern Variables, Create SEO Pattern, Set SEO Pattern, Reset SEO Pattern To Default |
+| Item | Get Item SEO Tags, List Item SEO Tags, Set Item SEO Tags, Bulk Set Item SEO Tags, Reset Item SEO Tags To Default |
+
 Work at the level that matches the change. Writing the same title onto many
 items is the same outcome as one pattern and much harder to undo. If the user's
 words fit more than one level, ask one short question before writing. An

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -44,8 +44,16 @@ words fit more than one level, ask one short question before writing. An
 explicit request to change a specific tag at a clear level is already
 confirmation to make that write.
 
-Work from the endpoints below rather than searching the API schemas. Every path
-is relative to `https://www.wixapis.com/promote/seo/v1`.
+Work from the endpoints below rather than searching the API schemas for them.
+The reference documents two bases for this service, and the runnable examples
+use the second:
+
+- `https://www.wixapis.com/promote/seo/v1` — used by the method schemas
+- `https://www.wixapis.com/seo-metatags-server/v1` — used by every curl example
+
+Send the service base your client is configured for. If a path returns `404`,
+retry it once on the other base before concluding anything about the method: a
+`404` here means the base was wrong, not that the feature is missing.
 
 | Level | Method | Call |
 |---|---|---|
@@ -194,10 +202,15 @@ value one level down — not the Wix built-in.
 - **`ITEM_NOT_FOUND`:** re-discover the item ID; do not guess a new one.
 - **Invalid tags:** tags are validated before anything is saved, so nothing
   changed; fix the tag and resend the same complete set.
+- **`400` on a request you built from this recipe:** the shape is wrong for that
+  method. Read that method's reference article once, correct the request, and
+  send it again. Never resend the same shape, and never walk through variations
+  hoping one is accepted.
 - **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading
   them is; say so instead of retrying.
 
-Everything needed to call these APIs is above: do not search the API schemas or
-re-read the reference for paths, field masks, or tag shapes. Consult the
-reference article for a specific method only when this recipe does not cover
-what you need — an unlisted error code, or a field absent from the shapes here.
+The paths, field masks, and tag shapes above are enough to build every call, so
+do not open a documentation search to rediscover them. Reading a method's
+reference article is still the right move for something this recipe does not
+carry — an unlisted error code, a field absent from the shapes here, or a
+request that came back `400`.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -160,10 +160,28 @@ success.
 - When reporting what a page will render with, use the `resolvedTags` already
   returned by the last Get or Set — not a fresh call — and name the source of
   each tag (site, default pattern, user pattern, host page, or the item
-  itself). Naming the source of each reported tag is required, not optional. `hasOverride: false` does not mean built-in
-  defaults — the item may inherit from a customized pattern or the site.
+  itself). Naming the source of each reported tag is required, not optional.
+  `hasOverride: false` does not mean built-in defaults — the item may inherit
+  from a customized pattern or the site.
 - `resolvedTags` excludes tags added by site code or apps at render time, so
   present it as what Wix manages, not a literal copy of the rendered page head.
+
+`resolvedTags` is an array of `{tag, source, inheritedTag}` — the tag itself is
+nested under `tag`, not spread onto the entry:
+
+```json
+"resolvedTags": [
+  { "tag": { "type": "title", "children": "Winter collection | Ceramics studio" },
+    "source": "TAG_SOURCE_ITEM",
+    "inheritedTag": { "type": "title", "children": "Ceramics studio" } }
+]
+```
+
+`source` is one of `TAG_SOURCE_SITE`, `TAG_SOURCE_DEFAULT_PATTERN`,
+`TAG_SOURCE_USER_PATTERN`, `TAG_SOURCE_HOST_PAGE`, `TAG_SOURCE_ITEM`, or
+`TAG_SOURCE_UNSPECIFIED` when it cannot be determined. `inheritedTag` appears
+only when this source replaced a value a lower source had set, and holds the
+value one level down — not the Wix built-in.
 
 ## Recovery rules
 
@@ -179,5 +197,7 @@ success.
 - **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading
   them is; say so instead of retrying.
 
-Load the current public API reference before constructing requests so field
-names, masks, permissions, and error schemas come from the live contract.
+Everything needed to call these APIs is above: do not search the API schemas or
+re-read the reference for paths, field masks, or tag shapes. Consult the
+reference article for a specific method only when this recipe does not cover
+what you need — an unlisted error code, or a field absent from the shapes here.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -55,7 +55,11 @@ the methods each level has:
 | Item | Get Item SEO Tags, List Item SEO Tags, Set Item SEO Tags, Bulk Set Item SEO Tags, Reset Item SEO Tags To Default |
 
 `Set` takes a `fieldMask` naming the properties to change (`tags`,
-`focusKeywords` for an item; `pattern` for a pattern). A tag is
+`focusKeywords` for an item; `pattern` for a pattern). Its shape differs by
+client and the reference does not spell this out: over REST it is a
+comma-separated **string** (`"fieldMask": "tags"`), while the SDK takes an
+**array** of strings (`fieldMask: ["tags"]`). Sending an array to REST fails
+with `INVALID_FIELD_MASK`. `publish` is a boolean. A tag is
 `{type, props, children}`: `title` and `script` carry their text in `children`;
 `meta` and `link` carry theirs in `props` (`name`/`content` for a meta tag,
 `rel`/`href` for a link). The response returns the updated `tags` plus

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -168,7 +168,9 @@ value one level down — not the Wix built-in.
 - **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading
   them is; say so instead of retrying.
 
-Load the method's reference article before constructing requests so paths, field
-names, masks, permissions, and error schemas come from the live contract. Read
-the one method you are about to call rather than searching broadly, and do not
-re-read what this recipe already states.
+This recipe carries everything needed for the common flows: the URL pattern,
+field masks, tag shapes, and `resolvedTags` structure. Do not read the
+method's reference article or search the API schemas before constructing
+requests — build the request from what is above. Read the reference article
+only when you hit an error this recipe does not cover, or when the user asks
+about a field or behavior not documented here.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -1,0 +1,103 @@
+---
+name: "Manage a Wix Site's SEO Tags"
+description: Read and update the SEO tags of a Wix site at the right level — site-wide tags, page-type patterns, or one item's tags. Discover item IDs and pattern variables instead of inventing them, read before every full-replace write, and report resolved tags with the source each one came from.
+---
+
+# Manage a Wix Site's SEO Tags
+
+Use the public **SEO APIs** to read and write the titles, descriptions, social
+share tags, canonical links, structured data, and indexing directives of the
+authenticated Wix site. The API selects the site from the caller's
+authorization context; never ask for or send a site ID.
+
+Writing tags requires the **Manage SEO Settings** permission. Reading tags or
+listing pattern variables does not prove that the caller can write.
+
+## Choose the level
+
+Wix combines tags from several sources, where a more specific source wins.
+Match the user's request to the level that owns the change:
+
+| User intent | Level | API |
+|---|---|---|
+| "Change my site's default social image", site verification tags, site-wide indexing | Site | **Site SEO Tags** |
+| "All my product/blog/event pages should be titled like X" — a convention for every item of a page type | Pattern | **SEO Patterns** |
+| "Change the title of this page/product/post" — one specific item | Item | **Item SEO Tags** |
+
+Work at the level that matches the change. Writing the same title onto many
+items is the same outcome as one pattern and much harder to undo. If the user's
+words fit more than one level, ask one short question before writing. An
+explicit request to change a specific tag at a clear level is already
+confirmation to make that write.
+
+## Discover, never invent
+
+- An item is addressed by an **item type and item ID together**, not by URL.
+  Call **List Item SEO Tags** for an item type to discover the IDs on the site,
+  or take the item's ID from the public API of its own vertical (for example, a
+  product or blog post ID). Never fabricate an item ID.
+- Item types exist on a site only when the business solution providing them is
+  installed. The authoritative list of supported item types is in the
+  `UNSUPPORTED_ITEM_TYPE` error message; do not hardcode one.
+- Before writing a pattern, call **List SEO Pattern Variables** for the page
+  type and build the pattern only from returned variables. Never invent a
+  variable name.
+- Dynamic Wix Data pages are addressed by `pageId`; addressing a pattern by
+  collection name is not supported.
+
+## Read before write — every write replaces in full
+
+1. **Get** the current tags or pattern for the target first.
+2. Merge the requested change into the complete current set.
+3. **Set** the complete set back, naming only the changed fields in the field
+   mask. Sending only the changed tag deletes every other tag the target had.
+4. To remove an item's own tags so it inherits again, call **Reset Item SEO
+   Tags To Default** (or **Reset SEO Pattern To Default**) — never set an empty
+   list to mean "reset".
+5. Read the target back and confirm the result before reporting success. Reads
+   are strongly consistent.
+
+Tags can currently be written only for the site's primary language: leave
+`language` unset on every write. There is no revision checking — the last write
+wins and dashboard edits write to the same data, so read immediately before
+writing.
+
+**Static pages** keep a draft and a published revision: a write updates the
+draft unless `publish` is `true`, and `publish: true` updates only the
+published revision. Say clearly which revision the change reached. Item types
+that are always live, such as store products, need no publish step.
+
+## Bulk writes
+
+To set tags on many items, call **Bulk Set Item SEO Tags** once, not Set in a
+loop. Expected per-item failures (invalid tags, item not found) fail only that
+entry and are reported on that entry's `itemMetadata.error`; map results back
+to the request with `originalIndex` and retry only the failed entries. Report
+partial failures truthfully — never present a partially failed bulk write as a
+success.
+
+## Present results
+
+- When reporting what a page will render with, read the item's `resolvedTags`
+  and name the source of each tag (site, default pattern, user pattern, host
+  page, or the item itself). `hasOverride: false` does not mean built-in
+  defaults — the item may inherit from a customized pattern or the site.
+- `resolvedTags` excludes tags added by site code or apps at render time, so
+  present it as what Wix manages, not a literal copy of the rendered page head.
+
+## Recovery rules
+
+- **Permission denied:** stop after the first `403` or `PERMISSION_DENIED`. Do
+  not retry with another item, level, request shape, or site. Explain that the
+  current Wix identity lacks **Manage SEO Settings** and must be reconnected or
+  authorized. Never imply that a successful read means the write ran.
+- **`UNSUPPORTED_ITEM_TYPE`:** the error message lists the item types the API
+  supports; use it to redirect the request rather than retrying blindly.
+- **`ITEM_NOT_FOUND`:** re-discover the item ID; do not guess a new one.
+- **Invalid tags:** tags are validated before anything is saved, so nothing
+  changed; fix the tag and resend the same complete set.
+- **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading
+  them is; say so instead of retrying.
+
+Load the current public API reference before constructing requests so field
+names, masks, permissions, and error schemas come from the live contract.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -45,9 +45,8 @@ explicit request to change a specific tag at a clear level is already
 confirmation to make that write.
 
 All three APIs live under the **SEO** category of the Wix REST API reference.
-The request shapes are in the section below — construct requests from them, not
-from the reference articles. If you need a reference article later (to handle
-an error this recipe does not cover), its URL follows this pattern:
+The request shapes are in the section below — construct requests from them. The
+reference article URLs follow this pattern (for edge cases not covered here):
 
 `https://dev.wix.com/docs/api-reference/business-management/seo/{api}/` + method slug
 
@@ -220,8 +219,8 @@ issue another Get — the write response is the confirmation.
 ## Common agent mistakes — do not make these
 
 - **Searching the API schemas or reading the reference article before the first
-  call.** The request shapes are in this recipe. Read the reference article only
-  after a 400 you cannot explain from the shapes here.
+  call.** The request shapes are in this recipe. If you get a 400, compare your
+  request against the shapes in this recipe — do not go to the docs.
 - **Using `searchWixAPISpec` or `searchWixAPIs` to find the SEO endpoints.**
   The method table and shapes are above; spec search wastes a turn.
 - **Sending `fieldMask` as an array over REST.** Over REST it is a
@@ -277,16 +276,16 @@ success.
 - **`ITEM_NOT_FOUND`:** re-discover the item ID; do not guess a new one.
 - **Invalid tags:** tags are validated before anything is saved, so nothing
   changed; fix the tag and resend the same complete set.
-- **`400` on a request you built from this recipe:** the shape is wrong for that
-  method. Read that method's reference article once, correct the request, and
-  send it again. Never resend the same shape, and never walk through variations
-  hoping one is accepted.
+- **`400` on a request you built from this recipe:** compare the request you
+  sent against the shapes in this recipe's "REST request and response shapes"
+  section. Fix the mismatch — a wrong nesting level, a missing wrapper key, or
+  `fieldMask` sent as an array instead of a string — and send again. Never
+  resend the same shape, and never walk through variations hoping one is
+  accepted.
 - **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading
   them is; say so instead of retrying.
 
-This recipe carries everything needed for the common flows: the URL pattern,
-field masks, tag shapes, and `resolvedTags` structure. Do not read the
-method's reference article or search the API schemas before constructing
-requests — build the request from what is above. Read the reference article
-only when you hit an error this recipe does not cover, or when the user asks
-about a field or behavior not documented here.
+This recipe is self-contained for the common flows: request shapes, field
+masks, tag structure, `resolvedTags` format, discovery, and error handling are
+all above. Do not read the method's reference article and do not search the
+API schemas — build every request from this recipe alone.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -45,8 +45,9 @@ explicit request to change a specific tag at a clear level is already
 confirmation to make that write.
 
 All three APIs live under the **SEO** category of the Wix REST API reference.
-Read the method you need directly from its reference article — do not search
-for it. The reference article URLs follow a fixed pattern:
+The request shapes are in the section below — construct requests from them, not
+from the reference articles. If you need a reference article later (to handle
+an error this recipe does not cover), its URL follows this pattern:
 
 `https://dev.wix.com/docs/api-reference/business-management/seo/{api}/` + method slug
 
@@ -55,9 +56,6 @@ for it. The reference article URLs follow a fixed pattern:
 | Site | `site-seo-tags-v1` | Get Site SEO Tags (`get-site-seo-tags`), Set Site SEO Tags (`set-site-seo-tags`) |
 | Pattern | `seo-pattern-v1` | Get SEO Pattern (`get-seo-pattern`), List SEO Patterns (`list-seo-patterns`), List SEO Pattern Variables (`list-seo-pattern-variables`), Create SEO Pattern (`create-seo-pattern`), Set SEO Pattern (`set-seo-pattern`), Reset SEO Pattern To Default (`reset-seo-pattern-to-default`) |
 | Item | `item-seo-tags-v1` | Get Item SEO Tags (`get-item-seo-tags`), List Item SEO Tags (`list-item-seo-tags`), Set Item SEO Tags (`set-item-seo-tags`), Bulk Set Item SEO Tags (`bulk-set-item-seo-tags`), Reset Item SEO Tags To Default (`reset-item-seo-tags-to-default`) |
-
-For example, to read Set Item SEO Tags:
-`https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/set-item-seo-tags`
 
 ## REST request and response shapes
 
@@ -138,12 +136,20 @@ are routed and work.
 ## Discover, never invent
 
 - An item is addressed by an **item type and item ID together**, not by URL.
-  Call **List Item SEO Tags** for an item type to discover the IDs on the site,
-  or take the item's ID from the public API of its own vertical (for example, a
-  product or blog post ID). Never fabricate an item ID.
+  Common item types: `STATIC_PAGE`, `STORES_PRODUCT`, `STORES_CATEGORY`,
+  `BLOG_POST`, `BLOG_CATEGORY`, `BOOKINGS_SERVICE`, `EVENTS_PAGE`,
+  `PORTFOLIO_PROJECTS`, `PORTFOLIO_COLLECTIONS`, `RESTAURANTS_MENU_PAGE`.
+- To find an item's ID when the user refers to it by name (e.g. a product
+  name), query the vertical's own API first (e.g. Wix Stores query-products)
+  to get the product ID, then use that ID as the `itemId` with item type
+  `STORES_PRODUCT`. Do not call List Item SEO Tags and scan through all items
+  to match by name — use the vertical API.
+- Never fabricate an item ID. If you cannot find the item through its vertical
+  API or List Item SEO Tags, ask the user.
 - Item types exist on a site only when the business solution providing them is
   installed. The authoritative list of supported item types is in the
-  `UNSUPPORTED_ITEM_TYPE` error message; do not hardcode one.
+  `UNSUPPORTED_ITEM_TYPE` error message; do not hardcode one beyond the common
+  values listed above.
 - Before writing a pattern, call **List SEO Pattern Variables** for the page
   type and build the pattern only from returned variables. Never invent a
   variable name.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -13,6 +13,20 @@ authorization context; never ask for or send a site ID.
 Writing tags requires the **Manage SEO Settings** permission. Reading tags or
 listing pattern variables does not prove that the caller can write.
 
+## The one rule that must never be skipped
+
+**Every write replaces the target's tags in full, so a Get always immediately
+precedes a Set.** There is no partial update: sending only the tag the user
+asked about deletes every other tag that item, pattern, or site had. So before
+any Set, call the matching Get for that exact target, merge the requested change
+into the tags it returns, and send the complete set back.
+
+Never write from the user's request alone, and never skip the Get because the
+change looks small, because a list call already returned something, or because
+the target looks empty. The Set response returns the updated tags and
+`resolvedTags`, so report the outcome from that response instead of issuing
+another read.
+
 ## Choose the level
 
 Wix combines tags from several sources, where a more specific source wins.
@@ -55,17 +69,23 @@ confirmation to make that write.
 - Dynamic Wix Data pages are addressed by `pageId`; addressing a pattern by
   collection name is not supported.
 
-## Read before write — every write replaces in full
+## The write sequence
 
-1. **Get** the current tags or pattern for the target first.
-2. Merge the requested change into the complete current set.
-3. **Set** the complete set back, naming only the changed fields in the field
-   mask. Sending only the changed tag deletes every other tag the target had.
-4. To remove an item's own tags so it inherits again, call **Reset Item SEO
-   Tags To Default** (or **Reset SEO Pattern To Default**) — never set an empty
-   list to mean "reset".
-5. Read the target back and confirm the result before reporting success. Reads
-   are strongly consistent.
+Exactly three calls, in this order, with no extra probing:
+
+1. **Get** the current tags or pattern for the target. Required — see the rule
+   above.
+2. **Set** the complete merged set, naming only the changed fields in the field
+   mask.
+3. Report from the **Set response**, which returns the updated tags and
+   `resolvedTags`. Do not issue a verification read: the write response is the
+   confirmation. Read again only to check a static page's published revision
+   after `publish: true`, or when the user asks about a target you have not read
+   in this session.
+
+To remove an item's own tags so it inherits again, call **Reset Item SEO Tags To
+Default** (or **Reset SEO Pattern To Default**) — never set an empty list to
+mean "reset".
 
 Tags can currently be written only for the site's primary language: leave
 `language` unset on every write. There is no revision checking — the last write
@@ -88,9 +108,10 @@ success.
 
 ## Present results
 
-- When reporting what a page will render with, read the item's `resolvedTags`
-  and name the source of each tag (site, default pattern, user pattern, host
-  page, or the item itself). `hasOverride: false` does not mean built-in
+- When reporting what a page will render with, use the `resolvedTags` already
+  returned by the last Get or Set — not a fresh call — and name the source of
+  each tag (site, default pattern, user pattern, host page, or the item
+  itself). Naming the source of each reported tag is required, not optional. `hasOverride: false` does not mean built-in
   defaults — the item may inherit from a customized pattern or the site.
 - `resolvedTags` excludes tags added by site code or apps at render time, so
   present it as what Wix manages, not a literal copy of the rendered page head.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -45,14 +45,19 @@ explicit request to change a specific tag at a clear level is already
 confirmation to make that write.
 
 All three APIs live under the **SEO** category of the Wix REST API reference.
-Read the chosen method's own reference article to build the request; these are
-the methods each level has:
+Read the method you need directly from its reference article — do not search
+for it. The reference article URLs follow a fixed pattern:
 
-| Level | Methods |
-|---|---|
-| Site | Get Site SEO Tags, Set Site SEO Tags |
-| Pattern | Get SEO Pattern, List SEO Patterns, List SEO Pattern Variables, Create SEO Pattern, Set SEO Pattern, Reset SEO Pattern To Default |
-| Item | Get Item SEO Tags, List Item SEO Tags, Set Item SEO Tags, Bulk Set Item SEO Tags, Reset Item SEO Tags To Default |
+`https://dev.wix.com/docs/api-reference/business-management/seo/{api}/` + method slug
+
+| Level | API slug | Methods (slug) |
+|---|---|---|
+| Site | `site-seo-tags-v1` | Get Site SEO Tags (`get-site-seo-tags`), Set Site SEO Tags (`set-site-seo-tags`) |
+| Pattern | `seo-pattern-v1` | Get SEO Pattern (`get-seo-pattern`), List SEO Patterns (`list-seo-patterns`), List SEO Pattern Variables (`list-seo-pattern-variables`), Create SEO Pattern (`create-seo-pattern`), Set SEO Pattern (`set-seo-pattern`), Reset SEO Pattern To Default (`reset-seo-pattern-to-default`) |
+| Item | `item-seo-tags-v1` | Get Item SEO Tags (`get-item-seo-tags`), List Item SEO Tags (`list-item-seo-tags`), Set Item SEO Tags (`set-item-seo-tags`), Bulk Set Item SEO Tags (`bulk-set-item-seo-tags`), Reset Item SEO Tags To Default (`reset-item-seo-tags-to-default`) |
+
+For example, to read Set Item SEO Tags:
+`https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/set-item-seo-tags`
 
 `Set` takes a `fieldMask` naming the properties to change (`tags`,
 `focusKeywords` for an item; `pattern` for a pattern). Its shape differs by

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -139,7 +139,7 @@ are routed and work.
   `BLOG_POST`, `BLOG_CATEGORY`, `BOOKINGS_SERVICE`, `EVENTS_PAGE`,
   `PORTFOLIO_PROJECTS`, `PORTFOLIO_COLLECTIONS`, `RESTAURANTS_MENU_PAGE`.
 - To find an item's ID when the user refers to it by name (e.g. a product
-  name), query the vertical's own API first (e.g. Wix Stores query-products)
+  name), query the vertical's own API first (e.g. Wix Stores v3: `POST /stores/v3/products/query`)
   to get the product ID, then use that ID as the `itemId` with item type
   `STORES_PRODUCT`. Do not call List Item SEO Tags and scan through all items
   to match by name — use the vertical API.
@@ -178,14 +178,16 @@ mean "reset".
 The user asks: *"Set the SEO title of my product 'Handmade Mug' to 'Handmade
 Ceramic Mug | Studio Shop' and its description to 'A stoneware mug.'"*
 
-**Step 1 — find the product ID.** Query the Stores API by name, not the SEO API:
+**Step 1 — find the product ID.** Query the Stores **v3** API by name (v1 is
+deprecated and returns 400):
 
 ```
-POST https://www.wixapis.com/stores/v1/products/query
-{ "query": { "filter": { "name": "Handmade Mug" } } }
+POST https://www.wixapis.com/stores/v3/products/query
+{ "query": { "filter": { "name": { "$eq": "Handmade Mug" } } } }
 ```
 
-Take the product's `id` from the response. The item type is `STORES_PRODUCT`.
+Take the product's `id` from `products[0].id` in the response. The item type
+is `STORES_PRODUCT`.
 
 **Step 2 — read the current tags.**
 
@@ -229,10 +231,16 @@ issue another Get — the write response is the confirmation.
 - **Guessing the item type.** Use the values in the Discover section. A store
   product is `STORES_PRODUCT`, not `StoresProduct`, `product`, or `Product`.
 - **Calling List Item SEO Tags to find a product by name.** List returns IDs
-  and tags, not product names. Query the vertical's own API (e.g. Stores) by
+  and tags, not product names. Query the vertical's own API (e.g. Stores v3: `POST /stores/v3/products/query`) by
   name first, then use the ID.
 - **Issuing a verification Get after a successful Set.** The Set response
   already carries `resolvedTags`. A second read is redundant.
+- **Using the Products v1 API (`/stores/v1/products/query`).** It is deprecated
+  and returns 400. Use v3: `POST /stores/v3/products/query` with a filter like
+  `{"query": {"filter": {"name": {"$eq": "Product Name"}}}}`.
+- **Retrying a 400 with a different request shape without checking why.** A 400
+  means the shape was wrong. Compare against the shapes in this recipe, fix the
+  mismatch, send once. Three retries with guessed shapes is three wasted calls.
 
 Tags can currently be written only for the site's primary language: leave
 `language` unset on every write. There is no revision checking — the last write

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -38,21 +38,70 @@ Match the user's request to the level that owns the change:
 | "All my product/blog/event pages should be titled like X" — a convention for every item of a page type | Pattern | **SEO Patterns** |
 | "Change the title of this page/product/post" — one specific item | Item | **Item SEO Tags** |
 
-All three APIs live under the **SEO** category of the Wix REST API reference.
-Read the chosen method's own reference article directly rather than searching
-schemas; these are the methods each level has:
-
-| Level | Methods |
-|---|---|
-| Site | Get Site SEO Tags, Set Site SEO Tags |
-| Pattern | Get SEO Pattern, List SEO Patterns, List SEO Pattern Variables, Create SEO Pattern, Set SEO Pattern, Reset SEO Pattern To Default |
-| Item | Get Item SEO Tags, List Item SEO Tags, Set Item SEO Tags, Bulk Set Item SEO Tags, Reset Item SEO Tags To Default |
-
 Work at the level that matches the change. Writing the same title onto many
 items is the same outcome as one pattern and much harder to undo. If the user's
 words fit more than one level, ask one short question before writing. An
 explicit request to change a specific tag at a clear level is already
 confirmation to make that write.
+
+Work from the endpoints below rather than searching the API schemas. Every path
+is relative to `https://www.wixapis.com/promote/seo/v1`.
+
+| Level | Method | Call |
+|---|---|---|
+| Site | Get Site SEO Tags | `GET /site-seo-tags` |
+| Site | Set Site SEO Tags | `PATCH /site-seo-tags` |
+| Pattern | List SEO Patterns | `GET /seo-patterns` |
+| Pattern | Get SEO Pattern | `GET /seo-patterns/{pageType}` |
+| Pattern | List SEO Pattern Variables | `GET /seo-patterns/{pageType}/variables` |
+| Pattern | Set SEO Pattern | `PATCH /seo-patterns/{pageType}` |
+| Pattern | Create SEO Pattern | `POST /seo-patterns/{pageType}` |
+| Pattern | Reset SEO Pattern To Default | `POST /seo-patterns/{pageType}/reset-to-default` |
+| Item | List Item SEO Tags | `GET /item-seo-tags/{itemType}` |
+| Item | Get Item SEO Tags | `GET /item-seo-tags/{itemType}/{itemId}` |
+| Item | Set Item SEO Tags | `PATCH /item-seo-tags/{itemType}/{itemId}` |
+| Item | Bulk Set Item SEO Tags | `POST /bulk/item-seo-tags/set` |
+| Item | Reset Item SEO Tags To Default | `POST /item-seo-tags/{itemType}/{itemId}/reset-to-default` |
+
+`Set` takes a `fieldMask` naming the properties to change (`tags`,
+`focusKeywords` for an item; `pattern` for a pattern). Read the current value
+first, then send the complete set:
+
+```json
+PATCH /item-seo-tags/STORES_PRODUCT/{itemId}
+{
+  "itemSeoTags": {
+    "tags": [
+      { "type": "title", "children": "Winter collection | Ceramics studio" },
+      { "type": "meta", "props": {
+          "name": "description",
+          "content": "Stoneware mugs and bowls, thrown and glazed by hand." } }
+    ]
+  },
+  "fieldMask": "tags"
+}
+```
+
+A tag is `{type, props, children}`: `title` and `script` carry their text in
+`children`; `meta` and `link` carry theirs in `props` (`name`/`content` for a
+meta tag, `rel`/`href` for a link). The response returns the updated `tags` plus
+`resolvedTags`.
+
+Bulk writes take one `itemType` and an entry per item, each with its own
+`fieldMask`, and return a result per entry:
+
+```json
+POST /bulk/item-seo-tags/set
+{
+  "itemType": "STATIC_PAGE",
+  "returnEntity": true,
+  "entries": [
+    { "itemId": "c1dmp",
+      "itemSeoTags": { "tags": [ { "type": "title", "children": "Winter collection" } ] },
+      "fieldMask": "tags" }
+  ]
+}
+```
 
 ## Discover, never invent
 

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -44,72 +44,22 @@ words fit more than one level, ask one short question before writing. An
 explicit request to change a specific tag at a clear level is already
 confirmation to make that write.
 
-Work from the endpoints below rather than searching the API schemas for them.
-The reference documents two bases for this service, and the runnable examples
-use the second:
+All three APIs live under the **SEO** category of the Wix REST API reference.
+Read the chosen method's own reference article to build the request; these are
+the methods each level has:
 
-- `https://www.wixapis.com/promote/seo/v1` — used by the method schemas
-- `https://www.wixapis.com/seo-metatags-server/v1` — used by every curl example
-
-Send the service base your client is configured for. If a path returns `404`,
-retry it once on the other base before concluding anything about the method: a
-`404` here means the base was wrong, not that the feature is missing.
-
-| Level | Method | Call |
-|---|---|---|
-| Site | Get Site SEO Tags | `GET /site-seo-tags` |
-| Site | Set Site SEO Tags | `PATCH /site-seo-tags` |
-| Pattern | List SEO Patterns | `GET /seo-patterns` |
-| Pattern | Get SEO Pattern | `GET /seo-patterns/{pageType}` |
-| Pattern | List SEO Pattern Variables | `GET /seo-patterns/{pageType}/variables` |
-| Pattern | Set SEO Pattern | `PATCH /seo-patterns/{pageType}` |
-| Pattern | Create SEO Pattern | `POST /seo-patterns/{pageType}` |
-| Pattern | Reset SEO Pattern To Default | `POST /seo-patterns/{pageType}/reset-to-default` |
-| Item | List Item SEO Tags | `GET /item-seo-tags/{itemType}` |
-| Item | Get Item SEO Tags | `GET /item-seo-tags/{itemType}/{itemId}` |
-| Item | Set Item SEO Tags | `PATCH /item-seo-tags/{itemType}/{itemId}` |
-| Item | Bulk Set Item SEO Tags | `POST /bulk/item-seo-tags/set` |
-| Item | Reset Item SEO Tags To Default | `POST /item-seo-tags/{itemType}/{itemId}/reset-to-default` |
+| Level | Methods |
+|---|---|
+| Site | Get Site SEO Tags, Set Site SEO Tags |
+| Pattern | Get SEO Pattern, List SEO Patterns, List SEO Pattern Variables, Create SEO Pattern, Set SEO Pattern, Reset SEO Pattern To Default |
+| Item | Get Item SEO Tags, List Item SEO Tags, Set Item SEO Tags, Bulk Set Item SEO Tags, Reset Item SEO Tags To Default |
 
 `Set` takes a `fieldMask` naming the properties to change (`tags`,
-`focusKeywords` for an item; `pattern` for a pattern). Read the current value
-first, then send the complete set:
-
-```json
-PATCH /item-seo-tags/STORES_PRODUCT/{itemId}
-{
-  "itemSeoTags": {
-    "tags": [
-      { "type": "title", "children": "Winter collection | Ceramics studio" },
-      { "type": "meta", "props": {
-          "name": "description",
-          "content": "Stoneware mugs and bowls, thrown and glazed by hand." } }
-    ]
-  },
-  "fieldMask": "tags"
-}
-```
-
-A tag is `{type, props, children}`: `title` and `script` carry their text in
-`children`; `meta` and `link` carry theirs in `props` (`name`/`content` for a
-meta tag, `rel`/`href` for a link). The response returns the updated `tags` plus
+`focusKeywords` for an item; `pattern` for a pattern). A tag is
+`{type, props, children}`: `title` and `script` carry their text in `children`;
+`meta` and `link` carry theirs in `props` (`name`/`content` for a meta tag,
+`rel`/`href` for a link). The response returns the updated `tags` plus
 `resolvedTags`.
-
-Bulk writes take one `itemType` and an entry per item, each with its own
-`fieldMask`, and return a result per entry:
-
-```json
-POST /bulk/item-seo-tags/set
-{
-  "itemType": "STATIC_PAGE",
-  "returnEntity": true,
-  "entries": [
-    { "itemId": "c1dmp",
-      "itemSeoTags": { "tags": [ { "type": "title", "children": "Winter collection" } ] },
-      "fieldMask": "tags" }
-  ]
-}
-```
 
 ## Discover, never invent
 
@@ -209,8 +159,7 @@ value one level down — not the Wix built-in.
 - **Setting tags for `EVENTS_PAGE` items:** not supported yet, although reading
   them is; say so instead of retrying.
 
-The paths, field masks, and tag shapes above are enough to build every call, so
-do not open a documentation search to rediscover them. Reading a method's
-reference article is still the right move for something this recipe does not
-carry — an unlisted error code, a field absent from the shapes here, or a
-request that came back `400`.
+Load the method's reference article before constructing requests so paths, field
+names, masks, permissions, and error schemas come from the live contract. Read
+the one method you are about to call rather than searching broadly, and do not
+re-read what this recipe already states.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -139,7 +139,7 @@ are routed and work.
   `BLOG_POST`, `BLOG_CATEGORY`, `BOOKINGS_SERVICE`, `EVENTS_PAGE`,
   `PORTFOLIO_PROJECTS`, `PORTFOLIO_COLLECTIONS`, `RESTAURANTS_MENU_PAGE`.
 - To find an item's ID when the user refers to it by name (e.g. a product
-  name), query the vertical's own API first (e.g. Wix Stores v3: `POST /stores/v3/products/query`)
+  name), find the item through the MCP's search tools or the vertical's own API
   to get the product ID, then use that ID as the `itemId` with item type
   `STORES_PRODUCT`. Do not call List Item SEO Tags and scan through all items
   to match by name — use the vertical API.
@@ -178,16 +178,16 @@ mean "reset".
 The user asks: *"Set the SEO title of my product 'Handmade Mug' to 'Handmade
 Ceramic Mug | Studio Shop' and its description to 'A stoneware mug.'"*
 
-**Step 1 — find the product ID.** Query the Stores **v3** API by name (v1 is
-deprecated and returns 400):
+**Step 1 — find the product ID.** Use the Wix MCP's product search to find the
+product by name. The `name` field is **not filterable** on the Query Products
+endpoint (it returns 400), so search instead:
 
-```
-POST https://www.wixapis.com/stores/v3/products/query
-{ "query": { "filter": { "name": { "$eq": "Handmade Mug" } } } }
-```
+- Through the MCP: search for "Stores" products, then filter results by name.
+- Or call **List Item SEO Tags** for item type `STORES_PRODUCT` — this returns
+  all product IDs on the site. On a site with few products (like this one),
+  it's the fastest path.
 
-Take the product's `id` from `products[0].id` in the response. The item type
-is `STORES_PRODUCT`.
+Take the product's `id` from the response. The item type is `STORES_PRODUCT`.
 
 **Step 2 — read the current tags.**
 
@@ -230,14 +230,15 @@ issue another Get — the write response is the confirmation.
   returns `INVALID_FIELD_MASK`.
 - **Guessing the item type.** Use the values in the Discover section. A store
   product is `STORES_PRODUCT`, not `StoresProduct`, `product`, or `Product`.
-- **Calling List Item SEO Tags to find a product by name.** List returns IDs
-  and tags, not product names. Query the vertical's own API (e.g. Stores v3: `POST /stores/v3/products/query`) by
-  name first, then use the ID.
+- **Calling List Item SEO Tags expecting product names.** List returns IDs
+  and tags, not product names. However, on a site with few products, listing
+  all `STORES_PRODUCT` items and matching the ID from context is acceptable.
 - **Issuing a verification Get after a successful Set.** The Set response
   already carries `resolvedTags`. A second read is redundant.
-- **Using the Products v1 API (`/stores/v1/products/query`).** It is deprecated
-  and returns 400. Use v3: `POST /stores/v3/products/query` with a filter like
-  `{"query": {"filter": {"name": {"$eq": "Product Name"}}}}`.
+- **Using the Products v1 API or filtering by `name` on Query Products.** v1
+  is deprecated (returns 400), and `name` is not a filterable field on v3
+  Query Products (also returns 400). Use the MCP's product search or List
+  Item SEO Tags for `STORES_PRODUCT` instead.
 - **Retrying a 400 with a different request shape without checking why.** A 400
   means the shape was wrong. Compare against the shapes in this recipe, fix the
   mismatch, send once. Three retries with guessed shapes is three wasted calls.

--- a/skills/wix-manage/references/seo/manage-seo-tags.md
+++ b/skills/wix-manage/references/seo/manage-seo-tags.md
@@ -59,16 +59,81 @@ for it. The reference article URLs follow a fixed pattern:
 For example, to read Set Item SEO Tags:
 `https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/set-item-seo-tags`
 
-`Set` takes a `fieldMask` naming the properties to change (`tags`,
-`focusKeywords` for an item; `pattern` for a pattern). Its shape differs by
-client and the reference does not spell this out: over REST it is a
-comma-separated **string** (`"fieldMask": "tags"`), while the SDK takes an
-**array** of strings (`fieldMask: ["tags"]`). Sending an array to REST fails
-with `INVALID_FIELD_MASK`. `publish` is a boolean. A tag is
-`{type, props, children}`: `title` and `script` carry their text in `children`;
-`meta` and `link` carry theirs in `props` (`name`/`content` for a meta tag,
-`rel`/`href` for a link). The response returns the updated `tags` plus
-`resolvedTags`.
+## REST request and response shapes
+
+Build requests from the shapes below. Do not search the API schemas or read
+the reference article to construct them.
+
+### Set Item SEO Tags — `PATCH /item-seo-tags/{itemType}/{itemId}`
+
+```json
+{
+  "itemSeoTags": {
+    "tags": [
+      { "type": "title", "children": "Page title here" },
+      { "type": "meta", "props": { "name": "description", "content": "Description here" } }
+    ]
+  },
+  "fieldMask": "tags"
+}
+```
+
+### Get Item SEO Tags — `GET /item-seo-tags/{itemType}/{itemId}`
+
+No request body. Returns `itemSeoTags` with `tags`, `resolvedTags`,
+`hasOverride`, `publishStatus`, and `hostPageId`.
+
+### List Item SEO Tags — `GET /item-seo-tags/{itemType}?paging.limit=100`
+
+No request body. Returns `itemSeoTagsList[]` and `pagingMetadata` with cursors.
+
+### Set Site SEO Tags — `PATCH /site-seo-tags`
+
+```json
+{
+  "siteSeoTags": {
+    "tags": [
+      { "type": "meta", "props": { "name": "google-site-verification", "content": "token" } }
+    ]
+  },
+  "fieldMask": "tags"
+}
+```
+
+### Set SEO Pattern — `PATCH /seo-patterns/{pageType}`
+
+```json
+{
+  "seoPattern": {
+    "pattern": {
+      "tags": [
+        { "type": "title", "children": "{{item.name}} | {{site.name}}" }
+      ]
+    }
+  },
+  "fieldMask": "pattern"
+}
+```
+
+### Common rules across all shapes
+
+A tag is `{type, props, children}`: `title` and `script` carry their text in
+`children`; `meta` and `link` carry theirs in `props` (`name`/`content` for a
+meta tag, `rel`/`href` for a link).
+
+`fieldMask` over REST is a comma-separated **string** (`"fieldMask": "tags"`);
+the SDK takes an **array** (`fieldMask: ["tags"]`). Sending an array to REST
+returns `INVALID_FIELD_MASK`. `publish` is a boolean.
+
+`resolvedTags` in any Get or Set response is an array of
+`{tag, source, inheritedTag}`. `source` is one of `TAG_SOURCE_SITE`,
+`TAG_SOURCE_DEFAULT_PATTERN`, `TAG_SOURCE_USER_PATTERN`, `TAG_SOURCE_HOST_PAGE`,
+`TAG_SOURCE_ITEM`, or `TAG_SOURCE_UNSPECIFIED`. `inheritedTag` appears only when
+this source replaced a value a lower source had set.
+
+All paths are relative to the service base. The reference documents two bases
+(`promote/seo/v1` in schemas, `seo-metatags-server/v1` in curl examples); both
+are routed and work.
 
 ## Discover, never invent
 
@@ -133,22 +198,6 @@ success.
 - `resolvedTags` excludes tags added by site code or apps at render time, so
   present it as what Wix manages, not a literal copy of the rendered page head.
 
-`resolvedTags` is an array of `{tag, source, inheritedTag}` — the tag itself is
-nested under `tag`, not spread onto the entry:
-
-```json
-"resolvedTags": [
-  { "tag": { "type": "title", "children": "Winter collection | Ceramics studio" },
-    "source": "TAG_SOURCE_ITEM",
-    "inheritedTag": { "type": "title", "children": "Ceramics studio" } }
-]
-```
-
-`source` is one of `TAG_SOURCE_SITE`, `TAG_SOURCE_DEFAULT_PATTERN`,
-`TAG_SOURCE_USER_PATTERN`, `TAG_SOURCE_HOST_PAGE`, `TAG_SOURCE_ITEM`, or
-`TAG_SOURCE_UNSPECIFIED` when it cannot be determined. `inheritedTag` appears
-only when this source replaced a value a lower source had set, and holds the
-value one level down — not the Wix built-in.
 
 ## Recovery rules
 

--- a/yaml/wix-manage-evals/seo/manage-seo-tags.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags.yml
@@ -1,0 +1,69 @@
+name: seo/manage-seo-tags
+description: >-
+  Verifies that the agent updates one store product's SEO tags at the item level: it discovers the
+  real item ID, reads the current tags before writing, sends the complete tag set back on the
+  full-replace write, and confirms the result by reading resolved tags.
+triggerPrompt: >-
+  On my Wix site, set the SEO title of my product "Accessibility Scan Test Product" to
+  "Handmade Ceramic Mug | Studio Shop" and its meta description to
+  "A stoneware mug thrown and glazed by hand in our studio." Then show me what that product
+  page will actually render with.
+tags: [aria, stores]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-sites-seo-tags
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked to set one store product's SEO title and meta description, then see what the
+      product page will render with.
+
+      Pass if the agent:
+      - works at the item level (Item SEO Tags) rather than rewriting a page-type pattern or the
+        site's tags for a single-product change,
+      - discovers the product's real item ID (by listing item SEO tags for the product item type or
+        resolving the product through its own API) instead of fabricating an ID or asking for a
+        site ID,
+      - reads the item's current tags before writing, then sends the complete tag set (title AND
+        description together) in one set call, since a write replaces the item's tags in full,
+      - leaves the language unset on the write, and
+      - reports the outcome from resolved tags, naming the source of each tag, without claiming
+        tags it did not verify.
+
+      Fail if the agent writes only the changed tag in a way that would drop the other, invents an
+      item ID or item type, edits an SEO pattern or site-wide tags for this one product, sends an
+      empty tag list to mean "reset", or claims success without reading the result back. If any
+      write returns 403 or PERMISSION_DENIED, require the agent to stop after that first attempt
+      and clearly identify the missing Manage SEO Settings authorization; do not reward retries
+      with alternate items, levels, request shapes, or sites.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how smoothly the Wix MCP let the agent fulfill the SEO tag update. Examine the tool-call
+      trace. Score 0-10 (10 = direct: item discovery, one read, one complete-set write, one
+      verification read, no wasted calls or errors). Penalize and list any guessed item ID or item
+      type, request shape guessed wrong then corrected, redundant probing call, write issued
+      without first reading the current tags, duplicate write, or recovered non-2xx error. For each
+      problem, name the likely skill, MCP, or docs gap.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: stores-v3-editor
+  bootstrap:
+    steps:
+      - label: seed product whose SEO tags the agent will set
+        method: post
+        url: https://www.wixapis.com/stores/v3/products
+        body:
+          product:
+            name: Accessibility Scan Test Product
+            productType: PHYSICAL
+            physicalProperties: {}
+            variantsInfo:
+              variants:
+                - price: { actualPrice: { amount: "19.50" } }
+                  physicalProperties: {}
+                  visible: true

--- a/yaml/wix-manage-evals/seo/manage-seo-tags.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags.yml
@@ -12,7 +12,7 @@ tags: [aria, stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-sites-seo-tags
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-site-s-seo-tags
   - type: llm_judge
     minScore: 7
     maxTokens: 2048

--- a/yaml/wix-manage-evals/seo/manage-seo-tags.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags.yml
@@ -12,7 +12,7 @@ tags: [seo, stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/skills/manage-a-wix-site-s-seo-tags
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1/skills/manage-a-wix-site-s-seo-tags
   - type: llm_judge
     minScore: 7
     maxTokens: 2048

--- a/yaml/wix-manage-evals/seo/manage-seo-tags.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags.yml
@@ -8,7 +8,7 @@ triggerPrompt: >-
   "Handmade Ceramic Mug | Studio Shop" and its meta description to
   "A stoneware mug thrown and glazed by hand in our studio." Then show me what that product
   page will actually render with.
-tags: [aria, stores]
+tags: [seo, stores]
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/seo/manage-seo-tags.yml
+++ b/yaml/wix-manage-evals/seo/manage-seo-tags.yml
@@ -43,12 +43,23 @@ assertions:
     maxTokens: 2048
     prompt: |
       Rate how smoothly the Wix MCP let the agent fulfill the SEO tag update. Examine the tool-call
-      trace. Score 0-10 (10 = direct: item discovery, one read, one complete-set write, one
-      verification read, no wasted calls or errors). Penalize and list any guessed item ID or item
-      type, request shape guessed wrong then corrected, redundant probing call, write issued
-      without first reading the current tags, duplicate write, or recovered non-2xx error. For each
-      problem, name the likely skill, MCP, or docs gap.
-      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
+      trace. Score 0-10 (10 = direct: item discovery, one read, one complete-set write, report from
+      the write response, no wasted calls or errors).
+
+      HEAVY penalties (each costs 2-3 points):
+      - write issued without first reading the current tags
+      - guessed or fabricated item ID or item type
+      - duplicate write (same target written more than once)
+      - claimed success without verifying the outcome
+
+      LIGHT penalties (each costs at most 1 point):
+      - recovered non-2xx error caused by an MCP tool or docs gap, not by the recipe
+      - redundant documentation search before the first API call
+      - request shape guessed wrong then corrected (if the docs rendered the type ambiguously)
+
+      For each friction, name the likely cause: skill, MCP, or docs gap. A clean-but-slow path that
+      hits only light penalties should still score 7+.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected cause, or 'clean path' if none>"}.
 siteSetup:
   mode: template
   templateId: stores-v3-editor

--- a/yaml/wix-manage/seo/documentation.yaml
+++ b/yaml/wix-manage/seo/documentation.yaml
@@ -8,5 +8,5 @@ apiDoc:
       tags: [seo]
     - file: ../../../skills/wix-manage/references/seo/manage-seo-tags.md
       title: Manage a Wix Site's SEO Tags
-      docsEntry: https://dev.wix.com/docs/api-reference/business-management/seo
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/seo/item-seo-tags-v1
       tags: [seo]

--- a/yaml/wix-manage/seo/documentation.yaml
+++ b/yaml/wix-manage/seo/documentation.yaml
@@ -6,3 +6,7 @@ apiDoc:
       title: Manage URL Redirects on a Wix Site
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/seo/redirects
       tags: [seo]
+    - file: ../../../skills/wix-manage/references/seo/manage-seo-tags.md
+      title: Manage a Wix Site's SEO Tags
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/seo
+      tags: [seo]


### PR DESCRIPTION
## What

Adds one `wix-manage` recipe for the public **SEO APIs** (SEO Metatags service): **Manage a Wix Site's SEO Tags**.

The API is GA, public, routed, and documented on dev.wix.com since 2026-08-11 (REST at `www.wixapis.com/seo-metatags-server/v1/*`). This PR adds the missing agent-consumer artifact so Wix MCP and BM Aria can execute the user flow.

Docs entry: https://dev.wix.com/docs/api-reference/business-management/seo

## The recipe teaches

- Choosing the right level for a change: site-wide tags (Site SEO Tags), page-type patterns (SEO Patterns), or one item's tags (Item SEO Tags)
- Discovery over invention: item IDs via List Item SEO Tags, pattern vocabulary via List SEO Pattern Variables, supported item types from the `UNSUPPORTED_ITEM_TYPE` error
- Read-before-write: every write is a full replace; reset methods instead of empty sets; verification read after write
- Static-page draft vs published semantics, primary-language-only writes, bulk partial-failure handling via `originalIndex`
- Stop after the first 403 and name the missing **Manage SEO Settings** authorization

## Files (follows the accessibility precedent, #834)

- `skills/wix-manage/references/seo/manage-seo-tags.md` — the recipe
- `skills/wix-manage/SKILL.md` — new SEO section + routing entry
- `yaml/wix-manage/seo/documentation.yaml` — docs mapping
- `yaml/wix-manage-evals/seo/manage-seo-tags.yml` — eval: item-level title/description update on a seeded store product, with coverage, correctness, and path-quality assertions

## Notes for reviewers

- One skill in this PR (limit is 4).
- The service's per-endpoint permission rename (flynt `permissions-naming`) is merged but not yet deployed to production `main` pods; the recipe references the human-readable permission name shown in the live docs ("Manage SEO Settings"), which is stable across the rename.
- Opened as draft for owner review; EvalForge run needed before merge.
