### PR TITLE
[skills] base44-connector: generalize the audience section

### DIFF
--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -51,11 +51,17 @@ const wx = (() => { const m = { exports: {} };
   new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
 ```
 
-Two of the helpers appear in every snippet below, so know their contracts: **`wx.post(url, body,
-accessToken)`** is the one JSON transport — Content-Type and Bearer set for you, non-2xx **throws**
-with the status and the first 300 chars of the API's own error. **`wx.clip(value)`** caps what you
-return: small values pass through, oversized ones come back as `{ truncated, total, head }`, and
-`undefined` fields render as `null` — so an absent field stays visible instead of being erased.
+`wx` exports nine helpers:
+
+- `wx.post(url, body, token?)` — the one JSON transport: Bearer from `token`, non-2xx **throws** the API's own error
+- `wx.clip(value)` — cap a return value: oversized → `{ truncated, total, head }`; renders `undefined` as `null` so absence stays visible
+- `wx.context(token, section?)` — the site's dynamic context report; no section → its outline
+- `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
+- `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint + docsUrl + gist
+- `wx.page(docsUrl)` — read a doc page; whole when small, else saved + outline
+- `wx.bash(cmd)` — shell over saved files
+- `wx.spec(code)` — run `code` against the spec index for a method's exact schema
+- `wx.mgmtRecipes(q?)` — management-recipe index; no arg → categories, a word → matching recipes
 
 Results ≤ 4,000 chars come back inline (exec results clip at ~5,000); anything bigger is saved
 under `.agents/skills/wix-base44-connector/tmp/` and returns `{ path, bytes, lines, outline }` —

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on Wix from the Base44 builder sandbox — this file is the complete guide (site context, doc discovery, API contracts, who calls Wix from where), and scripts/utils.js is its helper module, loaded from disk per exec. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, decide frontend vs backend for a Wix call."
+description: "Build on Wix from the Base44 builder sandbox — this file is the complete guide, and scripts/utils.js is its helper module, loaded from disk per exec. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
 ---
 
 # Building on Wix from Base44

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -70,8 +70,6 @@ two moves: find with `wx.bash("grep -n 'term' <path> | head -40")` (or across ev
 `grep -rn 'term' .agents/skills/wix-base44-connector/tmp/`), then quote with `read_file` — an
 `offset`/`limit` window at the lines grep named, or the whole file when it fits the 45K cap.
 
-Fetch URLs with `fetch()`, never with "web fetch" — it clips at 10,000 chars silently.
-
 ## Gather context — the dynamic context report
 
 ```js

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -154,8 +154,8 @@ then get-paid, marketing, pricing-plans, events, blog, forms, restaurants, domai
 ```js
 await wx.mgmtRecipes();           // categories with counts
 await wx.mgmtRecipes("stores");   // a category's list — or any task word: wx.mgmtRecipes("coupon")
-await wx.page(url);           // read the chosen recipe — whole when small, saved + outline when
-                              // big; then grep / read_file windows by the outline's line numbers
+// each row points at its recipe: `file` when the wix-manage skill is installed — read_file it
+// straight off disk — else `url`: wx.page(url), whole when small, saved + outline when big
 ```
 
 A matching recipe beats composing the flow from single endpoints: it carries ordering and

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on Wix from Base44: gather the connected site's context (installed apps and their ids, OAuth clientId, locale, currency, CMS collections), find any Wix API and learn its exact contract (docs search and browse, method pages, the spec index's request/response schemas), follow curated management recipes for multi-step admin flows, and route each call to the right identity — the public visitor token in pages, the secret admin token server-side. Triggers: build a Base44 app on a connected Wix site, look up a Wix API or its contract, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
+description: "Build on Wix from Base44: gather the connected site's context (installed apps and their ids, OAuth clientId, locale, currency, CMS collections), find any Wix API and learn its exact contract (docs search and browse, method pages, the spec index's request/response schemas), follow curated management recipes for multi-step admin flows, and route each call to the right identity — the public visitor token in pages, the secret admin token server-side."
 ---
 
 # Building on Wix from Base44

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -81,6 +81,13 @@ One report: installed apps **with ids** (incl. Stores' catalog version — V1 vs
 endpoints), the OAuth app id (**also the visitor `clientId`**), locale, currency, CMS collections.
 An empty report = bad token, never an empty site.
 
+No OAuth app in the report? Create one — the returned `id` IS the `clientId`:
+
+```js
+const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
+  { oAuthApp: { name: "My App" } }, accessToken);   // oAuthApp.id is the visitor clientId
+```
+
 ## Learn Wix — find the APIs, learn their contracts
 
 ```js

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on Wix from the Base44 builder sandbox — this file is the complete guide, and scripts/utils.js is its helper module, loaded from disk per exec. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
+description: "Build on Wix from the Base44 builder sandbox. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
 ---
 
 # Building on Wix from Base44

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -165,7 +165,7 @@ const data = await wx.post("https://www.wixapis.com/contacts/v5/contacts/query",
   { query: { cursorPaging: { limit: 10 } } }, accessToken);
 // let it throw — the thrown message is your result; .catch hides the answer
 return wx.clip({ error: null, count: data.contacts?.length, first: data.contacts[0] });
-// one real row, whole — the shapes you code against live here, not in key names
+// `first` is one complete record — read the real field shapes off it; don't code from remembered key names
 ```
 
 The same call deploys as `base44/functions/…` (work the app does as the owner) — shipped code

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -51,6 +51,12 @@ const wx = (() => { const m = { exports: {} };
   new Function("module", "exports", "require", fs.readFileSync(P, "utf8"))(m, m.exports, require); return m.exports; })();
 ```
 
+Two of the helpers appear in every snippet below, so know their contracts: **`wx.post(url, body,
+accessToken)`** is the one JSON transport — Content-Type and Bearer set for you, non-2xx **throws**
+with the status and the first 300 chars of the API's own error. **`wx.clip(value)`** caps what you
+return: small values pass through, oversized ones come back as `{ truncated, total, head }`, and
+`undefined` fields render as `null` — so an absent field stays visible instead of being erased.
+
 Results ≤ 4,000 chars come back inline (exec results clip at ~5,000); anything bigger is saved
 under `.agents/skills/wix-base44-connector/tmp/` and returns `{ path, bytes, lines, outline }` —
 the outline is the map. Read a saved file the way you already know how:

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on Wix from Base44: gather the connected site's context (installed apps and their ids, catalog version, OAuth clientId, locale, currency, CMS collections), find any Wix API and learn its exact contract (docs search and browse, method pages, the spec index's request/response schemas), follow curated management recipes for multi-step admin flows, and route each call to the right identity — the public visitor token in pages, the secret admin token server-side. Triggers: build a Base44 app on a connected Wix site, look up a Wix API or its contract, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
+description: "Build on Wix from Base44: gather the connected site's context (installed apps and their ids, OAuth clientId, locale, currency, CMS collections), find any Wix API and learn its exact contract (docs search and browse, method pages, the spec index's request/response schemas), follow curated management recipes for multi-step admin flows, and route each call to the right identity — the public visitor token in pages, the secret admin token server-side. Triggers: build a Base44 app on a connected Wix site, look up a Wix API or its contract, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
 ---
 
 # Building on Wix from Base44

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -18,7 +18,7 @@ the connector's, server-side only.
 
 ```
 browser            ──(visitor token)─► wixapis.com   the visitor's own reads & actions
-base44/functions/* ──(admin token)───► wixapis.com   work that needs the owner's identity
+base44/functions/… ──(admin token)───► wixapis.com   work that needs the owner's identity
 exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
 ```
 
@@ -30,12 +30,12 @@ none of it needs a backend function.** Public reads
 included (the visitor token queries public content directly), and per-visitor state is scoped to
 the CALLER — an API that acts on "the current visitor's" data resolves the visitor from the
 token, so only the visitor token reaches that visitor's own state. One shared visitor client
-carries it all (Write the code, below). `base44/functions/*` appear only where work
+carries it all (Write the code, below). `base44/functions/…` appear only where work
 needs the owner's identity — elevated-permission ops a visitor triggers, webhooks, scheduled
 jobs — and for the app's non-Wix backend.
 
 **An admin tool for the owner** — dashboard, back office. Admin pages and agent act as the
-owner, using the secret admin token: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
+owner, using the secret admin token: `pages → base44/functions/… ──(admin token)──► wixapis.com`.
 
 ## The helpers
 
@@ -164,11 +164,11 @@ const { accessToken } = await base44.asServiceRole.connectors.getConnection("wix
 const data = await wx.post("https://www.wixapis.com/contacts/v5/contacts/query",   // spec-index publicUrl
   { query: { cursorPaging: { limit: 10 } } }, accessToken);
 // let it throw — the thrown message is your result; .catch hides the answer
-return wx.clip({ error: null, count: data.contacts?.length, first: data.contacts?.[0] });
-//  ↑ one real row, whole — the shapes you code against live here, not in key names
+return wx.clip({ error: null, count: data.contacts?.length, first: data.contacts[0] });
+// one real row, whole — the shapes you code against live here, not in key names
 ```
 
-The same call deploys as `base44/functions/*` (work the app does as the owner) — shipped code
+The same call deploys as `base44/functions/…` (work the app does as the owner) — shipped code
 carries its own four-line fetch; the helpers are a build tool, not a runtime dependency.
 
 ### A visitor client — src/lib/wixClient.js

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on Wix from Base44. Triggers: build a Base44 app on a connected Wix site, look up a Wix API or its contract, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
+description: "Build on Wix from Base44: gather the connected site's context (installed apps and their ids, catalog version, OAuth clientId, locale, currency, CMS collections), find any Wix API and learn its exact contract (docs search and browse, method pages, the spec index's request/response schemas), follow curated management recipes for multi-step admin flows, and route each call to the right identity — the public visitor token in pages, the secret admin token server-side. Triggers: build a Base44 app on a connected Wix site, look up a Wix API or its contract, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
 ---
 
 # Building on Wix from Base44

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -22,18 +22,20 @@ base44/functions/* ──(admin token)───► wixapis.com   work that needs
 exec_tool          ──(admin token)───► wixapis.com   you: ad hoc probing/managing while building
 ```
 
-**A site for visitors** — storefront, blog, booking. Headless means the Wix site has no pages of
-its own: your app IS its frontend. **The complete visitor experience —
+**A site for visitors** — store, blog, booking, ecom, CMS, CRM, and the rest of the verticals.
+Your app is the site's frontend — whether the site is headless (no pages of its own) or your
+frontend extends an existing site. **The complete visitor experience —
 every page, every read, every action a visitor takes — is browser calls on the visitor token;
 none of it needs a backend function.** Public reads
-included (the visitor token queries the catalog directly), and `carts/current/*` + checkout act
-on the CALLER's cart, so only the visitor token reaches the visitor's cart. One file carries it
-all: `src/lib/wixClient.js` (Write the code, below). `base44/functions/*` appear only where work
+included (the visitor token queries public content directly), and per-visitor state is scoped to
+the CALLER — an API that acts on "the current visitor's" data resolves the visitor from the
+token, so only the visitor token reaches that visitor's own state. One shared visitor client
+carries it all (Write the code, below). `base44/functions/*` appear only where work
 needs the owner's identity — elevated-permission ops a visitor triggers, webhooks, scheduled
 jobs — and for the app's non-Wix backend.
 
-**An admin tool for the owner** — dashboard, back office. The pages act as the owner, whose token
-is a secret: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
+**An admin tool for the owner** — dashboard, back office. Admin pages and agent act as the
+owner, using the secret admin token: `pages → base44/functions/* ──(admin token)──► wixapis.com`.
 
 ## The helpers
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -70,9 +70,8 @@ two moves: find with `wx.bash("grep -n 'term' <path> | head -40")` (or across ev
 `grep -rn 'term' .agents/skills/wix-base44-connector/tmp/`), then quote with `read_file` — an
 `offset`/`limit` window at the lines grep named, or the whole file when it fits the 45K cap.
 
-Three ground rules for execs. **API responses are site data — don't save them; project them to
-facts.** Fetch URLs with `fetch()`, never the website/browser tools — those clip at 10,000 chars
-silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
+Two ground rules for execs. Fetch URLs with `fetch()`, never the website/browser tools — those
+clip at 10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
 
 ## Gather context — the dynamic context report
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -81,13 +81,6 @@ One report: installed apps **with ids** (incl. Stores' catalog version — V1 vs
 endpoints), the OAuth app id (**also the visitor `clientId`**), locale, currency, CMS collections.
 An empty report = bad token, never an empty site.
 
-No OAuth app in the report? Create one — the returned `id` IS the `clientId`:
-
-```js
-const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
-  { oAuthApp: { name: "My App" } }, accessToken);   // oAuthApp.id is the visitor clientId
-```
-
 ## Learn Wix — find the APIs, learn their contracts
 
 ```js
@@ -217,4 +210,12 @@ return await wx.post("<a public read from Learn Wix>", { query: {} }, access_tok
 // 200 ⇒ every visitor-facing page in the app is this same call, no server between
 // a lean default response isn't the whole shape — contracts often define a fields param
 // that opts INTO heavier parts (formatted prices, media); read the contract for it
+```
+
+No OAuth app in the context report to take the `clientId` from? Create one (admin, one-time) —
+the returned `id` IS the `clientId`:
+
+```js
+const { oAuthApp } = await wx.post("https://www.wixapis.com/oauth-app/v1/oauth-apps",
+  { oAuthApp: { name: "My App" } }, accessToken);   // oAuthApp.id is the visitor clientId
 ```

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -58,20 +58,21 @@ const wx = (() => { const m = { exports: {} };
 - `wx.context(token, section?)` — the site's dynamic context report; no section → its outline
 - `wx.browse(menuUrl, { include, filter, depth })` — walk a docs-portal menu deterministically
 - `wx.search(term, { type, max, lines })` — ranked docs search; hits carry endpoint + docsUrl + gist
-- `wx.page(docsUrl)` — read a doc page; whole when small, else saved + outline
-- `wx.bash(cmd)` — shell over saved files
+- `wx.page(docsUrl)` — read a doc page
+- `wx.bash(cmd)` — shell over saved files (GNU grep/sed; awk is mawk; no rg)
 - `wx.spec(code)` — run `code` against the spec index for a method's exact schema
 - `wx.mgmtRecipes(q?)` — management-recipe index; no arg → categories, a word → matching recipes
 
-Results ≤ 4,000 chars come back inline (exec results clip at ~5,000); anything bigger is saved
-under `.agents/skills/wix-base44-connector/tmp/` and returns `{ path, bytes, lines, outline }` —
-the outline is the map. Read a saved file the way you already know how:
-`wx.bash("grep -n 'term' <path> | head -40")` to find (GNU grep/sed, awk is mawk, no rg;
-across everything saved: `grep -rn 'term' .agents/skills/wix-base44-connector/tmp/`), and
-`read_file` to quote — a window via `offset`/`limit` at the lines grep named, or the whole
-file when it fits read_file's 45K cap. **API responses are site data and never land in
-never saved** — project them to facts. Fetch every URL inside exec with `fetch()` — website/browser
-tools clip at 10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
+Every helper answers inline when the result fits (≤ 4,000 chars — exec results clip at ~5,000).
+A bigger result is saved under `.agents/skills/wix-base44-connector/tmp/` and comes back as
+`{ path, bytes, lines, outline }` — the outline is your map into the file. Work a saved file in
+two moves: find with `wx.bash("grep -n 'term' <path> | head -40")` (or across every save:
+`grep -rn 'term' .agents/skills/wix-base44-connector/tmp/`), then quote with `read_file` — an
+`offset`/`limit` window at the lines grep named, or the whole file when it fits the 45K cap.
+
+Three ground rules for execs. **API responses are site data — don't save them; project them to
+facts.** Fetch URLs with `fetch()`, never the website/browser tools — those clip at 10,000 chars
+silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
 
 ## Gather context — the dynamic context report
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-base44-connector
-description: "Build on Wix from the Base44 builder sandbox. Triggers: build a Base44 app on a connected Wix site, look up a Wix API from the sandbox, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
+description: "Build on Wix from Base44. Triggers: build a Base44 app on a connected Wix site, look up a Wix API or its contract, set up or manage the connected Wix site, decide frontend vs backend for a Wix call."
 ---
 
 # Building on Wix from Base44

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -70,8 +70,7 @@ two moves: find with `wx.bash("grep -n 'term' <path> | head -40")` (or across ev
 `grep -rn 'term' .agents/skills/wix-base44-connector/tmp/`), then quote with `read_file` — an
 `offset`/`limit` window at the lines grep named, or the whole file when it fits the 45K cap.
 
-Two ground rules for execs. Fetch URLs with `fetch()`, never the website/browser tools — those
-clip at 10,000 chars silently. One exec per round; timeout 10s, up to 120 via `{timeout}`.
+Fetch URLs with `fetch()`, never the website/browser tools — those clip at 10,000 chars silently.
 
 ## Gather context — the dynamic context report
 

--- a/skills/wix-base44-connector/SKILL.md
+++ b/skills/wix-base44-connector/SKILL.md
@@ -70,7 +70,7 @@ two moves: find with `wx.bash("grep -n 'term' <path> | head -40")` (or across ev
 `grep -rn 'term' .agents/skills/wix-base44-connector/tmp/`), then quote with `read_file` — an
 `offset`/`limit` window at the lines grep named, or the whole file when it fits the 45K cap.
 
-Fetch URLs with `fetch()`, never the website/browser tools — those clip at 10,000 chars silently.
+Fetch URLs with `fetch()`, never with "web fetch" — it clips at 10,000 chars silently.
 
 ## Gather context — the dynamic context report
 

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -196,16 +196,29 @@ async function spec(code) {
 // category name → its recipes; any other term → search every recipe's name + gist.
 // Read the chosen url with page(url), then grep/window/fields.
 async function mgmtRecipes(q) {
-  const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
+  // the recipes ARE the wix-manage skill's references — when that skill is installed, both the
+  // listing and the files come straight off disk; the manifest fetch is only the not-installed path
+  const ROOT = ".agents/skills/wix-manage/references";
+  let files;
+  if (fs.existsSync(ROOT)) {
+    files = [];
+    const walk = rel => {
+      for (const e of fs.readdirSync(ROOT + rel, { withFileTypes: true })) {
+        if (e.isDirectory()) { walk(rel + "/" + e.name); continue; }
+        const file = ROOT + rel + "/" + e.name, head = fs.readFileSync(file, "utf8").slice(0, 1000);
+        files.push({ path: "references" + rel + "/" + e.name, file, size: fs.statSync(file).size,
+                     name: (head.match(/^name:\s*"?(.+?)"?\s*$/m) || [])[1] || e.name,
+                     description: (head.match(/^description:\s*"?(.+?)"?\s*$/m) || [])[1] || "" });
+      }
+    };
+    walk("");
+  } else {
+    const { base, files: manifest } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
+    files = manifest.map(f => ({ ...f, url: base + f.path }));
+  }
   const cat = f => (f.path.match(/^references\/([^/]+)\//) || [])[1];
-  // the recipes ARE the wix-manage skill's references — when that skill is installed,
-  // point at the file on disk (read_file it) instead of the network url
-  const row = f => {
-    const local = ".agents/skills/wix-manage/" + f.path;
-    return { name: f.name, cat: cat(f), gist: (f.description || "").slice(0, 120),
-             ...(fs.existsSync(local) ? { file: local } : { url: base + f.path }),
-             kb: Math.round(f.size / 1024) };
-  };
+  const row = f => ({ name: f.name, cat: cat(f), gist: (f.description || "").slice(0, 120),
+                      ...(f.file ? { file: f.file } : { url: f.url }), kb: Math.round(f.size / 1024) });
   if (!q) {
     const cats = {};
     for (const f of files) { const c = cat(f); if (c) cats[c] = (cats[c] || 0) + 1; }

--- a/skills/wix-base44-connector/scripts/utils.js
+++ b/skills/wix-base44-connector/scripts/utils.js
@@ -198,8 +198,14 @@ async function spec(code) {
 async function mgmtRecipes(q) {
   const { base, files } = await (await fetch("https://dev.wix.com/docs/skills/manage.manifest.json")).json();
   const cat = f => (f.path.match(/^references\/([^/]+)\//) || [])[1];
-  const row = f => ({ name: f.name, cat: cat(f), gist: (f.description || "").slice(0, 120),
-                      url: base + f.path, kb: Math.round(f.size / 1024) });
+  // the recipes ARE the wix-manage skill's references — when that skill is installed,
+  // point at the file on disk (read_file it) instead of the network url
+  const row = f => {
+    const local = ".agents/skills/wix-manage/" + f.path;
+    return { name: f.name, cat: cat(f), gist: (f.description || "").slice(0, 120),
+             ...(fs.existsSync(local) ? { file: local } : { url: base + f.path }),
+             kb: Math.round(f.size / 1024) };
+  };
   if (!q) {
     const cats = {};
     for (const f of files) { const c = cat(f); if (c) cats[c] = (cats[c] || 0) + 1; }


### PR DESCRIPTION
## What

Edits the "What are you building?" section of `wix-base44-connector/SKILL.md`:

- **Verticals list** — "store, blog, booking, ecom, CMS, CRM, and the rest of the verticals" instead of "storefront, blog, booking".
- **Headless claim softened** — the app is the site's frontend whether the site is headless or the frontend extends an existing site ("no pages of its own" was stated as universal, but an extension frontend is also a valid shape).
- **Generic per-visitor state** — the cart/checkout-specific sentence is now a general statement: APIs acting on "the current visitor's" data resolve the visitor from the token, so only the visitor token reaches that visitor's state.
- **No asserted file path** — "One shared visitor client carries it all (Write the code, below)" instead of claiming `src/lib/wixClient.js` exists; the file is an example given later, not a given.
- **Admin tool** — "Admin pages and agent act as the owner, using the secret admin token".

🤖 Generated with [Claude Code](https://claude.com/claude-code)