### PR TITLE
🦞 igor-claw: document Bulk Import Files + N-distinct-images-to-N-CMS-items recipe

### DIFF
--- a/skills/wix-manage/references/cms/cms-data-items-crud.md
+++ b/skills/wix-manage/references/cms/cms-data-items-crud.md
@@ -336,6 +336,45 @@ Unlike bulk update, this only modifies the specified fields - other fields remai
 >
 > Error `WDE0303` occurs when attempting to set multi-reference fields via data operations.
 
+## Assign N Distinct Images to N CMS Items (by Key)
+
+Common pattern: fixing bad or missing images across many items in a collection (e.g. every item needs its own representative photo, one image field per item). Don't zip image upload results to items by array position — CMS query order and bulk-import result order are not guaranteed to line up, especially with partial import failures. Match by a stable key instead (e.g. the item's `title`/`name` field):
+
+1. **Query the items you need to fix**, keeping the key field (e.g. `name`) alongside each `_id`:
+   ```json
+   { "dataCollectionId": "Destinos", "query": { "filter": { "mainImage": { "$eq": "<placeholder-or-duplicated-asset-url>" } } } }
+   ```
+2. **Bulk-import one image per item** — see [Bulk Import Files](../media/upload-media-to-wix.md#method-bulk-import-files-from-external-urls-multiple-files). Set each `displayName` to that item's key value (e.g. `"Bogotá.jpg"`) so the import result stays traceable even if you don't correlate by index.
+3. **Correlate results to items** using `results[].itemMetadata.originalIndex` back to the request you built in step 2 (which you built in the same order as the items from step 1) — don't assume `results` preserves array position on partial failure.
+4. **Bulk-patch each item's image field** with the imported file's Wix Media URI, using the item's own `_id`, not any other item's:
+   ```json
+   {
+     "dataCollectionId": "Destinos",
+     "patches": [
+       {
+         "dataItemId": "<item-1-id>",
+         "fieldModifications": [
+           {
+             "fieldPath": "mainImage",
+             "action": "SET_FIELD",
+             "setFieldOptions": { "value": "wix:image://v1/<mediaId-1>/Bogotá.jpg" }
+           }
+         ]
+       },
+       {
+         "dataItemId": "<item-2-id>",
+         "fieldModifications": [
+           {
+             "fieldPath": "mainImage",
+             "action": "SET_FIELD",
+             "setFieldOptions": { "value": "wix:image://v1/<mediaId-2>/Medellín.jpg" }
+           }
+         ]
+       }
+     ]
+   }
+   ```
+
 ## Delete Data Item
 
 **Endpoint**: `DELETE /wix-data/v2/items/{itemId}?dataCollectionId={collectionId}`

--- a/skills/wix-manage/references/media/upload-media-to-wix.md
+++ b/skills/wix-manage/references/media/upload-media-to-wix.md
@@ -1,6 +1,6 @@
 ---
 name: "Upload Media to Wix"
-description: Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
+description: Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs (single and bulk), checking file status, and using the returned wixstatic.com URL in other APIs.
 ---
 # RECIPE: Upload Media to Wix Media Manager
 
@@ -85,6 +85,54 @@ curl -X POST 'https://www.wixapis.com/site-media/v1/files/import' \
 > - You want guaranteed consistency for critical operations
 >
 > **Practical approach:** Try using the URL immediately. If it fails, poll until `operationStatus: "READY"`.
+
+---
+
+## Method: Bulk Import Files from External URLs (Multiple Files)
+
+Importing more than one file? Use the bulk endpoint instead of calling Import File once per file — this is the common case when you need to attach N distinct images to N distinct items (e.g. a photo per CMS collection item, product, or destination).
+
+### API Endpoint
+
+```
+POST https://www.wixapis.com/site-media/v1/bulk/files/import-v2
+```
+
+### Request Example
+
+```bash
+curl -X POST 'https://www.wixapis.com/site-media/v1/bulk/files/import-v2' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+    "importFileRequests": [
+      { "url": "https://images.unsplash.com/photo-eiffel-tower.jpg", "displayName": "Paris.jpg" },
+      { "url": "https://images.unsplash.com/photo-colosseum.jpg", "displayName": "Rome.jpg" }
+    ]
+}'
+```
+
+`importFileRequests` accepts 1-100 items per call.
+
+### Response Example
+
+```json
+{
+  "results": [
+    {
+      "itemMetadata": { "originalIndex": 0, "success": true },
+      "item": { "id": "...", "displayName": "Paris.jpg", "url": "https://static.wixstatic.com/..." }
+    },
+    {
+      "itemMetadata": { "originalIndex": 1, "success": true },
+      "item": { "id": "...", "displayName": "Rome.jpg", "url": "https://static.wixstatic.com/..." }
+    }
+  ],
+  "bulkActionMetadata": { "totalSuccesses": 2, "totalFailures": 0 }
+}
+```
+
+> **Correlating results back to your inputs:** always match by `results[].itemMetadata.originalIndex` (the index of the request in `importFileRequests`), not by the position of the item in the `results` array — a partial failure can make the two diverge. See [CMS Data Items CRUD](../cms/cms-data-items-crud.md#assign-n-distinct-images-to-n-cms-items-by-key) for the full pattern of importing N images and writing each to a different CMS item.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR was opened automatically by an AI agent acting on behalf of Ayal (`ayalg@wix.com`), researching Wix MCP feedback. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787422484890029

A user's travel-agency CMS collection (`Destinos`) had many destination items incorrectly sharing one country-level `mainImage` (a data-seeding quality issue, not a Wix bug — e.g. 8 Colombian destinations all pointing at one Cartagena photo). The agent could read this via CMS tools fine, but the `wix-manage` skill had no documented pattern for the fix: "N CMS items, each needs a *different* image."

Both underlying APIs already fully support this — it's a pure docs/recipe gap:
- `references/media/upload-media-to-wix.md` only documented the single-file **Import File** endpoint. It never mentioned **Bulk Import File** (`POST /site-media/v1/bulk/files/import-v2`), which already accepts up to 100 distinct images per call.
- `references/cms/cms-data-items-crud.md` documents **Bulk Update**/**Bulk Patch** (both already support per-item distinct values) but had no recipe for the actual join step: import N images, then write each to the *correct* CMS item by a stable key — not by assuming array order lines up. Bulk import responses correlate via `results[].itemMetadata.originalIndex`, not array position, since a partial failure can make the two diverge.

## Changes
- Add a "Bulk Import Files from External URLs" section to the media upload recipe.
- Add an "Assign N Distinct Images to N CMS Items (by Key)" section to the CMS data items recipe, cross-linked to the media recipe.

## Test plan
- [x] Docs-only change, no code paths affected.
- [x] Verified both referenced endpoints (`bulk/files/import-v2`, `bulk/items/patch`) and their schemas against live Wix REST docs during research.