### PR TITLE
test(wix-manage): parent-index discovery scenarios for blog

### DIFF
--- a/yaml/wix-manage-evals/blog/parent-index-navigation.yml
+++ b/yaml/wix-manage-evals/blog/parent-index-navigation.yml
@@ -1,0 +1,81 @@
+name: blog/parent-index-navigation
+description: >-
+  When the skills index lists a product area's recipes page instead of its individual recipes, the
+  agent has to open that page to reach the recipe it needs. This verifies the two hops happen in
+  order for a task that a recipe covers: area page first, then the recipe, then the API — rather
+  than the agent guessing the API from the area page's summary alone.
+triggerPrompt: >-
+  Publish a blog post titled "Autumn Menu" with a short paragraph about our new seasonal dishes.
+tags: [discovery]
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: Install the Wix Blog app so the site has a blog to post to
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 14bcded7-0066-7c35-14d7-466cb3f09103
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/blog-recipes
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/how-to-create-blog-posts
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Publish a blog post titled \"Autumn Menu\" with a short
+      paragraph about our new seasonal dishes."
+
+      The skills index in this run lists a blog recipes page
+      (.../blog/skills/blog-recipes) rather than the individual blog recipes. That page names the
+      area's recipes and links to them; the create recipe (.../blog/skills/how-to-create-blog-posts)
+      holds the actual field shapes, the author-memberId requirement, and the rich-content body
+      format.
+
+      The site is freshly provisioned with only the Wix Blog app installed, so it has NO site
+      members, and a post needs `memberId` — the id of a site member created via
+      POST https://www.wixapis.com/members/v1/members.
+
+      Judge the tool-call trace and the final answer together. Score:
+
+      - 9-10: the agent read the blog recipes page, then read the create recipe, then published a
+        post titled "Autumn Menu" successfully (2xx) with a rich-content body and a memberId it
+        resolved through the Members API. Both reads happened before the first Blog write call.
+      - 7-8: the same outcome, but with one extra exploratory read or one recoverable wrong-shape
+        request along the way.
+      - 4-6: the post was published, but the agent skipped the create recipe — it worked from the
+        area page's summary, a docs search, or the API spec instead. Note which.
+      - 3: the post was published but the agent never opened the blog recipes page at all (it
+        reached the recipe some other way), or the body was sent as a plain string rather than
+        rich content.
+      - 0-2: no post was published, the publish call failed (non-2xx), the title is wrong, the
+        agent only explained how instead of doing it, or it stopped to ask the user a question
+        instead of acting.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence naming the order of the docs reads and
+      the Blog call that published the post>"}.
+  - type: llm_judge
+    minScore: 0
+    maxTokens: 2048
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how cleanly the two-hop discovery path worked. Examine the
+      tool-call trace. Score 0-10 (10 = direct: area page, recipe, API, no detours).
+
+      Penalize and LIST any of: an area recipes page opened for an area unrelated to blogging; more
+      than two area recipes pages opened in total; a docs or spec search issued before the blog
+      recipes page was read; a call that returned a non-2xx error even if the agent recovered; a
+      request body shape guessed wrong then corrected.
+
+      For each issue, name the likely cause — an unclear area page, a missing link on it, a recipe
+      that omits a field, or index wording that did not make the two-hop path obvious.
+
+      Return ONLY {"score":<0-10>,"reason":"<issues found, or 'none'>"}.

