### PR TITLE
🦞 igor-claw: add Domain Connection Troubleshooting recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -182,6 +182,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 ### [Domains Dashboard Navigation](references/domains/domains-dashboard-navigation.md)
 **Technical:** Direct links to the site-level domain settings page and the account-level My Domains page on manage.wix.com, paired with the Domain Search read APIs.
 
+### [Domain Connection Troubleshooting](references/domains/domain-connection-troubleshooting.md)
+**Technical:** Diagnose why an already-connected domain isn't resolving or shows an SSL error — checks DNS propagation status via the DNS Propagation API and explains the record-level failure. Use this instead of the connect flow above when the domain is already bound and the user reports the site is down or unreachable.
+
 ---
 
 ## eCommerce

--- a/skills/wix-manage/references/domains/domain-connection-troubleshooting.md
+++ b/skills/wix-manage/references/domains/domain-connection-troubleshooting.md
@@ -32,6 +32,24 @@ If the call itself fails with a permission/authorization error rather than retur
 surface the raw error. Say diagnostics aren't available right now and go straight to the dashboard
 link below.
 
+### `IN_PROGRESS` for far longer than 48 hours, with `actualDnsRecords` empty
+
+The API has no status for "this domain isn't a real registered domain" — a domain string that was
+typo'd when connecting it, or was never actually registered anywhere, also reports `IN_PROGRESS` with
+`dnsResolverIncludesWixNs: false` and `actualDnsRecords: []` and can stay that way forever, since it's
+indistinguishable from a domain that's genuinely still propagating. Don't tell the user to "keep
+waiting" indefinitely. If the user says they connected this domain a long time ago (well past 48
+hours) and it's never moved off `IN_PROGRESS`:
+
+- Double-check the exact spelling of the domain the user gave you against what's actually connected to
+  the site (e.g. via the site's connected domains), rather than retyping it from memory or from an
+  earlier message — a single mistyped character produces exactly this symptom.
+- If you have a way to do a plain public DNS/NS lookup independent of Wix's APIs, use it to check
+  whether the domain resolves at all on the public internet. If it doesn't (e.g. an NXDOMAIN-style
+  result), the domain was likely never actually registered, or was registered under a different
+  spelling than what's connected — the fix is to correct/re-purchase the domain, not to keep waiting
+  for propagation.
+
 ## 2. SSL / HTTPS errors after DNS has succeeded
 
 There is no API to check SSL certificate issuance status. Wix provisions the certificate

