### PR TITLE
polish(wix-base44-connector): trim search corpus to REST · WIX_HEADLESS; browse is REST-only

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -75,8 +75,8 @@ An empty report = bad token, never an empty site.
 ```js
 // know the product? browse is deterministic — menuUrl alone orients (children + counts);
 // filter before listing methods. browse maps the REST (api-reference) portal ONLY — for
-// other portals (WIX_HEADLESS, BUILD_APPS) use search with { type } (below). Deprecated
-// methods are hidden by default (the header still counts them); pass deprecated: "SHOW" to see them.
+// the WIX_HEADLESS portal use search with { type } (below). Deprecated methods are hidden
+// by default (the header still counts them); pass deprecated: "SHOW" to see them.
 await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
 
@@ -85,10 +85,9 @@ await wx.search("pause a pricing plan subscription and resume it");
 // → { hits: [{ method, endpoint /* callable */, docsUrl, gist }] } — hits often ARE the answer
 
 // { type } picks the portal (default "REST" — the HTTP APIs this skill calls). Same query,
-// different corpus — and the way to reach non-REST portals, since browse is REST-only:
+// other corpus — and the way to reach the non-REST portal, since browse is REST-only:
 //   WIX_HEADLESS — headless/external client code (visitor auth, JS SDK, quick-starts)
-//   BUILD_APPS   — building a Wix app (App Market / Blocks / dashboard extensions / OAuth / webhooks)
-// Non-REST portals return article-style hits (method gists thin out) — read the saved path.
+// The headless portal returns article-style hits (method gists thin out) — read the saved path.
 await wx.search("mint a visitor token and read the current cart", { type: "WIX_HEADLESS" });
 ```
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -74,7 +74,9 @@ An empty report = bad token, never an empty site.
 
 ```js
 // know the product? browse is deterministic — menuUrl alone orients (children + counts);
-// filter before listing methods, unfiltered listings clip
+// filter before listing methods. browse maps the REST (api-reference) portal ONLY — for
+// other portals (WIX_HEADLESS, BUILD_APPS) use search with { type } (below). Deprecated
+// methods are hidden by default (the header still counts them); pass deprecated: "SHOW" to see them.
 await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
 
@@ -83,9 +85,10 @@ await wx.search("pause a pricing plan subscription and resume it");
 // → { hits: [{ method, endpoint /* callable */, docsUrl, gist }] } — hits often ARE the answer
 
 // { type } picks the portal (default "REST" — the HTTP APIs this skill calls). Same query,
-// different corpus: WIX_HEADLESS (headless / external apps) · BUILD_APPS · CLI.
-// Non-REST portals return article-style hits — the
-// method gists thin out, so read the saved path.
+// different corpus — and the way to reach non-REST portals, since browse is REST-only:
+//   WIX_HEADLESS — headless/external client code (visitor auth, JS SDK, quick-starts)
+//   BUILD_APPS   — building a Wix app (App Market / Blocks / dashboard extensions / OAuth / webhooks)
+// Non-REST portals return article-style hits (method gists thin out) — read the saved path.
 await wx.search("mint a visitor token and read the current cart", { type: "WIX_HEADLESS" });
 ```
 

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -111,7 +111,7 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
 
 // Semantic search — ranks, never says "no match". The reduced hits come back inline
 // AND the full raw content is saved for grep/window follow-ups. { type } picks the portal:
-// REST (default) · WIX_HEADLESS · BUILD_APPS.
+// REST (default) · WIX_HEADLESS.
 async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
   const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
     { search_term: term, document_type: type, maximum_results: max, lines_in_each_result: lines });

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -111,7 +111,7 @@ async function browse(menuUrl, { include, filter, depth } = {}) {
 
 // Semantic search — ranks, never says "no match". The reduced hits come back inline
 // AND the full raw content is saved for grep/window follow-ups. { type } picks the portal:
-// REST (default) · WIX_HEADLESS · BUILD_APPS · CLI.
+// REST (default) · WIX_HEADLESS · BUILD_APPS.
 async function search(term, { type = "REST", max = 5, lines = 6 } = {}) {
   const { content } = await post("https://www.wixapis.com/mcp-docs-search/v1/docs/search/markdown",
     { search_term: term, document_type: type, maximum_results: max, lines_in_each_result: lines });


### PR DESCRIPTION
## What
- **Trim the `wx.search({ type })` corpus to `REST · WIX_HEADLESS`** — removed `CLI` and `BUILD_APPS` (neither is relevant to building a storefront/integration on Base44; BUILD_APPS is for developing Wix App-Market/Blocks apps).
- **Clarify `browse` is REST-only.** Browsing a non-REST portal returns `{"error":"menu_url does not map to an enabled portal (REST)"}`, so the skill now states browse maps the api-reference portal only, and to reach **WIX_HEADLESS** you use `wx.search({ type: "WIX_HEADLESS" })`, not browse.
- **Annotate WIX_HEADLESS**: headless/external client code (visitor auth, JS SDK, quick-starts).
- **Note browse hides deprecated methods** by default (header still counts them; `deprecated: "SHOW"` reveals) — why a fully-deprecated category (e.g. Checkout V1) shows "N methods" + "No matching entries". Also drops a stale "unfiltered listings clip" note.

## Why
Verified live against the docs-search API: browse rejects `build-apps`/`go-headless` menu URLs (REST-only); the corpus `type` list carried unused values. Portal contents confirmed via `document_type` search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)