### PR TITLE
feat(wix-manage): a parent recipe index per product area

### DIFF
--- a/skills/wix-manage/references/accessibility/accessibility-recipes.md
+++ b/skills/wix-manage/references/accessibility/accessibility-recipes.md
@@ -7,7 +7,15 @@ description: "Site accessibility auditing — scan a whole site, a single page, 
 
 Accessibility work on a Wix site goes through a scan: it runs asynchronously, so the recipe covers starting a scan, polling it to completion, and reading the findings — including which pages failed to scan at all. Scans can target the whole site, one page, or a page collection, so establish the scope the user means before starting one.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Scan a Wix Site for Accessibility Issues](https://dev.wix.com/docs/api-reference/site/accessibility/skills/scan-a-wix-site-for-accessibility-issues)
-Use for any accessibility request: scanning a site, a page or a collection, polling the scan, and reading which issues to fix first.
+**Technical:** Run a Wix accessibility scan for a full site, one page, or every page in
+any supported page collection, including products, blog posts, booking services, events,
+and restaurant pages. Poll the asynchronous scan to completion, report failed pages
+separately, retrieve prioritized findings, and use the returned fix guidance to help the
+user resolve and verify issues.

--- a/skills/wix-manage/references/accessibility/accessibility-recipes.md
+++ b/skills/wix-manage/references/accessibility/accessibility-recipes.md
@@ -1,0 +1,13 @@
+---
+name: "Accessibility Recipes"
+description: "Site accessibility auditing — scan a whole site, a single page, or every page in a collection (products, blog posts, booking services, events, restaurant pages) for accessibility issues and read the prioritized findings. Use for anything users call accessibility, a11y, WCAG, compliance, screen-reader, or contrast problems."
+---
+
+# Accessibility Recipes
+
+Accessibility work on a Wix site goes through a scan: it runs asynchronously, so the recipe covers starting a scan, polling it to completion, and reading the findings — including which pages failed to scan at all. Scans can target the whole site, one page, or a page collection, so establish the scope the user means before starting one.
+
+## Recipes
+
+### [Scan a Wix Site for Accessibility Issues](https://dev.wix.com/docs/api-reference/site/accessibility/skills/scan-a-wix-site-for-accessibility-issues)
+Use for any accessibility request: scanning a site, a page or a collection, polling the scan, and reading which issues to fix first.

--- a/skills/wix-manage/references/analytics/analytics-recipes.md
+++ b/skills/wix-manage/references/analytics/analytics-recipes.md
@@ -7,10 +7,22 @@ description: "Site analytics — query traffic, sales, behavior and marketing me
 
 Answering a numbers question is a three-step flow: list the semantic models, inspect the model's schema to learn its measures and dimensions, then query it with a time interval (always required), filters, sorting and paging. Use **Query Site Analytics** for the data itself, and **Analytics Dashboard Navigation** when the user wants to see it in their dashboard — pairing the two lets an answer come back with a link to the matching report.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Query Site Analytics](https://dev.wix.com/docs/api-reference/business-management/analytics/skills/query-site-analytics)
-Use when the user asks for numbers: listing models, reading a model's schema, and querying it with a time interval, filters and paging.
+**Technical:** Retrieve a Wix site's analytics through the Semantic Model API. Covers
+listing semantic models, inspecting a model's schema (measures, dimensions, parameters),
+and querying model data with a required time interval, filters, sorting, paging, and
+human-readable formatting.
 
 ### [Analytics Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/analytics/skills/analytics-dashboard-navigation)
-Use when the user wants to see analytics in their dashboard, or an API answer should come back with a link to the matching report.
+**Technical:** Builds direct links to Wix Analytics dashboard pages on manage.wix.com —
+highlights, reports, per-domain overviews (traffic, behavior, sales, marketing), and
+performance insights/benchmarks. Pairs analytics data with its read API so you can
+answer a question via API and hand back a 'see it in your dashboard' link. Use when the
+user asks where something is in the Wix dashboard, wants a direct link to a dashboard
+page, or you need a dashboard URL to include with the result of an API operation.

--- a/skills/wix-manage/references/analytics/analytics-recipes.md
+++ b/skills/wix-manage/references/analytics/analytics-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Analytics Recipes"
+description: "Site analytics — query traffic, sales, behavior and marketing metrics through the Semantic Model API, and link users to the analytics dashboard. Use for anything users call analytics, stats, metrics, reports, traffic, visitors, conversion, or performance numbers."
+---
+
+# Analytics Recipes
+
+Answering a numbers question is a three-step flow: list the semantic models, inspect the model's schema to learn its measures and dimensions, then query it with a time interval (always required), filters, sorting and paging. Use **Query Site Analytics** for the data itself, and **Analytics Dashboard Navigation** when the user wants to see it in their dashboard — pairing the two lets an answer come back with a link to the matching report.
+
+## Recipes
+
+### [Query Site Analytics](https://dev.wix.com/docs/api-reference/business-management/analytics/skills/query-site-analytics)
+Use when the user asks for numbers: listing models, reading a model's schema, and querying it with a time interval, filters and paging.
+
+### [Analytics Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/analytics/skills/analytics-dashboard-navigation)
+Use when the user wants to see analytics in their dashboard, or an API answer should come back with a link to the matching report.

--- a/skills/wix-manage/references/app-installation/app-installation-recipes.md
+++ b/skills/wix-manage/references/app-installation/app-installation-recipes.md
@@ -1,0 +1,19 @@
+---
+name: "App Installation Recipes"
+description: "Wix app installation — install apps on a site, enable Velo, list what is already installed, and link to the App Market and installed-apps dashboard pages. Use for anything users call installing an app, adding a feature, app market, plugins, or a 428 / app-not-installed error."
+---
+
+# App Installation Recipes
+
+Most business-solution APIs return 428 until the owning app is installed on the site, which makes this area a prerequisite for the rest: when an API call fails that way, check **List Installed Apps** and then install with **Install Wix Apps**. Installing is also the first step whenever a user asks to add a capability (a store, bookings, a blog) that the site does not have yet.
+
+## Recipes
+
+### [Install Wix Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/install-wix-apps)
+Use when a site needs an app it does not have — including enabling Velo and finding the right app definition ID.
+
+### [List Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/list-installed-apps)
+Use to check what is installed before calling a product API, or to diagnose a 428 or authorization error.
+
+### [App Management Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/app-management-dashboard-navigation)
+Use when the user wants the App Market or the installed-apps management page.

--- a/skills/wix-manage/references/app-installation/app-installation-recipes.md
+++ b/skills/wix-manage/references/app-installation/app-installation-recipes.md
@@ -7,13 +7,23 @@ description: "Wix app installation — install apps on a site, enable Velo, list
 
 Most business-solution APIs return 428 until the owning app is installed on the site, which makes this area a prerequisite for the rest: when an API call fails that way, check **List Installed Apps** and then install with **Install Wix Apps**. Installing is also the first step whenever a user asks to add a capability (a store, bookings, a blog) that the site does not have yet.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Install Wix Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/install-wix-apps)
-Use when a site needs an app it does not have — including enabling Velo and finding the right app definition ID.
+**Technical:** Installs Wix apps on a site using Apps Installer API. Covers enabling
+Velo (Wix Code), app installation, and common app definition IDs.
 
 ### [List Installed Apps](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/list-installed-apps)
-Use to check what is installed before calling a product API, or to diagnose a 428 or authorization error.
+**Technical:** Lists all apps installed on a site using Apps Installer API. Useful for
+verifying app installations before making API calls and diagnosing authorization errors.
 
 ### [App Management Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/app-installation/skills/app-management-dashboard-navigation)
-Use when the user wants the App Market or the installed-apps management page.
+**Technical:** Builds direct links to the app-management dashboard pages on
+manage.wix.com — the App Market and the installed-apps management page. Pairs installed
+apps with the List Installed Apps read API. Use when the user asks where something is in
+the Wix dashboard, wants a direct link to a dashboard page, or you need a dashboard URL
+to include with the result of an API operation.

--- a/skills/wix-manage/references/blog/blog-recipes.md
+++ b/skills/wix-manage/references/blog/blog-recipes.md
@@ -1,0 +1,30 @@
+---
+name: "Blog Recipes"
+description: "Blog content management — create and publish posts, drafts, authors, categories and tags, rich-content bodies, cover images, comment moderation, and direct links to Blog dashboard pages. Use for anything users call blog posts, articles, writing, publishing, or blogging."
+---
+
+# Blog Recipes
+
+Recipes for the Wix Blog APIs. Posts always need an author `memberId` — if the
+site has no members yet, one must be created first; the create recipe covers
+this. Post bodies are Ricos rich content, not plain strings or HTML; images go
+through the Media Manager before they can be referenced. For rich-content
+authoring beyond the basics see
+[Rich Content](../rich-content/author-ricos-rich-content.md).
+
+Use **How to Create Blog Posts** for anything that writes: drafting,
+publishing, categories and tags, cover images, bulk creation. Use **Blog
+Dashboard Navigation** when the user asks where something lives in the
+dashboard, or when a result should come back with a "view it in your
+dashboard" link.
+
+## Recipes
+
+### [How to Create Blog Posts](how-to-create-blog-posts.md)
+Use when creating, publishing or bulk-loading posts — including resolving the
+author member, Ricos bodies, image upload, and category/tag assignment.
+
+### [Blog Dashboard Navigation](blog-dashboard-navigation.md)
+Use when the user wants a dashboard link — posts list, drafts, categories,
+tags, writers, comment moderation, analytics, monetization or settings — or to
+pair an API result with the page where the user can see it.

--- a/skills/wix-manage/references/blog/blog-recipes.md
+++ b/skills/wix-manage/references/blog/blog-recipes.md
@@ -18,13 +18,22 @@ Dashboard Navigation** when the user asks where something lives in the
 dashboard, or when a result should come back with a "view it in your
 dashboard" link.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [How to Create Blog Posts](https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts)
-Use when creating, publishing or bulk-loading posts — including resolving the
-author member, Ricos bodies, image upload, and category/tag assignment.
+**Technical:** Creates and publishes blog posts using Blog Posts API. Covers resolving
+the required author memberId (including creating an author member when the site has
+none), Ricos rich content format, image upload via Media Manager, category/tag
+assignment, and bulk post creation.
 
 ### [Blog Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/blog-dashboard-navigation)
-Use when the user wants a dashboard link — posts list, drafts, categories,
-tags, writers, comment moderation, analytics, monetization or settings — or to
-pair an API result with the page where the user can see it.
+**Technical:** Builds direct links to Wix Blog dashboard pages on manage.wix.com — posts
+list (published and draft tabs), categories, tags, writers, comment moderation, blog
+analytics, monetization, and settings. Pairs each main Blog entity with its read API so
+you can fetch an entity and hand back a 'view it in your dashboard' link. Use when the
+user asks where something is in the Wix dashboard, wants a direct link to a dashboard
+page, or you need a dashboard URL to include with the result of an API operation.

--- a/skills/wix-manage/references/blog/blog-recipes.md
+++ b/skills/wix-manage/references/blog/blog-recipes.md
@@ -10,7 +10,7 @@ site has no members yet, one must be created first; the create recipe covers
 this. Post bodies are Ricos rich content, not plain strings or HTML; images go
 through the Media Manager before they can be referenced. For rich-content
 authoring beyond the basics see
