### PR TITLE
docs(wix-manage): query all sites with the WIX+HEADLESS namespace filter

### DIFF
--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -62,18 +62,9 @@ async function listAllSites(wixPost) {
 
 ## Find a specific site
 
-`sites/query` has **no working server-side text filter** — filtering by `name` or `id` matches
-nothing (QA-confirmed), and `displayName` is not filterable. To find a site:
-
-- **By name** — resolve it directly with the dynamic-context endpoint, which matches `displayName`
-  and returns each matching site's `id` (this is the only server-side name lookup):
-  ```bash
-  curl -X POST 'https://dev.wix.com/_api/dynamic-context/v1/dynamic-context' \
-    -H 'Authorization: <ACCOUNT_TOKEN>' -H 'Content-Type: application/json' \
-    -d '{ "site_name": "Kintsugi Akira Ceramics" }'   # → { sites: [{ id, displayName, … }], … }
-  ```
-  (Add `/markdown` to the path for a ready-to-read report instead of raw JSON.)
-- **Client-side** — for exact control, `listAllSites()` then match on `displayName`.
+`sites/query` filters reliably on `namespace`, `published`, and `premium`, but a filter on `name`
+or `displayName` does not narrow results. To find a site by name, `listAllSites()` and match on
+`displayName` in code.
 
 ## Response — the `Site` object
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -27,8 +27,8 @@ and `cursorPaging` (max `limit` 100).
 
 ## Count before you enumerate
 
-An account can hold thousands of sites, and there is no server-side text filter (below), so
-paginating everything is the only way to search — count first and decide whether that's worth it:
+An account can hold thousands of sites. To find one by name, search (see "Find a site by name")
+rather than enumerate. To walk the whole list, count first and decide whether that's worth it:
 
 ```bash
 curl -X POST 'https://www.wixapis.com/site-list/v2/sites/count' \
@@ -60,11 +60,30 @@ async function listAllSites(wixPost) {
 }
 ```
 
-## Find a specific site
+## Find a site by name
 
-`sites/query` filters reliably on `namespace`, `published`, and `premium`, but a filter on `name`
-or `displayName` does not narrow results. To find a site by name, `listAllSites()` and match on
-`displayName` in code.
+`sites/query` doesn't text-search (`name`/`displayName` filters don't narrow it). Search sites by
+name — substring match — with the meta-site-search service. **Note the host: `www.wix.com`, not
+`www.wixapis.com`.**
+
+```bash
+curl -X POST 'https://www.wix.com/meta-site-search-web/v2/search' \
+  -H 'Authorization: <ACCOUNT_TOKEN>' -H 'Content-Type: application/json' \
+  -d '{
+    "filters": {
+      "searchTerm": "kintsugi",
+      "namespaceFilter": { "multi": { "namespaces": ["WIX", "HEADLESS"] } }
+    },
+    "paging": { "pageSize": 20 }
+  }'
+# → { "entries": [ { "metaSiteId": "58a49788-…" }, … ] }   metaSiteId is the site id
+```
+
+- The account token's own identity authorizes it — do **not** put `accountId`/`userId` in the body
+  (that forces a permission-gated path and fails with "No valid identity for search authorization").
+- Same namespace rule: include `namespaceFilter` or headless sites are excluded.
+- Entries carry `metaSiteId` (the site id); resolve names/other fields via `sites/query` or
+  `GetSiteContext` if you need them.
 
 ## Response — the `Site` object
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -62,23 +62,14 @@ async function listAllSites(wixPost) {
 
 ## Find a site by name
 
-`sites/query` is list-by-metadata; name search is a separate service, meta-site-search — substring
-match. **Host it on `www.wix.com` (the meta-site-search service lives there, not `www.wixapis.com`).**
+Substring-search by display name with `GET manage.wix.com/account/sites/api/sites/search`. It
+returns full site records (headless included) and, with `getCount=true`, the total:
 
 ```bash
-curl -X POST 'https://www.wix.com/meta-site-search-web/v2/search' \
-  -H 'Authorization: <ACCOUNT_TOKEN>' -H 'Content-Type: application/json' \
-  -d '{
-    "filters": {
-      "searchTerm": "kintsugi",
-      "namespaceFilter": { "multi": { "namespaces": ["WIX", "HEADLESS"] } }
-    },
-    "paging": { "pageSize": 20 }
-  }'
-# → { "entries": [ { "metaSiteId": "58a49788-…" }, … ] }   metaSiteId is the site id
+curl 'https://manage.wix.com/account/sites/api/sites/search?query=kintsugi&getCount=true' \
+  -H 'Authorization: <ACCOUNT_TOKEN>' -H 'accept: application/json'
+# → { "sites": [ { "metaSiteId", "displayName", "namespace", "published", "editUrl", … } ], "totalCount": 5 }
 ```
-
-Include `namespaceFilter` to cover headless sites, as with `sites/query`.
 
 ## Response — the `Site` object
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -36,7 +36,22 @@ The request takes a `query` object that supports `filter`, `sort`, and `cursorPa
 }
 ```
 
-All three fields are optional — `{ "query": { "cursorPaging": { "limit": 50 } } }` lists every site.
+All three fields are optional — `{ "query": { "cursorPaging": { "limit": 50 } } }` lists every
+**`WIX`-namespace** site (see the namespace note below — it is not "every site").
+
+> ### Include headless sites — the most correct way to query
+>
+> By default the query returns only `WIX`-namespace sites; **headless sites are silently excluded**
+> — no error, they are simply absent. Anything built on a connected OAuth app (Base44 apps, custom
+> headless storefronts, most programmatically-created sites) lives under the **`HEADLESS`**
+> namespace. To query *all* of an account's sites, always filter on both namespaces:
+>
+> ```json
+> { "query": { "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } }, "cursorPaging": { "limit": 100 } } }
+> ```
+>
+> Make this your default. When you can't find a site you know exists, it is almost always a
+> headless site hidden by the default `WIX`-only view — add the namespace filter and it appears.
 
 **Request**:
 ```bash
@@ -180,12 +195,19 @@ async function listAllSites() {
 ## Common Use Cases
 
 ### List all sites
-Omit `filter` and page through with `cursorPaging` until `metadata.hasNext` is `false`.
+Filter on `{ "namespace": { "$in": ["WIX", "HEADLESS"] } }` (so headless sites are included) and
+page through with `cursorPaging` until `metadata.hasNext` is `false`.
 
 ### Find a specific site
-Prefer server-side `filter` (e.g. `{ "editorType": "EDITOR" }`) and `sort` over fetching
-everything and filtering client-side. Filterable fields match the site object (e.g. `name`,
-`displayName`, `editorType`, `published`).
+Prefer server-side `filter` and `sort` over fetching everything and filtering client-side — but
+know what is actually filterable, because a filter on a non-filterable field is **silently
+ignored** (it returns everything, as if no filter were set):
+
+- **Filterable** (`$eq`, `$in`, `$startsWith`, …): `id`, `name` (the URL slug), `namespace`,
+  `editorType`, `published`, `premium`, `domainConnected`, `folderId`, the date fields.
+- **Not filterable — sort only**: `displayName`. There is **no substring/`$contains` search** on
+  any field. To find a site by its human-readable name, list with the namespace filter and match
+  `displayName` client-side, or `$startsWith` on the `name` slug if you know its prefix.
 
 ---
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -1,173 +1,58 @@
 ---
 name: "Query Sites"
-description: Lists and queries all sites associated with a Wix account using the Sites API. Covers filtering, sorting, and cursor-based pagination.
+description: List, count, and find the sites in a Wix account. Covers the namespace filter for headless sites, counting before enumerating, cursor pagination, and resolving a site by name.
 ---
 # Query Sites
 
-This recipe demonstrates how to list and query the sites associated with a Wix account.
+List, count, and find the sites in a Wix account.
 
-## Prerequisites
+- **Auth**: account-level (a Wix user token, or an account-level API key). `wix token` prints one.
+- **Permission**: `SITE_LIST.READ` (scope `SCOPE.ACC-DC-OS.READ-SITE`).
+- **Endpoints**: list `POST https://www.wixapis.com/site-list/v2/sites/query` · count
+  `POST https://www.wixapis.com/site-list/v2/sites/count`.
 
-- Account-level API access (authenticated as a Wix user or using an account-level API key)
-- Permission `SITE_LIST.READ` (scope `SCOPE.ACC-DC-OS.READ-SITE`)
+## Include headless sites — filter by `namespace`
 
-## Required APIs
+Both endpoints see only `WIX`-namespace sites by default; **headless sites** (anything built on a
+connected OAuth app) are silently excluded. Filter on both namespaces to see everything:
 
-- **Query Sites API**: [REST](https://dev.wix.com/docs/api-reference/account-level/sites/sites/query-sites)
-
-> Returns up to **100** sites per request. Use cursor paging (below) to retrieve more.
-
----
-
-## Query Sites
-
-**Endpoint**: `POST https://www.wixapis.com/site-list/v2/sites/query`
-
-The request takes a `query` object that supports `filter`, `sort`, and `cursorPaging`.
-
-**Request Body** — filter on `namespace` to include headless sites; an unfiltered query returns
-only `WIX` sites:
-```json
-{
-  "query": {
-    "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } },
-    "sort": [{ "fieldName": "createdDate", "order": "ASC" }],
-    "cursorPaging": { "limit": 100 }
-  }
-}
-```
-
-`filter`, `sort`, and `cursorPaging` are all optional.
-
-**Request**:
 ```bash
-curl -X POST \
-  'https://www.wixapis.com/site-list/v2/sites/query' \
-  -H 'Authorization: <AUTH>' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "query": {
-      "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } },
-      "cursorPaging": { "limit": 100 }
-    }
-  }'
+curl -X POST 'https://www.wixapis.com/site-list/v2/sites/query' \
+  -H 'Authorization: <ACCOUNT_TOKEN>' -H 'Content-Type: application/json' \
+  -d '{ "query": { "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } }, "cursorPaging": { "limit": 100 } } }'
 ```
 
----
+`query` takes optional `filter`, `sort` (e.g. `[{ "fieldName": "createdDate", "order": "DESC" }]`),
+and `cursorPaging` (max `limit` 100).
 
-## Response Structure
+## Count before you enumerate
 
-The response has the sites array plus **two** paging objects: a top-level `cursorPaging`
-(echoes the applied limit and the next cursor) and `metadata` (count, `cursors.next`, `hasNext`).
+An account can hold thousands of sites, and there is no server-side text filter (below), so
+paginating everything is the only way to search — count first and decide whether that's worth it:
 
-> ⚠️ There is **no** `pagingMetadata` field. Read paging info from `metadata`.
-
-```json
-{
-  "sites": [
-    {
-      "id": "f6061c5f-6aa3-42f8-8822-36a4981dabb2",
-      "htmlAppId": "70df538d-906c-44ca-9f27-c186b62f2b2b",
-      "name": "my-site-47",
-      "displayName": "My Site 47",
-      "createdDate": "2023-02-01T14:56:09.831Z",
-      "updatedDate": "2026-06-22T03:55:49.031Z",
-      "published": true,
-      "premium": false,
-      "viewUrl": "https://username.wixsite.com/my-site-47",
-      "editUrl": "/editor/f6061c5f-6aa3-42f8-8822-36a4981dabb2?editorSessionId=...",
-      "thumbnail": "/site-thumbnail/f6061c5f-6aa3-42f8-8822-36a4981dabb2",
-      "ownerAccountId": "e6a89eda-d100-4b2d-8a47-3040e2134497",
-      "contributorAccountIds": [],
-      "editorType": "EDITOR",
-      "blocked": false,
-      "namespace": "WIX",
-      "domainConnected": false,
-      "parentChildRole": "NONE"
-    }
-  ],
-  "cursorPaging": {
-    "limit": 50,
-    "cursor": "<cursor-for-next-page>"
-  },
-  "metadata": {
-    "count": 50,
-    "cursors": {
-      "next": "<cursor-for-next-page>"
-    },
-    "hasNext": true
-  }
-}
+```bash
+curl -X POST 'https://www.wixapis.com/site-list/v2/sites/count' \
+  -H 'Authorization: <ACCOUNT_TOKEN>' -H 'Content-Type: application/json' \
+  -d '{ "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } } }'   # → { "count": 1335 }
 ```
 
-### Site object fields
+Enumerating costs **~0.7s per 100 sites** (100 → ~0.7s, 500 → ~3.4s, ~1,300 → ~9s). For a large
+count, render the first N sites with a "…and N more" note instead of fetching all of them.
 
-Each entry in `sites` has these fields (from the `Site` schema):
+## Paginate
 
-| Field | Type | Notes |
-|---|---|---|
-| `id` | string | Site ID — use for site-level API calls |
-| `htmlAppId` | string | Internal HTML app ID |
-| `name` | string | URL slug / internal name |
-| `displayName` | string | Human-readable site name |
-| `createdDate` / `updatedDate` | datetime | |
-| `trashedDate` | datetime | Present only if the site is in the trash |
-| `published` | boolean | Whether the site is published |
-| `premium` | boolean | Whether the site has a Wix Premium (paid) plan |
-| `viewUrl` | string | Public site address; empty string when unpublished. **There is no `siteUrl` field.** |
-| `editUrl` | string | Relative editor path; prefix with `https://manage.wix.com` to open |
-| `thumbnail` | string | Relative thumbnail path |
-| `ownerAccountId` | string | |
-| `contributorAccountIds` | string[] | |
-| `editorType` | string | e.g. `EDITOR`, `ODEDITOR` — also a valid `filter` field |
-| `blocked` | boolean | |
-| `folderId` / `parentId` | string | Set for sites organized in folders / parent-child setups |
-| `namespace` | string | e.g. `WIX` |
-| `domainConnected` | boolean | |
-| `parentChildRole` | string | e.g. `NONE` |
+The next cursor is at `metadata.cursors.next` (there is **no** `pagingMetadata` field); it already
+encodes the filter/sort, so follow-up pages send only the cursor:
 
----
-
-## Pagination
-
-Cursor-based. Read the next cursor from `metadata.cursors.next` and stop when
-`metadata.hasNext` is `false`.
-
-> The cursor does **not** carry the page limit, and it already encodes the filter/sort
-> from the first request. On follow-up pages send **only** the cursor (plus `limit` if you
-> want a non-default page size) — do **not** repeat `filter` or `sort`.
-
-**First request**:
-```json
-{
-  "query": {
-    "filter": { "editorType": "EDITOR" },
-    "sort": [{ "fieldName": "createdDate", "order": "ASC" }],
-    "cursorPaging": { "limit": 50 }
-  }
-}
-```
-
-**Next page** (cursor from `metadata.cursors.next`):
-```json
-{
-  "query": {
-    "cursorPaging": {
-      "limit": 50,
-      "cursor": "<metadata.cursors.next from previous response>"
-    }
-  }
-}
-```
-
-**Loop**:
 ```javascript
-async function listAllSites() {
+async function listAllSites(wixPost) {
   const sites = [];
   let cursor = null;
   do {
-    const cursorPaging = cursor ? { limit: 100, cursor } : { limit: 100 };
-    const res = await wixRequest({ query: { cursorPaging } }); // POST .../site-list/v2/sites/query
+    const query = cursor
+      ? { cursorPaging: { limit: 100, cursor } }
+      : { filter: { namespace: { $in: ["WIX", "HEADLESS"] } }, cursorPaging: { limit: 100 } };
+    const res = await wixPost("/site-list/v2/sites/query", { query });
     sites.push(...res.sites);
     cursor = res.metadata.hasNext ? res.metadata.cursors.next : null;
   } while (cursor);
@@ -175,28 +60,53 @@ async function listAllSites() {
 }
 ```
 
----
+## Find a specific site
 
-## Common Use Cases
+`sites/query` has **no working server-side text filter** — filtering by `name` or `id` matches
+nothing (QA-confirmed), and `displayName` is not filterable. To find a site:
 
-### List all sites
-Filter on `{ "namespace": { "$in": ["WIX", "HEADLESS"] } }` (so headless sites are included) and
-page through with `cursorPaging` until `metadata.hasNext` is `false`.
+- **By name** — resolve it directly with the dynamic-context endpoint, which matches `displayName`
+  and returns each matching site's `id` (this is the only server-side name lookup):
+  ```bash
+  curl -X POST 'https://dev.wix.com/_api/dynamic-context/v1/dynamic-context' \
+    -H 'Authorization: <ACCOUNT_TOKEN>' -H 'Content-Type: application/json' \
+    -d '{ "site_name": "Kintsugi Akira Ceramics" }'   # → { sites: [{ id, displayName, … }], … }
+  ```
+  (Add `/markdown` to the path for a ready-to-read report instead of raw JSON.)
+- **Client-side** — for exact control, `listAllSites()` then match on `displayName`.
 
-### Find a site by name
-`displayName` holds the human name. List with the namespace filter and match it in code:
-```javascript
-const sites = await listAllSites(); // filter { namespace: { $in: ["WIX", "HEADLESS"] } }
-const site = sites.find(s => s.displayName === "Kintsugi Akira Ceramics");
+## Response — the `Site` object
+
+`sites` is an array of:
+
+```typescript
+interface Site {
+  id: string;                 // site ID — use for site-level API calls
+  htmlAppId: string;
+  name: string;               // URL slug / internal name; opaque `headless-<id>` for headless sites
+  displayName: string;        // human-readable name
+  createdDate: string;        // ISO datetime
+  updatedDate: string;        // ISO datetime
+  trashedDate?: string;       // present only when the site is in the trash
+  published: boolean;
+  premium: boolean;           // has a Wix Premium (paid) plan
+  viewUrl: string;            // public address; "" when unpublished (there is no `siteUrl` field)
+  editUrl: string;            // relative; prefix with https://manage.wix.com to open
+  thumbnail: string;
+  ownerAccountId: string;
+  contributorAccountIds: string[];
+  editorType: string;         // EDITOR | ODEDITOR | STUDIO | EDITORLESS
+  blocked: boolean;
+  folderId?: string;          // set for sites organized in folders / parent-child setups
+  namespace: string;          // WIX | HEADLESS
+  domainConnected: boolean;
+  parentChildRole: string;    // e.g. NONE
+}
 ```
-For headless sites `name` is an opaque slug (`headless-<id>`), so `displayName` is the field to
-match on.
-
----
 
 ## Next Steps
 
-After finding a site:
-- Use the site `id` for site-level API calls
-- Create new sites using [Create Site from Template](create-site-from-template.md)
-- Manage site settings and content
+Use a site's `id` for site-level API calls — derive a site token from the account token
+(`wix token --site <id>`, or the `oauth2/token` refresh-grant in wix-auth `device-flow`), then read
+its context via [Read Site Context](read-site-context.md) or create sites with
+[Create Site from Template](create-site-from-template.md).

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -25,9 +25,8 @@ This recipe demonstrates how to list and query the sites associated with a Wix a
 
 The request takes a `query` object that supports `filter`, `sort`, and `cursorPaging`.
 
-**Request Body** — filter on `namespace` to include headless sites (Base44 apps, custom
-storefronts, most programmatically-created sites); an unfiltered query silently returns only
-`WIX` sites:
+**Request Body** — filter on `namespace` to include headless sites; an unfiltered query returns
+only `WIX` sites:
 ```json
 {
   "query": {
@@ -185,16 +184,13 @@ Filter on `{ "namespace": { "$in": ["WIX", "HEADLESS"] } }` (so headless sites a
 page through with `cursorPaging` until `metadata.hasNext` is `false`.
 
 ### Find a site by name
-Filter by `name` (the URL slug) — it supports `$eq`, `$in`, and `$startsWith`:
-```json
-{ "query": { "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] }, "name": { "$startsWith": "kintsugi" } } } }
+`displayName` holds the human name. List with the namespace filter and match it in code:
+```javascript
+const sites = await listAllSites(); // filter { namespace: { $in: ["WIX", "HEADLESS"] } }
+const site = sites.find(s => s.displayName === "Kintsugi Akira Ceramics");
 ```
-
-Filterable fields and their operators come from the method's schema (spec index →
-`queryFieldsCapabilitiesMap`). For this API: `id`, `name`, `folderId` take
-`$eq/$ne/$in/$exists/$gt/$gte/$lt/$lte/$startsWith`; `namespace`, `editorType`, `published`,
-`premium`, `domainConnected` take `$eq/$ne/$in/$exists`. `displayName` and the date fields are
-**sortable** — sort by them, and match `displayName` client-side.
+For headless sites `name` is an opaque slug (`headless-<id>`), so `displayName` is the field to
+match on.
 
 ---
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -25,33 +25,20 @@ This recipe demonstrates how to list and query the sites associated with a Wix a
 
 The request takes a `query` object that supports `filter`, `sort`, and `cursorPaging`.
 
-**Request Body**:
+**Request Body** — filter on `namespace` to include headless sites (Base44 apps, custom
+storefronts, most programmatically-created sites); an unfiltered query silently returns only
+`WIX` sites:
 ```json
 {
   "query": {
-    "filter": { "editorType": "EDITOR" },
+    "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } },
     "sort": [{ "fieldName": "createdDate", "order": "ASC" }],
-    "cursorPaging": { "limit": 50 }
+    "cursorPaging": { "limit": 100 }
   }
 }
 ```
 
-All three fields are optional — `{ "query": { "cursorPaging": { "limit": 50 } } }` lists every
-**`WIX`-namespace** site (see the namespace note below — it is not "every site").
-
-> ### Include headless sites — the most correct way to query
->
-> By default the query returns only `WIX`-namespace sites; **headless sites are silently excluded**
-> — no error, they are simply absent. Anything built on a connected OAuth app (Base44 apps, custom
-> headless storefronts, most programmatically-created sites) lives under the **`HEADLESS`**
-> namespace. To query *all* of an account's sites, always filter on both namespaces:
->
-> ```json
-> { "query": { "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } }, "cursorPaging": { "limit": 100 } } }
-> ```
->
-> Make this your default. When you can't find a site you know exists, it is almost always a
-> headless site hidden by the default `WIX`-only view — add the namespace filter and it appears.
+`filter`, `sort`, and `cursorPaging` are all optional.
 
 **Request**:
 ```bash
@@ -61,9 +48,8 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -d '{
     "query": {
-      "filter": { "editorType": "EDITOR" },
-      "sort": [{ "fieldName": "createdDate", "order": "ASC" }],
-      "cursorPaging": { "limit": 50 }
+      "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] } },
+      "cursorPaging": { "limit": 100 }
     }
   }'
 ```
@@ -198,16 +184,17 @@ async function listAllSites() {
 Filter on `{ "namespace": { "$in": ["WIX", "HEADLESS"] } }` (so headless sites are included) and
 page through with `cursorPaging` until `metadata.hasNext` is `false`.
 
-### Find a specific site
-Prefer server-side `filter` and `sort` over fetching everything and filtering client-side — but
-know what is actually filterable, because a filter on a non-filterable field is **silently
-ignored** (it returns everything, as if no filter were set):
+### Find a site by name
+Filter by `name` (the URL slug) — it supports `$eq`, `$in`, and `$startsWith`:
+```json
+{ "query": { "filter": { "namespace": { "$in": ["WIX", "HEADLESS"] }, "name": { "$startsWith": "kintsugi" } } } }
+```
 
-- **Filterable** (`$eq`, `$in`, `$startsWith`, …): `id`, `name` (the URL slug), `namespace`,
-  `editorType`, `published`, `premium`, `domainConnected`, `folderId`, the date fields.
-- **Not filterable — sort only**: `displayName`. There is **no substring/`$contains` search** on
-  any field. To find a site by its human-readable name, list with the namespace filter and match
-  `displayName` client-side, or `$startsWith` on the `name` slug if you know its prefix.
+Filterable fields and their operators come from the method's schema (spec index →
+`queryFieldsCapabilitiesMap`). For this API: `id`, `name`, `folderId` take
+`$eq/$ne/$in/$exists/$gt/$gte/$lt/$lte/$startsWith`; `namespace`, `editorType`, `published`,
+`premium`, `domainConnected` take `$eq/$ne/$in/$exists`. `displayName` and the date fields are
+**sortable** — sort by them, and match `displayName` client-side.
 
 ---
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -79,11 +79,8 @@ curl -X POST 'https://www.wix.com/meta-site-search-web/v2/search' \
 # → { "entries": [ { "metaSiteId": "58a49788-…" }, … ] }   metaSiteId is the site id
 ```
 
-- The account token's own identity authorizes it — do **not** put `accountId`/`userId` in the body
-  (that forces a permission-gated path and fails with "No valid identity for search authorization").
-- Same namespace rule: include `namespaceFilter` or headless sites are excluded.
-- Entries carry `metaSiteId` (the site id); resolve names/other fields via `sites/query` or
-  `GetSiteContext` if you need them.
+- Don't add `accountId`/`userId` to the body — the token's own identity authorizes; sending them 401s.
+- Omit `namespaceFilter` and headless sites are dropped, as with `sites/query`.
 
 ## Response — the `Site` object
 

--- a/skills/wix-manage/references/sites/query-sites.md
+++ b/skills/wix-manage/references/sites/query-sites.md
@@ -62,9 +62,8 @@ async function listAllSites(wixPost) {
 
 ## Find a site by name
 
-`sites/query` doesn't text-search (`name`/`displayName` filters don't narrow it). Search sites by
-name — substring match — with the meta-site-search service. **Note the host: `www.wix.com`, not
-`www.wixapis.com`.**
+`sites/query` is list-by-metadata; name search is a separate service, meta-site-search — substring
+match. **Host it on `www.wix.com` (the meta-site-search service lives there, not `www.wixapis.com`).**
 
 ```bash
 curl -X POST 'https://www.wix.com/meta-site-search-web/v2/search' \
@@ -79,8 +78,7 @@ curl -X POST 'https://www.wix.com/meta-site-search-web/v2/search' \
 # → { "entries": [ { "metaSiteId": "58a49788-…" }, … ] }   metaSiteId is the site id
 ```
 
-- Don't add `accountId`/`userId` to the body — the token's own identity authorizes; sending them 401s.
-- Omit `namespaceFilter` and headless sites are dropped, as with `sites/query`.
+Include `namespaceFilter` to cover headless sites, as with `sites/query`.
 
 ## Response — the `Site` object
 


### PR DESCRIPTION
## What

The **Query Sites** recipe defaulted to an unfiltered query and described it as listing "every site." It doesn't: an unfiltered `sites/query` **silently returns only `WIX`-namespace sites** — headless sites are omitted with no error. Headless sites (Base44 apps, custom headless storefronts, most programmatically-created sites) live under the `HEADLESS` namespace, and an account can have far more of them than `WIX` sites (e.g. 1074 vs 261 in one account here), so "list every site" was quietly missing the majority.

The correct pattern is already documented in `wix-auth/references/device-flow.md` (`namespace: { $in: ["WIX", "HEADLESS"] }`, with the warning "headless sites are silently excluded") — but the recipe literally named **Query Sites** didn't carry it. This aligns them.

## Changes

- Make `filter: { namespace: { $in: ["WIX", "HEADLESS"] } }` the **recommended default**, with a callout explaining the silent exclusion and the "can't find a site you know exists → it's headless" heuristic.
- Update the "List all sites" use case to include the namespace filter.
- **Correct a real error:** the recipe listed `displayName` as filterable. It is **sort-only** (operators: none), and there is no `$contains`/substring search on any field — a filter on a non-filterable field is **silently ignored** (returns everything). Now documents what's actually filterable (`name` slug via `$startsWith`, etc.) and how to match `displayName` client-side.

Endpoint, auth, and the (already-correct) `metadata.cursors.next` pagination are unchanged.