### PR TITLE
polish(wix-base44-connector): browse works for HEADLESS too, not just REST

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -74,10 +74,9 @@ An empty report = bad token, never an empty site.
 
 ```js
 // know the product? browse is deterministic — menuUrl alone orients (children + counts);
-// filter before listing methods. browse spans several portals — REST (api-reference),
-// WIX_HEADLESS (go-headless), SDK, CLI, BUILD_APPS (not VELO/WDS) — just pass that portal's
-// menu URL. Deprecated methods are hidden by default (the header still counts them);
-// pass deprecated: "SHOW" to see them.
+// filter before listing methods. browse works for both portals this skill uses — REST
+// (api-reference) and WIX_HEADLESS (go-headless) — just pass that portal's menu URL.
+// Deprecated methods are hidden by default (the header still counts them); pass deprecated: "SHOW" to see them.
 await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
 // non-REST portal — same call, that portal's menu URL:

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -76,7 +76,6 @@ An empty report = bad token, never an empty site.
 // know the product? browse is deterministic — menuUrl alone orients (children + counts);
 // filter before listing methods. browse works for both portals this skill uses — REST
 // (api-reference) and WIX_HEADLESS (go-headless) — just pass that portal's menu URL.
-// Deprecated methods are hidden by default (the header still counts them); pass deprecated: "SHOW" to see them.
 await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
 // non-REST portal — same call, that portal's menu URL:

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -74,20 +74,22 @@ An empty report = bad token, never an empty site.
 
 ```js
 // know the product? browse is deterministic — menuUrl alone orients (children + counts);
-// filter before listing methods. browse maps the REST (api-reference) portal ONLY — for
-// the WIX_HEADLESS portal use search with { type } (below). Deprecated methods are hidden
-// by default (the header still counts them); pass deprecated: "SHOW" to see them.
+// filter before listing methods. browse spans several portals — REST (api-reference),
+// WIX_HEADLESS (go-headless), SDK, CLI, BUILD_APPS (not VELO/WDS) — just pass that portal's
+// menu URL. Deprecated methods are hidden by default (the header still counts them);
+// pass deprecated: "SHOW" to see them.
 await wx.browse("https://dev.wix.com/docs/api-reference/business-solutions/bookings/bookings",
                 { include: ["METHOD"], filter: "resched", depth: 4 });
+// non-REST portal — same call, that portal's menu URL:
+await wx.browse("https://dev.wix.com/docs/go-headless/authentication", { depth: 2 });
 
 // don't know where it lives? search ranks, never says "no match" — drop wrong-product hits
 await wx.search("pause a pricing plan subscription and resume it");
 // → { hits: [{ method, endpoint /* callable */, docsUrl, gist }] } — hits often ARE the answer
 
 // { type } picks the portal (default "REST" — the HTTP APIs this skill calls). Same query,
-// other corpus — and the way to reach the non-REST portal, since browse is REST-only:
-//   WIX_HEADLESS — headless/external client code (visitor auth, JS SDK, quick-starts)
-// The headless portal returns article-style hits (method gists thin out) — read the saved path.
+// other corpus — search WIX_HEADLESS for headless/external client code (visitor auth,
+// JS SDK, quick-starts). It returns article-style hits (method gists thin out) — read the saved path.
 await wx.search("mint a visitor token and read the current cart", { type: "WIX_HEADLESS" });
 ```
 


### PR DESCRIPTION
## What
Correct the browse note (just merged in #1090 as "REST-only"): the docs-search browse endpoint now also maps the **WIX_HEADLESS** portal, so the skill documents browse for its two portals — **REST (api-reference)** and **WIX_HEADLESS (go-headless)** — and adds a headless browse example.

(Browse actually supports SDK/CLI/BUILD_APPS too now, but this skill only uses REST + HEADLESS, so we keep the note scoped to those — matching the trimmed search corpus.)

## Evidence
Verified live: browsing a disabled portal returns `menu_url does not map to an enabled portal (REST, FRONTEND_SDK, CLI, BUILD_APPS, WIX_HEADLESS)`; `go-headless/authentication` browses cleanly (30 articles, 9 categories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)