### PR TITLE
🦞 igor-claw: Add Contact Wix Support recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, dashboard-navigation."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, dashboard-navigation, support."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -411,3 +411,10 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Stores Dashboard Navigation](references/stores/stores-dashboard-navigation.md)
 **Technical:** Direct links to Wix Stores and eCommerce dashboard pages on manage.wix.com (products list, edit product, categories, inventory, orders list, order details, abandoned checkouts, gift cards, shipping, tax), pairing each main Stores/eCommerce entity with its read API for "view it in your dashboard" links.
+
+---
+
+## Support
+
+### [Contact Wix Support](references/support/contact-wix-support.md)
+**Technical:** The correct escalation path when a user needs a real human at Wix — billing, payouts, charges, a linked bank account, compliance corrections, account access, or anything else no Wix management API covers. Points to `wix.com/contact` (the ticketed Customer Care channel — chat, callback, or email). Explicitly do not suggest emailing `support@wix.com`: it is not a monitored inbox and creates no trackable case, which is especially risky for billing/payout/compliance matters.

--- a/skills/wix-manage/references/support/contact-wix-support.md
+++ b/skills/wix-manage/references/support/contact-wix-support.md
@@ -1,0 +1,20 @@
+---
+name: "Contact Wix Support"
+description: "The correct escalation path when a user needs a real human at Wix — billing, payouts, charges, a linked bank account, compliance corrections, account access, or anything else that isn't a Wix management API operation. Use when the user asks how to contact Wix, reach support, escalate a billing/compliance issue, or file a case, especially anything urgent or funds-related. Do NOT suggest emailing support@wix.com — it is not a monitored inbox and mail sent there creates no trackable case."
+---
+
+# Contact Wix Support
+
+This is for the user's own support/compliance/billing needs with Wix itself — not for [sending feedback about the Wix MCP or building tools](../../SKILL.md), and not something any Wix management API can do.
+
+## The correct channel
+
+Direct the user to **[wix.com/contact](https://www.wix.com/contact)** (while logged into their Wix account). It is a ticketed intake that routes to Wix Customer Care via chat, callback, or email, and — unlike an unmonitored inbox — produces a trackable case.
+
+## Do not suggest emailing support@wix.com
+
+`support@wix.com` is not a monitored Wix support channel. It circulates widely in outdated articles and third-party "how to contact Wix" pages, but Wix's own docs consistently point to `wix.com/contact` instead, never to that address. Mail sent there can bounce or go unanswered with no case created — which is especially risky when the matter involves billing, payouts, charges, or a linked bank account, since the user may believe an urgent case is already in progress when Wix has never received it.
+
+## If the matter is time-sensitive or funds-related
+
+Say so explicitly when relaying the contact path — e.g. billing disputes, payout holds, or suspected unauthorized charges — so the user knows to use chat or callback (faster, confirmed-received) rather than the email option, which can still take longer to reach a person.

--- a/yaml/wix-manage-evals/support/contact-wix-support.yml
+++ b/yaml/wix-manage-evals/support/contact-wix-support.yml
@@ -1,0 +1,32 @@
+name: support/contact-wix-support
+description: >-
+  Verifies the agent routes a real Wix support/billing question to the Contact
+  Wix Support recipe and points the user at wix.com/contact rather than an
+  unmonitored support@wix.com mailbox.
+triggerPrompt: >-
+  I noticed an unauthorized charge on my Wix account and need to get a real
+  person at Wix to look into it urgently. How do I contact Wix support?
+tags: [support]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/articles/ai-tools/wix-mcp/skills/contact-wix-support
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user reported a suspected unauthorized charge and asked how to reach real Wix support,
+      urgently.
+
+      Pass if the response:
+      - directs the user to wix.com/contact (while logged into their Wix account) as the channel
+        to reach Wix Customer Care, AND
+      - does not suggest emailing support@wix.com, AND
+      - reflects the urgency — e.g. suggests chat or callback rather than only the email option.
+
+      Fail if the response:
+      - suggests emailing support@wix.com as a way to reach Wix, OR
+      - claims there is no way to contact Wix support, OR
+      - tries to resolve the billing dispute itself via a management API call instead of directing
+        the user to Wix Support.

--- a/yaml/wix-manage/support/documentation.yaml
+++ b/yaml/wix-manage/support/documentation.yaml
@@ -1,0 +1,8 @@
+apiDoc:
+  title: Wix Support Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/support/contact-wix-support.md
+      title: Contact Wix Support
+      docsEntry: https://dev.wix.com/docs/api-reference/articles/ai-tools/wix-mcp
+      tags: [support]


### PR DESCRIPTION
## Summary
- Adds a **Contact Wix Support** recipe to `skills/wix-manage` (surfaced via the Wix MCP's `WixREADME` index) so agents have a correct, sourced escalation path when a user needs a real human at Wix — billing, payouts, a linked bank account, compliance corrections, account access — none of which is a management-API operation.
- Points to `wix.com/contact` (Wix's documented Customer Care intake — chat/callback/email, produces a trackable case) and explicitly tells agents **not** to suggest emailing `support@wix.com`.

## Root cause
`support@wix.com` is not a monitored Wix inbox. It's widely repeated in stale third-party "how to contact Wix" pages, but Wix's own docs never point to it — `wix-private/developer-docs` consistently link `wix.com/contact` instead (e.g. `dw-sdk-articles/get-started/overview/about-developing-websites.md`, `studio-two/.../about-site-development.md`, `velo-articles/.../About Velo by Wix.md`). Meanwhile `wix/skills` and the MCP's `WixREADME` index had **no entry at all** for "how do I contact Wix support" — nothing authoritative to route an agent away from repeating the stale address from its own general knowledge.

## Context
This closes the specific gap reported in Wix MCP feedback: a user (via an external AI agent) attempted to email `support@wix.com` about a compliance-related correction; the message was never received and no trackable case was created — risky given the matter could touch billing/payouts/a bank account. The mail-delivery/routing question itself is outside this repo (Wix Care/support infra, not reproducible or fixable here); this PR closes the piece that's actually in scope for `wix/skills`: giving MCP-connected agents the correct channel instead of silence.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787416741139919

Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com) researching Wix MCP feedback — not written or reviewed by Ayal personally.

## Test plan
- [x] New recipe file follows the existing link-only recipe pattern (matches `dashboard-navigation.md` style: frontmatter `name`/`description`, no API calls)
- [x] `SKILL.md` index and top-level skill `description` updated to route to the new section
- [ ] Human review of tone/placement