### PR TITLE
🦞 igor-claw: Site Import skill — offer commerce-data fallback on NOT_ENABLED

### DIFF
--- a/skills/wix-manage/references/sites/site-import.md
+++ b/skills/wix-manage/references/sites/site-import.md
@@ -279,6 +279,19 @@ the user has no way to open a file.
   dead end. If a Wix feedback tool is available in your environment, you may
   offer to send feedback noting their interest; that is the only channel that
   reaches the team. Do not retry or fall back to another site-creation tool.
+- **NOT_ENABLED exception — commerce-data-only migrations.** If the user's
+  goal is specifically moving their **product catalog and/or order history**
+  off Shopify/WooCommerce/Magento (not a full page-for-page site clone), two
+  separate, ungated REST APIs cover that without Site Import: [Bulk Create
+  Products / Bulk Create Products With Inventory](https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-create-products-with-inventory)
+  (`POST /stores/v3/bulk/products[-with-inventory]/create`, up to 100
+  products/request) and [Import Order](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/orders/orders/import-order)
+  (`POST /ecom/v1/orders/import`, Beta, one historical order per call,
+  preserves original number/date/status). After delivering the NOT_ENABLED
+  message above, you may offer this as a fallback — but only after the user
+  confirms they want catalog/orders moved without a full site clone (it
+  won't recreate pages, theme, or design), and only if they can supply their
+  platform's own product/order export for you to map into the Wix shape.
 - Any other `403` on Start means the caller is not authorized — tell the user
   and stop. Do not probe other endpoints to diagnose this. A `400` means a
   required field is missing (`request`/`message` must be 1–20000 chars),


### PR DESCRIPTION
🤖 This PR was opened automatically by an AI research agent acting on behalf of Ayal (`ayalg@wix.com`) — not a manually-written PR.

## What's broken

Site Import's account-level Conductor gate (`replatformSiteImport`, in `wix-private/replatform-sb`'s `assertImportEnabled`) is tracked as a recurring, no-self-service-path blocker in [wix-private/replatform-sb#77](https://github.com/wix-private/replatform-sb/issues/77) — 6+ independent field reports so far, most recently a Shopify-to-Wix migration report (Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787238756913659).

That gate itself is a product/rollout decision, not a bug — no code fix here. But most "migrate off Shopify/WooCommerce/Magento" requests are really about the **product catalog and order history**, not a pixel-for-pixel page clone. Two REST APIs cover exactly that, and neither is behind the Site Import gate at all:

- **Catalog V3 Bulk Create Products / Bulk Create Products With Inventory** — `POST /stores/v3/bulk/products[-with-inventory]/create`, up to 100 products/request.
- **Orders API Import Order** — `POST /ecom/v1/orders/import` (Beta), imports one historical order at a time, preserving original number/date/status.

`site-import.md`'s `NOT_ENABLED` rule told agents to tell the user and stop — full stop, no mention that this ungated fallback exists for the catalog/orders-only case. So an agent (Claude, ChatGPT, whatever) hitting the gate had no way to know a real, available alternative existed for the most common underlying need.

## The fix

Adds a `NOT_ENABLED`-exception rule to the skill's `## Rules` section: after delivering the existing "not available yet" message, an agent may offer the Catalog V3 + Orders Import Order fallback — but only once the user confirms they want catalog/orders migrated without a full site clone, and only if they can supply their platform's own export for the agent to map into the Wix shape.

Confirmed both APIs are live, documented, and ungated via `SearchWixRESTDocumentation`/`ReadFullDocsArticle` in this session — this isn't a guess.

## Reviewer

`@itayhe` — top human committer on this file's history (`gh api commits?path=`) and the Site Import feature owner (also author of the `releaseGate.ts` gate itself).