--- a/yaml/wix-manage-evals/blog/parent-index-negative-discovery.yml
+++ b/yaml/wix-manage-evals/blog/parent-index-negative-discovery.yml
@@ -1,0 +1,74 @@
+name: blog/parent-index-negative-discovery
+description: >-
+  The failure mode a per-area index introduces is a task with no covering recipe: the agent must
+  read the area's recipes page, treat it as exhaustive for that area, and move on to docs discovery
+  — rather than opening other areas' pages looking for something that is not there, or claiming a
+  recipe covers the task.
+triggerPrompt: >-
+  Delete every draft blog post on my site.
+tags: [discovery]
+siteSetup:
+  mode: template
+  templateId: blank-editor
+  bootstrap:
+    steps:
+      - label: Install the Wix Blog app so the site has a blog to work against
+        method: post
+        url: https://www.wixapis.com/apps-installer-service/v1/app-instance/install
+        body:
+          tenant:
+            id: "{{siteId}}"
+            tenantType: SITE
+          appInstance:
+            appDefId: 14bcded7-0066-7c35-14d7-466cb3f09103
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-solutions/blog/skills/blog-recipes
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user's request (verbatim): "Delete every draft blog post on my site."
+
+      The skills index in this run lists product-area recipes pages (URLs ending in
+      `-recipes`) rather than individual recipes. The blog area has recipes for creating posts and
+      for dashboard navigation — none of them covers deleting draft posts. The Blog API does
+      support it (Bulk Delete Draft Posts,
+      POST https://www.wixapis.com/blog/v3/bulk/draft-posts/delete), so the correct behaviour is to
+      check the blog area page, find nothing covering deletion, and go to docs discovery
+      (SearchWixRESTDocumentation, BrowseWixRESTDocsMenu, or SearchWixAPISpec) for the method.
+
+      Judge the tool-call trace and the final answer together. Score:
+
+      - 9-10: the agent opened the blog recipes page, did not open any other area recipes page,
+        moved to docs discovery for the delete method, and either deleted the draft posts
+        successfully (2xx) or correctly reported there were none to delete.
+      - 7-8: the same, but with one additional area recipes page opened, or one recoverable
+        non-2xx call on the way to the right method.
+      - 4-6: the task was completed, but the agent opened three or more area recipes pages
+        (trawling) before reaching docs discovery. Name the pages it opened.
+      - 3: the agent asserted that a recipe covers deleting draft posts, or cited the blog recipes
+        page as the source of the delete call it made.
+      - 0-2: the agent claimed the operation is impossible, gave up, asked the user a question
+        instead of acting, or made a destructive call against the wrong entity (published posts,
+        categories, members) instead of draft posts.
+
+      Return ONLY {"score":<0-10>,"reason":"<one sentence listing which area pages were opened and
+      how the delete method was found>"}.
+  - type: llm_judge
+    minScore: 0
+    maxTokens: 2048
+    prompt: |
+      DIAGNOSTIC, non-gating — rate how efficiently the agent established that no recipe covered
+      the task. Examine the tool-call trace. Score 0-10 (10 = one area page read, then straight to
+      the right docs method).
+
+      Count and LIST: how many `-recipes` area pages were opened; how many docs or spec searches
+      were issued; any non-2xx calls; any point where the agent re-read a page it had already read.
+
+      For each inefficiency, name the likely cause — index wording that did not say the area pages
+      are exhaustive, an area page that reads as if it covers more than it does, or a missing
+      fallback instruction.
+
+      Return ONLY {"score":<0-10>,"reason":"<counts and issues, or 'none'>"}.


### PR DESCRIPTION
## What

Two scenarios for the discovery path a per-area index introduces, both in `yaml/wix-manage-evals/blog/`:

- **`blog/parent-index-navigation`** — a task a recipe covers. Asserts the agent reads the blog recipes page, then `how-to-create-blog-posts`, then publishes with a rich-content body and a Members-API-resolved `memberId`. Both reads must precede the first Blog write.
- **`blog/parent-index-negative-discovery`** — a task no recipe covers (deleting draft posts). Asserts the agent reads the blog recipes page, treats it as exhaustive for the area, and moves to docs discovery for Bulk Delete Draft Posts — without opening other areas' pages or claiming a recipe covers it.

Each carries a gating judge with score bands plus a non-gating diagnostic judge that counts area-page reads and detours, matching the shape of the existing blog scenarios.

## How to run them before the index changes

They are meaningful against an MCP connection whose skills index is filtered to area pages. That needs no deploy: the connection URL accepts `skillsTags`, so an EvalForge capability pointing at

```
https://mcp.wix.com/mcp?skillsRepo=wix/skills&skillsPr=<sha of the parent PR>&skillsTags=manage-index,<every other area tag>
```

serves the filtered index computed from that branch. Against the default connection the blog recipes page is not in the index, so the first assertion of each scenario will not be satisfied — hence draft until the index change lands.

## Placement note

Both files sit in the `blog/` area directory rather than a shared `discovery/` one: the gate matches doc coverage by area directory (`coverage.ts`, `EVALS_AREA_RE`), so a scenario in `discovery/` would not count as covering `skills/wix-manage/references/blog/blog-recipes.md`. Verified by simulating the gate's matcher — both scenarios now register as covering that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)