### PR TITLE
🦞 igor-claw: add consent/privacy app-overlap diagnostic to List Installed Apps

### DIFF
--- a/skills/wix-manage/references/app-installation/list-installed-apps.md
+++ b/skills/wix-manage/references/app-installation/list-installed-apps.md
@@ -102,6 +102,14 @@ If you receive `401 Unauthorized` or `403 Forbidden` errors from Wix APIs:
 3. **If missing**: Install the app using the [Install Wix Apps](install-wix-apps.md) recipe
 4. **Retry the original API call**
 
+### Diagnose Overlapping Consent/Privacy Apps
+
+Wix's native cookie banner is a site-property, not an installed app — it's a separate mechanism from any third-party cookie-consent/GDPR app installed from the App Market. A site can have both active at once with no built-in warning, which can cause duplicate banners or conflicting cookie/script-blocking behavior. If a site owner reports odd banner behavior, unexplained script blocking, or you're ruling out consent-related causes for a rendering issue:
+
+1. **List installed apps** using this recipe and flag any whose name suggests a consent/privacy/GDPR function (e.g. containing "Cookie", "Consent", "GDPR", "Privacy").
+2. **Separately check Wix's native banner** with [Get Cookie Banner Settings](https://dev.wix.com/docs/api-reference/business-management/cookie-consent-policy/cookie-banner-settings/get-cookie-banner-settings) (`GET .../cookie-consent/v1/cookie-banner-settings/get/<languageCode>`) — `settings.appEnabled` tells you if it's active. This won't show up in step 1's results.
+3. **If both are active**, confirm with the site owner which one they intend to keep, then either disable the native banner (`enabled: false` via [Update Cookie Banner Settings](https://dev.wix.com/docs/api-reference/business-management/cookie-consent-policy/cookie-banner-settings/update-cookie-banner-settings)) or uninstall the redundant app ([Uninstall App](https://dev.wix.com/docs/api-reference/business-management/app-installation/app-installation/uninstall-app), `POST .../apps-installer-service/v1/app-instance/uninstall`).
+
 ---
 
 ## Error Handling


### PR DESCRIPTION
## What
Adds a "Diagnose Overlapping Consent/Privacy Apps" use case to the **List Installed Apps** recipe (`skills/wix-manage/references/app-installation/list-installed-apps.md`).

## Why
Wix's native cookie banner is a site-property (`cookie-consent-policy` / Cookie Banner Settings API), not an installed app instance — it's a separate mechanism from any third-party cookie-consent/GDPR app installed from the App Market. A site can have both active simultaneously with no built-in conflict warning, causing duplicate banners or conflicting script-blocking behavior.

This surfaced from a real support case: a Wix Studio + Velo site had a redundant dual cookie-consent-app installation that an agent found and fixed only after directly querying installed apps — there was no recipe guidance pointing at this pattern. The new use case gives a concrete 3-step check using the already-documented Get/Update Cookie Banner Settings and Uninstall App endpoints, so future agents catch this case directly instead of stumbling into it.

## Scope note
This was one finding from a broader investigation into a report about a site failing to render inside Instagram's in-app browser. That core issue itself has **no confirmed root cause or PR** — it was investigated via the Wix MCP tools, Thunderbolt source, and edge/bot-management config, but none produced a concrete, fixable bug (see the linked thread for the full writeup). This PR only captures the one grounded, low-risk side-finding from that investigation.

---
Opened automatically by an AI agent acting on behalf of Ayal (ayalg@wix.com) — not written or reviewed by Ayal personally.

Slack thread: https://wix.slack.com/archives/C08P5DKLJR5/p1787710017189029