### PR TITLE
Protect Wix CLI authentication material in Headless skill

### DIFF
--- a/skills/wix-headless/references/managed/AUTHENTICATION.md
+++ b/skills/wix-headless/references/managed/AUTHENTICATION.md
@@ -4,6 +4,11 @@ For a **managed** project (hosted on Wix infrastructure), every Wix call uses a 
 
 ## 1 · Ensure an authenticated CLI session
 
+### Secret boundary — mandatory
+
+Never read authentication material or tokens into agent context.
+Never emit them to stdout, stderr, logs, prompts, or tool results.
+
 ```bash
 npx @wix/cli@latest whoami   # exits 0 when logged in; non-zero when logged out
 ```


### PR DESCRIPTION
Adds a mandatory secret boundary to the managed Headless authentication guide. It explicitly prohibits inspecting `~/.wix/auth` or other credential values and prohibits secrets from reaching command output, logs, prompts, tool results, or agent context. It also makes `whoami` the only permitted existing-session check.