### PR TITLE
🦞 igor-claw: add UpdateFileDescriptor fieldMask/altText recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -314,6 +314,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Upload Media to Wix](references/media/upload-media-to-wix.md)
 **Technical:** Uploads images and files to the Wix Media Manager using the Import File API. Covers importing from external URLs, checking file status, and using the returned wixstatic.com URL in other APIs.
 
+### [Update Media Manager File Descriptors (Names, Labels, Alt Text)](references/media/update-media-file-descriptors.md)
+**Technical:** Updates existing Media Manager files (display name, labels, folder, internal tags) via UpdateFileDescriptor. Covers the required `fieldMask` parameter's real format (a comma-separated string, not an array or object, and undocumented on the method's docs page) and the fact that image `altText` cannot be set through this API today.
+
 ---
 
 ## Pricing Plans

--- a/skills/wix-manage/references/media/update-media-file-descriptors.md
+++ b/skills/wix-manage/references/media/update-media-file-descriptors.md
@@ -1,0 +1,59 @@
+---
+name: "Update Media Manager File Descriptors (Names, Labels, Alt Text)"
+description: Updates existing Media Manager files (display name, labels, folder, internal tags) via UpdateFileDescriptor. Covers the required `fieldMask` parameter's real format (a comma-separated string, not an array or object) and the fact that image `altText` cannot be set through this API today.
+---
+# RECIPE: Update Media Manager File Descriptors
+
+Learn how to update metadata on files already in a site's Media Manager — for example, bulk-renaming files or relabeling them. This is a separate flow from [uploading media](upload-media-to-wix.md).
+
+---
+
+## API Endpoint
+
+```
+PATCH https://www.wixapis.com/site-media/v1/files/update-file-descriptor
+```
+
+## What you can actually update
+
+Only these fields are accepted, regardless of what the response schema/docs page shows for the full `FileDescriptor` object:
+
+| Field | Notes |
+|-------|-------|
+| `displayName` | File name as shown in the Media Manager |
+| `parentFolderId` | Moves the file to a different folder |
+| `labels` | User/Google-Vision-assigned tags |
+| `internalTags` | Internal tagging |
+
+**`media.image.altText` is NOT settable through this API**, even though the docs/schema show it as a plain writable string with no `readOnly` flag. It's an AI-computed annotation populated internally when an image is processed — there is currently no public endpoint to set custom alt text on a Media Manager image or a Wix Stores product image. Don't spend time retrying different request shapes for it; any attempt is rejected (see below) or, on older calls, may silently no-op. If you're asked to fix "missing alt text" accessibility/SEO findings on Media Manager or product images, tell the user this isn't currently possible via API rather than attempting a workaround.
+
+## The `fieldMask` parameter — required, and NOT documented on the method's docs page
+
+The docs page for this method (and its schema) shows **no `fieldMask` parameter at all**. Despite that, every call **requires** it — omitting it returns:
+
+```json
+{"message":"Invalid request message","errorCode":-100,"details":{"validationError":{"fieldViolations":[{"field":"fieldMask","description":"must be an array"}]}}}
+```
+
+**That error message is misleading — do not pass an array.** `fieldMask` is a `google.protobuf.FieldMask`, whose real wire format here is a **plain comma-separated string of top-level field names**, passed as a top-level request property (a sibling of `file`, not nested inside it):
+
+```bash
+curl -X PATCH 'https://www.wixapis.com/site-media/v1/files/update-file-descriptor' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: <AUTH>' \
+-d '{
+  "file": {
+    "id": "e6a89e_d918d88028af49328a09469b9f2d3616~mv2.png",
+    "displayName": "Front porch with hanging lights"
+  },
+  "fieldMask": "displayName"
+}'
+```
+
+To update more than one field in the same call, comma-separate the names: `"fieldMask": "displayName,labels"`.
+
+**Do not** pass `fieldMask` as a JSON array (`["displayName"]`) or as an object (`{"paths": ["displayName"]}`) — both fail with a generic `Failed to parse request message` error. This same string-not-array/object gotcha applies to `fieldMask`/`field_mask` parameters on other Wix REST APIs too — when a method takes a `google.protobuf.FieldMask`, try the plain comma-separated-string form first if the docs don't show a worked example.
+
+## Bulk alt-text / accessibility remediation
+
+If asked to fix missing `alt` attributes across many product/media images (e.g. from a PageSpeed Insights or Lighthouse report): there is currently no API to do this. Say so plainly, rather than looping through `UpdateFileDescriptor` fieldMask variations — none of them will persist an alt text change.


### PR DESCRIPTION
## Summary

A user's agent got stuck trying to bulk-fix missing `alt` attributes on ~1,900 Wix Stores product images (PageSpeed/Lighthouse remediation) via Media Manager's `UpdateFileDescriptor`:

- The method's public docs page and schema show **no `fieldMask` parameter at all** (it's marked `field_exposure = INTERNAL` in the owning proto), yet the endpoint requires it on every call.
- Omitting `fieldMask` returns `{"field":"fieldMask","description":"must be an array"}` — **that error text is wrong**. Live-reproduced: the real wire format is a plain **comma-separated string** (`"fieldMask": "displayName"`), not a JSON array (`["displayName"]`, which 400s with a generic parse error) or an object (`{"paths":[...]}`, same).
- `media.image.altText` cannot be set through this API at all regardless of fieldMask shape — it's AI-computed, not user-writable (tracked separately in wix-private/p13n#3442 and already fixed for the silent-no-op half in wix-private/media-manager-node-services#1586).

This adds a recipe under `skills/wix-manage/references/media/` documenting the actual updatable fields, the real `fieldMask` format with a working curl example, and the altText limitation — so agents stop rediscovering this through trial and error.

## Test plan
- [ ] Docs-only change; no yaml eval exists for the sibling `upload-media-to-wix.md` recipe either, so none added here.

## Context

Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`) — not personally written by Ayal. Based on Wix MCP user feedback: https://wix.slack.com/archives/C08P5DKLJR5/p1787431478927979