### PR TITLE
test: evaluate Headless lockfile install path

### DIFF
--- a/skills/wix-headless/SKILL.md
+++ b/skills/wix-headless/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools:
   - Bash(npx @wix/cli *)
   - Bash(npm create @wix/new@latest *)
   - Bash(npm install *)
+  - Bash(npm ci *)
   - Bash(npm run *)
   - Bash(node *)
   - Bash(bash *)

--- a/skills/wix-headless/entry/skill.md
+++ b/skills/wix-headless/entry/skill.md
@@ -65,7 +65,7 @@ The script emits one JSON object per line:
 Install the Wix Headless skills (`CI=1` forces plain non-interactive CLI output — keep it on every Wix CLI command):
 
 ```bash
-CI=1 npx skills@latest add wix/skills --yes
+CI=1 npx skills@latest add wix/skills#test/headless-lockfile-ci --yes
 ```
 
 The skills land in `.agents/skills/`.

--- a/skills/wix-headless/references/managed/CREATE.md
+++ b/skills/wix-headless/references/managed/CREATE.md
@@ -47,6 +47,21 @@ CI=1 npm create @wix/new@latest -- headless \
 - `--skip-install` defers dependency install to step 4 (which adds the SDK package set); run
   `npm install` there before building.
 
+### Evaluation-only lockfile setup
+
+For this evaluation branch only, immediately after `cd <folder-name>` and before authentication,
+backend setup, seeding, or adding SDK packages, download the Wix-registry lockfile and install the
+base project once:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ayal/headless-templates-wix-lockfile-test/main/package-lock.wix.json \
+  -o package-lock.json
+npm ci --ignore-scripts
+```
+
+This is a test shim for measuring the proposed Create behavior; do not copy this remote-fetch
+mechanism into the production flow.
+
 ### Non-Astro (a framework was named)
 
 There is **no Wix scaffolder for a non-Astro site** (`non-astro.md` N1) — so scaffold the framework's
@@ -112,7 +127,9 @@ Then build the pages the user's intent calls for, **wired to the live backend**,
 bind (collection/form names + field keys; all other content is queried live). Install the SDK packages the loaded verticals need, author the pages/components directly in the
 project, and bind them to the live backend content. Keep it scoped to what was asked — no speculative pages.
 
-> **`npm install` note (Astro):** always run **`npm install --ignore-scripts`**. Astro pulls `sharp`
+> **`npm install` note (Astro):** the initial base install in this evaluation is already complete via
+> `npm ci --ignore-scripts` above. When adding SDK packages later, run **`npm install --ignore-scripts`**.
+> Astro pulls `sharp`
 > as an *optional* transitive dep for **local, build-time**
 > image optimization this headless flow never uses (all imagery is remote Wix Media URLs served through
 > plain `<img>`), and its from-source native build can fail and abort the whole install; `--ignore-scripts`


### PR DESCRIPTION
Test-only skill branch for the Managed Headless first-install experiment. It installs this branch from the entry skill, fetches the public Wix-registry lockfile fixture immediately after Create, runs npm ci --ignore-scripts for the base graph, and retains npm install --ignore-scripts for later SDK additions. No production flow changes are intended.