--- a/skills/wix-manage/references/domains/domain-connection-troubleshooting.md
+++ b/skills/wix-manage/references/domains/domain-connection-troubleshooting.md
@@ -1,0 +1,57 @@
+---
+name: "Domain Connection Troubleshooting"
+description: "Diagnose why a custom domain that's already connected/bound to a Wix site isn't resolving or is showing a browser/SSL error. Uses the DNS Propagation API to check DNS record status. Use when the user reports the site 'doesn't open', 'not found', 'can't be reached', or an SSL/certificate warning on a domain they already connected — not for the connect flow itself, which is Domain Search, Purchase and Connect."
+---
+
+# Domain Connection Troubleshooting
+
+This is the follow-up flow, not the connect flow. Use it when a domain is **already** connected to a
+site (per [Domain Search, Purchase and Connect](domain-search-purchase-and-connect.md)) and the user
+comes back saying the site still doesn't load, or the browser shows a not-found / connection / SSL
+error. Do not use this to connect a domain in the first place — that flow deliberately says nothing
+about timing, propagation or SSL because none of it is knowable at bind time. Here, it is.
+
+## 1. Check DNS propagation status
+
+```
+GET https://www.wixapis.com/premium/domains/v1/dns-propagations/{domain}
+```
+
+Call via `CallWixSiteAPI` with the site's `siteId` (the docs example uses a `wix-site-id` header,
+which `CallWixSiteAPI` supplies automatically). `{domain}` is the bare domain, no protocol.
+
+Read `status`:
+
+| `status` | Meaning | What to tell the user |
+|---|---|---|
+| `SUCCEEDED` | DNS records are correctly configured and propagated | DNS is fine. If the site still doesn't load, go to §2 (SSL) rather than re-checking DNS. |
+| `IN_PROGRESS` | Records are still propagating | This is expected and can take **up to 48 hours** after a domain is connected or its DNS records change. Ask the user to check back later rather than repeating this call in a tight loop. |
+| `FAILED` | One or more records are misconfigured | Read `failureInfo.invalidRecords` and the matching `invalidARecordInfo` / `invalidNsRecordInfo` / `invalidCnameRecordInfo` objects. Tell the user plainly which record type is wrong and what value is expected (`expectedDnsRecords`) versus what's actually there (`actualDnsRecords`) — this is exactly the information the user needs to fix it at their registrar. |
+
+If the call itself fails with a permission/authorization error rather than returning a status, do not
+surface the raw error. Say diagnostics aren't available right now and go straight to the dashboard
+link below.
+
+## 2. SSL / HTTPS errors after DNS has succeeded
+
+There is no API to check SSL certificate issuance status. Wix provisions the certificate
+automatically once DNS resolves correctly — it is not something to request or poll for. If DNS
+propagation shows `SUCCEEDED` but the browser still shows a certificate warning:
+
+- It is usually still catching up — issuance normally follows shortly after DNS is confirmed valid.
+- Point the user at the site's domain settings for a status view a dashboard user can act on:
+  `https://manage.wix.com/dashboard/{metaSiteId}/domain-settings` (see
+  [Domains Dashboard Navigation](domains-dashboard-navigation.md)).
+- If it hasn't cleared after 48 hours from when DNS succeeded, this needs a human — hand off to Wix
+  Support rather than continuing to guess.
+
+## What not to do
+
+- Don't tell the user DNS is fine because the domain shows as "Connected" in site context — that only
+  reflects the *binding*, not whether DNS has actually propagated. Always check propagation status
+  before reassuring the user.
+- Don't invent an SSL status — there is no field or endpoint for it. Saying "SSL is provisioning" as a
+  fact rather than an expectation is a guess dressed as a diagnosis.
+- Don't loop this call more than once or twice in the same conversation — propagation is checked by
+  Wix on its own schedule (up to 48 hours after a change, then every ~4 days for stable domains); rapid
+  re-polling won't produce a different answer.

--- a/yaml/wix-manage/domains/documentation.yaml
+++ b/yaml/wix-manage/domains/documentation.yaml
@@ -10,3 +10,7 @@ apiDoc:
       title: Domains Dashboard Navigation
       docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains
       tags: [domains]
+    - file: ../../../skills/wix-manage/references/domains/domain-connection-troubleshooting.md
+      title: Domain Connection Troubleshooting
+      docsEntry: https://dev.wix.com/docs/api-reference/account-level/domains/dns-propagation
+      tags: [domains]


### PR DESCRIPTION
## Summary
- The domains skill (`domain-search-purchase-and-connect.md`) only covers buying/connecting a domain. By design it says nothing about propagation, DNS or SSL at connect time, since none of that is knowable yet — but there was no companion recipe for when the user comes back later saying the site still doesn't load, which is exactly when that information *is* knowable.
- Adds `references/domains/domain-connection-troubleshooting.md`: calls the DNS Propagation API (`GET /premium/domains/v1/dns-propagations/{domain}`) to check `SUCCEEDED` / `IN_PROGRESS` / `FAILED`, surfaces the specific misconfigured record from `failureInfo` on failure, and explains there's no SSL-status API (Wix auto-issues the cert once DNS resolves) with a dashboard/support fallback.
- Registered in `SKILL.md` and `yaml/wix-manage/domains/documentation.yaml`.

## Context
Opened automatically by an AI agent on behalf of Ayal (`ayalg@wix.com`), researching MCP feedback about a custom domain not resolving after being connected to a Premium Wix site — the agent handling that report had no skill guidance for this exact situation.
Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787649099835169

Companion fix (the DNS Propagation API's own doc examples had a wrong base path): wix-private/premium#31234

## Test plan
- [x] Confirmed live that `GET /premium/domains/v1/dns-propagations/{domain}` is the correct working path
- [x] Verified no SSL/certificate-status API exists anywhere in the Domains API docs
- [x] Checked no existing skill file already covers post-connect troubleshooting