### PR TITLE
🦞 igor-claw: add checkout payment button unresponsive troubleshooting recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -261,6 +261,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Get Paid Dashboard Navigation](references/get-paid/get-paid-dashboard-navigation.md)
 **Technical:** Direct links to payments and invoicing dashboard pages on manage.wix.com (payment links, invoices list, new invoice, invoice settings, recurring invoices, accept-payments settings), pairing each get-paid entity with its read API for "view it in your dashboard" links.
 
+### [Checkout Payment Button Unresponsive](references/get-paid/get-paid-troubleshoot-checkout-unresponsive-button.md)
+**Technical:** Diagnostic tree for when "Place Order & Pay" does nothing — no redirect, no order, no Cashier transaction. Distinguishes a provider-side decline from a platform/client-side bug via Abandoned Checkouts + Order Transactions + Cashier Transactions signals, and flags the benign `ecom-platform-providers` console warning that's commonly misdiagnosed as the root cause.
+
 ---
 
 ## Google Ads

--- a/skills/wix-manage/references/get-paid/get-paid-troubleshoot-checkout-unresponsive-button.md
+++ b/skills/wix-manage/references/get-paid/get-paid-troubleshoot-checkout-unresponsive-button.md
@@ -1,0 +1,75 @@
+---
+name: "Get Paid: Checkout Payment Button Unresponsive"
+description: Diagnostic tree for when a buyer clicks "Place Order & Pay" and nothing happens — no redirect to the payment provider, no order, no Cashier transaction. Distinguishes a platform-side/client bug from a merchant payment-provider misconfiguration, and flags a commonly misread benign console warning.
+layer: troubleshoot
+---
+# Troubleshoot: Checkout Payment Button Unresponsive
+
+## When to use
+
+A merchant or buyer reports that clicking the checkout submit button ("Place Order & Pay" / "Place Order") does nothing — the page doesn't navigate, no error is shown, and no payment happens. This applies to any payment provider (Wix Payments or a 3rd-party PSP like PayPlus, Stripe, etc.), on Wix Stores / eCommerce checkout.
+
+---
+
+## Step 1: Rule out obvious merchant-side configuration
+
+Check quickly before deeper diagnosis:
+
+- Site is Published.
+- Wix Stores / eCommerce is installed and enabled.
+- The intended payment provider shows **Active** in Accept Payments.
+- Site country/currency match what the provider expects.
+
+If all of these are fine, **do not loop on disconnect/reconnect-the-provider or republish-the-site as a diagnostic step** — those only fix merchant-side config drift. They do nothing for a client-side bug or a Wix-side incident, and repeating them wastes turns. Move to Step 2.
+
+---
+
+## Step 2: Determine whether the backend was ever reached
+
+For a recent failed attempt (ask for or reproduce a synthetic checkout), check whether the click produced *any* server-side trace:
+
+1. [Search Abandoned Checkouts](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/abandoned-checkout/search-abandoned-checkouts) or [Query Abandoned Checkouts](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/abandoned-checkout/query-abandoned-checkouts) — confirms the buyer reached checkout and entered details.
+2. [List Transactions For Single Order](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/orders/order-transactions/list-transactions-for-single-order) (eCommerce) for any order created around the failure time.
+3. [Transactions List](https://dev.wix.com/docs/api-reference/business-management/payments/cashier/payments/transaction/transactions-list) (Cashier) filtered to the same time window.
+
+Interpret the combination:
+
+| Abandoned checkout created? | Cashier transaction / order created? | Interpretation |
+|---|---|---|
+| Yes | Yes (declined/failed) | Backend received the place-order request; look at `cashierError` / provider reason code — this is a provider-side decline, not a platform bug. |
+| Yes | **No**, repeatedly, across multiple attempts | The click never resulted in a place-order call reaching Wix's backend. This is a **client-side or platform-side bug**, not something a merchant can self-fix by reconnecting the provider or republishing. Escalate (Step 4). |
+| No | No | Buyer isn't reaching the payment step at all — check earlier checkout steps (delivery method, required fields) instead. |
+
+---
+
+## Step 3: Don't misread the `ecom-platform-providers` console warning
+
+If browser console diagnostics on the live checkout show:
+
+```
+ContextProviderFactory: failed to import "ecom-platform-providers", rendering children without provider.
+TypeError: Failed to resolve module specifier 'ecom-platform-providers'
+```
+
+**This is expected, benign behavior on any non-Wix-Studio (classic Editor) site** — it is a deliberate fallback (`@wix/context-provider-import-ooi`) for environments where the Builder-only context-provider module isn't published. It fires on essentially every classic-Editor Stores checkout, working or broken, and by design lets checkout continue rendering (`PassthroughProvider`) without this optional context. It affects only editor-platform site-plugin slots consuming `useCheckout()`, not the core place-order flow.
+
+**Do not report this warning as the root cause of an unresponsive button.** If it's the only console signal found, keep looking for an actual uncaught exception, failed network request, or blocked script tied to the place-order click itself.
+
+---
+
+## Step 4: Escalate when no order-side trace exists
+
+If Step 2 shows repeated attempts with **no** Cashier transaction, **no** order, and no other client-side error to explain it, self-service troubleshooting (reconnect provider, republish, clear cache) has no mechanism to fix it — reaching the payment provider requires a working client bundle and a successful place-order call to Wix's eCommerce backend, neither of which merchant-side settings control.
+
+**Resolution**: escalate to Wix Support with: the site ID, a reproduction checkout ID, the exact console errors observed (if any) excluding the benign warning above, and confirmation that no Cashier transaction/order was created for the failed attempts. This needs backend traces (BI/error-monitoring) that aren't exposed via public APIs.
+
+---
+
+## Summary: Diagnostic checklist
+
+| Step | Check | Common resolution |
+|---|---|---|
+| 1 | Site published, Stores enabled, provider Active, country/currency match | Fix the specific misconfigured setting; don't loop reconnect/republish once confirmed fine |
+| 2 | Abandoned checkout / order / Cashier transaction for the failed attempt | Tells you whether the backend was ever reached |
+| 3 | `ecom-platform-providers` console warning | Benign on non-Studio sites — not the root cause, keep looking |
+| 4 | No order-side trace across repeated attempts | Escalate to Wix Support with reproduction details; not fixable via merchant-side settings |

--- a/yaml/wix-manage-evals/get-paid/get-paid-checkout-payment-button-unresponsive.yml
+++ b/yaml/wix-manage-evals/get-paid/get-paid-checkout-payment-button-unresponsive.yml
@@ -1,0 +1,39 @@
+name: get-paid/get-paid-checkout-payment-button-unresponsive
+description: >-
+  Verifies the agent reads the checkout-payment-button-unresponsive recipe
+  when a merchant reports the "Place Order & Pay" button doing nothing, and
+  cross-checks abandoned checkouts / orders / Cashier transactions to tell a
+  provider-side decline apart from a client/platform-side bug, instead of
+  blaming the benign ecom-platform-providers console warning.
+triggerPrompt: >-
+  Customers say that when they click "Place Order and Pay" at checkout,
+  nothing happens — no redirect, no error, they just stay on the same page.
+  No new order shows up. What's going on?
+tags: [get-paid, stores]
+maxTokens: 30000
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/abandoned-checkout/introduction/skills/get-paid-checkout-payment-button-unresponsive
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user reports that clicking "Place Order and Pay" at checkout does
+      nothing — no redirect, no error, no new order.
+
+      Pass if the response:
+      - checks for a server-side trace of the attempt (abandoned checkouts,
+        eCommerce orders, Cashier transactions) to determine whether the
+        place-order request ever reached Wix's backend, AND
+      - if no such trace exists across repeated attempts, explains this is a
+        client/platform-side issue that isn't fixable via merchant-side
+        settings (reconnecting the provider, republishing), and recommends
+        escalating with reproduction details.
+
+      Fail if the response:
+      - jumps straight to "reconnect your payment provider" or "republish
+        your site" as the fix without checking for a backend trace first, OR
+      - blames a `ecom-platform-providers` / `ContextProviderFactory`
+        browser console warning as the root cause — that warning is benign
+        and expected on non-Wix-Studio sites.

--- a/yaml/wix-manage-evals/get-paid/get-paid-checkout-payment-button-unresponsive.yml
+++ b/yaml/wix-manage-evals/get-paid/get-paid-checkout-payment-button-unresponsive.yml
@@ -10,7 +10,7 @@ triggerPrompt: >-
   nothing happens — no redirect, no error, they just stay on the same page.
   No new order shows up. What's going on?
 tags: [get-paid, stores]
-maxTokens: 30000
+maxTokens: 300000
 assertions:
   - tool: ReadFullDocsArticle
     params:

--- a/yaml/wix-manage/get-paid/documentation.yaml
+++ b/yaml/wix-manage/get-paid/documentation.yaml
@@ -18,3 +18,7 @@ apiDoc:
       title: Get Paid Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
       tags: [get-paid]
+    - file: ../../../skills/wix-manage/references/get-paid/get-paid-troubleshoot-checkout-unresponsive-button.md
+      title: "Get Paid: Checkout Payment Button Unresponsive"
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/purchase-flow/checkout/abandoned-checkout/introduction
+      tags: [get-paid, stores]


### PR DESCRIPTION
## What's missing
No recipe in `skills/wix-manage` covers an unresponsive checkout "Place Order & Pay" button (click does nothing — no redirect to the payment provider, no order, no Cashier transaction). An agent hit this while diagnosing a real merchant report and had to reinvent the diagnostic path (Abandoned Checkouts + Order Transactions + Cashier Transactions cross-check) from scratch, and along the way misattributed a benign, unrelated console warning (`ContextProviderFactory: failed to import "ecom-platform-providers"`, fixed separately in [wix-private/editor-platform#14887](https://github.com/wix-private/editor-platform/pull/14887)) as the root cause.

## Fix
New recipe `references/get-paid/get-paid-troubleshoot-checkout-unresponsive-button.md`, linked from `SKILL.md`'s Get Paid section:
- Quick merchant-side config check (published, Stores enabled, provider Active, country/currency).
- Cross-check Abandoned Checkouts / Order Transactions / Cashier Transactions to tell a provider-side decline apart from a client/platform-side bug where the place-order call never reaches Wix's backend.
- Explicit callout that the `ecom-platform-providers` console warning is expected on non-Wix-Studio sites and not evidence of a broken checkout.
- Escalation guidance for when no order-side trace exists across repeated attempts (not fixable via merchant-side settings).

## Context
Opened automatically by an AI research agent on behalf of Ayal (ayalg@wix.com), while investigating Wix MCP user feedback about a checkout/payment issue. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787500153107209