### PR TITLE
🦞 igor-claw: fix accessibility scan target/status docs in recipe

### DIFF
--- a/skills/wix-manage/references/accessibility/scan-site-accessibility.md
+++ b/skills/wix-manage/references/accessibility/scan-site-accessibility.md
@@ -23,6 +23,20 @@ Match the user's words to one target:
 | "Scan this page" or a specific URL/page | One page, identified by its URL or page ID |
 | "Scan all products/blog posts/menu pages/etc." | One supported page collection |
 
+`target` is a `oneOf`, but its discriminator field `targetType` is **not**
+populated automatically from whichever sibling field you set — you must set
+it explicitly, or the call fails with `INVALID_SCAN_TARGET` ("target type is
+unsupported"). Always include it:
+
+```json
+// Full site
+{ "target": { "targetType": "SCOPE", "scope": "ACCESSIBILITY_SCAN_SCOPE_FULL_SITE" } }
+// One page
+{ "target": { "targetType": "PAGE", "page": { "pageId": "..." } } }
+// Page collection
+{ "target": { "targetType": "PAGE_COLLECTION", "pageCollection": { "collectionId": "..." } } }
+```
+
 For a generated vertical page, prefer its page URL unless a unique Wix page ID
 is already available. The caller never needs to know the page type.
 
@@ -42,14 +56,15 @@ request to scan, check, or audit is already confirmation to create the scan job.
    UUID only when retrying this exact request; use a new UUID for a new scan.
 3. Poll **Get Accessibility Scan** with that scan ID. Respect each response's
    suggested polling interval until the status is terminal.
-4. On `COMPLETED` or `PARTIALLY_COMPLETED`, read:
+4. On `ACCESSIBILITY_SCAN_STATUS_COMPLETED` or
+   `ACCESSIBILITY_SCAN_STATUS_PARTIALLY_COMPLETED`, read:
    - the scan summary for totals and executed-rule coverage;
    - **List Accessibility Scan Page Summaries** for every discovered page,
      including clear pages and pages that failed to scan;
    - **List Accessibility Scan Findings** for actionable issues. Follow cursor
      paging for the result set the user requested.
-5. On `FAILED`, report the public failure guidance. Do not request findings or
-   present the scan as clean.
+5. On `ACCESSIBILITY_SCAN_STATUS_FAILED`, report the public failure guidance.
+   Do not request findings or present the scan as clean.
 
 Use a findings filter when the user asks about one page, rule, severity, or
 accessibility category. Do not issue a separate findings request for every page.


### PR DESCRIPTION
## Summary
- Opened automatically by an AI agent acting on behalf of Ayal (`ayalg@wix.com`), from a Wix MCP feedback report: https://wix.slack.com/archives/C08P5DKLJR5/p1787620735888789
- The `Scan a Wix Site for Accessibility Issues` recipe never showed the `target.targetType` discriminator — only whichever sibling field (`scope`/`page`/`pageCollection`) matched the user's intent. `Run Accessibility Scan`'s `target` is a proto `oneOf`, and its `targetType` discriminator is **not** inferred from the populated sibling field. Following the recipe as written (e.g. `{"target": {"scope": "ACCESSIBILITY_SCAN_SCOPE_FULL_SITE"}}`) fails with `INVALID_SCAN_TARGET` ("target type is unsupported").
- Live-reproduced on an owned test site: the call above 400s with `INVALID_SCAN_TARGET`; adding `"targetType": "SCOPE"` alongside `scope` succeeds and starts the scan.
- Also fixed the terminal-status names in steps 4/5, which used the unprefixed `COMPLETED`/`PARTIALLY_COMPLETED`/`FAILED` instead of the actual enum values the API returns (`ACCESSIBILITY_SCAN_STATUS_COMPLETED` etc., confirmed on the same live call) — the mismatch cost an extra poll-and-reconcile cycle for the reporting agent.

## Test plan
- [x] Reproduced `INVALID_SCAN_TARGET` on a live, owned Wix site by POSTing `target: {scope: "ACCESSIBILITY_SCAN_SCOPE_FULL_SITE"}` without `targetType`.
- [x] Confirmed the corrected shape (`targetType` + `scope`) succeeds and returns a running scan.
- [x] Confirmed the live scan's status value is `ACCESSIBILITY_SCAN_STATUS_RUNNING` (prefixed), matching the doc fix.