### PR TITLE
🦞 igor-claw: add recipe for pointing a Wix-registered domain at external hosting

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -172,6 +172,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Domains Dashboard Navigation](references/domains/domains-dashboard-navigation.md)
 **Technical:** Direct links to the site-level domain settings page and the account-level My Domains page on manage.wix.com, paired with the Domain Search read APIs.
 
+### [Pointing a Wix-Registered Domain at External (Non-Wix) Hosting](references/domains/pointing-a-registered-domain-to-external-hosting.md)
+**Technical:** Moves hosting for a domain purchased through Wix to a non-Wix host without transferring or unlocking the domain, using the Domain DNS API's Update DNS Zone to edit A/CNAME records — not the Connected Domains / domain-purchase flow, which only connects domains *into* Wix. Use when the user wants to keep a Wix-registered domain but host elsewhere.
+
 ---
 
 ## eCommerce

--- a/skills/wix-manage/references/domains/pointing-a-registered-domain-to-external-hosting.md
+++ b/skills/wix-manage/references/domains/pointing-a-registered-domain-to-external-hosting.md
@@ -1,0 +1,82 @@
+---
+name: "Pointing a Wix-Registered Domain at External (Non-Wix) Hosting"
+description: A domain purchased through Wix can be pointed at non-Wix hosting without transferring it away from Wix — via the Domain DNS API's Update DNS Zone, not the domain-connect flow. Read this when the user wants to move their site off Wix but keep the Wix-registered domain.
+---
+
+# Pointing a Wix-Registered Domain at External (Non-Wix) Hosting
+
+## When to use this
+
+The user owns a domain **purchased through Wix** (a "registered domain") and wants their domain name
+to resolve to a site hosted **somewhere other than Wix** — e.g. they built a static site elsewhere
+(GitHub Pages, Netlify, Vercel, a self-hosted server) and want `theirdomain.com` to point there instead
+of their Wix site, while keeping the domain itself registered and billed through Wix.
+
+This is the mirror image of [Domain Search, Purchase and Connect](domain-search-purchase-and-connect.md),
+which only ever connects a domain **into** Wix. That skill's hard boundary (§A1.1) is deliberate and
+correct for its job — but it means a "move my domain off Wix hosting" request has nowhere else to land
+today. Route here instead.
+
+## The API exists — it's just not where you'd expect it
+
+It's tempting to conclude this isn't possible: registered-domain nameservers stay on Wix
+(`ns4.wixdns.net` / `ns5.wixdns.net`), there's no "disconnect domain" button in the domain-purchase
+flow, and the Connected Domains API only works in the other direction (bringing an external domain
+*into* Wix). None of that is the relevant API.
+
+**[Domain DNS API → Update DNS Zone](https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns/update-dns-zone)**
+(`PATCH https://www.wixapis.com/domains/v1/dns-zones/{domainName}`) edits the actual DNS records (A,
+CNAME, MX, TXT, …) inside the zone Wix hosts for a registered domain — **without** touching nameserver
+delegation. The domain keeps `ns4/ns5.wixdns.net` as its nameservers (registration/renewal/billing via
+Wix is unaffected); only the record *values inside that zone* change, so the hostname resolves to the
+external host's IP/CNAME instead of Wix's. This is exactly the officially documented
+["Update DNS records for a registered domain"](https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns/sample-flows#update-dns-records-for-a-registered-domain)
+use case — it is not a workaround or an unsupported trick.
+
+Confirmed reachable from an MCP session: `GetDnsZone`/`PreviewDnsZone` (read side) succeed via
+`ManageWixSite` despite the docs stating these calls "cannot be authenticated with the standard
+authorization header" — the Wix MCP's account-level credential already satisfies that requirement, so
+no separate account-level API key needs to be minted for this flow.
+
+## Steps
+
+1. **Confirm the domain is actually registered through Wix**, not merely connected. Call
+   [Preview Dns Zone](https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns/preview-dns-zone)
+   or [Get Dns Zone](https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns/get-dns-zone)
+   (`GET /v1/dns-zones/{domainName}`) via `ManageWixSite`. An `NS` record pointing at
+   `ns4.wixdns.net`/`ns5.wixdns.net` confirms Wix hosts this zone.
+2. **Get the external host's required DNS values** (its IP for an `A` record, or its CNAME target) from
+   the user or the external hosting provider's own setup instructions.
+3. **Call [Update DNS Zone](https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns/update-dns-zone)**
+   (`PATCH /v1/dns-zones/{domainName}`) via `ManageWixSite`, passing:
+   - `deletions`: the current `A` record (and `CNAME` on `www`, if present) that points at Wix.
+   - `additions`: the new `A`/`CNAME` record(s) pointing at the external host.
+   - **Do not touch `MX`/`TXT` records** unless the user also wants to move email or verification
+     records — deleting them will break existing email delivery or domain-verification tokens (e.g.
+     Google Workspace, SPF, DKIM) that have nothing to do with hosting.
+4. **This takes the domain off Wix hosting immediately once DNS propagates** (up to 48 hours, though
+   often much faster). The Wix site remains reachable at its default `*.wixsite.com` /
+   `*.editorx.io` URL, but no longer at this custom domain. Confirm this explicitly with the user before
+   calling `Update DNS Zone` — it is not easily or instantly reversible from the visitor's perspective
+   (DNS caching), and if the user is mid-troubleshooting (e.g. this is the same conversation where an
+   attempt to get their design onto the Wix site itself has failed), moving the domain away is often a
+   bigger, harder-to-reverse step than the problem that prompted it.
+
+## What this does NOT do
+
+- It doesn't cancel or transfer the domain registration — renewal/billing through Wix is unaffected.
+- It doesn't change nameservers — the domain still resolves via `ns4/ns5.wixdns.net`, it's just the
+  records inside that zone that changed.
+- It doesn't help the user get a **Wix-hosted design onto their Wix site** — if that's what actually
+  failed first (e.g. `import-claude-design-from-url` only accepts Claude Design's own export URLs, or
+  there's no API to place a design on an *existing* site — see
+  [Editing Pages, Menus, or Homepage Layout on an Existing Site — Known Gap](../sites/editing-existing-site-pages-menus-and-homepage.md)),
+  moving the domain elsewhere doesn't solve that; it just relocates hosting to wherever the design
+  already works. Make sure the user actually wants to leave Wix hosting, not merely deliver a design to
+  their current Wix site.
+
+## Dashboard fallback
+
+If the user (or a human with account access) would rather do this by hand: **My Domains**
+(`https://manage.wix.com/account/domains`) exposes DNS record management for domains purchased through
+Wix — see [Domains Dashboard Navigation](domains-dashboard-navigation.md).

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: Domains Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
       tags: [domains]
+    - file: ../../../skills/wix-manage/references/domains/pointing-a-registered-domain-to-external-hosting.md
+      title: Pointing a Wix-Registered Domain at External (Non-Wix) Hosting
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns
+      tags: [domains]


### PR DESCRIPTION
## Gap

The `wix-manage` domains skill ([Domain Search, Purchase and Connect](skills/wix-manage/references/domains/domain-search-purchase-and-connect.md)) only routes "connect a domain" toward bringing a domain **into** Wix — its own §A1.1 hard boundary says explicitly "This skill sells Wix domains and connects domains to Wix sites. That is the whole job." There is zero coverage for the reverse: a user who already owns a domain **purchased through Wix** and wants to point it at **non-Wix hosting**.

## This is already possible — just undiscoverable

The [Domain DNS API's Update DNS Zone](https://dev.wix.com/docs/api-reference/account-level/domains/domain-dns/update-dns-zone) already supports exactly this (its own docs have a sample flow titled "Update DNS records for a registered domain"), by editing the A/CNAME records inside the zone Wix hosts — no domain transfer/unlock/nameserver change needed. Confirmed live via `ManageWixSite`: `GetDnsZone`/`PreviewDnsZone` succeed against a real domain despite the docs saying these calls require a distinct "account level API key" — the Wix MCP's own credential already satisfies that.

Companion fix: https://github.com/wix-private/premium/pull/31097 — the API's own public intro doc contradicted its "Before you begin" section against its own use-case section, which would have sent a reader (or an agent reading docs) to the wrong conclusion even if they found the API.

## Fix

New recipe: `skills/wix-manage/references/domains/pointing-a-registered-domain-to-external-hosting.md`, registered in `SKILL.md` and `yaml/wix-manage/domains/documentation.yaml`. Covers: what the API does/doesn't do, concrete steps (get current zone → get external host's target → `Update DNS Zone` with additions/deletions), the MX/TXT-preservation caveat, and an explicit confirm-before-doing-it note since this detaches the domain from Wix hosting once DNS propagates.

## Context

Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com), researching a Wix MCP user feedback report (Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787241396495399). A customer with a finished, high-quality static site and a Wix-registered domain had no supported way to publish it, and separately no discoverable way to point the domain at hosting where it *would* work — pushing him toward abandoning Wix hosting entirely while still paying for a Premium plan and domain registration.