### PR TITLE
🦞 igor-claw: document Menu.urlQueryParam as the SEO-URL lever for Restaurants Menu pages

### DIFF
--- a/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
+++ b/skills/wix-manage/references/restaurants/wix-restaurants-setup.md
@@ -275,6 +275,38 @@ For complex restaurant menus, use this order to avoid dependency issues:
 6. Update menu with `sectionIds`.
 7. Update items with `modifierGroups` to attach the groups from step 2.
 
+## Menu Page SEO URL
+
+Wix Restaurants Menu pages that host multiple menus render each menu at
+`{pageSlug}?menu={urlQueryParam}`. `urlQueryParam` is a per-menu field on the Menu entity —
+it's the *only* part of that URL settable through this API.
+
+**Endpoint**: `PATCH https://www.wixapis.com/restaurants/menus-menu/v1/menus/{menu.id}`
+
+```json
+{
+  "menu": {
+    "id": "<MENU_ID>",
+    "revision": "<MENU_REVISION>",
+    "urlQueryParam": "dinner-menu"
+  }
+}
+```
+
+Notes:
+- `urlQueryParam` must be unique across the site's menus; reusing another menu's value is rejected.
+- This only changes the `?menu=` query segment. The page's own base slug (the part before `?`) has
+  no update endpoint in this API or any other — if a page was auto-created with a placeholder slug
+  (e.g. `blank-3-7-3`), that prefix cannot be renamed via a Wix API call. This is the same
+  no-page-slug-rename-API gap tracked in `wix/skills#619`.
+- In the Wix Harmony editor, the per-page "SEO et accessibilité" panel cannot edit this value for
+  Menu pages — it shows a locked, generic `/?menu=` placeholder instead of the real value. To set it
+  through the UI, go to Business Manager's Restaurants Menus app, open the menu's "..." menu, and
+  choose "SEO Settings" — that panel edits `urlQueryParam` directly (with the same uniqueness
+  validation) and creates a redirect from the old value automatically. The classic Wix Editor's own
+  "Plus d'actions" > "Bases de référencement" flow (documented in Wix's Restaurants Menu SEO help
+  article) is the same feature but is not available in Harmony.
+
 ## Item Labels
 
 Common dietary labels:


### PR DESCRIPTION
## What's missing

The Restaurants Setup recipe (`skills/wix-manage/references/restaurants/wix-restaurants-setup.md`) documents the full Menu → Section → Item CRUD flow but never mentions `Menu.urlQueryParam` — the field that controls a menu page's `?menu=` URL segment, and the only part of a Restaurants Menu page's URL that's writable through the REST API (confirmed via `UpdateMenu`'s schema and the `Supported Filters and Sorting` doc for the Menu resource).

This gap surfaced from a Wix MCP feedback report where an agent, tasked with cleaning up a site's SEO slugs, found a Wix Restaurants Menu page's URL locked in Harmony's editor UI and had no doc pointing it toward the actual API-level lever or the actual working UI for it.

## What this adds

A "Menu Page SEO URL" section documenting:
- `urlQueryParam` is set via `UpdateMenu`, must be unique across the site's menus.
- It only covers the `?menu=` query segment — the page's base slug has no update endpoint anywhere (cross-referenced to the already-tracked `wix/skills#619`).
- In Harmony, the page's own "SEO et accessibilité" panel can't edit this for Menu pages (shows a locked generic placeholder) — Business Manager's Menu "..." → "SEO Settings" is the actual working UI, and it auto-creates a redirect on rename.
- The classic Wix Editor's "Bases de référencement" flow (from Wix's own Restaurants Menu SEO help article) is the same feature, just not available in Harmony.

## Context

Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching a Wix MCP feedback report. Report's Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787537330388989

Companion code fix (the missing "where do I edit this" escape hatch in Harmony's own panel): https://github.com/wix-private/promote-seo/pull/15107