### PR TITLE
🦞 igor-claw: document read-site-context cache staleness after property writes

### DIFF
--- a/skills/wix-manage/references/sites/read-site-context.md
+++ b/skills/wix-manage/references/sites/read-site-context.md
@@ -6,6 +6,8 @@ description: Probe a Wix site or account for full context in one call — instal
 
 Returns a site's name, URL, status, locale/region, and all installed apps with human-readable display names.
 
+> **Staleness warning:** the `properties` block (locale, timezone, currency, address) is served from a per-site cache with up to a **30-minute TTL and no write-side invalidation**. If you just wrote to Site Properties or Locations (e.g. changed the business address or timezone), this endpoint can keep returning the pre-write value for up to 30 minutes. Don't use it to verify a property write just landed — call [Get Site Properties](https://dev.wix.com/docs/api-reference/business-management/site-properties/properties/get-site-properties) directly for that instead.
+
 ---
 
 ## Markdown endpoint (recommended)


### PR DESCRIPTION
## Summary

Opened automatically by an **AI agent acting on behalf of Ayal (`ayalg@wix.com`)** — not written by Ayal personally.

**Report:** a user's agent updated a site's timezone via the Site Properties API (successful version bump) but the site context surface kept showing the old timezone. Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787515817934399

**Root cause (live-reproduced on an owned test site):** the dynamic-context service's `SitePropertiesClient` caches site properties (locale, timezone, currency, address) per site for 30 minutes with no write-side invalidation. Companion fixes: `wix-private/wix-vmr-repo#28152` (proto doc source) and `wix-private/igor-tools#1613` (MCP tool description).

**Fix:** adds a staleness warning to this recipe so agents don't use `GetDynamicContext`/`GetDynamicContextMarkdown` to verify a just-made property write, and points them at Get Site Properties instead.

## Test plan
- [ ] Docs-only change