### PR TITLE
🦞 igor-claw: add Diagnose Checkout Payment Failures recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -261,6 +261,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Get Paid Dashboard Navigation](references/get-paid/get-paid-dashboard-navigation.md)
 **Technical:** Direct links to payments and invoicing dashboard pages on manage.wix.com (payment links, invoices list, new invoice, invoice settings, recurring invoices, accept-payments settings), pairing each get-paid entity with its read API for "view it in your dashboard" links.
 
+### [Diagnose Checkout Payment Failures](references/get-paid/diagnose-checkout-payment-failures.md)
+**Technical:** Diagnoses why online checkout payments fail — especially when one payment method (e.g. Apple Pay/Google Pay) fails while another (e.g. cards) succeeds through the same provider. Checks Cashier transaction reason codes, then cross-checks the connected provider's declared `expressFlow`/`regularFlow` capabilities via Site Payment Method Types before concluding it's a platform bug.
+
 ---
 
 ## Google Ads

--- a/skills/wix-manage/references/get-paid/diagnose-checkout-payment-failures.md
+++ b/skills/wix-manage/references/get-paid/diagnose-checkout-payment-failures.md
@@ -8,6 +8,8 @@ This recipe is for reports like *"customers can't complete checkout,"* *"payment
 
 > **Read this first if the complaint singles out one payment method.** "Cards work, Apple Pay doesn't" (or vice versa) is very often **not** a bug at all — see [Step 3](#step-3--if-only-one-payment-method-fails-check-the-providers-declared-capabilities-first). Skipping straight to "the platform is broken" here wastes the owner's time chasing the wrong fix.
 
+> **A known false lead: don't chase a "failed to import ecom-platform-providers" (or similar) browser console warning.** If the report cites a JS console error/warning like `ContextProviderFactory: failed to import "ecom-platform-providers", rendering children without provider` as the cause of a checkout/payment failure, that warning is an **expected, benign fallback** — it fires whenever a Builder-only editor-context module (used to expose checkout data to site-plugin slots, e.g. a Loyalty Program checkout widget) isn't published for the current runtime. This happens on essentially every non-Wix-Studio (classic Editor) site's checkout, **working or broken**, and only affects that one slot's plugin — never core checkout, place-order, or payment-provider invocation. Two separate reports have already misdiagnosed this exact log line as blocking payments; skip it and go straight to Step 1.
+
 ## Step 1 — Pull the failing transactions
 
 Use [Transactions List](https://dev.wix.com/docs/api-reference/business-management/payments/cashier/payments/transaction/transactions-list) (`GET https://www.wixapis.com/payments/api/merchant/v2/transactions`), filtered to a recent time window, to find the failed attempts. For each failed transaction, note:

--- a/skills/wix-manage/references/get-paid/diagnose-checkout-payment-failures.md
+++ b/skills/wix-manage/references/get-paid/diagnose-checkout-payment-failures.md
@@ -1,0 +1,58 @@
+---
+name: "Diagnose Checkout Payment Failures"
+description: "Diagnoses why online checkout payments are failing, especially when one payment method (e.g. Apple Pay / Google Pay) fails while another (e.g. cards) succeeds through the same connected provider. Pulls recent Cashier transactions for their failure reason code, cross-checks the connected provider's declared capabilities (Site Payment Method Types), and only then treats it as a platform bug. Use when a site owner reports 'customers can't pay' / 'checkout payment fails' / 'Apple Pay doesn't work but cards do' for a specific payment provider."
+---
+# Diagnose Checkout Payment Failures
+
+This recipe is for reports like *"customers can't complete checkout,"* *"payment fails at checkout,"* or (the most common false alarm) *"Apple Pay / Google Pay fails but credit cards work fine."* It routes the failure to one of three buckets — provider-side decline, provider-capability mismatch, or genuinely unclear — **before** concluding it's a Wix platform bug.
+
+> **Read this first if the complaint singles out one payment method.** "Cards work, Apple Pay doesn't" (or vice versa) is very often **not** a bug at all — see [Step 3](#step-3--if-only-one-payment-method-fails-check-the-providers-declared-capabilities-first). Skipping straight to "the platform is broken" here wastes the owner's time chasing the wrong fix.
+
+## Step 1 — Pull the failing transactions
+
+Use [Transactions List](https://dev.wix.com/docs/api-reference/business-management/payments/cashier/payments/transaction/transactions-list) (`GET https://www.wixapis.com/payments/api/merchant/v2/transactions`), filtered to a recent time window, to find the failed attempts. For each failed transaction, note:
+
+- `status` (e.g. `FAILED`)
+- The failure/reason code and message
+- `providerId` — which connected payment provider handled it
+- The payment method data type (e.g. card vs. a wallet/express payment method)
+- Whether a **provider transaction ID** was actually created
+
+## Step 2 — Look up the reason code
+
+Cashier's [Reason Codes](https://dev.wix.com/docs/api-reference/business-management/payments/payment-service-provider-service-plugin/reason-codes) reference explains what each numeric code means (e.g. `1006` = "Request is not allowed," `3012` = "Insufficient funds," `5001` = "Risk management declined"). These codes are what the **provider** (PSP) returns to Wix — for the `1000`–`1014` "general error" range in particular, ownership of the underlying cause sits mostly with the provider, not Wix.
+
+**A failure with no provider transaction ID is a strong signal the request never reached the provider's actual charge logic** (an immediate reject, a capability mismatch, or a provider-side pre-check) — as opposed to a decline that happened *after* a real authorization attempt.
+
+## Step 3 — If only one payment method fails, check the provider's declared capabilities *first*
+
+Before assuming a platform bug, check whether the connected provider even declares support for the failing payment method. Call [Get Site Payment Method Type](https://dev.wix.com/docs/api-reference/business-management/payments/site-payment-method-types/get-site-payment-method-type) for the provider's payment method type ID (found on the transaction, or in **Settings → Accept Payments** in the dashboard):
+
+```
+GET https://www.wixapis.com/payments/site-payment-method-types/v1/site-payment-method-types/{id}?countryCode={country}&currencyCode={currency}
+```
+
+Check `features`:
+
+- **`expressFlow.supported`** — whether this provider can be used for one-tap "express" wallet checkout (Apple Pay, Google Pay). If a wallet-type payment fails for this provider and `expressFlow.supported` is `false`, **that is the answer** — the provider isn't wired for wallet payments through Wix, regardless of what its marketing description or Wix's own support article for it says. This is a real, observed inconsistency for at least one provider (PayPlus, ID `d4c66807-090c-46ea-add7-93470c2b9132`): its `description` field and Wix's public support article for it both mention Apple Pay, but `expressFlow.supported` is `false`.
+- **`regularFlow.supported`** — standard card-entry / redirect payments.
+- Other relevant flags: `installments`, `moto`, `authCapture`, `regularTokenization` — check these if the failing payment type matches one of them.
+
+> **Don't trust the provider's `description` text or a support article alone.** They can be out of sync with the structured `features` flags that actually govern runtime behavior — `features` is the source of truth for what will and won't work.
+
+If `expressFlow.supported` is `false` (or the relevant feature flag is unsupported) for the connected provider, tell the owner plainly: *this provider doesn't support [Apple Pay / Google Pay / whichever method] on Wix — switch to a provider that does, or advise customers to use a card instead.* Don't file this as a platform bug.
+
+## Step 4 — If the capability check doesn't explain it
+
+If the failing payment method **is** declared as supported (`expressFlow.supported: true` or the matching flag is `true`) and it still fails while other methods succeed:
+
+- Check **Checkout Settings** ([Checkout Settings API](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/checkout-settings/introduction)) for anything that could restrict payment methods.
+- Confirm the failure is reproducible and not a one-off (retry, or check for repeated occurrences across multiple buyers/sessions).
+- At this point it's reasonable to treat it as a genuine provider-side or platform issue worth escalating — either as Wix feedback if it looks like a Wix-side gap, or by contacting the provider directly if their own endpoint is rejecting requests it declared it supports (`expressFlow.supported: true` but consistently returns an immediate decline with no provider transaction ID for that payment method).
+
+## Presenting to the user
+
+Keep it plain-language and specific to what you found — don't dump raw reason codes or JSON at a site owner:
+
+- ✅ "Your payment provider (PayPlus) doesn't support Apple Pay through Wix, even though its description mentions it — that's why those payments fail immediately while card payments go through fine. I'd recommend [contacting PayPlus / switching providers / asking customers to pay by card]."
+- ❌ "Transaction failed with reasonCode 1006, PaymentMethodDataType WalletPaymentMethodData, providerTransactionId empty."

--- a/yaml/wix-manage-evals/get-paid/diagnose-checkout-payment-failures.yml
+++ b/yaml/wix-manage-evals/get-paid/diagnose-checkout-payment-failures.yml
@@ -9,7 +9,7 @@ triggerPrompt: >-
   immediately with no error shown. Both go through the same connected payment
   provider. Is this a bug on Wix's end?
 tags: [get-paid, stores]
-maxTokens: 30000
+maxTokens: 300000
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage-evals/get-paid/diagnose-checkout-payment-failures.yml
+++ b/yaml/wix-manage-evals/get-paid/diagnose-checkout-payment-failures.yml
@@ -1,0 +1,38 @@
+name: get-paid/diagnose-checkout-payment-failures
+description: >-
+  Verifies the agent reads the diagnose-checkout-payment-failures recipe when
+  a site owner reports one payment method failing while another succeeds
+  through the same provider, and checks the provider's declared
+  expressFlow/regularFlow capabilities before concluding it's a platform bug.
+triggerPrompt: >-
+  My customers can pay by credit card at checkout, but Apple Pay always fails
+  immediately with no error shown. Both go through the same connected payment
+  provider. Is this a bug on Wix's end?
+tags: [get-paid, stores]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/payments/site-payment-method-types/skills/diagnose-checkout-payment-failures
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user reports that Apple Pay fails immediately at checkout while
+      cards succeed, through the same connected payment provider, and asks
+      whether it's a Wix bug.
+
+      Pass if the response:
+      - looks up the connected provider's declared capabilities (Site
+        Payment Method Types `features.expressFlow.supported` /
+        `regularFlow.supported`) before concluding anything, AND
+      - explains that if `expressFlow.supported` is false for that provider,
+        the provider simply isn't wired for wallet/express payments through
+        Wix — regardless of the provider's own marketing description — and
+        that's the answer, not a platform bug.
+
+      Fail if the response:
+      - immediately declares this a Wix platform bug without checking the
+        provider's declared capabilities first, OR
+      - dumps raw reason codes / JSON at the user instead of a plain-language
+        explanation.

--- a/yaml/wix-manage/get-paid/documentation.yaml
+++ b/yaml/wix-manage/get-paid/documentation.yaml
@@ -18,3 +18,7 @@ apiDoc:
       title: Get Paid Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
       tags: [get-paid]
+    - file: ../../../skills/wix-manage/references/get-paid/diagnose-checkout-payment-failures.md
+      title: Diagnose Checkout Payment Failures
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/payments/site-payment-method-types
+      tags: [get-paid, stores]


### PR DESCRIPTION
## Summary
- Adds a `wix-manage` recipe for "checkout payment fails" reports, targeting the common shape: **one payment method (Apple Pay/Google Pay) fails while another (cards) succeeds through the same connected provider.**
- Routes the agent to check Cashier's [Reason Codes](https://dev.wix.com/docs/api-reference/business-management/payments/payment-service-provider-service-plugin/reason-codes) first, then cross-check the provider's declared capabilities via [Get Site Payment Method Type](https://dev.wix.com/docs/api-reference/business-management/payments/site-payment-method-types/get-site-payment-method-type) (`features.expressFlow.supported` for wallet/one-tap payments) **before** concluding it's a Wix platform bug.

## Why
While researching a live merchant report (PayPlus checkout, Wix Cashier reason code `1006` "Request is not allowed" on every `WalletPaymentMethodData` attempt, while card payments through the same provider succeeded), I confirmed via `GetSitePaymentMethodType` that **PayPlus's own Wix metadata already says `expressFlow.supported: false`** - yet its `description` field ("Allows you to accept credit or debit cards, Apple Pay, and more.") and Wix's own public support article for connecting PayPlus both advertise Apple Pay support. That mismatch is very likely why the merchant/buyer tried Apple Pay in the first place.

This is a good, generically-useful diagnostic pattern (not specific to PayPlus) - any provider can have this kind of description/capability mismatch - so it's worth capturing as a recipe rather than a one-off fix.

---
Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com), researching Wix MCP feedback. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787295379844099

## Test plan
- [ ] Recipe file renders correctly and links resolve.
- [ ] SKILL.md index entry matches the recipe's frontmatter description.