### PR TITLE
🦞 igor-claw: Add Submit a Wix Product Feature Request recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, seo, dashboard-navigation."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, seo, dashboard-navigation, support."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -48,6 +48,13 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Scan a Wix Site for Accessibility Issues](references/accessibility/scan-site-accessibility.md)
 **Technical:** Runs an asynchronous accessibility scan for a full site, one page, or every page in any supported Wix page collection. Discovers collection IDs instead of hardcoding verticals, polls the scan to completion, separates failed pages from clean pages, and returns prioritized, agent-friendly findings and fix guidance.
+
+---
+
+## Support
+
+### [Submit a Wix Product Feature Request](references/support/submit-feature-request.md)
+**Technical:** Points to Wix's official feature-request/roadmap page for genuine product-idea feedback, distinct from the `SupportAndFeedback` MCP tool (scoped to the MCP/API/docs building experience) and from `wix.com/contact` (support/billing/account issues).
 
 ---
 

--- a/skills/wix-manage/references/support/submit-feature-request.md
+++ b/skills/wix-manage/references/support/submit-feature-request.md
@@ -1,0 +1,18 @@
+---
+name: "Submit a Wix Product Feature Request"
+description: "Points to Wix's official product feature-request/roadmap channel for genuine product-idea feedback (a new business feature, editor capability, etc.) that is NOT about the Wix MCP/API/docs building experience and NOT a support/billing/account issue. Use when the user wants to suggest a new Wix product feature, asks where to submit a product idea, or reports that a prior feedback submission got an automated sales reply instead of reaching Wix's product team."
+---
+
+# Submit a Wix Product Feature Request
+
+A request to add or change a **Wix product capability** (a new business feature, editor tool, app behavior, etc.) is not the same as feedback about building with Wix via APIs/MCP, and not the same as a support case. Route each kind correctly:
+
+| The user wants to... | Correct channel |
+|---|---|
+| Suggest a new Wix product feature or capability | Wix's official feature-request/roadmap page: `https://www.wix.com/updates?showRequestFeature=true` — has a "Submit a request" flow, reviewed by Wix product teams, and lets other users see/vote on it |
+| Report friction with the Wix MCP tools, REST/SDK APIs, or docs | The `SupportAndFeedback` MCP tool — that channel is scoped to the building/API experience, not general product ideas, and cannot be replied to or tracked |
+| Get help with billing, payouts, a linked bank account, compliance corrections, or account access | `https://www.wix.com/contact` (Wix Customer Care — produces a trackable case). Do not suggest emailing `support@wix.com`; it is not a monitored inbox |
+
+**Why this matters:** generic contact forms (e.g. `wix.com/contact`) are triaged by intent, and a product-idea submission dropped into the wrong category there can bounce back as an automated sales reply instead of reaching product. The feature-request/roadmap page is the channel Wix product teams actually watch for this.
+
+If the idea isn't about Wix at all (e.g. a feature request for a third-party AI chat client's own UI), say so plainly — Wix has no channel that can act on another vendor's product.


### PR DESCRIPTION
## Summary
- Adds a **Submit a Wix Product Feature Request** recipe to `skills/wix-manage` (surfaced via the Wix MCP's `WixREADME` index) so agents can route genuine product-idea feedback to `https://www.wix.com/updates?showRequestFeature=true` — Wix's official, product-team-reviewed feature-request/roadmap page.
- Distinguishes this from the `SupportAndFeedback` MCP tool (scoped to MCP/API/docs building friction, untracked/unreplied) and from `wix.com/contact` (support/billing/account issues).

## Root cause
`wix/skills` had zero entry and zero mention of "feature request" or Wix's roadmap page anywhere in the repo, so an MCP-connected agent had no authoritative channel to route a user's genuine product idea to. Left to its own devices, an agent would either misuse `SupportAndFeedback` (which explicitly is not for this and can't be tracked/replied to) or point the user back at `wix.com/contact`, a generic intake form that triages by category and can bounce a product idea into an automated sales reply instead of reaching product.

## Context
Closes the specific gap reported in Wix MCP feedback: a user submitted a genuine Wix/AI-workflow product feature idea and asked to confirm the correct product-feedback routing after a prior attempt only got an automated sales response. Verified `https://www.wix.com/updates?showRequestFeature=true` is Wix's real, current feature-request/roadmap page (redirects from the legacy `support.wix.com/en/roadmap?showRequestFeature=true`), with a "Submit a request" flow reviewed by product teams.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787638722328649

Opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com) researching Wix MCP feedback — not written or reviewed by Ayal personally.

## Test plan
- [x] New recipe file follows the existing link-only recipe pattern (matches `contacts-dashboard-navigation.md` style: frontmatter `name`/`description`, no API calls)
- [x] `SKILL.md` index and top-level skill `description` updated to route to the new section
- [ ] Human review of tone/placement