### PR TITLE
fix(wix-base44-connector): scratch names can no longer collide

### DIFF
--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -62,7 +62,10 @@ const outlineOf = (lines, cap = 30) => {
 
 // A ref is a scratch path or the URL it came from — resolve to lines, fetching+saving
 // URLs on first touch (the .md suffix is appended for extensionless docs URLs).
-const slugOf = (url) => url.replace(/\?.*$/, "").split("/").pop().replace(/\.md$/, "") + ".md";
+// two path segments, not one: doc leaves repeat across products (every API has an
+// introduction.md), and a one-segment name makes resolveRef's cache return the WRONG document
+const slugOf = (url) => url.replace(/\?.*$/, "").replace(/\.md$/, "")
+  .split("/").filter(Boolean).slice(-2).join("-") + ".md";
 async function resolveRef(ref) {
   const isUrl = /^https?:/.test(ref);
   const name = isUrl ? slugOf(ref) : ref.split("/").pop();
@@ -177,7 +180,9 @@ async function spec(code) {
     return { result, note: "empty — the query missed the shape, not proof of absence; find the resource by docsUrl on lightIndex" };
   const text = JSON.stringify(result, null, 1);
   if (text.length <= BUDGET) return result;
-  return { ...save("spec.json", text),
+  let h = 5381;
+  for (const ch of code) h = ((h * 33) ^ ch.charCodeAt(0)) >>> 0;   // same query → same file
+  return { ...save("spec-" + h.toString(36) + ".json", text),
            shape: Array.isArray(result) ? `Array(${result.length})` : Object.keys(result || {}).slice(0, 15),
            head: text.slice(0, 600) };
 }


### PR DESCRIPTION
slugOf keyed on the last URL segment — but every API has an introduction.md, and resolveRef's cache-by-name then silently returns the WRONG document for the second same-leaf URL (a lying cache, not just an overwrite; run 6a86ed49 actually saved an introduction.md). Slugs now join the last two path segments. spec() overflow saved a fixed spec.json — now spec-<query-hash>.json, deterministic per query.

Verified live: catalog-v3-introduction.md vs blog-introduction.md, distinct spec queries → distinct files, same query → same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)