### PR TITLE
Reuse existing Wix CLI sessions in Headless bootstrap

### DIFF
--- a/skills/wix-headless/entry/bootstrap.mjs
+++ b/skills/wix-headless/entry/bootstrap.mjs
@@ -40,7 +40,14 @@ function checkCli() {
   emit('cli_ok', { version });
 }
 
-// ── 2. Login (human-in-the-loop device code; forward the CLI's own events) ───
+// ── 2. Reuse an existing session, or start device login ──────────────────────
+function hasExistingSession() {
+  const r = capture(WIX[0], [...WIX.slice(1), 'whoami']);
+  if (r.status !== 0) return false;
+  emit('logged_in');
+  return true;
+}
+
 function login() {
   return new Promise((resolve) => {
     const child = spawn(WIX[0], [...WIX.slice(1), 'login'], { shell: isWin, env: AGENT_ENV });
@@ -90,4 +97,4 @@ function login() {
 
 // ── main ────────────────────────────────────────────────────────────────────
 checkCli();
-await login();
+if (!hasExistingSession()) await login();


### PR DESCRIPTION
The Headless bootstrap now runs `whoami` first. When the CLI is already authenticated, it emits `logged_in` and continues; only a missing session triggers the device-login flow. This makes the documented existing-session behavior match the implementation.