### PR TITLE
🦞 igor-claw: add Branches and Test Sites recipe

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -373,6 +373,9 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ## Sites
 
+### [Branches and Test Sites](references/sites/branches-and-test-sites.md)
+**Technical:** Create and manage Branches (test sites) via the Branches API. Critical caveat: a branch clones the source branch's current draft, not the published/live snapshot — if the draft has drifted from live, the branch, editor, and Site History all show the same stale design, and there's no API to restore/sync a branch from what's currently live.
+
 ### [Create Site from Template](references/sites/create-site-from-template.md)
 **Technical:** Creates new Wix sites from templates using account-level APIs. Covers template search, site creation, and publishing. Not for headless sites.
 

--- a/skills/wix-manage/references/sites/branches-and-test-sites.md
+++ b/skills/wix-manage/references/sites/branches-and-test-sites.md
@@ -1,0 +1,52 @@
+---
+name: "Branches and Test Sites"
+description: Create and manage Wix Branches (a.k.a. test sites) to edit a site without touching the live version. Covers the critical caveat that a branch mirrors draft content, not the published site, and what to do when they've diverged.
+---
+# Branches and Test Sites
+
+A **branch** (a.k.a. [test site](https://support.wix.com/en/article/about-test-sites)) is an isolated,
+editable copy of a site's **draft** content. Use it to let a site owner test changes without touching
+the live site.
+
+- **Auth**: site-level (a site API key/token with `wix-site-id`, or a Wix user token).
+- **Permission**: `EDITOR.BRANCH_*` (scope `SCOPE.DC-DOCUMENT-MANAGEMENT.MANAGE-BRANCHES`).
+- **Endpoints**: `POST /branches/v1/branches` (create) · `GET /branches/v1/branches/{branchId}` (get) ·
+  `GET /branches/v1/branches/default` (get default) · `POST /branches/v1/branches/query` (list) ·
+  `POST /branches/v1/branches/{branchId}/set-default` · `PATCH /branches/v1/branches/{branch.id}` ·
+  `DELETE /branches/v1/branches/{branchId}`.
+- This API manages branch **metadata** only (name, tags, default flag). Editing a branch's actual
+  content is only possible in the editor — open it with [Get Editor URLs](https://dev.wix.com/docs/api-reference/business-management/site-urls/editor-urls/get-editor-urls)
+  plus `&branchId=<id>` appended to the returned `editorUrl`.
+
+## Critical caveat: a branch mirrors draft content, not the live site
+
+`CreateBranch` with `sourceType: SOURCE_BRANCH` clones the source branch's **current draft** —
+not its last-published/live snapshot. If that draft has already diverged from what's actually
+live (for example, a different branch was published more recently, or content was pushed through
+a path that doesn't touch the standard editor draft), the new branch — and the editor, and Site
+History — will all show that same stale/wrong design, not the live one.
+
+**Don't assume** that creating a branch, opening the editor, or restoring a Site History entry
+will ever produce a copy of the currently-published site. None of them do. Concretely:
+
+```bash
+curl -X POST 'https://www.wixapis.com/branches/v1/branches' \
+  -H 'Authorization: <AUTH>' -H 'Content-Type: application/json' \
+  -d '{"branch": {"type": "USER", "name": "safe-copy",
+       "sourceType": "SOURCE_BRANCH",
+       "sourceBranchProperties": {"branchId": "<ORIGINAL_OR_DEFAULT_BRANCH_ID>"}}}'
+```
+
+This clones whatever is currently in `<ORIGINAL_OR_DEFAULT_BRANCH_ID>`'s draft — verify that
+matches expectations before telling the user their edits are "safe," especially if the site has
+more than one branch (`POST /branches/v1/branches/query`).
+
+## There is no API to restore/sync a branch from the live site
+
+If a branch's draft (including the `ORIGINAL_BRANCH`) has drifted from what's live, there is
+**no supported API, and no editor UI action**, that pulls the live/published content back into
+an editable draft. The only related tool is [Site History](https://support.wix.com/en/article/viewing-and-managing-your-site-history)
+(dashboard-only, no REST API), which restores a **past revision of that same branch's document
+history** — not "whatever is currently live" if live came from a different branch or a
+non-standard publish path. Set expectations accordingly and point the site owner to Wix Support
+if they need the live design recovered into an editable state.

--- a/yaml/wix-manage/sites/documentation.yaml
+++ b/yaml/wix-manage/sites/documentation.yaml
@@ -2,6 +2,10 @@ apiDoc:
   title: Wix Sites Management Recipes
 
   docs:
+    - file: ../../../skills/wix-manage/references/sites/branches-and-test-sites.md
+      title: Branches and Test Sites
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/branches
+      tags: [sites]
     - file: ../../../skills/wix-manage/references/sites/read-site-context.md
       title: Read Account or Site Context
       docsEntry: https://dev.wix.com/docs/api-reference/tools/dynamic-site-context


### PR DESCRIPTION
## Gap

`WixREADME` (the `skills/wix-manage` index) has no routing at all for the Branches API, `branchId` on editor URLs, or Site History. An agent that hits "my new branch / the editor / Site History all show the wrong design, but the live site is correct" has nothing to consult and has to reason it out from raw REST docs — which, until now, didn't document the gap either.

## What this adds

A new recipe: `references/sites/branches-and-test-sites.md`, covering:
- How to create/manage branches (metadata-only API; content is edited in the editor).
- **The critical caveat**: `SOURCE_BRANCH` clones the source branch's current *draft*, not its published/live snapshot. If that draft has diverged from what's live, the new branch — and the editor, and Site History — all surface the same stale/wrong design.
- There's no API or editor action to sync/restore a branch from the live site; Site History is the closest tool, but it restores a past revision of *that branch's own history*, not "whatever is live."

Registered in `SKILL.md` and `yaml/wix-manage/sites/documentation.yaml` following the existing `sites/` pattern.

## Context

This came out of a Wix MCP feedback report where a user's branch clone, editor, and Site History all showed a design that didn't match the (correct) live site. Two companion fixes landed on the API/docs side:
- wix-private/editor-server#15268 — fixes a real staleness bug (non-strongly-consistent read) in `CreateBranch`'s `SOURCE_BRANCH` path.
- wix-private/editor-server#15269 — clarifies the same draft-vs-published distinction in the public API reference intro.

This recipe is the harness-side (WixREADME/agent) counterpart so agents get the caveat proactively instead of rediscovering it the hard way.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787669490998989

This PR was opened automatically by an AI agent on behalf of Ayal (ayalg@wix.com).