-[Rich Content](../rich-content/author-ricos-rich-content.md).
+[Rich Content](https://dev.wix.com/docs/api-reference/assets/rich-content/skills/author-ricos-rich-content).
 
 Use **How to Create Blog Posts** for anything that writes: drafting,
 publishing, categories and tags, cover images, bulk creation. Use **Blog
@@ -20,11 +20,11 @@ dashboard" link.
 
 ## Recipes
 
-### [How to Create Blog Posts](how-to-create-blog-posts.md)
+### [How to Create Blog Posts](https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts)
 Use when creating, publishing or bulk-loading posts — including resolving the
 author member, Ricos bodies, image upload, and category/tag assignment.
 
-### [Blog Dashboard Navigation](blog-dashboard-navigation.md)
+### [Blog Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/blog-dashboard-navigation)
 Use when the user wants a dashboard link — posts list, drafts, categories,
 tags, writers, comment moderation, analytics, monetization or settings — or to
 pair an API result with the page where the user can see it.

--- a/skills/wix-manage/references/bookings/bookings-recipes.md
+++ b/skills/wix-manage/references/bookings/bookings-recipes.md
@@ -1,0 +1,53 @@
+---
+name: "Bookings Recipes"
+description: "Appointment scheduling — create appointment, class and course services, set staff and their working hours, booking policies and waitlists, multi-resource services, external calendar sync, run the end-to-end booking and payment flow, and diagnose why a service is not bookable. Use for anything users call bookings, appointments, classes, courses, sessions, scheduling, staff, calendar availability, or reservations."
+---
+
+# Bookings Recipes
+
+Service type drives everything: **APPOINTMENT** (one-on-one, needs a staff member), **CLASS** (group, recurring sessions) and **COURSE** (group, fixed run of sessions) have different required fields. If the user's wording makes the type clear, go straight to **Create Appointment Service**, **Create Class Service** or **Create Course Service**; if it does not, **Create Booking Service from Prompt** resolves the type first. **Create and Update Booking Services** is the general CRUD reference for editing existing services.
+
+Two things commonly block bookability after a service exists: staff have no working hours (**Bookings Staff Setup** — create staff, assign a schedule, then create working-hours events, in that order) and the business has no default hours at all (see the calendar recipes). When a service should be bookable but is not, **Diagnose Bookings Availability Issues** answers that directly rather than guessing.
+
+For the rest: **Booking Service Policy Setup** for booking and cancellation rules and waitlists, **Multi-Resource Service Creation** when a session needs rooms or equipment alongside staff, **External Calendar Integration** for Google, Outlook or Apple sync, **End-to-End Booking Flow** to take a booking through availability and payment, and **Booking System Integration Gaps** for the undocumented Bookings-to-eCommerce payment patterns.
+
+## Recipes
+
+### [End-to-End Booking Flow](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/end-to-end-booking-flow)
+Use to actually book something: find the service, check time slots, create the booking, take payment through checkout.
+
+### [Create and Update Booking Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-and-update-booking-services)
+Use as the general CRUD reference: service types, pricing, location and schedule fields, and editing existing services.
+
+### [Bookings Staff Setup](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/bookings-staff-setup)
+Use to add staff and give them working hours — create staff, assign the schedule, then create the working-hours events.
+
+### [Booking Service Policy Setup](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/booking-service-policy-setup)
+Use for booking and cancellation policies and waitlist settings on a service.
+
+### [Multi-Resource Service Creation](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/multi-resource-service-creation)
+Use when a session needs resources beyond staff — rooms, equipment — with automatic allocation.
+
+### [External Calendar Integration](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/external-calendar-integration)
+Use to connect Google, Outlook or Apple calendars, including the OAuth flow and sync configuration.
+
+### [Booking System Integration Gaps](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/booking-system-integration-gaps)
+Use for booking payments through eCommerce — booking-to-catalog-item transformation and async payment confirmation.
+
+### [Create Booking Service from Prompt](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-booking-service-from-prompt)
+Use when the user's request does not clearly name a service type — it resolves appointment versus class versus course, then creates it.
+
+### [Create Appointment Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-appointment-service)
+Use for one-on-one services (consultations, sessions, personal training) — staff assignment is required.
+
+### [Create Class Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-class-service)
+Use for group services with recurring sessions (yoga, pilates, group fitness) — capacity and session defaults.
+
+### [Create Course Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-course-service)
+Use for a fixed run of group sessions (workshops, bootcamps, programmes) — capacity and session count.
+
+### [Diagnose Bookings Availability Issues](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/diagnose-bookings-availability-issues)
+Use when a service should be bookable but is not, or the owner asks why nothing is available.
+
+### [Bookings Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/bookings-dashboard-navigation)
+Use when the user wants the services list, a service editor, the calendar, bookings list, staff, availability, resources or settings.

--- a/skills/wix-manage/references/bookings/bookings-recipes.md
+++ b/skills/wix-manage/references/bookings/bookings-recipes.md
@@ -11,43 +11,88 @@ Two things commonly block bookability after a service exists: staff have no work
 
 For the rest: **Booking Service Policy Setup** for booking and cancellation rules and waitlists, **Multi-Resource Service Creation** when a session needs rooms or equipment alongside staff, **External Calendar Integration** for Google, Outlook or Apple sync, **End-to-End Booking Flow** to take a booking through availability and payment, and **Booking System Integration Gaps** for the undocumented Bookings-to-eCommerce payment patterns.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [End-to-End Booking Flow](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/end-to-end-booking-flow)
-Use to actually book something: find the service, check time slots, create the booking, take payment through checkout.
+**Technical:** Complete booking flow from service discovery to payment. Query services,
+check availability with Time Slots V2, create bookings, and process payment via
+eCommerce checkout.
 
 ### [Create and Update Booking Services](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-and-update-booking-services)
-Use as the general CRUD reference: service types, pricing, location and schedule fields, and editing existing services.
+**Technical:** Full CRUD operations for Wix Bookings services using Services API. Covers
+service types (APPOINTMENT, CLASS, COURSE), pricing configuration, location setup, and
+schedule management.
 
 ### [Bookings Staff Setup](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/bookings-staff-setup)
-Use to add staff and give them working hours — create staff, assign the schedule, then create the working-hours events.
+**Technical:** Creates staff members and configures custom working hours using Staff API
++ Calendar Events API. Critical two-step process: create staff → assign schedule →
+create working hours events.
 
 ### [Booking Service Policy Setup](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/booking-service-policy-setup)
-Use for booking and cancellation policies and waitlist settings on a service.
+**Technical:** Sets up booking policies, cancellation rules, and waitlist configuration
+using the Services API policy fields. Covers bookingPolicy, cancellationPolicy, and
+waitlist settings.
 
 ### [Multi-Resource Service Creation](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/multi-resource-service-creation)
-Use when a session needs resources beyond staff — rooms, equipment — with automatic allocation.
+**Technical:** Creates resource types and individual resources using Resources API.
+Enables services that require multiple resources (rooms + equipment + staff) with
+automatic allocation.
 
 ### [External Calendar Integration](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/external-calendar-integration)
-Use to connect Google, Outlook or Apple calendars, including the OAuth flow and sync configuration.
+**Technical:** OAuth-based integration with Google Calendar, Microsoft Outlook, and
+Apple Calendar. Covers authentication flows, sync configuration, and bidirectional event
+management.
 
 ### [Booking System Integration Gaps](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/booking-system-integration-gaps)
-Use for booking payments through eCommerce — booking-to-catalog-item transformation and async payment confirmation.
+**Technical:** Documents undocumented API patterns for booking payments. Covers
+Bookings→Ecommerce integration, booking ID transformation to catalog items, and async
+payment confirmation flows.
 
 ### [Create Booking Service from Prompt](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-booking-service-from-prompt)
-Use when the user's request does not clearly name a service type — it resolves appointment versus class versus course, then creates it.
+**Technical:** Create a booking service from a user prompt — e.g. 'create a yoga class
+for $50', 'set up consultations for $75', 'add a personal training appointment', 'create
+a 6-week photography workshop', 'create a hidden free test course with 8 online
+sessions'. Determines the service type (APPOINTMENT, CLASS, or COURSE) and delegates to
+the type-specific recipe. For COURSE services with session dates/counts, follow the
+course recipe's separate Calendar bulkCreateEvents step; Services V2 alone does not
+create bookable course sessions.
 
 ### [Create Appointment Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-appointment-service)
-Use for one-on-one services (consultations, sessions, personal training) — staff assignment is required.
+**Technical:** Create an appointment booking service — e.g. 'set up consultations',
+'create a 1-on-1 session', 'add a personal training appointment', 'create a meeting
+service for $25'. Handles staff assignment (required), session duration, pricing, and
+1-on-1 capacity defaults via bulkCreateServices API.
 
 ### [Create Class Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-class-service)
-Use for group services with recurring sessions (yoga, pilates, group fitness) — capacity and session defaults.
+**Technical:** Create a class booking service — e.g. 'create a yoga class for $50', 'set
+up a pilates class', 'add a group fitness session', 'create a weekly meditation class'.
+Handles group capacity, recurring session defaults, and pricing via bulkCreateServices
+API. Staff assignment is not used for classes.
 
 ### [Create Course Service](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/create-course-service)
-Use for a fixed run of group sessions (workshops, bootcamps, programmes) — capacity and session count.
+**Technical:** Create a course booking service — e.g. 'create a 6-week photography
+workshop', 'set up a training program', 'add a bootcamp course for $300', 'create a
+hidden free test course with 8 sessions'. Handles group capacity, full-course pricing,
+bulkCreateServices, and separate course session events via bulkCreateEvents. Staff
+assignment is not used for courses.
 
 ### [Diagnose Bookings Availability Issues](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/diagnose-bookings-availability-issues)
-Use when a service should be bookable but is not, or the owner asks why nothing is available.
+**Technical:** Answers whether an appointment-based Wix Bookings service currently has
+bookable availability — the primary question — and diagnoses the cause only when there's
+no availability or the owner asks why. To diagnose, first rules out service-level
+blockers the availability endpoint can't see (service hidden, online booking off), then
+runs DiagnoseAvailability for ordered, machine-readable staff/setup reasons, with a
+manual fallback for booking-policy and capacity causes. Use when someone asks whether a
+service has availability, or why a service shows no times / customers can't book it.
 
 ### [Bookings Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/bookings-dashboard-navigation)
-Use when the user wants the services list, a service editor, the calendar, bookings list, staff, availability, resources or settings.
+**Technical:** Builds direct links to Wix Bookings dashboard pages on manage.wix.com —
+services list, edit a specific service, calendar, booking list, staff, availability,
+resources, and settings pages. Pairs each main Bookings entity with its read API so you
+can fetch an entity and hand back a 'view it in your dashboard' link. Use when the user
+asks where something is in the Wix dashboard, wants a direct link to a dashboard page,
+or you need a dashboard URL to include with the result of an API operation.

--- a/skills/wix-manage/references/calendar/calendar-recipes.md
+++ b/skills/wix-manage/references/calendar/calendar-recipes.md
@@ -1,0 +1,13 @@
+---
+name: "Calendar Recipes"
+description: "Business availability and working hours — set the default business hours a site's services and staff are bookable within, using calendar events on the business schedule. Use for anything users call business hours, opening hours, working hours, availability windows, or schedules."
+---
+
+# Calendar Recipes
+
+Base availability lives on the business schedule as working-hours calendar events. The most common failure here is reaching for the Site Properties API, which looks like it should hold opening hours but does not affect bookability — the recipe covers the correct call and that distinction. Individual staff schedules and per-service policies belong to Bookings, not here.
+
+## Recipes
+
+### [Configure Default Business Hours](https://dev.wix.com/docs/api-reference/business-management/calendar/skills/configure-default-business-hours)
+Use when setting or changing the hours a business is open and bookable, including which API actually governs availability.

--- a/skills/wix-manage/references/calendar/calendar-recipes.md
+++ b/skills/wix-manage/references/calendar/calendar-recipes.md
@@ -7,7 +7,13 @@ description: "Business availability and working hours — set the default busine
 
 Base availability lives on the business schedule as working-hours calendar events. The most common failure here is reaching for the Site Properties API, which looks like it should hold opening hours but does not affect bookability — the recipe covers the correct call and that distinction. Individual staff schedules and per-service policies belong to Bookings, not here.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Configure Default Business Hours](https://dev.wix.com/docs/api-reference/business-management/calendar/skills/configure-default-business-hours)
-Use when setting or changing the hours a business is open and bookable, including which API actually governs availability.
+**Technical:** Uses Calendar Events API to create WORKING_HOURS events on the business
+schedule. Covers the critical distinction between Calendar Events API (correct) vs Site
+Properties API (incorrect) for setting base availability.

--- a/skills/wix-manage/references/cms/cms-recipes.md
+++ b/skills/wix-manage/references/cms/cms-recipes.md
@@ -7,25 +7,51 @@ description: "CMS collections and their data — create and change collection sc
 
 Decide schema versus data first: **CMS Schema Management** creates and alters collections and their fields; everything else operates on items inside an existing collection. **CMS Data Items CRUD** is the default for reading and writing items, with **CMS Data Operations Extended** for count, upsert and update-by-filter. Two cases have their own recipes because the ordinary endpoints silently will not do the job: multi-reference fields can only be changed through the reference endpoints in **CMS References And Relationships**, and collections using the Draft Items plugin need **CMS Publishing Flow & Visible/Hidden** to reach published versus draft items. Use **CMS eCommerce Catalog Integration** when collection items must become purchasable.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [CMS Data Items CRUD](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-data-items-crud)
-Use for the everyday item work: insert, query with filters, update, patch, delete, and the bulk variants.
+**Technical:** Add, query, update, and delete items in CMS collections. Use this to
+insert content, bulk insert/update/patch/delete items, query with filters, and manage
+collection data. Key endpoints: /wix-data/v2/items, /wix-data/v2/bulk/items/*.
 
 ### [CMS Data Operations Extended](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-data-operations-extended)
-Use for count, upsert / bulk save, and update-by-filter operations.
+**Technical:** Additional CMS data operations including count, upsert (bulk save), and
+update by filter patterns.
 
 ### [CMS Schema Management](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-schema-management)
-Use when the collection itself must change: listing collections, creating one, adding or removing fields, collection settings.
+**Technical:** Create and modify CMS collection structures. Covers listing collections,
+creating collections with fields, adding/removing fields, and updating collection
+settings.
 
 ### [CMS References And Relationships](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-references-and-relationships)
-Use for MULTI_REFERENCE fields — these cannot be set through ordinary insert or update calls.
+**Technical:** Add, replace, or remove items from MULTI_REFERENCE fields. Use
+insert-references, replace-references, remove-references endpoints. Required for
+managing multi-reference relationships - these CANNOT be set via regular
+insert/update/patch operations. Also covers single references and querying with expanded
+references.
 
 ### [CMS eCommerce Catalog Integration](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-e-commerce-catalog-integration)
-Use when collection items (tickets, memberships, bookings) should be sold through Wix checkout.
+**Technical:** The recommended way to sell existing CMS collection items (tickets,
+bookings, memberships) through Wix checkout. Add the CATALOG plugin to convert any CMS
+collection into purchasable products with cart and payment integration.
 
 ### [CMS Publishing Flow & Visible/Hidden](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/hidden)
-Use when a collection gates items behind draft/publish — detecting the plugin, finding the drafts collection, reading and authoring either version.
+**Technical:** Interact with CMS collections that gate their items behind a
+draft/publish workflow via the Draft Items plugin. Covers detecting the plugin, locating
+the paired drafts collection, reading published vs draft items, authoring/editing
+drafts, and publishing, unpublishing, reverting, and deleting items. Key endpoints:
+/wix-data/v2/items/publish-draft, /wix-data/v2/items/unpublish,
+/wix-data/v2/collections/add-draft-items-plugin, and the paired drafts collection
+referenced by draftItemsPluginOptions.draftsCollectionId.
 
 ### [CMS Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-dashboard-navigation)
-Use when the user wants the collections list or a specific collection's items view.
+**Technical:** Builds direct links to the Wix CMS (Content Manager) dashboard pages on
+manage.wix.com — the collections list and a specific collection's items view. Pairs
+collections and data items with their read APIs so you can fetch data and hand back a
+'view it in your dashboard' link. Use when the user asks where something is in the Wix
+dashboard, wants a direct link to a dashboard page, or you need a dashboard URL to
+include with the result of an API operation.

--- a/skills/wix-manage/references/cms/cms-recipes.md
+++ b/skills/wix-manage/references/cms/cms-recipes.md
@@ -1,0 +1,31 @@
+---
+name: "CMS Recipes"
+description: "CMS collections and their data — create and change collection schemas, insert, query, update and delete items in bulk, manage multi-reference relationships, sell collection items through checkout, handle draft/publish collections, and link to the Content Manager dashboard. Use for anything users call CMS, collections, content manager, database, data items, records, or fields."
+---
+
+# CMS Recipes
+
+Decide schema versus data first: **CMS Schema Management** creates and alters collections and their fields; everything else operates on items inside an existing collection. **CMS Data Items CRUD** is the default for reading and writing items, with **CMS Data Operations Extended** for count, upsert and update-by-filter. Two cases have their own recipes because the ordinary endpoints silently will not do the job: multi-reference fields can only be changed through the reference endpoints in **CMS References And Relationships**, and collections using the Draft Items plugin need **CMS Publishing Flow & Visible/Hidden** to reach published versus draft items. Use **CMS eCommerce Catalog Integration** when collection items must become purchasable.
+
+## Recipes
+
+### [CMS Data Items CRUD](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-data-items-crud)
+Use for the everyday item work: insert, query with filters, update, patch, delete, and the bulk variants.
+
+### [CMS Data Operations Extended](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-data-operations-extended)
+Use for count, upsert / bulk save, and update-by-filter operations.
+
+### [CMS Schema Management](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-schema-management)
+Use when the collection itself must change: listing collections, creating one, adding or removing fields, collection settings.
+
+### [CMS References And Relationships](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-references-and-relationships)
+Use for MULTI_REFERENCE fields — these cannot be set through ordinary insert or update calls.
+
+### [CMS eCommerce Catalog Integration](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-e-commerce-catalog-integration)
+Use when collection items (tickets, memberships, bookings) should be sold through Wix checkout.
+
+### [CMS Publishing Flow & Visible/Hidden](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/hidden)
+Use when a collection gates items behind draft/publish — detecting the plugin, finding the drafts collection, reading and authoring either version.
+
+### [CMS Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/cms/skills/cms-dashboard-navigation)
+Use when the user wants the collections list or a specific collection's items view.

--- a/skills/wix-manage/references/contacts/contacts-recipes.md
+++ b/skills/wix-manage/references/contacts/contacts-recipes.md
@@ -7,19 +7,37 @@ description: "CRM contacts — create and update contacts with their emails, pho
 
 Single-contact work and bulk work are different APIs, so pick by scale first. **Create a Contact** and **Update a Contact** cover the single case, including two shapes that trip up most attempts: `email` and `phone` are single objects rather than arrays, and state, region and province codes must be ISO 3166-2. Updating also needs the contact's current revision, and finding a contact the user named rather than identified. **Bulk Label and Unlabel Contacts** and **Bulk Delete Contacts** are filter-driven — read the delete recipe's safety notes before running one.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Bulk Delete Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/bulk-delete-contacts)
-Use to delete many contacts by filter — read its safety, GDPR and soft-delete notes first.
+**Technical:** Deletes multiple contacts using filter-based bulk delete. Covers safe
+deletion patterns, GDPR compliance, soft delete alternatives, and batch processing
+strategies.
 
 ### [Bulk Label and Unlabel Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/bulk-label-and-unlabel-contacts)
-Use to add or remove labels across many contacts by filter, including creating the label and handling rate limits.
+**Technical:** Adds/removes labels from multiple contacts using Contacts API bulk
+operations. Covers label creation, contact filtering, batch processing, and rate limit
+handling.
 
 ### [Create a Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/create-a-contact)
-Use for a new contact: the minimum identifying fields, the single-object email and phone shapes, and address formatting.
+**Technical:** Creates a contact with the Contacts API. Covers the minimum identifying
+fields, the single-object shape of `email` and `phone`, and adding a physical address
+with the ISO 3166-2 subdivision format required for state, region, and province codes.
 
 ### [Update a Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/update-a-contact)
-Use to change an existing contact — including locating it by name and passing its current revision.
+**Technical:** Updates an existing contact's email, phone, name, or address with the
+Contacts API. Covers locating the contact when the user identifies it by name, passing
+its current revision, and the ISO 3166-2 subdivision format required for state, region
+and province codes.
 
 ### [Contacts Dashboard Navigation](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/contacts-dashboard-navigation)
-Use when the user wants the contacts list, a single contact's page, import, or segments.
+**Technical:** Builds direct links to Wix Contacts (CRM) dashboard pages on
+manage.wix.com — the contacts list, a specific contact's view page, contact import, and
+the segments page. Pairs each main contacts entity with its read API so you can fetch an
+entity and hand back a 'view it in your dashboard' link. Use when the user asks where
+something is in the Wix dashboard, wants a direct link to a dashboard page, or you need
+a dashboard URL to include with the result of an API operation.

--- a/skills/wix-manage/references/contacts/contacts-recipes.md
+++ b/skills/wix-manage/references/contacts/contacts-recipes.md
@@ -1,0 +1,25 @@
+---
+name: "Contacts Recipes"
+description: "CRM contacts — create and update contacts with their emails, phones and addresses, label or delete them in bulk, and link to the contacts dashboard. Use for anything users call contacts, CRM, customers, leads, subscribers, labels, tags, or segments."
+---
+
+# Contacts Recipes
+
+Single-contact work and bulk work are different APIs, so pick by scale first. **Create a Contact** and **Update a Contact** cover the single case, including two shapes that trip up most attempts: `email` and `phone` are single objects rather than arrays, and state, region and province codes must be ISO 3166-2. Updating also needs the contact's current revision, and finding a contact the user named rather than identified. **Bulk Label and Unlabel Contacts** and **Bulk Delete Contacts** are filter-driven — read the delete recipe's safety notes before running one.
+
+## Recipes
+
+### [Bulk Delete Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/bulk-delete-contacts)
+Use to delete many contacts by filter — read its safety, GDPR and soft-delete notes first.
+
+### [Bulk Label and Unlabel Contacts](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/bulk-label-and-unlabel-contacts)
+Use to add or remove labels across many contacts by filter, including creating the label and handling rate limits.
+
+### [Create a Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/create-a-contact)
+Use for a new contact: the minimum identifying fields, the single-object email and phone shapes, and address formatting.
+
+### [Update a Contact](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/update-a-contact)
+Use to change an existing contact — including locating it by name and passing its current revision.
+
+### [Contacts Dashboard Navigation](https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts/skills/contacts-dashboard-navigation)
+Use when the user wants the contacts list, a single contact's page, import, or segments.

--- a/skills/wix-manage/references/dashboard-navigation/dashboard-navigation-recipes.md
+++ b/skills/wix-manage/references/dashboard-navigation/dashboard-navigation-recipes.md
@@ -7,7 +7,19 @@ description: "Direct links into a site's Wix dashboard on manage.wix.com — the
 
 This area holds the shared rules for constructing dashboard URLs: site versus account scope, the app-ID fallback, entity deep links, and the machine-readable route list. Each product area also has its own dashboard-navigation recipe with that product's specific pages — start here for the URL structure, then use the product's own recipe for its pages.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/dashboard-navigation)
-Use for the shared dashboard URL structure — site versus account scope, entity deep links, and where to find a given product's pages.
+**Technical:** Entry point for building direct links into a site's Wix dashboard
+(manage.wix.com). Documents the shared URL structure for all dashboard pages (site and
+account level, app-ID fallback, entity deep links, machine-readable routes.json) and
+routes to a per-business-solution recipe for every covered solution — bookings,
+stores/ecommerce, blog, pricing plans, restaurants, CMS, contacts, forms, marketing, get
+paid, analytics, google ads, app management, site settings, sites, and domains. Use when
+the user asks where something is in the Wix dashboard, wants a direct link to a
+dashboard page, or you need a dashboard URL to include with the result of an API
+operation.

--- a/skills/wix-manage/references/dashboard-navigation/dashboard-navigation-recipes.md
+++ b/skills/wix-manage/references/dashboard-navigation/dashboard-navigation-recipes.md
@@ -1,0 +1,13 @@
+---
+name: "Dashboard Navigation Recipes"
+description: "Direct links into a site's Wix dashboard on manage.wix.com — the shared URL structure for site-level and account-level pages, entity deep links, and the per-product dashboard pages. Use when the user asks where something is in the dashboard, wants a link to a settings or management page, or an API result should come back with a place to see it."
+---
+
+# Dashboard Navigation Recipes
+
+This area holds the shared rules for constructing dashboard URLs: site versus account scope, the app-ID fallback, entity deep links, and the machine-readable route list. Each product area also has its own dashboard-navigation recipe with that product's specific pages — start here for the URL structure, then use the product's own recipe for its pages.
+
+## Recipes
+
+### [Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/bookings/skills/dashboard-navigation)
+Use for the shared dashboard URL structure — site versus account scope, entity deep links, and where to find a given product's pages.

--- a/skills/wix-manage/references/domains/domains-recipes.md
+++ b/skills/wix-manage/references/domains/domains-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Domains Recipes"
+description: "Domains — search for and buy a domain through Wix, or connect one the user already owns, plus links to the domain-management dashboard pages. Use for anything users call domains, URLs, web addresses, DNS, connecting a domain, or buying a domain."
+---
+
+# Domains Recipes
+
+Start by establishing intent: buying a new domain through Wix and connecting an existing external domain are different flows with different prerequisites, and **Domain Search, Purchase and Connect a domain** covers both including availability checks. Use **Domains Dashboard Navigation** for the site-level domain settings page or the account-level My Domains page.
+
+## Recipes
+
+### [Domain Search, Purchase and Connect a domain](https://dev.wix.com/docs/api-reference/account-level/domains/skills/domain-search-purchase-and-connect-a-domain)
+Use for buying a domain through Wix or connecting an existing one, including availability checks and the connection steps.
+
+### [Domains Dashboard Navigation](https://dev.wix.com/docs/api-reference/account-level/domains/skills/domains-dashboard-navigation)
+Use when the user wants the domain settings page for a site, or the account-level My Domains page.

--- a/skills/wix-manage/references/domains/domains-recipes.md
+++ b/skills/wix-manage/references/domains/domains-recipes.md
@@ -7,10 +7,20 @@ description: "Domains — search for and buy a domain through Wix, or connect on
 
 Start by establishing intent: buying a new domain through Wix and connecting an existing external domain are different flows with different prerequisites, and **Domain Search, Purchase and Connect a domain** covers both including availability checks. Use **Domains Dashboard Navigation** for the site-level domain settings page or the account-level My Domains page.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Domain Search, Purchase and Connect a domain](https://dev.wix.com/docs/api-reference/account-level/domains/skills/domain-search-purchase-and-connect-a-domain)
-Use for buying a domain through Wix or connecting an existing one, including availability checks and the connection steps.
+**Technical:** Buy a domain through Wix or connect one the user already owns — intent,
+availability, suggestions, site resolution, registration, privacy, cart and checkout,
+plus the connect path including ownership lookup and binding a domain to a site.
 
 ### [Domains Dashboard Navigation](https://dev.wix.com/docs/api-reference/account-level/domains/skills/domains-dashboard-navigation)
-Use when the user wants the domain settings page for a site, or the account-level My Domains page.
+**Technical:** Builds direct links to the domain-management pages on manage.wix.com —
+the site-level domain settings page and the account-level My Domains page. Pairs domain
+search/purchase with its read APIs. Use when the user asks where something is in the Wix
+dashboard, wants a direct link to a dashboard page, or you need a dashboard URL to
+include with the result of an API operation.

--- a/skills/wix-manage/references/ecommerce/ecommerce-recipes.md
+++ b/skills/wix-manage/references/ecommerce/ecommerce-recipes.md
@@ -1,0 +1,93 @@
+---
+name: "eCommerce Recipes"
+description: "Store commerce beyond the catalog — coupons, discount rules and promotions, shipping rates, regions, pickup and free-shipping thresholds, gift cards, and data-driven recommendations for raising order value, clearing stock or running seasonal campaigns. Use for anything users call discounts, coupons, promotions, sales, shipping, delivery, pickup, gift cards, upsells, bundles, clearance, or 'grow my sales'."
+
+---
+
+# eCommerce Recipes
+
+Two habits make this area work. First, **load the store's context before recommending anything** — currency, country, recent orders and visitors come from the context recipe, and every recommendation depends on them. Second, this area is organised around **dispatchers**: for a question about discounts or shipping, open that domain's dispatcher first, because it owns the boundary rules and routes to the specific recipe. Product and catalog work lives in the stores recipes, not here.
+
+The recommendation recipes are layered: a **goal** recipe owns classification and routing for one kind of ask, and its **flow** recipe is the sub-step it hands off to. Enter through a goal, never directly through a flow. If the user asks broadly for ideas rather than one action, start from the unified strategy recipe.
+
+## Start here
+
+### [eCommerce: Load Context](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/e-commerce-load-context)
+Use before any recommendation or promotion work — loads site currency, country, industry and recent order and visitor figures.
+
+### [Recommend: eCommerce Strategy](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy)
+Use when the user asks broadly for ideas or 'what should I do' — analyses the site across domains and produces a short list of actions.
+
+### [API: Recommendation Tracking](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/api-recommendation-tracking)
+Use alongside any generated recommendations — the tracking calls that record what was suggested.
+
+## Pricing and promotions
+
+### [Pricing & Promotions](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-promotions)
+Open this first for any discount, coupon, sale, ribbon or bundle question — it owns the boundary rules and routes onward.
+
+### [Pricing: Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon)
+Use to create a coupon, including converting a coupon recommendation into a real one.
+
+### [Pricing: Create Discount Rule](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule)
+Use for automatic discounts — percentage or fixed amount, scoped catalog-wide, to collections, or to specific products.
+
+### [Pricing: Discount Not Applying](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-discount-not-applying)
+Use when a discount exists but is not applying at checkout — a diagnostic path through status, time window, scope and app install.
+
+## Shipping
+
+### [Shipping](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping)
+Open this first for any shipping-setup question — rates, regions, pickup, free shipping — it owns the boundary and routes onward.
+
+### [Shipping: Set Up Rates](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-rates)
+Use to configure rate types (flat, tiered, free), conditions, and a free-shipping threshold calibrated against order value.
+
+### [Shipping: Set Up Regions](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-regions)
+Use for delivery profiles and regions — destinations, carriers, backup rates, and externally managed regions.
+
+### [Shipping: Set Up Pickup / Local Delivery](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/local-delivery)
+Use to offer in-store pickup or local delivery at checkout, via the Pickup carrier on a delivery profile.
+
+### [Shipping: Add Free Shipping](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-add-free-shipping)
+Use to add a free-shipping option with a threshold validated against the catalog's price distribution.
+
+### [Shipping: Optimize Rates](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-optimize-rates)
+Use to review an existing rate structure — flat-to-tiered conversion, tier gaps, and per-item penalties.
+
+### [Shipping: Fix Coverage Gaps](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-fix-coverage-gaps)
+Use when an active delivery region has no shipping options at all, leaving customers unable to check out.
+
+### [Shipping: API Reference](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-api-reference)
+Use for the exact Shipping Options endpoints and request shapes when a recipe above is not enough.
+
+## Goals (enter here for recommendations)
+
+### [Goal: Increase AOV](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov)
+Use for upsell, average-order-value or 'boost my sales' asks — owns the lever map across discounts, shipping and bundles.
+
+### [Goal: Clear Inventory](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-clear-inventory)
+Use for clearance, overstock, slow-moving or dead-stock asks.
+
+### [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue)
+Use for holiday, event or date-tied promotions — and note it takes priority when a seasonal signal competes with an upsell one.
+
+### [Goal: Drive Cross-Sells](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-drive-cross-sells)
+Use for bundling, cross-sell, multi-item or 'buy together' asks.
+
+### [Goal: Sell Gift Cards](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-sell-gift-cards)
+Use for gift-card asks — sizes denominations from the site's own order values and catalog prices.
+
+## Flows (sub-steps, reached from a goal above)
+
+### [Flow: Upsell Boost](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-upsell-boost)
+Reached from Goal: Increase AOV — do not enter directly.
+
+### [Flow: Stock Mover](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-stock-mover)
+Reached from Goal: Clear Inventory — do not enter directly.
+
+### [Flow: Seasonal Promotion](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-seasonal-promotion)
+Reached from Goal: Seasonal Revenue — do not enter directly.
+
+### [Flow: Bundle and Save](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-bundle-and-save)
+Reached from Goal: Drive Cross-Sells — do not enter directly.

--- a/skills/wix-manage/references/ecommerce/ecommerce-recipes.md
+++ b/skills/wix-manage/references/ecommerce/ecommerce-recipes.md
@@ -10,84 +10,142 @@ Two habits make this area work. First, **load the store's context before recomme
 
 The recommendation recipes are layered: a **goal** recipe owns classification and routing for one kind of ask, and its **flow** recipe is the sub-step it hands off to. Enter through a goal, never directly through a flow. If the user asks broadly for ideas rather than one action, start from the unified strategy recipe.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Start here
 
 ### [eCommerce: Load Context](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/e-commerce-load-context)
-Use before any recommendation or promotion work — loads site currency, country, industry and recent order and visitor figures.
+**Technical:** eCommerce L1 context loader — calls
+wix-profile-client/v4/profile/metasite (NOT site-properties) to load siteId, country,
+currency, industry, last-30-day visitors/orders/GPV. Skip if already loaded.
 
 ### [Recommend: eCommerce Strategy](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/recommend-e-commerce-strategy)
-Use when the user asks broadly for ideas or 'what should I do' — analyses the site across domains and produces a short list of actions.
+**Technical:** Unified eCommerce recommendation skill — analyzes site data across ALL
+domains (discounts, shipping, and future domains) and generates up to 5 actionable
+recommendations. Entry point for requests about earning more from the visitors a store
+already has: sales, promotions, discounts, coupons, clearance, holiday deals, AOV,
+shipping. Out of scope — traffic acquisition (SEO, ads, social, content); route \"grow
+my traffic\" requests to marketing instead. Tracking is built-in.
 
 ### [API: Recommendation Tracking](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/api-recommendation-tracking)
-Use alongside any generated recommendations — the tracking calls that record what was suggested.
+**Technical:** Cross-cutting tracking API for AI-generated recommendations across
+eCommerce categories (checkout, shipping, pricing). ALWAYS LOAD BEFORE generating a
+"give me N recommendations / concrete actions" response, in addition to the category
+recipe.
 
 ## Pricing and promotions
 
 ### [Pricing & Promotions](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-promotions)
-Open this first for any discount, coupon, sale, ribbon or bundle question — it owns the boundary rules and routes onward.
+**Technical:** Pricing & Promotions boundary owner — discounts, coupons, sales, ribbons,
+bundles. **Always load this dispatcher first when a question touches both discount work
+and refunds, payments, product-price edits, or shipping rates** — the rules for which
+side owns each topic live in this file, not in this README line.
 
 ### [Pricing: Create Coupon](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-coupon)
-Use to create a coupon, including converting a coupon recommendation into a real one.
+**Technical:** PREFERRED recipe for converting a COUPON recommendation (mechanism:
+COUPON) into a Wix coupon. Use THIS entry — NOT the legacy setup-coupons entry which is
+superseded. Maps scope/discountType/conditions to Coupons V2 API fields.
 
 ### [Pricing: Create Discount Rule](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-create-discount-rule)
-Use for automatic discounts — percentage or fixed amount, scoped catalog-wide, to collections, or to specific products.
+**Technical:** Configures automatic discount rules using the eCommerce Discount Rules
+API. Covers percentage and fixed-amount discounts, scope targeting (catalog-wide,
+specific collections, or individual products), scheduling active periods, and the
+find-by-name + update pattern.
 
 ### [Pricing: Discount Not Applying](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/pricing-discount-not-applying)
-Use when a discount exists but is not applying at checkout — a diagnostic path through status, time window, scope and app install.
+**Technical:** Diagnostic tree for when a discount rule exists but isn't applying at
+checkout. Checks active status, time window, scope targeting, revision, and app
+installation.
 
 ## Shipping
 
 ### [Shipping](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping)
-Open this first for any shipping-setup question — rates, regions, pickup, free shipping — it owns the boundary and routes onward.
+**Technical:** Shipping-setup boundary owner for an eCommerce store. **Always load this
+dispatcher first whenever a question touches shipping setup** — rates, regions, pickup,
+free-shipping thresholds, and diagnosing wrong/missing shipping. Order fulfillment (mark
+shipped, tracking, labels, invoices) is currently handled outside the routing tree.
 
 ### [Shipping: Set Up Rates](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-rates)
-Use to configure rate types (flat, tiered, free), conditions, and a free-shipping threshold calibrated against order value.
+**Technical:** Configures shipping option rates — rate types (flat, tiered, free),
+condition types and operators, free shipping threshold calibration, AOV sanity check,
+per-item penalty avoidance, and tier gap detection.
 
 ### [Shipping: Set Up Regions](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-set-up-regions)
-Use for delivery profiles and regions — destinations, carriers, backup rates, and externally managed regions.
+**Technical:** Configures delivery profiles and regions — creating profiles, adding
+regions with destinations, assigning carriers, enabling backup rates, and handling
+externally managed regions.
 
 ### [Shipping: Set Up Pickup / Local Delivery](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/local-delivery)
-Use to offer in-store pickup or local delivery at checkout, via the Pickup carrier on a delivery profile.
+**Technical:** Configures a pickup option for an online store so customers can choose
+in-store pickup at checkout. Uses the Delivery Profiles API to discover the Pickup
+carrier, add a delivery region, and attach the carrier with a free pickup rate.
 
 ### [Shipping: Add Free Shipping](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-add-free-shipping)
-Use to add a free-shipping option with a threshold validated against the catalog's price distribution.
+**Technical:** Creates a free shipping option with an AOV-calibrated threshold to reduce
+cart abandonment and increase average order value. Validates threshold against catalog
+price distribution.
 
 ### [Shipping: Optimize Rates](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-optimize-rates)
-Use to review an existing rate structure — flat-to-tiered conversion, tier gaps, and per-item penalties.
+**Technical:** Analyzes catalog price distribution and current rate structure to
+recommend optimal shipping rate strategy. Handles flat-to-tiered conversion, tier gap
+detection, and per-item penalty removal.
 
 ### [Shipping: Fix Coverage Gaps](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-fix-coverage-gaps)
-Use when an active delivery region has no shipping options at all, leaving customers unable to check out.
+**Technical:** Coverage gap = active delivery region with ZERO Shipping Options (NOT
+zero carriers or no backup rate). Step 1: POST /ecom/v1/delivery-profiles/query. Step 2:
+POST /ecom/v1/shipping-options/query — count options per region; gap = active region
+with count 0. Step 3: POST /ecom/v1/shipping-options to create standard shipping for
+each gap region.
 
 ### [Shipping: API Reference](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/shipping-api-reference)
-Use for the exact Shipping Options endpoints and request shapes when a recipe above is not enough.
+**Technical:** Shipping Options API: POST /ecom/v1/shipping-options/query (list all),
+POST /ecom/v1/shipping-options (create), PATCH /ecom/v1/shipping-options/{id} (update),
+DELETE /ecom/v1/shipping-options/{id} (delete). Delivery Profiles API: POST
+/ecom/v1/delivery-profiles/query. Base: https://www.wixapis.com/ecom
 
 ## Goals (enter here for recommendations)
 
 ### [Goal: Increase AOV](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-increase-aov)
-Use for upsell, average-order-value or 'boost my sales' asks — owns the lever map across discounts, shipping and bundles.
+**Technical:** UPSELL_BOOST goal — always load BEFORE recommending AOV / upsell / "boost
+my sales" / shipping-threshold actions. Owns the cross-domain lever map (discount +
+shipping + bundle) for open-ended sales prompts.
 
 ### [Goal: Clear Inventory](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-clear-inventory)
-Use for clearance, overstock, slow-moving or dead-stock asks.
+**Technical:** STOCK_MOVER clearance goal — always load BEFORE recommending any
+clearance / overstock / slow-stock / dead-inventory action.
 
 ### [Goal: Seasonal Revenue](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-seasonal-revenue)
-Use for holiday, event or date-tied promotions — and note it takes priority when a seasonal signal competes with an upsell one.
+**Technical:** SEASONAL goal — always load BEFORE recommending any holiday / event /
+date-tied promotion. Owns the priority rule (holiday beats UPSELL_BOOST when both
+signals are present).
 
 ### [Goal: Drive Cross-Sells](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-drive-cross-sells)
-Use for bundling, cross-sell, multi-item or 'buy together' asks.
+**Technical:** BUNDLE_AND_SAVE goal — always load BEFORE recommending bundling /
+cross-sell / multi-item / "buy together" actions.
 
 ### [Goal: Sell Gift Cards](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/goal-sell-gift-cards)
-Use for gift-card asks — sizes denominations from the site's own order values and catalog prices.
+**Technical:** SELL_GIFT_CARDS goal — the GIFT_CARDS domain logic loaded by the strategy
+orchestrator. Sizes a gift card product from the site's own AOV and catalog prices
+(preset denominations, custom amount range, expiration policy) and gates on the site
+already selling gift cards. Sub-step, NOT a direct entry point — load Recommend:
+eCommerce Strategy first; it owns domain activation, cross-domain dedup, and tracking.
 
 ## Flows (sub-steps, reached from a goal above)
 
 ### [Flow: Upsell Boost](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-upsell-boost)
-Reached from Goal: Increase AOV — do not enter directly.
+**Technical:** UPSELL_BOOST sub-flow — load [Goal: Increase AOV] FIRST (it owns
+classification and routing); this is a sub-step, NOT a direct entry from README.
 
 ### [Flow: Stock Mover](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-stock-mover)
-Reached from Goal: Clear Inventory — do not enter directly.
+**Technical:** Stock-mover clearance sub-flow — load [Goal: Clear Inventory] FIRST (it
+owns the routing); this is a sub-step.
 
 ### [Flow: Seasonal Promotion](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-seasonal-promotion)
-Reached from Goal: Seasonal Revenue — do not enter directly.
+**Technical:** SEASONAL sub-flow — load [Goal: Seasonal Revenue] FIRST (it owns
+classification and routing); this is a sub-step, NOT a direct entry from README.
 
 ### [Flow: Bundle and Save](https://dev.wix.com/docs/api-reference/business-solutions/e-commerce/skills/flow-bundle-and-save)
-Reached from Goal: Drive Cross-Sells — do not enter directly.
+**Technical:** BUNDLE_AND_SAVE sub-flow — load [Goal: Drive Cross-Sells] FIRST (it owns
+classification and routing); this is a sub-step, NOT a direct entry from README.

--- a/skills/wix-manage/references/events/events-recipes.md
+++ b/skills/wix-manage/references/events/events-recipes.md
@@ -7,10 +7,23 @@ description: "Event planning and management — create one-off or recurring even
 
 Route carefully: several unrelated Wix APIs are called "Events" — these recipes cover public events guests attend, not calendar sessions (Bookings) or webhook domain events. Use **Create Event** to bring a new event into existence, including its date, location, registration type and ticket tiers. Use **Manage Events** for anything about an event that already exists: publishing a draft, cancelling, rescheduling, cloning, updating details, or counting.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Create Event](https://dev.wix.com/docs/api-reference/business-solutions/events/skills/create-event)
-Use when the user wants a new event — one-off or recurring, RSVP or ticketed — including date and time, location, capacity, description and ticket pricing.
+**Technical:** Creates an event with the Wix Events V3 API — the required request body,
+ISO-8601 date and time settings, venue/online/TBD location, RSVP vs ticketed
+registration, guest capacity, short vs rich-text descriptions, ticket tiers and pricing,
+and recurring series. Covers the exact field shapes and the API's misleading validation
+messages. Use when the user wants to create an event, set its date, location,
+description, guest limit or ticket prices, or set up a repeating event.
 
 ### [Manage Events](https://dev.wix.com/docs/api-reference/business-solutions/events/skills/manage-events)
-Use when the event already exists: publishing, cancelling, deleting, cloning, rescheduling, updating details, or counting events.
+**Technical:** Operates on events that already exist with the Wix Events V3 API —
+publishing a draft, cancelling, deleting, cloning, updating an event's date or details,
+and counting events. Use when the user wants to publish or cancel an event, duplicate
+one, move an event's date, or count their events. Creating an event, its tickets or a
+recurring series is a separate recipe.

--- a/skills/wix-manage/references/events/events-recipes.md
+++ b/skills/wix-manage/references/events/events-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Events Recipes"
+description: "Event planning and management — create one-off or recurring events, RSVPs, ticketing and ticket tiers, guest capacity, venues, then publish, cancel, reschedule, clone or count them. Use for anything users call events, happenings, gatherings, workshops, concerts, meetups, or webinars."
+---
+
+# Events Recipes
+
+Route carefully: several unrelated Wix APIs are called "Events" — these recipes cover public events guests attend, not calendar sessions (Bookings) or webhook domain events. Use **Create Event** to bring a new event into existence, including its date, location, registration type and ticket tiers. Use **Manage Events** for anything about an event that already exists: publishing a draft, cancelling, rescheduling, cloning, updating details, or counting.
+
+## Recipes
+
+### [Create Event](https://dev.wix.com/docs/api-reference/business-solutions/events/skills/create-event)
+Use when the user wants a new event — one-off or recurring, RSVP or ticketed — including date and time, location, capacity, description and ticket pricing.
+
+### [Manage Events](https://dev.wix.com/docs/api-reference/business-solutions/events/skills/manage-events)
+Use when the event already exists: publishing, cancelling, deleting, cloning, rescheduling, updating details, or counting events.

--- a/skills/wix-manage/references/forms/forms-recipes.md
+++ b/skills/wix-manage/references/forms/forms-recipes.md
@@ -7,10 +7,21 @@ description: "Site forms — build forms and their fields through the Form Schem
 
 Use **Create Form** to define a form and its fields, layout, and what happens after a visitor submits. Use **Forms Dashboard Navigation** when the user wants the forms list, the submissions table for a form, the form builder, templates, or forms settings — including pairing a submission fetched through the API with a link to where it can be reviewed.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Create Form](https://dev.wix.com/docs/api-reference/crm/forms/skills/create-form)
-Use when building a form: its fields, layout, and what happens after submission.
+**Technical:** Creates a form with fields (name, email, etc.) using the Form Schemas
+API. Covers field configuration, layout, and post-submission triggers.
 
 ### [Forms Dashboard Navigation](https://dev.wix.com/docs/api-reference/crm/forms/skills/forms-dashboard-navigation)
-Use when the user wants the forms list, a form's submissions, the builder for a specific form, templates, or forms settings.
+**Technical:** Builds direct links to Wix Forms dashboard pages on manage.wix.com — the
+forms list, the submissions table, the form builder for a specific form, standalone
+forms, templates, and forms settings. Pairs each main Forms entity (form, submission)
+with its read API so you can fetch an entity and hand back a 'view it in your dashboard'
+link. Use when the user asks where something is in the Wix dashboard, wants a direct
+link to a dashboard page, or you need a dashboard URL to include with the result of an
+API operation.

--- a/skills/wix-manage/references/forms/forms-recipes.md
+++ b/skills/wix-manage/references/forms/forms-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Forms Recipes"
+description: "Site forms — build forms and their fields through the Form Schemas API, wire up post-submission behaviour, and link to the forms and submissions dashboard pages. Use for anything users call forms, contact forms, surveys, sign-up forms, submissions, or fields."
+---
+
+# Forms Recipes
+
+Use **Create Form** to define a form and its fields, layout, and what happens after a visitor submits. Use **Forms Dashboard Navigation** when the user wants the forms list, the submissions table for a form, the form builder, templates, or forms settings — including pairing a submission fetched through the API with a link to where it can be reviewed.
+
+## Recipes
+
+### [Create Form](https://dev.wix.com/docs/api-reference/crm/forms/skills/create-form)
+Use when building a form: its fields, layout, and what happens after submission.
+
+### [Forms Dashboard Navigation](https://dev.wix.com/docs/api-reference/crm/forms/skills/forms-dashboard-navigation)
+Use when the user wants the forms list, a form's submissions, the builder for a specific form, templates, or forms settings.

--- a/skills/wix-manage/references/get-paid/get-paid-recipes.md
+++ b/skills/wix-manage/references/get-paid/get-paid-recipes.md
@@ -7,16 +7,31 @@ description: "Taking payments outside a store checkout — set up Wix Payments, 
 
 A site cannot collect anything until a provider is configured, so start with **How to Setup Wix Payments** when payments are new or failing — eligibility, business verification, bank account and enabled payment methods. Then use **Create Payment Links** for catalog products or custom line items, or **Payment Links for Bookings** when the amount owed belongs to an existing booking, since that flow ties the link to the booking id and its redirect.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Create Payment Links](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/create-payment-links)
-Use to request payment for store products or a custom amount, including variants, due dates, and emailing the link.
+**Technical:** Creates payment links for collecting payments without a checkout flow.
+Covers store products (catalog items), custom line items, variants, due dates, and
+sending links via email.
 
 ### [How to Setup Wix Payments](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/how-to-setup-wix-payments)
-Use when payments are not yet configured or a payment attempt fails on provider setup — eligibility, verification, bank account, payment methods.
+**Technical:** Configures Wix Payments as the payment provider. Covers eligibility
+checking, business verification, bank account setup, and payment method configuration
+(cards, PayPal, Apple Pay).
 
 ### [Payment Links for Bookings](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/payment-links-for-bookings)
-Use when the outstanding amount belongs to an existing booking and the link must be tied to it.
+**Technical:** Creates payment links for unpaid bookings using Payment Links API. Links
+booking IDs to payment requests with proper redirect handling.
 
 ### [Get Paid Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/get-paid-dashboard-navigation)
-Use when the user wants payment links, invoices, recurring invoices, or the accept-payments settings page.
+**Technical:** Builds direct links to Wix payments and invoicing dashboard pages on
+manage.wix.com — payment links, invoices (list, create, settings), recurring invoices,
+and the accept-payments settings page. Pairs each main get-paid entity with its read API
+so you can fetch an entity and hand back a 'view it in your dashboard' link. Use when
+the user asks where something is in the Wix dashboard, wants a direct link to a
+dashboard page, or you need a dashboard URL to include with the result of an API
+operation.

--- a/skills/wix-manage/references/get-paid/get-paid-recipes.md
+++ b/skills/wix-manage/references/get-paid/get-paid-recipes.md
@@ -1,0 +1,22 @@
+---
+name: "Get Paid Recipes"
+description: "Taking payments outside a store checkout — set up Wix Payments, create payment links for products, custom amounts or unpaid bookings, and link to the payments and invoicing dashboard. Use for anything users call getting paid, payment links, invoices, collecting money, card payments, PayPal, or payment setup."
+---
+
+# Get Paid Recipes
+
+A site cannot collect anything until a provider is configured, so start with **How to Setup Wix Payments** when payments are new or failing — eligibility, business verification, bank account and enabled payment methods. Then use **Create Payment Links** for catalog products or custom line items, or **Payment Links for Bookings** when the amount owed belongs to an existing booking, since that flow ties the link to the booking id and its redirect.
+
+## Recipes
+
+### [Create Payment Links](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/create-payment-links)
+Use to request payment for store products or a custom amount, including variants, due dates, and emailing the link.
+
+### [How to Setup Wix Payments](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/how-to-setup-wix-payments)
+Use when payments are not yet configured or a payment attempt fails on provider setup — eligibility, verification, bank account, payment methods.
+
+### [Payment Links for Bookings](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/payment-links-for-bookings)
+Use when the outstanding amount belongs to an existing booking and the link must be tied to it.
+
+### [Get Paid Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/get-paid/skills/get-paid-dashboard-navigation)
+Use when the user wants payment links, invoices, recurring invoices, or the accept-payments settings page.

--- a/skills/wix-manage/references/google-ads/google-ads-recipes.md
+++ b/skills/wix-manage/references/google-ads/google-ads-recipes.md
@@ -1,0 +1,31 @@
+---
+name: "Google Ads Recipes"
+description: "Google paid advertising for a Wix site — install the Google Ads app and create the account, get AI campaign suggestions, launch and manage Performance Max campaigns, read performance analytics and billing. Use for anything users call Google Ads, paid ads, PPC, campaigns, ad spend, keywords, or advertising."
+---
+
+# Google Ads Recipes
+
+Everything here depends on a Google Ads account existing, so **Install Google Ads and Create an Account** is the first stop whenever ads are new to the site or a call fails on a missing account. From there: **Get AI Campaign Suggestions** supplies keyword themes, geo targets and budget tiers to build a campaign from; **Create and Launch a Performance Max Campaign** creates and starts one; **Manage Campaign Lifecycle** handles everything afterwards — launch versus resume, pausing (optionally with auto-resume), and editing budget or targeting. **Query Campaign Performance Analytics** answers how a campaign is doing, and **Retrieve Google Ads Billing and Payment Details** answers what it cost.
+
+## Recipes
+
+### [Install Google Ads and Create an Account](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/install-google-ads-and-create-an-account)
+Use first for any ads work — installing the app and creating or finding the Google Ads account everything else needs.
+
+### [Get AI Campaign Suggestions for Google Ads](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/get-ai-campaign-suggestions-for-google-ads)
+Use to gather inputs before building a campaign: keyword themes, geo-target options, and budget tiers.
+
+### [Create and Launch a Performance Max Campaign](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/create-and-launch-a-performance-max-campaign)
+Use to create a new campaign and launch it, including its asset group of headlines, descriptions and images.
+
+### [Google Ads Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/google-ads-dashboard-navigation)
+Use when the user wants the Wix Google Ads dashboard page where campaigns are managed.
+
+### [Manage Campaign Lifecycle](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/manage-campaign-lifecycle)
+Use for existing campaigns: list or get, launch versus resume, pause with optional auto-resume, and update name, budget or targeting.
+
+### [Query Campaign Performance Analytics](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/query-campaign-performance-analytics)
+Use when the user asks how ads are performing — impressions, clicks, CTR, cost, leads, with period comparisons.
+
+### [Retrieve Google Ads Billing and Payment Details](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/retrieve-google-ads-billing-and-payment-details)
+Use for ad spend, Wix service fee, coupon adjustments, and the billing period.

--- a/skills/wix-manage/references/google-ads/google-ads-recipes.md
+++ b/skills/wix-manage/references/google-ads/google-ads-recipes.md
@@ -7,25 +7,84 @@ description: "Google paid advertising for a Wix site — install the Google Ads 
 
 Everything here depends on a Google Ads account existing, so **Install Google Ads and Create an Account** is the first stop whenever ads are new to the site or a call fails on a missing account. From there: **Get AI Campaign Suggestions** supplies keyword themes, geo targets and budget tiers to build a campaign from; **Create and Launch a Performance Max Campaign** creates and starts one; **Manage Campaign Lifecycle** handles everything afterwards — launch versus resume, pausing (optionally with auto-resume), and editing budget or targeting. **Query Campaign Performance Analytics** answers how a campaign is doing, and **Retrieve Google Ads Billing and Payment Details** answers what it cost.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Install Google Ads and Create an Account](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/install-google-ads-and-create-an-account)
-Use first for any ads work — installing the app and creating or finding the Google Ads account everything else needs.
+**Technical:** One-time setup for running Google paid ads on a Wix site: install the Wix
+Google Ads app, then create the Google Ads account that every campaign, suggestion, and
+analytics call depends on. Covers checking whether an account already exists, choosing a
+currency, optionally attaching a promotional incentive (credit offer), linking a Google
+Merchant Center account, and deleting an account. Use when the user wants to 'set up
+Google Ads', 'connect Google Ads', 'start advertising on Google', 'create a Google Ads
+account', or hits an ACCOUNT_NOT_FOUND / app-not-installed error before creating a
+campaign. Google Ads REST API, base https://www.wixapis.com/google-ads/v1.
 
 ### [Get AI Campaign Suggestions for Google Ads](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/get-ai-campaign-suggestions-for-google-ads)
-Use to gather inputs before building a campaign: keyword themes, geo-target options, and budget tiers.
+**Technical:** Reference for the Google Ads Suggestions API on a Wix site:
+AI/Google-generated inputs that help build effective campaigns — keyword themes (from a
+URL or autocomplete), geo-target options, low/recommended/high daily-budget tiers with
+estimated clicks, PMAX budget recommendations, text assets (headlines/descriptions), AI
+image assets (auto-uploaded to Wix Media), search themes, promotional incentive offers,
+and complete AI-generated campaign configurations from a campaign brief. Use when the
+user asks 'suggest keywords for my ads', 'what budget should I use', 'where should I
+target', 'generate ad copy/headlines', 'generate ad images', 'suggest a whole campaign',
+or when a create-campaign flow needs suggested values. REST base
+https://www.wixapis.com/google-ads/v1.
 
 ### [Create and Launch a Performance Max Campaign](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/create-and-launch-a-performance-max-campaign)
-Use to create a new campaign and launch it, including its asset group of headlines, descriptions and images.
+**Technical:** Creates and launches a Google Ads Performance Max (PMAX) campaign for a
+Wix site — a goal-based campaign that runs across all Google channels (Search, Display,
+YouTube, Gmail, Discover, Maps) from an asset group of headlines, descriptions, images,
+and (for PMAX Leads) search-theme signals. Covers generating AI text and image assets,
+generating search themes, getting a Google budget recommendation, assembling the asset
+group with the required minimum assets, choosing PERFORMANCE_MAX vs
+PERFORMANCE_MAX_LEADS (leads: phone/form goals, negative keywords, 28-day learning) vs
+retail/Shopping (Merchant Center feed), creating in PAUSED, and launching. Use for
+'create a Performance Max campaign', 'PMAX', 'run ads across all of Google', 'lead-gen
+Google campaign', or 'Google Shopping ads'. Requires an existing Google Ads account.
+REST base https://www.wixapis.com/google-ads/v1.
 
 ### [Google Ads Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/google-ads-dashboard-navigation)
-Use when the user wants the Wix Google Ads dashboard page where campaigns are managed.
+**Technical:** Builds a direct link to the Wix Google Ads dashboard page on
+manage.wix.com, where campaigns created via the Google Ads API recipes are managed. Use
+when the user asks where something is in the Wix dashboard, wants a direct link to a
+dashboard page, or you need a dashboard URL to include with the result of an API
+operation.
 
 ### [Manage Campaign Lifecycle](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/manage-campaign-lifecycle)
-Use for existing campaigns: list or get, launch versus resume, pause with optional auto-resume, and update name, budget or targeting.
+**Technical:** Manages existing Google Ads campaigns on a Wix site: list/get, launch
+(first activation) vs resume (reactivate after a pause), pause a running campaign —
+optionally with a scheduled auto-resume date — update name/budget/targeting, change the
+daily budget, delete permanently, and read status history / change log. Use when the
+user wants to 'pause my Google ad', 'resume my campaign', 'stop the campaign', 'change
+my daily budget', 'rename the campaign', 'delete this campaign', 'list my Google Ads
+campaigns', or 'why did my campaign status change'. Requires an existing Google Ads
+account and campaign. REST base https://www.wixapis.com/google-ads/v1.
 
 ### [Query Campaign Performance Analytics](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/query-campaign-performance-analytics)
-Use when the user asks how ads are performing — impressions, clicks, CTR, cost, leads, with period comparisons.
+**Technical:** Reads performance analytics for a Google Ads campaign on a Wix site:
+daily performance metrics (impressions, clicks, CTR, cost, leads, phone calls) with
+optional previous-period comparison and trends; conversion metrics from Wix Analytics
+(orders, revenue, leads, CPL, ROAS); the search terms that triggered a campaign's ads;
+per-product shopping performance for retail campaigns; and per-asset performance
+(headlines, descriptions, images) for PMAX Leads. Explains when to use
+campaignResourceName vs the Wix campaignId, the dateRange shape, field enums, sorting,
+and paging. Use when the user asks 'how is my campaign doing', 'show ad performance',
+'what search terms triggered my ads', 'which products/assets perform best', 'campaign
+ROI/ROAS', or 'conversions from my Google ads'. REST base
+https://www.wixapis.com/google-ads/v1.
 
 ### [Retrieve Google Ads Billing and Payment Details](https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads/skills/retrieve-google-ads-billing-and-payment-details)
-Use for ad spend, Wix service fee, coupon adjustments, and the billing period.
+**Technical:** Retrieves billing and payment details for a Wix site's Google Ads
+account: the current billing period's ad spend (usage), the Wix service fee, the total
+charge, any promotional coupon adjustment, the billing period dates, and the account's
+credit balance (positive = available credits, negative = outstanding debt not yet
+charged). Also explains reading current vs remaining budget from the account object. Use
+when the user asks 'how much have I spent on Google Ads', 'what's my next Google Ads
+charge', 'show my ad billing', 'do I have ad credits left', 'why was I charged', or
+'upcoming Google Ads payment'. Requires an existing Google Ads account. REST base
+https://www.wixapis.com/google-ads/v1.

--- a/skills/wix-manage/references/marketing/marketing-recipes.md
+++ b/skills/wix-manage/references/marketing/marketing-recipes.md
@@ -7,13 +7,41 @@ description: "Social and email marketing — generate, publish and schedule soci
 
 Publishing needs a channel the site owner has already connected, so establish that before composing anything. Use **Create and Publish a Social Media Post** for a single post — generated with AI or supplied by the user, published now or scheduled. Use **Generate a Marketing Plan and Schedule Its Posts** when the user wants an ongoing plan rather than one post; configure the marketing settings (goal, tone, cadence, content pillars) first, since they shape everything the plan generates.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Create and Publish a Social Media Post (with AI generation)](https://dev.wix.com/docs/api-reference/business-management/marketing/skills/create-and-publish-a-social-media-post-with-ai-generation)
-Use for one post: generating or accepting its content, then publishing or scheduling it to a connected channel.
+**Technical:** End-to-end flow to create a social media post, optionally generating it
+with AI, and publish or schedule it to a site's connected channel (Instagram, Facebook,
+LinkedIn, X/Twitter, TikTok, Pinterest, YouTube, Google Business Profile) using the Wix
+Publisher API. Can generate a full per-channel post from a free-text idea or from the
+site's own assets (products, blog posts, events, bookings, coupons, categories),
+generate caption/title suggestions, and edit an existing image with AI. Settles the post
+content with you first, then confirms the channel is connected, checks premium quota,
+creates a draft, and publishes now or schedules it. Use for 'create a post', 'generate a
+post from my product/idea', 'write a caption', 'caption ideas/suggestions', 'edit a post
+image with AI', 'post to Instagram/Facebook/TikTok', 'connect my
+Instagram/Pinterest/LinkedIn', or 'schedule a post'.
 
 ### [Generate a Marketing Plan and Schedule Its Posts](https://dev.wix.com/docs/api-reference/business-management/marketing/skills/generate-a-marketing-plan-and-schedule-its-posts)
-Use when the user wants a plan or content calendar rather than a single post, including scheduling the posts it generates.
+**Technical:** End-to-end flow to generate an AI-powered social media marketing plan for
+a site and schedule its generated posts for publishing, using the Wix Marketing Plan
+API. Recommends configuring marketing settings (goal, tone, cadence, content pillars)
+before the first generation, generates the plan asynchronously, polls until it's ready,
+then schedules the DRAFT posts. Includes generating posts for additional activities. Use
+for 'generate a marketing plan', 'create a social media plan/calendar', or 'schedule my
+plan's posts' requests.
 
 ### [Marketing Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/marketing/skills/marketing-dashboard-navigation)
-Use when the user wants the social posts hub, post templates and saved designs, or the email-marketing pages.
+**Technical:** Builds direct links to Wix marketing dashboard pages on manage.wix.com —
+the social posts hub (drafts, scheduled and published posts across connected channels),
+post design templates, saved designs, and the email marketing pages (campaigns list,
+campaign templates, campaign analytics). Pairs each main marketing entity (social post
+item, connected social account, marketing-plan post, email campaign) with its read API
+so you can fetch an entity and hand back a 'view it in your dashboard' link. Use when
+the user asks where something is in the Wix dashboard, wants a direct link to a
+dashboard page, or you need a dashboard URL to include with the result of an API
+operation.

--- a/skills/wix-manage/references/marketing/marketing-recipes.md
+++ b/skills/wix-manage/references/marketing/marketing-recipes.md
@@ -1,0 +1,19 @@
+---
+name: "Marketing Recipes"
+description: "Social and email marketing — generate, publish and schedule social posts to connected channels, build an AI marketing plan with its content calendar, and link to the marketing dashboard pages. Use for anything users call social media, posts, campaigns, marketing, promotion, Instagram, Facebook, LinkedIn, or email marketing."
+---
+
+# Marketing Recipes
+
+Publishing needs a channel the site owner has already connected, so establish that before composing anything. Use **Create and Publish a Social Media Post** for a single post — generated with AI or supplied by the user, published now or scheduled. Use **Generate a Marketing Plan and Schedule Its Posts** when the user wants an ongoing plan rather than one post; configure the marketing settings (goal, tone, cadence, content pillars) first, since they shape everything the plan generates.
+
+## Recipes
+
+### [Create and Publish a Social Media Post (with AI generation)](https://dev.wix.com/docs/api-reference/business-management/marketing/skills/create-and-publish-a-social-media-post-with-ai-generation)
+Use for one post: generating or accepting its content, then publishing or scheduling it to a connected channel.
+
+### [Generate a Marketing Plan and Schedule Its Posts](https://dev.wix.com/docs/api-reference/business-management/marketing/skills/generate-a-marketing-plan-and-schedule-its-posts)
+Use when the user wants a plan or content calendar rather than a single post, including scheduling the posts it generates.
+
+### [Marketing Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/marketing/skills/marketing-dashboard-navigation)
+Use when the user wants the social posts hub, post templates and saved designs, or the email-marketing pages.

--- a/skills/wix-manage/references/media/media-recipes.md
+++ b/skills/wix-manage/references/media/media-recipes.md
@@ -7,7 +7,13 @@ description: "Media Manager uploads — import images and files into a site's Me
 
 Almost every media need is the same flow: import a file by URL, wait for it to finish, then reference the returned `wixstatic.com` URL wherever an image is needed — product images, blog cover images, event images, rich content. If a user hands over a picture for another API, come here first to get a usable URL.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Upload Media to Wix](https://dev.wix.com/docs/api-reference/assets/media/skills/upload-media-to-wix)
-Use whenever a file or image has to get into Wix before another API can reference it — import, status check, and the hosted URL to reuse.
+**Technical:** Uploads images and files to the Wix Media Manager using the Import File
+API. Covers importing from external URLs, checking file status, and using the returned
+wixstatic.com URL in other APIs.

--- a/skills/wix-manage/references/media/media-recipes.md
+++ b/skills/wix-manage/references/media/media-recipes.md
@@ -1,0 +1,13 @@
+---
+name: "Media Recipes"
+description: "Media Manager uploads — import images and files into a site's Media Manager from external URLs, track import status, and use the resulting hosted URL in other APIs. Use for anything users call uploading, images, photos, files, assets, or media."
+---
+
+# Media Recipes
+
+Almost every media need is the same flow: import a file by URL, wait for it to finish, then reference the returned `wixstatic.com` URL wherever an image is needed — product images, blog cover images, event images, rich content. If a user hands over a picture for another API, come here first to get a usable URL.
+
+## Recipes
+
+### [Upload Media to Wix](https://dev.wix.com/docs/api-reference/assets/media/skills/upload-media-to-wix)
+Use whenever a file or image has to get into Wix before another API can reference it — import, status check, and the hosted URL to reuse.

--- a/skills/wix-manage/references/pricing-plans/pricing-plans-recipes.md
+++ b/skills/wix-manage/references/pricing-plans/pricing-plans-recipes.md
@@ -1,0 +1,19 @@
+---
+name: "Pricing Plans Recipes"
+description: "Subscriptions and paid plans — create recurring, one-time and free plans with trials and perks, connect plans to bookings as memberships or packages, and link to the plans dashboard. Use for anything users call plans, subscriptions, memberships, packages, recurring payments, or tiers."
+---
+
+# Pricing Plans Recipes
+
+Create the plan first with **Create and Update Pricing Plans** — pricing model, trial period, perks and visibility all live there. Only then connect it to what it grants: **Pricing Plans Bookings Integration** covers benefit programs, which is how a plan becomes a membership or class package that grants booking access. A plan on its own grants nothing until that link exists.
+
+## Recipes
+
+### [Create and Update Pricing Plans](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/create-and-update-pricing-plans)
+Use when defining or changing a plan: recurring, one-time or free pricing, trial periods, perks, and whether the plan is public.
+
+### [Pricing Plans Bookings Integration](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/pricing-plans-bookings-integration)
+Use when a plan should grant access to booking services — memberships, class packages, and benefit programs.
+
+### [Pricing Plans Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/pricing-plans-dashboard-navigation)
+Use when the user wants the plans list, plan editor, a manual order, or plans settings.

--- a/skills/wix-manage/references/pricing-plans/pricing-plans-recipes.md
+++ b/skills/wix-manage/references/pricing-plans/pricing-plans-recipes.md
@@ -7,13 +7,25 @@ description: "Subscriptions and paid plans — create recurring, one-time and fr
 
 Create the plan first with **Create and Update Pricing Plans** — pricing model, trial period, perks and visibility all live there. Only then connect it to what it grants: **Pricing Plans Bookings Integration** covers benefit programs, which is how a plan becomes a membership or class package that grants booking access. A plan on its own grants nothing until that link exists.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Create and Update Pricing Plans](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/create-and-update-pricing-plans)
-Use when defining or changing a plan: recurring, one-time or free pricing, trial periods, perks, and whether the plan is public.
+**Technical:** Creates subscription and one-time payment plans using Plans API. Covers
+pricing models (recurring, one-time, free), trial periods, perks configuration, and plan
+visibility.
 
 ### [Pricing Plans Bookings Integration](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/pricing-plans-bookings-integration)
-Use when a plan should grant access to booking services — memberships, class packages, and benefit programs.
+**Technical:** Links Pricing Plans to Bookings services using the Benefit Programs API.
+Enables package deals and memberships that grant booking access.
 
 ### [Pricing Plans Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans/skills/pricing-plans-dashboard-navigation)
-Use when the user wants the plans list, plan editor, a manual order, or plans settings.
+**Technical:** Builds direct links to Wix Pricing Plans dashboard pages on
+manage.wix.com — plans list, create a plan, edit a plan, record a manual order, and
+settings. Pairs each main Pricing Plans entity (plan, order) with its read API so you
+can fetch an entity and hand back a 'view it in your dashboard' link. Use when the user
+asks where something is in the Wix dashboard, wants a direct link to a dashboard page,
+or you need a dashboard URL to include with the result of an API operation.

--- a/skills/wix-manage/references/restaurants/restaurants-recipes.md
+++ b/skills/wix-manage/references/restaurants/restaurants-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Restaurants Recipes"
+description: "Restaurant setup — menus, sections, items, modifiers, prices and availability schedules, plus ordering settings and links to the restaurants dashboard. Use for anything users call restaurant, menu, dishes, food items, modifiers, online ordering, reservations, or table booking."
+---
+
+# Restaurants Recipes
+
+Menus are hierarchical — Menu, then Section, then Item — and modifiers take a two-step flow (modifier groups, then modifiers), which is where most attempts go wrong; **Wix Restaurants Setup** covers the whole structure including pricing and availability schedules. Use **Restaurants Dashboard Navigation** for menu pages, the online-orders board, fulfilment settings, reservations and floor plans.
+
+## Recipes
+
+### [Wix Restaurants Setup](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/wix-restaurants-setup)
+Use for menu work: menu, section and item structure, modifiers and modifier groups, prices, availability schedules and ordering settings.
+
+### [Restaurants Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/restaurants-dashboard-navigation)
+Use when the user wants menu pages, the online-orders board, fulfilment settings, the reservations list, or floor plans.

--- a/skills/wix-manage/references/restaurants/restaurants-recipes.md
+++ b/skills/wix-manage/references/restaurants/restaurants-recipes.md
@@ -7,10 +7,23 @@ description: "Restaurant setup — menus, sections, items, modifiers, prices and
 
 Menus are hierarchical — Menu, then Section, then Item — and modifiers take a two-step flow (modifier groups, then modifiers), which is where most attempts go wrong; **Wix Restaurants Setup** covers the whole structure including pricing and availability schedules. Use **Restaurants Dashboard Navigation** for menu pages, the online-orders board, fulfilment settings, reservations and floor plans.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Wix Restaurants Setup](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/wix-restaurants-setup)
-Use for menu work: menu, section and item structure, modifiers and modifier groups, prices, availability schedules and ordering settings.
+**Technical:** Configures restaurant menus, sections, and items using Menus API. Covers
+menu structure (Menu → Section → Item), the two-step item modifier / modifier group
+flow, pricing, availability schedules, and ordering settings.
 
 ### [Restaurants Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/restaurants/skills/restaurants-dashboard-navigation)
-Use when the user wants menu pages, the online-orders board, fulfilment settings, the reservations list, or floor plans.
+**Technical:** Builds direct links to Wix Restaurants dashboard pages on manage.wix.com
+— menus, menu items, the online orders board, online-ordering fulfillment settings
+(pickup, delivery, dine-in), the reservations list, floor plans, and reservation
+experience settings. Pairs each main Restaurants entity (menu, section, item, order,
+reservation) with its read API so you can fetch an entity and hand back a 'view it in
+your dashboard' link. Use when the user asks where something is in the Wix dashboard,
+wants a direct link to a dashboard page, or you need a dashboard URL to include with the
+result of an API operation.

--- a/skills/wix-manage/references/rich-content/rich-content-recipes.md
+++ b/skills/wix-manage/references/rich-content/rich-content-recipes.md
@@ -7,10 +7,22 @@ description: "Ricos rich content — hand-author the richContent/nodes JSON that
 
 Any API field that takes formatted text wants a Ricos document, not a string or HTML — passing plain text is the single most common failure across blog, stores, events and CMS. Use **Author Ricos Rich Content** to write or read that JSON directly; use **Ricos Converter Service** when content already exists as HTML, Markdown or plain text and needs converting, or when a document should be validated before it is sent.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Ricos Converter Service](https://dev.wix.com/docs/api-reference/assets/rich-content/skills/ricos-converter-service)
-Use when content exists as HTML, Markdown or plain text and needs converting to or from Ricos, or when a document should be validated.
+**Technical:** Validates and converts content between Ricos documents and
+HTML/Markdown/plain text using the Ricos Documents API. Covers plugin configuration,
+format conversion in both directions, and document validation.
 
 ### [Author Ricos Rich Content](https://dev.wix.com/docs/api-reference/assets/rich-content/skills/author-ricos-rich-content)
-Use when writing Ricos JSON by hand for a post, description, event or CMS field, or when reading an existing rich-content tree.
+**Technical:** Authoritative recipe for hand-authoring valid Ricos rich-content JSON
+(the richContent/nodes tree) used across Wix Blog posts, Stores product descriptions,
+Events, and CMS rich-text fields. Use whenever a user asks to create, output, or return
+Ricos, richContent, or nodes-tree JSON; retrieve and read this full recipe before API
+schema search or constructing the JSON. Covers paragraphs, headings, lists, blockquotes,
+dividers, tables, code blocks, images, buttons, audio, video, galleries, collapsible
+lists, HTML embeds, inline decorations, and nesting rules.

--- a/skills/wix-manage/references/rich-content/rich-content-recipes.md
+++ b/skills/wix-manage/references/rich-content/rich-content-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Rich Content Recipes"
+description: "Ricos rich content — hand-author the richContent/nodes JSON that Wix Blog posts, Stores descriptions, Events and CMS rich-text fields expect, and convert between Ricos and HTML, Markdown or plain text. Use whenever a body of text needs formatting, or the words Ricos, richContent, nodes tree, or rich text appear."
+---
+
+# Rich Content Recipes
+
+Any API field that takes formatted text wants a Ricos document, not a string or HTML — passing plain text is the single most common failure across blog, stores, events and CMS. Use **Author Ricos Rich Content** to write or read that JSON directly; use **Ricos Converter Service** when content already exists as HTML, Markdown or plain text and needs converting, or when a document should be validated before it is sent.
+
+## Recipes
+
+### [Ricos Converter Service](https://dev.wix.com/docs/api-reference/assets/rich-content/skills/ricos-converter-service)
+Use when content exists as HTML, Markdown or plain text and needs converting to or from Ricos, or when a document should be validated.
+
+### [Author Ricos Rich Content](https://dev.wix.com/docs/api-reference/assets/rich-content/skills/author-ricos-rich-content)
+Use when writing Ricos JSON by hand for a post, description, event or CMS field, or when reading an existing rich-content tree.

--- a/skills/wix-manage/references/site-properties/site-properties-recipes.md
+++ b/skills/wix-manage/references/site-properties/site-properties-recipes.md
@@ -7,10 +7,21 @@ description: "Site-level settings — payment currency, time zone and primary la
 
 One call covers currency, time zone and primary language, and it needs a field mask naming the top-level properties being changed — **Change Payment Currency (Site Properties)** documents the exact shape. Note that this API does not control business opening hours (see the calendar recipes) or store-level pricing behaviour. Use **Site Settings Dashboard Navigation** for the settings hub, website settings, and language and region pages.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Change Payment Currency (Site Properties)](https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/change-payment-currency-site-properties)
-Use when changing a site's payment currency, time zone or primary language — including the field mask the call requires.
+**Technical:** Updates the site-level payment currency (store billing currency) using
+Site Properties API, including the required request body shape and field mask. Covers
+the site time zone and primary language through the same call, whose field mask names
+top-level properties.
 
 ### [Site Settings Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/site-settings-dashboard-navigation)
-Use when the user wants the settings hub, website settings, or the language and region page.
+**Technical:** Builds direct links to the site-settings dashboard pages on
+manage.wix.com — the settings hub, website settings, and language & region. Pairs site
+properties with the Site Properties read API. Use when the user asks where something is
+in the Wix dashboard, wants a direct link to a dashboard page, or you need a dashboard
+URL to include with the result of an API operation.

--- a/skills/wix-manage/references/site-properties/site-properties-recipes.md
+++ b/skills/wix-manage/references/site-properties/site-properties-recipes.md
@@ -1,0 +1,16 @@
+---
+name: "Site Properties Recipes"
+description: "Site-level settings — payment currency, time zone and primary language through the Site Properties API, plus links to the site-settings dashboard pages. Use for anything users call site settings, currency, timezone, language, region, or general site configuration."
+---
+
+# Site Properties Recipes
+
+One call covers currency, time zone and primary language, and it needs a field mask naming the top-level properties being changed — **Change Payment Currency (Site Properties)** documents the exact shape. Note that this API does not control business opening hours (see the calendar recipes) or store-level pricing behaviour. Use **Site Settings Dashboard Navigation** for the settings hub, website settings, and language and region pages.
+
+## Recipes
+
+### [Change Payment Currency (Site Properties)](https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/change-payment-currency-site-properties)
+Use when changing a site's payment currency, time zone or primary language — including the field mask the call requires.
+
+### [Site Settings Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-management/site-properties/skills/site-settings-dashboard-navigation)
+Use when the user wants the settings hub, website settings, or the language and region page.

--- a/skills/wix-manage/references/stores/stores-recipes.md
+++ b/skills/wix-manage/references/stores/stores-recipes.md
@@ -1,0 +1,34 @@
+---
+name: "Stores Recipes"
+description: "Store catalog work — find, create and update products and their options, variants, pricing, visibility and pre-orders, add missing store pages, and link to the stores dashboard. Use for anything users call store, shop, products, catalog, SKUs, variants, inventory, or product options."
+---
+
+# Stores Recipes
+
+Catalog version decides the recipe: a site is on Catalog V3 or Catalog V1, and the request shapes differ, so establish which before mutating anything — **Find Products (Catalog V3)** and **Query Products (Catalog V1)** cover reading on each, **Create Product (Catalog V3)** and **Create Product (Catalog V1)** cover creating. Never invent a price: creating a product requires an explicit name and price, and an absent price is not zero. **Update Product with Options (Catalog V3)** handles option choices, variant pricing and storefront visibility; **Update Product Pre-Order (Catalog V3)** handles pre-order settings and their inventory prerequisites. Orders, coupons, discounts and shipping live in the ecommerce recipes, not here.
+
+## Recipes
+
+### [Find Products (Query and Search, Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3)
+Use to find or list products on a V3 catalog — which endpoint to use, field enums, filtering including price, sorting and paging.
+
+### [Query Products (Catalog V1)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/query-products-catalog-v1)
+Use to find or list products when the site is on Catalog V1.
+
+### [Create Product (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/create-product-catalog-v3)
+Use for every V3 create-product request — required name and price, and how to handle a product the user has not fully specified.
+
+### [Create Product (Catalog V1)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/create-product-catalog-v1)
+Use to create products when the site is on Catalog V1, including products with options.
+
+### [Update Product with Options (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3)
+Use to change an existing V3 product: option choices, variant pricing, and showing or hiding it in the storefront.
+
+### [Update Product Pre-Order (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-pre-order-catalog-v3)
+Use for pre-order settings on variants — enabling, messages, limits, and the trackQuantity requirement.
+
+### [Add Store Pages to Site](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/add-store-pages-to-site)
+Use when cart or checkout pages are missing after a migration or a partial setup.
+
+### [Stores Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/stores-dashboard-navigation)
+Use when the user wants the products list, a product editor, categories, inventory, orders, abandoned checkouts, gift cards, or shipping and tax settings.

--- a/skills/wix-manage/references/stores/stores-recipes.md
+++ b/skills/wix-manage/references/stores/stores-recipes.md
@@ -7,28 +7,56 @@ description: "Store catalog work — find, create and update products and their 
 
 Catalog version decides the recipe: a site is on Catalog V3 or Catalog V1, and the request shapes differ, so establish which before mutating anything — **Find Products (Catalog V3)** and **Query Products (Catalog V1)** cover reading on each, **Create Product (Catalog V3)** and **Create Product (Catalog V1)** cover creating. Never invent a price: creating a product requires an explicit name and price, and an absent price is not zero. **Update Product with Options (Catalog V3)** handles option choices, variant pricing and storefront visibility; **Update Product Pre-Order (Catalog V3)** handles pre-order settings and their inventory prerequisites. Orders, coupons, discounts and shipping live in the ecommerce recipes, not here.
 
+**Open the recipe before calling any API.** This page names the area's recipes and says
+when to reach for each one; the endpoints, request shapes, required fields and field names
+live only in the recipes themselves.
+
 ## Recipes
 
 ### [Find Products (Query and Search, Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/find-products-query-and-search-catalog-v3)
-Use to find or list products on a V3 catalog — which endpoint to use, field enums, filtering including price, sorting and paging.
+**Technical:** Find, search, query, and list products from a Wix Store using Catalog V3
+Search Products and Query Products endpoints. Explains when to use each endpoint,
+correct fields enum values, filtering (including by price), sorting, and paging.
 
 ### [Query Products (Catalog V1)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/query-products-catalog-v1)
-Use to find or list products when the site is on Catalog V1.
+**Technical:** Query and list products from a Wix Store using the Catalog V1 Query
+Products endpoint. Use this recipe when the site's catalog version is CATALOG_V1. Covers
+basic queries, filtering, sorting, and paging.
 
 ### [Create Product (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/create-product-catalog-v3)
-Use for every V3 create-product request — required name and price, and how to handle a product the user has not fully specified.
+**Technical:** Mandatory first recipe for every Wix Stores Catalog V3 create-product
+request. Before any mutation, require an explicit name and price for every product; an
+absent price is never 0. If no product is identified, offer both image-upload and
+text-description paths and stop. If name or price is missing, ask or offer a suggestion
+and stop. When both are present, create from the supplied details without requiring
+optional enrichment. Covers single/bulk creation, inventory, physical/digital products,
+images, options, variants, SKUs, and validation.
 
 ### [Create Product (Catalog V1)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/create-product-catalog-v1)
-Use to create products when the site is on Catalog V1, including products with options.
+**Technical:** Create products using the Catalog V1 Products API. Use this recipe when
+the site's catalog version is CATALOG_V1. Covers simple product creation, product with
+options, and key V1 request structure differences from V3.
 
 ### [Update Product with Options (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-with-options-catalog-v3)
-Use to change an existing V3 product: option choices, variant pricing, and showing or hiding it in the storefront.
+**Technical:** Modifies existing products and variants using Catalog V3 Products API.
+Covers adding/removing option choices, variant-specific pricing, product visibility
+(hide, unhide, or show a product in the storefront — a product-level `visible` update,
+never a delete), and revision-based updates to prevent conflicts.
 
 ### [Update Product Pre-Order (Catalog V3)](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/update-product-pre-order-catalog-v3)
-Use for pre-order settings on variants — enabling, messages, limits, and the trackQuantity requirement.
+**Technical:** Manages pre-order settings for product variants using V3 Inventory API.
+Covers enabling/disabling pre-orders, setting messages, configuring limits, and handling
+trackQuantity requirements.
 
 ### [Add Store Pages to Site](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/add-store-pages-to-site)
-Use when cart or checkout pages are missing after a migration or a partial setup.
+**Technical:** Adds missing checkout and cart pages to a site when Stores app is
+installed. Used when store pages are missing after migration or setup issues.
 
 ### [Stores Dashboard Navigation](https://dev.wix.com/docs/api-reference/business-solutions/stores/skills/stores-dashboard-navigation)
-Use when the user wants the products list, a product editor, categories, inventory, orders, abandoned checkouts, gift cards, or shipping and tax settings.
+**Technical:** Builds direct links to Wix Stores and eCommerce dashboard pages on
+manage.wix.com — products list, edit a specific product, categories, inventory, orders
+list, a specific order, abandoned checkouts, gift cards, shipping and tax settings.
+Pairs each main Stores/eCommerce entity with its read API so you can fetch an entity and
+hand back a 'view it in your dashboard' link. Use when the user asks where something is
+in the Wix dashboard, wants a direct link to a dashboard page, or you need a dashboard
+URL to include with the result of an API operation.

--- a/yaml/wix-manage/accessibility/documentation.yaml
+++ b/yaml/wix-manage/accessibility/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Scan a Wix Site for Accessibility Issues
       docsEntry: https://dev.wix.com/docs/api-reference/site/accessibility
       tags: [aria, stores]
+
+    - file: ../../../skills/wix-manage/references/accessibility/accessibility-recipes.md
+      title: Accessibility Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/site/accessibility
+      tags: [manage-index, accessibility]

--- a/yaml/wix-manage/accessibility/documentation.yaml
+++ b/yaml/wix-manage/accessibility/documentation.yaml
@@ -10,4 +10,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/accessibility/accessibility-recipes.md
       title: Accessibility Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/site/accessibility
-      tags: [manage-index, accessibility]
+      tags: [wix-manage-index, accessibility]

--- a/yaml/wix-manage/analytics/documentation.yaml
+++ b/yaml/wix-manage/analytics/documentation.yaml
@@ -10,3 +10,8 @@ apiDoc:
       title: Analytics Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/analytics
       tags: [analytics]
+
+    - file: ../../../skills/wix-manage/references/analytics/analytics-recipes.md
+      title: Analytics Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/analytics
+      tags: [manage-index, analytics]

--- a/yaml/wix-manage/analytics/documentation.yaml
+++ b/yaml/wix-manage/analytics/documentation.yaml
@@ -14,4 +14,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/analytics/analytics-recipes.md
       title: Analytics Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/analytics
-      tags: [manage-index, analytics]
+      tags: [wix-manage-index, analytics]

--- a/yaml/wix-manage/app-installation/documentation.yaml
+++ b/yaml/wix-manage/app-installation/documentation.yaml
@@ -14,3 +14,8 @@ apiDoc:
       title: App Management Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
       tags: [app-installation]
+
+    - file: ../../../skills/wix-manage/references/app-installation/app-installation-recipes.md
+      title: App Installation Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
+      tags: [manage-index, app-installation]

--- a/yaml/wix-manage/app-installation/documentation.yaml
+++ b/yaml/wix-manage/app-installation/documentation.yaml
@@ -18,4 +18,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/app-installation/app-installation-recipes.md
       title: App Installation Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/app-installation
-      tags: [manage-index, app-installation]
+      tags: [wix-manage-index, app-installation]

--- a/yaml/wix-manage/blog/documentation.yaml
+++ b/yaml/wix-manage/blog/documentation.yaml
@@ -15,4 +15,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/blog/blog-recipes.md
       title: Blog Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/blog
-      tags: [manage-index, blog]
+      tags: [wix-manage-index, blog]

--- a/yaml/wix-manage/blog/documentation.yaml
+++ b/yaml/wix-manage/blog/documentation.yaml
@@ -11,3 +11,8 @@ apiDoc:
       title: Blog Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/blog
       tags: [blog]
+
+    - file: ../../../skills/wix-manage/references/blog/blog-recipes.md
+      title: Blog Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/blog
+      tags: [manage-index, blog]

--- a/yaml/wix-manage/bookings/documentation.yaml
+++ b/yaml/wix-manage/bookings/documentation.yaml
@@ -54,3 +54,8 @@ apiDoc:
       title: Bookings Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
       tags: [bookings]
+
+    - file: ../../../skills/wix-manage/references/bookings/bookings-recipes.md
+      title: Bookings Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [manage-index, bookings]

--- a/yaml/wix-manage/bookings/documentation.yaml
+++ b/yaml/wix-manage/bookings/documentation.yaml
@@ -58,4 +58,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/bookings/bookings-recipes.md
       title: Bookings Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
-      tags: [manage-index, bookings]
+      tags: [wix-manage-index, bookings]

--- a/yaml/wix-manage/calendar/documentation.yaml
+++ b/yaml/wix-manage/calendar/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Configure Default Business Hours
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/calendar
       tags: [bookings, calendar]
+
+    - file: ../../../skills/wix-manage/references/calendar/calendar-recipes.md
+      title: Calendar Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/calendar
+      tags: [manage-index, calendar]

--- a/yaml/wix-manage/calendar/documentation.yaml
+++ b/yaml/wix-manage/calendar/documentation.yaml
@@ -10,4 +10,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/calendar/calendar-recipes.md
       title: Calendar Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/calendar
-      tags: [manage-index, calendar]
+      tags: [wix-manage-index, calendar]

--- a/yaml/wix-manage/cms/documentation.yaml
+++ b/yaml/wix-manage/cms/documentation.yaml
@@ -34,4 +34,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/cms/cms-recipes.md
       title: Cms Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
-      tags: [manage-index, cms]
+      tags: [wix-manage-index, cms]

--- a/yaml/wix-manage/cms/documentation.yaml
+++ b/yaml/wix-manage/cms/documentation.yaml
@@ -30,3 +30,8 @@ apiDoc:
       title: CMS Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
       tags: [cms]
+
+    - file: ../../../skills/wix-manage/references/cms/cms-recipes.md
+      title: Cms Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/cms
+      tags: [manage-index, cms]

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -26,4 +26,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/contacts/contacts-recipes.md
       title: Contacts Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
-      tags: [manage-index, contacts]
+      tags: [wix-manage-index, contacts]

--- a/yaml/wix-manage/contacts/documentation.yaml
+++ b/yaml/wix-manage/contacts/documentation.yaml
@@ -22,3 +22,8 @@ apiDoc:
       title: Contacts Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
       tags: [contacts]
+
+    - file: ../../../skills/wix-manage/references/contacts/contacts-recipes.md
+      title: Contacts Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/members-contacts/contacts
+      tags: [manage-index, contacts]

--- a/yaml/wix-manage/dashboard-navigation/documentation.yaml
+++ b/yaml/wix-manage/dashboard-navigation/documentation.yaml
@@ -10,4 +10,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/dashboard-navigation/dashboard-navigation-recipes.md
       title: Dashboard Navigation Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
-      tags: [manage-index, dashboard-navigation]
+      tags: [wix-manage-index, dashboard-navigation]

--- a/yaml/wix-manage/dashboard-navigation/documentation.yaml
+++ b/yaml/wix-manage/dashboard-navigation/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
       tags: [bookings, stores]
+
+    - file: ../../../skills/wix-manage/references/dashboard-navigation/dashboard-navigation-recipes.md
+      title: Dashboard Navigation Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/bookings
+      tags: [manage-index, dashboard-navigation]

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -14,4 +14,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/domains/domains-recipes.md
       title: Domains Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
-      tags: [manage-index, domains]
+      tags: [wix-manage-index, domains]

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -10,3 +10,8 @@ apiDoc:
       title: Domains Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
       tags: [domains]
+
+    - file: ../../../skills/wix-manage/references/domains/domains-recipes.md
+      title: Domains Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
+      tags: [manage-index, domains]

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -164,4 +164,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/ecommerce/ecommerce-recipes.md
       title: Ecommerce Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
-      tags: [manage-index, ecommerce]
+      tags: [wix-manage-index, ecommerce]

--- a/yaml/wix-manage/ecommerce/documentation.yaml
+++ b/yaml/wix-manage/ecommerce/documentation.yaml
@@ -160,3 +160,8 @@ apiDoc:
       title: "Goal: Sell Gift Cards"
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
       tags: [ecommerce]
+
+    - file: ../../../skills/wix-manage/references/ecommerce/ecommerce-recipes.md
+      title: Ecommerce Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/e-commerce
+      tags: [manage-index, ecommerce]

--- a/yaml/wix-manage/events/documentation.yaml
+++ b/yaml/wix-manage/events/documentation.yaml
@@ -10,3 +10,8 @@ apiDoc:
       title: Manage Events
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
       tags: [events]
+
+    - file: ../../../skills/wix-manage/references/events/events-recipes.md
+      title: Events Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
+      tags: [manage-index, events]

--- a/yaml/wix-manage/events/documentation.yaml
+++ b/yaml/wix-manage/events/documentation.yaml
@@ -14,4 +14,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/events/events-recipes.md
       title: Events Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/events
-      tags: [manage-index, events]
+      tags: [wix-manage-index, events]

--- a/yaml/wix-manage/forms/documentation.yaml
+++ b/yaml/wix-manage/forms/documentation.yaml
@@ -15,4 +15,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/forms/forms-recipes.md
       title: Forms Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/crm/forms
-      tags: [manage-index, forms]
+      tags: [wix-manage-index, forms]

--- a/yaml/wix-manage/forms/documentation.yaml
+++ b/yaml/wix-manage/forms/documentation.yaml
@@ -11,3 +11,8 @@ apiDoc:
       title: Forms Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/crm/forms
       tags: [forms]
+
+    - file: ../../../skills/wix-manage/references/forms/forms-recipes.md
+      title: Forms Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/crm/forms
+      tags: [manage-index, forms]

--- a/yaml/wix-manage/get-paid/documentation.yaml
+++ b/yaml/wix-manage/get-paid/documentation.yaml
@@ -22,4 +22,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/get-paid/get-paid-recipes.md
       title: Get Paid Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
-      tags: [manage-index, get-paid]
+      tags: [wix-manage-index, get-paid]

--- a/yaml/wix-manage/get-paid/documentation.yaml
+++ b/yaml/wix-manage/get-paid/documentation.yaml
@@ -18,3 +18,8 @@ apiDoc:
       title: Get Paid Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
       tags: [get-paid]
+
+    - file: ../../../skills/wix-manage/references/get-paid/get-paid-recipes.md
+      title: Get Paid Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/get-paid
+      tags: [manage-index, get-paid]

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -30,3 +30,8 @@ apiDoc:
       title: Retrieve Google Ads Billing and Payment Details
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
       tags: [marketing]
+
+    - file: ../../../skills/wix-manage/references/google-ads/google-ads-recipes.md
+      title: Google Ads Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
+      tags: [manage-index, google-ads]

--- a/yaml/wix-manage/google-ads/documentation.yaml
+++ b/yaml/wix-manage/google-ads/documentation.yaml
@@ -34,4 +34,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/google-ads/google-ads-recipes.md
       title: Google Ads Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing/ads/google-ads
-      tags: [manage-index, google-ads]
+      tags: [wix-manage-index, google-ads]

--- a/yaml/wix-manage/marketing/documentation.yaml
+++ b/yaml/wix-manage/marketing/documentation.yaml
@@ -14,3 +14,8 @@ apiDoc:
       title: Marketing Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing
       tags: [marketing]
+
+    - file: ../../../skills/wix-manage/references/marketing/marketing-recipes.md
+      title: Marketing Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing
+      tags: [manage-index, marketing]

--- a/yaml/wix-manage/marketing/documentation.yaml
+++ b/yaml/wix-manage/marketing/documentation.yaml
@@ -18,4 +18,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/marketing/marketing-recipes.md
       title: Marketing Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/marketing
-      tags: [manage-index, marketing]
+      tags: [wix-manage-index, marketing]

--- a/yaml/wix-manage/media/documentation.yaml
+++ b/yaml/wix-manage/media/documentation.yaml
@@ -6,3 +6,8 @@ apiDoc:
       title: Upload Media to Wix
       docsEntry: https://dev.wix.com/docs/api-reference/assets/media
       tags: [media]
+
+    - file: ../../../skills/wix-manage/references/media/media-recipes.md
+      title: Media Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/assets/media
+      tags: [manage-index, media]

--- a/yaml/wix-manage/media/documentation.yaml
+++ b/yaml/wix-manage/media/documentation.yaml
@@ -10,4 +10,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/media/media-recipes.md
       title: Media Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/assets/media
-      tags: [manage-index, media]
+      tags: [wix-manage-index, media]

--- a/yaml/wix-manage/pricing-plans/documentation.yaml
+++ b/yaml/wix-manage/pricing-plans/documentation.yaml
@@ -14,3 +14,8 @@ apiDoc:
       title: Pricing Plans Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
       tags: [pricing-plans]
+
+    - file: ../../../skills/wix-manage/references/pricing-plans/pricing-plans-recipes.md
+      title: Pricing Plans Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
+      tags: [manage-index, pricing-plans]

--- a/yaml/wix-manage/pricing-plans/documentation.yaml
+++ b/yaml/wix-manage/pricing-plans/documentation.yaml
@@ -18,4 +18,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/pricing-plans/pricing-plans-recipes.md
       title: Pricing Plans Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/pricing-plans
-      tags: [manage-index, pricing-plans]
+      tags: [wix-manage-index, pricing-plans]

--- a/yaml/wix-manage/restaurants/documentation.yaml
+++ b/yaml/wix-manage/restaurants/documentation.yaml
@@ -11,3 +11,8 @@ apiDoc:
       title: Restaurants Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/restaurants
       tags: [restaurants]
+
+    - file: ../../../skills/wix-manage/references/restaurants/restaurants-recipes.md
+      title: Restaurants Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/restaurants
+      tags: [manage-index, restaurants]

--- a/yaml/wix-manage/restaurants/documentation.yaml
+++ b/yaml/wix-manage/restaurants/documentation.yaml
@@ -15,4 +15,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/restaurants/restaurants-recipes.md
       title: Restaurants Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/restaurants
-      tags: [manage-index, restaurants]
+      tags: [wix-manage-index, restaurants]

--- a/yaml/wix-manage/rich-content/documentation.yaml
+++ b/yaml/wix-manage/rich-content/documentation.yaml
@@ -14,4 +14,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/rich-content/rich-content-recipes.md
       title: Rich Content Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/assets/rich-content
-      tags: [manage-index, rich-content]
+      tags: [wix-manage-index, rich-content]

--- a/yaml/wix-manage/rich-content/documentation.yaml
+++ b/yaml/wix-manage/rich-content/documentation.yaml
@@ -10,3 +10,8 @@ apiDoc:
       title: Author Ricos Rich Content
       docsEntry: https://dev.wix.com/docs/api-reference/assets/rich-content
       tags: [rich-content]
+
+    - file: ../../../skills/wix-manage/references/rich-content/rich-content-recipes.md
+      title: Rich Content Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/assets/rich-content
+      tags: [manage-index, rich-content]

--- a/yaml/wix-manage/site-properties/documentation.yaml
+++ b/yaml/wix-manage/site-properties/documentation.yaml
@@ -14,4 +14,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/site-properties/site-properties-recipes.md
       title: Site Properties Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/site-properties
-      tags: [manage-index, site-properties]
+      tags: [wix-manage-index, site-properties]

--- a/yaml/wix-manage/site-properties/documentation.yaml
+++ b/yaml/wix-manage/site-properties/documentation.yaml
@@ -10,3 +10,8 @@ apiDoc:
       title: Site Settings Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-management/site-properties
       tags: [site-properties]
+
+    - file: ../../../skills/wix-manage/references/site-properties/site-properties-recipes.md
+      title: Site Properties Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/site-properties
+      tags: [manage-index, site-properties]

--- a/yaml/wix-manage/stores/documentation.yaml
+++ b/yaml/wix-manage/stores/documentation.yaml
@@ -38,4 +38,4 @@ apiDoc:
     - file: ../../../skills/wix-manage/references/stores/stores-recipes.md
       title: Stores Recipes
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
-      tags: [manage-index, stores]
+      tags: [wix-manage-index, stores]

--- a/yaml/wix-manage/stores/documentation.yaml
+++ b/yaml/wix-manage/stores/documentation.yaml
@@ -34,3 +34,8 @@ apiDoc:
       title: Stores Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
       tags: [stores]
+
+    - file: ../../../skills/wix-manage/references/stores/stores-recipes.md
+      title: Stores Recipes
+      docsEntry: https://dev.wix.com/docs/api-reference/business-solutions/stores
+      tags: [manage-index, stores]


### PR DESCRIPTION
## What

Adds one index page per product area — `skills/wix-manage/references/<area>/<area>-recipes.md` for 22 areas — each describing which of the area's recipes to reach for, plus the prerequisites and routing traps the area shares (catalog version for stores, service type for bookings, dispatcher-first for ecommerce pricing and shipping, app-install 428s, Ricos bodies, and so on).

Each page is registered with `tags: [wix-manage-index, <area>]`, so:

- a skills index requested with `tags=[wix-manage-index]` returns **one page per area** instead of 97 individual recipes;
- an unfiltered index — what production requests today — keeps listing every recipe exactly where it is and adds each page inside its own area section.

So merging this changes nothing about what an agent can reach; it only makes the area pages available.

## Recipes are linked by published URL

Relative links are rewritten to published URLs only when the page itself is published, so a page read straight from a branch would hand the agent paths it cannot open. Absolute URLs read the same either way, which is what lets the flow be evaluated before it ships.

## Measured from this branch

Requesting the index with `tags=[wix-manage-index]`, `repo=wix/skills` and this head SHA:

- **22 sections, 22 entries, 9,974 chars** — 20% of the current 48,816-char index
- every parent sits in its own area section (the tag name sorts after every area name; `manage-index` would have lumped marketing through stores into one section)
- a parent fetched from the branch returns absolute, openable child URLs

## Left out

`seo` and `sites` have registered recipes that are not published yet (`Manage a Wix Site's SEO Tags`, `Read Account or Site Context`, `Manage OAuth Apps` all 404). An index page must not link to a page that does not exist, so those two areas keep no parent for now and continue to list their recipes individually.

## Draft on purpose

Held as a draft until the regression corpus has run against this branch through an MCP capability carrying `skillsRepo`/`skillsPr`/`skillsTags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)