### PR TITLE
feat(google-business-profile): add connect and manage-locations recipes [WIXSEO-3914]

### DIFF
--- a/skills/wix-manage/SKILL.md
+++ b/skills/wix-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-manage
-description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, analytics, accessibility, seo, dashboard-navigation."
+description: "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Routes to: stores, bookings, get-paid, CMS, contacts, forms, media, app-installation, pricing-plans, restaurants, ricos rich-content, sites, blog, calendar, domains, events, site-properties, ecommerce, marketing, google-ads, google-business-profile, analytics, accessibility, seo, dashboard-navigation."
 compatibility: Requires Wix REST API access (API key or OAuth).
 ---
 
@@ -303,6 +303,18 @@ These recipes do NOT cover frontend development or SDK usage for displaying data
 
 ### [Google Ads Dashboard Navigation](references/google-ads/google-ads-dashboard-navigation.md)
 **Technical:** Direct link to the Wix Google Ads dashboard page on manage.wix.com where API-created campaigns are managed.
+
+---
+
+## Google Business Profile
+
+**Routing — how a business appears on Google Search and Maps.** A Google connection is the prerequisite for all Google-backed location work: check it first, and route "connect / reconnect / disconnect Google" to the connection recipe.
+
+### [Connect a Wix Site to Google Business Profile](references/google-business-profile/connect-google-business-profile.md)
+**Technical:** Establishes, checks, and removes the site's Google Business Profile connection. Reads the connection status (`NEVER_CONNECTED` / `VALID` / `NEEDS_RECONNECT`), requests a single-use 15-minute connect URL for the site owner to authorize in their own browser, confirms completion by re-reading the status, and warns before any reconnect that permanently removes the site's imported locations. Never auto-retries the non-idempotent connect-URL call.
+
+### [Manage Google Business Profile Locations for a Wix Site](references/google-business-profile/manage-google-business-profile-locations.md)
+**Technical:** Imports locations from the connected Google account (accounts → unimported locations → bulk create with per-item results), queries them Wix-only or hydrated with live Google data, routes each update to the correct side (Wix row vs Google listing), creates new Google listings, checks profile liveness via Voice of Merchant, and distinguishes un-importing from Wix from deleting the real Google listing. Reports a missing connection as a setup step and respects Google's shared ~10-edits-per-minute budget.
 
 ---
 

--- a/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
+++ b/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
@@ -7,11 +7,11 @@ description: Connect the authenticated Wix site to a Google Business Profile acc
 
 Use the public **Google Business Profile Connection API** to link the
 authenticated Wix site to a Google Business Profile account. The REST requests
-do not contain a site ID, but the MCP still needs a site selected so it can set
-the authorization context. Use a site already supplied by the environment. If
-none is supplied, call **ListWixSites** once: auto-select the only site, or ask
-the user to choose by site name when several are available. Never invent a site
-ID or ask the user to type one. A connection is the prerequisite for Google-backed work in the Google
+do not contain a site ID — the site comes from the caller's authorization
+context. Use the site the environment already supplies; if no site is selected,
+list the user's sites once and auto-select the only one, or ask the user to
+choose by site name when several are available. Never invent a site ID or ask
+the user to type one. A connection is the prerequisite for Google-backed work in the Google
 Business Profile Locations API — establish it before importing or managing
 locations.
 

--- a/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
+++ b/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
@@ -1,0 +1,103 @@
+---
+name: "Connect a Wix Site to Google Business Profile"
+description: Connect the authenticated Wix site to a Google Business Profile account, check whether an existing connection is still usable, recover a connection whose stored credentials are gone, switch to a different Google account, or disconnect. The site owner authorizes in their own browser through a single-use connect URL; the agent never completes the Google authorization itself. Warns before any reconnect that permanently removes the site's imported locations.
+---
+
+# Connect a Wix Site to Google Business Profile
+
+Use the public **Google Business Profile Connection API** to link the
+authenticated Wix site to a Google Business Profile account. No request field
+takes a site ID — the API resolves the site from the caller's authorization
+context, so never ask the user for one. A connection is the prerequisite for Google-backed work in the Google
+Business Profile Locations API — establish it before importing or managing
+locations.
+
+Wix stores the Google credentials server-side. The API never returns tokens or
+any Google identity — only whether a connection exists and its dates.
+
+## Check the status first
+
+Always start with **Get Connection** and branch on `status`:
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `VALID` | Wix holds a credential for this site | Proceed with Google-backed work |
+| `NEVER_CONNECTED` | The site has never been connected | Run the connect flow — this is a setup step, not an error |
+| `NEEDS_RECONNECT` | The connection record exists but the stored credentials are gone | Warn the owner (see below), then run the connect flow |
+
+`VALID` is not a live health check: **Get Connection** deliberately does not
+call Google, so a connection can report `VALID` and still be refused by
+Google — for example after the owner revoked Wix's access in their Google
+account settings. Treat a Google-side authorization failure on a Locations
+call as the authoritative signal and re-run the connect flow when one appears.
+
+## Run the connect flow
+
+1. Call **Get Connect URL** once and read `connectUrl`.
+2. Present `connectUrl` to the site owner as a link to open in their own
+   browser, where they sign in to Google and grant access. Never fetch or open
+   the URL yourself — it is for a human, single-use, and expires after
+   15 minutes.
+3. Explain that completion is asynchronous: Google redirects the owner's
+   browser back to Wix, which finishes the OAuth exchange and stores the
+   credentials server-side.
+4. When the owner reports they have finished (or while waiting, on a modest
+   interval of a few seconds), call **Get Connection** and confirm `status` is
+   `VALID`. The `status` field is the only source of truth — a returned
+   connect URL alone proves nothing.
+5. If the 15-minute window elapses with `status` unchanged, request a fresh
+   URL and let the owner try again.
+
+**Get Connect URL is not idempotent, despite its GET route.** Every successful
+call creates a distinct live authorization attempt. Never retry it
+automatically after a timeout or ambiguous response — re-check
+**Get Connection** first and let the owner explicitly start another attempt.
+
+## Warn before a reconnect that replaces the connection
+
+Two flows permanently remove every Business Profile location imported into the
+site — the locations created through Wix as well as the imported ones. For
+locations migrated from an earlier Wix integration this cannot be reversed by
+re-importing. Get the owner's explicit confirmation **before** handing them
+the connect URL; there is no confirmation step later:
+
+- **Switching to a different Google account.** No Disconnect is needed — the
+  new account simply replaces the connection when its authorization completes.
+- **Reconnecting from `NEEDS_RECONNECT`, even with the same Google account.**
+  The stored credentials are gone, so there is nothing to match the incoming
+  account against and the reconnect is always treated as a replacement.
+
+While credentials are still present (`VALID`), authorizing again with the
+**same** Google account heals the connection in place and removes nothing.
+
+Also tell the owner that replacing or disconnecting changes nothing inside
+Google Business Profile itself — locations, reviews, and photos stay exactly
+as they are on Google — and does not revoke Wix's access inside their old
+Google account; they remove that from their Google account settings.
+
+## Disconnect
+
+Call **Disconnect** only after the owner confirms. It deletes the credentials
+Wix stores; it does not touch the Google Business Profile and does not revoke
+Wix's grant inside the Google account.
+
+## Recovery rules
+
+- **`CONNECTING_USER_LOOKUP_UNAVAILABLE`:** the site-owner lookup failed
+  temporarily, before any authorization attempt was created. This is the one
+  failure of **Get Connect URL** that is safe to retry.
+- **`CONNECTING_USER_NOT_RESOLVABLE`:** Wix could not identify a user to own
+  the credential. Stop — this is not retryable until the caller identity or
+  site ownership is corrected. Explain the blocker instead of trying other
+  request shapes.
+- **Timeout or ambiguous response from Get Connect URL:** do not retry. Call
+  **Get Connection** to learn the actual state, then let the owner decide.
+- **`MULTIPLE_CONNECTIONS_NOT_REPRESENTABLE`:** the site holds more than one
+  connection and the API will not guess which one is meant. Not a caller error
+  and not retryable — report it and direct the user to contact Wix support.
+- **Permission denied:** stop after the first `403` or `PERMISSION_DENIED`.
+  Do not retry with another request shape or site. Explain that the current
+  Wix identity is not authorized to manage the site's Google connection.
+
+Load the current public API reference before constructing requests so field
+names, statuses, permissions, and error schemas come from the live contract.

--- a/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
+++ b/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
@@ -12,6 +12,15 @@ context, so never ask the user for one. A connection is the prerequisite for Goo
 Business Profile Locations API — establish it before importing or managing
 locations.
 
+> **Bounded connect path — read first.** Read the connection once. For
+> `NEVER_CONNECTED`, request one connect URL and hand it to the owner; for
+> `VALID`, stop unless the user asked for other Google-backed work. A `403`,
+> `PERMISSION_DENIED`, or other terminal recovery-rule error ends the flow:
+> explain it and make no further API probes, documentation searches, alternate
+> request-shape attempts, or calls against another site. Only the explicitly
+> retryable `CONNECTING_USER_LOOKUP_UNAVAILABLE` error permits another connect-URL
+> attempt.
+
 Wix stores the Google credentials server-side. The API never returns tokens or
 any Google identity — only whether a connection exists and its dates.
 
@@ -96,8 +105,11 @@ Wix's grant inside the Google account.
   connection and the API will not guess which one is meant. Not a caller error
   and not retryable — report it and direct the user to contact Wix support.
 - **Permission denied:** stop after the first `403` or `PERMISSION_DENIED`.
-  Do not retry with another request shape or site. Explain that the current
-  Wix identity is not authorized to manage the site's Google connection.
+  Do not retry with another request shape or site, and do not search for an
+  alternate API or method. Explain that the current Wix identity is not
+  authorized to manage the site's Google connection.
 
-Load the current public API reference before constructing requests so field
-names, statuses, permissions, and error schemas come from the live contract.
+Before the first call, load only the specific public method reference needed to
+construct that request so fields and errors come from the live contract. Once a
+status or typed error selects a branch above, do not search or browse for an
+alternate API, method, or request shape.

--- a/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
+++ b/skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
@@ -6,9 +6,12 @@ description: Connect the authenticated Wix site to a Google Business Profile acc
 # Connect a Wix Site to Google Business Profile
 
 Use the public **Google Business Profile Connection API** to link the
-authenticated Wix site to a Google Business Profile account. No request field
-takes a site ID — the API resolves the site from the caller's authorization
-context, so never ask the user for one. A connection is the prerequisite for Google-backed work in the Google
+authenticated Wix site to a Google Business Profile account. The REST requests
+do not contain a site ID, but the MCP still needs a site selected so it can set
+the authorization context. Use a site already supplied by the environment. If
+none is supplied, call **ListWixSites** once: auto-select the only site, or ask
+the user to choose by site name when several are available. Never invent a site
+ID or ask the user to type one. A connection is the prerequisite for Google-backed work in the Google
 Business Profile Locations API — establish it before importing or managing
 locations.
 
@@ -16,13 +19,29 @@ locations.
 > `NEVER_CONNECTED`, request one connect URL and hand it to the owner; for
 > `VALID`, stop unless the user asked for other Google-backed work. A `403`,
 > `PERMISSION_DENIED`, or other terminal recovery-rule error ends the flow:
-> explain it and make no further API probes, documentation searches, alternate
-> request-shape attempts, or calls against another site. Only the explicitly
+> the **next action is the final response** explaining the blocker. Make no
+> further tool call: no API probe, documentation search, alternate request
+> shape, or call against another site. Only the explicitly
 > retryable `CONNECTING_USER_LOOKUP_UNAVAILABLE` error permits another connect-URL
 > attempt.
 
 Wix stores the Google credentials server-side. The API never returns tokens or
 any Google identity — only whether a connection exists and its dates.
+
+## Direct calls for this flow
+
+These are the complete request shapes needed for a fresh connection. Use them
+directly; do not search the API reference before calling them.
+
+| Method | Call |
+|---|---|
+| **Get Connection** | `GET https://www.wixapis.com/gbp/v1/connection` — no body or parameters |
+| **Get Connect URL** | `GET https://www.wixapis.com/gbp/v1/connect-url` — no body or parameters |
+
+For the common `NEVER_CONNECTED` path the only API calls are one **Get
+Connection**, then one **Get Connect URL**. If either returns `403` or
+`PERMISSION_DENIED`, stop immediately and explain it; do not look for another
+method or request shape.
 
 ## Check the status first
 
@@ -109,7 +128,7 @@ Wix's grant inside the Google account.
   alternate API or method. Explain that the current Wix identity is not
   authorized to manage the site's Google connection.
 
-Before the first call, load only the specific public method reference needed to
-construct that request so fields and errors come from the live contract. Once a
-status or typed error selects a branch above, do not search or browse for an
-alternate API, method, or request shape.
+The direct calls above are self-contained for the normal connect path. Consult a
+specific public method reference only for an edge case not covered here, and
+only before making a call. Once a status or typed error selects a branch above,
+do not search or browse for an alternate API, method, or request shape.

--- a/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+++ b/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
@@ -7,9 +7,12 @@ description: Import Google Business Profile locations into the authenticated Wix
 
 Use the public **Google Business Profile Locations API** to manage the
 authenticated Wix site's Business Profile locations — the entries that decide
-how the business appears on Google Search and Maps. No request field takes a
-site ID — the API resolves the site from the caller's authorization context,
-so never ask the user for one.
+how the business appears on Google Search and Maps. The REST requests do not
+contain a site ID, but the MCP still needs a site selected so it can set the
+authorization context. Use a site already supplied by the environment. If none
+is supplied, call **ListWixSites** once: auto-select the only site, or ask the
+user to choose by site name when several are available. Never invent a site ID
+or ask the user to type one.
 
 > **Unconnected-site fast path — read first.** Read the connection once. Treat
 > `NEVER_CONNECTED`, `NEEDS_RECONNECT`, or a single
@@ -19,11 +22,31 @@ so never ask the user for one.
 > unimported-location selection → bulk-create flow, and stop. Do not call a
 > Google-backed location method or make further API probes or documentation
 > searches until the connection is `VALID`. A `403` or `PERMISSION_DENIED` is
-> terminal: explain it and stop without the Wix-only query or any other call.
+> terminal: the **next action is the final response** explaining it. Stop
+> without the Wix-only query, documentation search, or any other tool call.
 
 The API is a live view onto Google, not a copy: most calls make a real Google
 request, with Google's latency and rate limits. A location's ID is Google's
 opaque location ID and is what identifies it everywhere.
+
+## Direct calls for the unconnected-site path
+
+Use these request shapes directly; do not search the API reference before
+calling them.
+
+| Method | Call |
+|---|---|
+| **Get Connection** | `GET https://www.wixapis.com/gbp/v1/connection` — no body or parameters |
+| **Query GBP Locations** | `POST https://www.wixapis.com/gbp/v1/locations/query` with body below |
+
+```json
+{ "query": { "paging": { "limit": 100 } } }
+```
+
+On a fresh, unconnected site, make exactly those two calls: read the connection
+once, query the Wix-stored locations once, then report the empty result and the
+future import steps. Do not call List GBP Accounts or any other Google-backed
+method until the connection is `VALID`.
 
 ## Check the connection first
 

--- a/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+++ b/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
@@ -11,6 +11,16 @@ how the business appears on Google Search and Maps. No request field takes a
 site ID — the API resolves the site from the caller's authorization context,
 so never ask the user for one.
 
+> **Unconnected-site fast path — read first.** Read the connection once. Treat
+> `NEVER_CONNECTED`, `NEEDS_RECONNECT`, or a single
+> `CONNECTION_NOT_FOUND`/not-found response from that connection check as the
+> same setup state. Query Wix-only GBP locations once to answer what the site
+> already has, report the result, explain the connect → account selection →
+> unimported-location selection → bulk-create flow, and stop. Do not call a
+> Google-backed location method or make further API probes or documentation
+> searches until the connection is `VALID`. A `403` or `PERMISSION_DENIED` is
+> terminal: explain it and stop without the Wix-only query or any other call.
+
 The API is a live view onto Google, not a copy: most calls make a real Google
 request, with Google's latency and rate limits. A location's ID is Google's
 opaque location ID and is what identifies it everywhere.
@@ -124,10 +134,13 @@ wait, verify, comply, or resolve the conflict.
 - **Rate limited (`429`):** wait, then retry; interleaved writes share one
   budget per profile.
 - **Permission denied:** stop after the first `403` or `PERMISSION_DENIED`.
-  Do not retry with other locations, request shapes, or sites. Deleting
-  locations requires the site's `GBP_ADMIN` role.
+  Do not retry with other locations, request shapes, or sites, and do not
+  search for an alternate API or method. Deleting locations requires the
+  site's `GBP_ADMIN` role.
 
 The same API also covers reviews and replies, photos and bulk media uploads,
 attributes, verification, performance insights, and location admins — load the
-current public API reference before constructing any request so field names,
-filters, permissions, and error schemas come from the live contract.
+specific public method reference needed before constructing a request so field
+names, filters, permissions, and errors come from the live contract. Once a
+connection state or typed error selects a branch above, do not search or browse
+for an alternate API, method, or request shape.

--- a/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+++ b/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
@@ -1,0 +1,133 @@
+---
+name: "Manage Google Business Profile Locations for a Wix Site"
+description: Import Google Business Profile locations into the authenticated Wix site, list and query them with or without live Google data, update Wix-side and Google-side details through the correct method for each, create a new Google listing, check whether a profile is actually live on Google, and remove a location from Wix or delete its Google listing. Checks the site's Google connection first and reports a missing one as a setup step, warns before destructive or Google-visible writes, and respects Google's shared rate budget.
+---
+
+# Manage Google Business Profile Locations for a Wix Site
+
+Use the public **Google Business Profile Locations API** to manage the
+authenticated Wix site's Business Profile locations — the entries that decide
+how the business appears on Google Search and Maps. No request field takes a
+site ID — the API resolves the site from the caller's authorization context,
+so never ask the user for one.
+
+The API is a live view onto Google, not a copy: most calls make a real Google
+request, with Google's latency and rate limits. A location's ID is Google's
+opaque location ID and is what identifies it everywhere.
+
+## Check the connection first
+
+Google-backed methods require a Google connection, established through the
+**Google Business Profile Connection API** (see the connect recipe). Before
+Google-backed work, call **Get Connection**:
+
+- `VALID` — proceed.
+- `NEVER_CONNECTED` or `NEEDS_RECONNECT` — report a setup step, not an error,
+  and offer to run the connect flow. Do not retry location calls until the
+  connection is `VALID`.
+
+Wix-only reads and deletes still work without active Google credentials:
+**Get GBP Location**, **Query GBP Locations**, **Update Location**,
+**Delete Location**, and **Bulk Delete Locations**.
+
+## Import locations
+
+Importing registers listings that already exist at Google; it never creates
+one. Each step narrows the next:
+
+1. Call **List GBP Accounts**. One Google login can hold several Business
+   Profile accounts, so present the list and let the owner pick — never assume
+   the first one.
+2. Call **List Unimported Locations** with the chosen `accountId`. It returns
+   only what the site hasn't imported yet, so re-running never offers
+   duplicates.
+3. Let the owner select which locations to import, and confirm before writing.
+4. Call **Bulk Create Locations** with the selected locations, supplying `id`
+   and `accountId` on each.
+5. Inspect every `results[].itemMetadata.error`. The call reports per-item
+   failures instead of aborting, so a `200` does not mean every location
+   imported. Report failures explicitly.
+
+Repeat steps 2–5 per account if the owner wants locations from more than one.
+
+## List and query locations
+
+Choose by whether live Google data is needed:
+
+- **Just the site's locations:** call **Query GBP Locations**. Wix-stored rows
+  only — fast, no Google round-trip, no Google rate limit. Use it for counts,
+  ID lookups, and anything driven by `id`, `googleLocationId`, or `accountId`.
+- **Locations with live business details:** call **Query Google Locations**
+  (or **Get Google Location** for one). Each row is hydrated with a live
+  Google fetch. Check each row for `googleError` — one location failing at
+  Google does not fail the request or break paging, so render it as a
+  per-location problem, not an empty result.
+
+## Update the correct side
+
+Wix stores almost nothing; the method name tells you which side a write
+reaches. Check before calling anything destructive:
+
+| Method | Wix row | Google listing |
+|---|---|---|
+| **Create Location**, **Bulk Create Locations** | created | untouched (imports an existing listing) |
+| **Create Google Location** | created | **created** |
+| **Update Location** | updated | untouched (writes Wix-stored fields only) |
+| **Update Google Location** | untouched | **updated** |
+| **Delete Location**, **Bulk Delete Locations** | deleted | untouched |
+| **Delete Google Location** | deleted | **deleted** |
+
+- **Update Location** is not the way to edit a Business Profile — it writes
+  only Wix-stored fields. To change Google-owned data (title, address, hours,
+  categories), call **Update Google Location**, and confirm with the owner
+  first: the change is publicly visible on Google.
+- To create a brand-new Google listing, call **Create Google Location** after
+  explicit confirmation. Use the API's reference-data methods (address schema,
+  category and region suggestions) rather than inventing values.
+- Google allows roughly 10 profile edits per minute per Business Profile, and
+  the budget is shared across every write method. Pace the profile as a whole
+  and treat a `429` as worth retrying after a delay, not as a rejection.
+
+## Remove a location
+
+Decide first whether the owner is removing it from Wix or deleting the real
+Google listing — these are different operations and one is irreversible.
+Confirm which they mean before calling anything:
+
+- **Un-import from Wix, leave Google alone:** call **Delete Location**, or
+  **Bulk Delete Locations** for several. Inspect every
+  `results[].itemMetadata` entry — the bulk call can partially succeed.
+- **Delete the Google listing as well:** call **Delete Google Location** once
+  per location; there is no bulk Google delete. Require explicit confirmation
+  naming the location — the listing disappears from Google Search and Maps.
+- If **Delete Google Location** returns `LOCATION_DB_PERSIST_FAILED`, Google
+  deleted the listing but Wix didn't record it. The error payload carries the
+  location ID; call **Delete Location** with it to reconcile.
+
+## Check whether a profile is actually live
+
+A location existing in Wix does not mean it appears on Google — verification
+can be pending, the profile suspended, or ownership contested. Call
+**Get Voice of Merchant** for the location and act on what Google reports:
+wait, verify, comply, or resolve the conflict.
+
+## Recovery rules
+
+- **`FAILED_PRECONDITION` with `CONNECTION_NOT_FOUND`:** the site has no
+  usable Google connection. Report the setup step and offer the connect flow;
+  do not retry the same call.
+- **`GOOGLE_API_CALL_FAILED`:** read the carried Google code and description.
+  Some failures are permanent (profile suspended, field not editable) —
+  retrying will not help; explain instead.
+- **Per-row `googleError` on hydrating reads:** report it per location and
+  continue with the rest of the page.
+- **Rate limited (`429`):** wait, then retry; interleaved writes share one
+  budget per profile.
+- **Permission denied:** stop after the first `403` or `PERMISSION_DENIED`.
+  Do not retry with other locations, request shapes, or sites. Deleting
+  locations requires the site's `GBP_ADMIN` role.
+
+The same API also covers reviews and replies, photos and bulk media uploads,
+attributes, verification, performance insights, and location admins — load the
+current public API reference before constructing any request so field names,
+filters, permissions, and error schemas come from the live contract.

--- a/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+++ b/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
@@ -19,8 +19,10 @@ user to type one.
 > `CONNECTION_NOT_FOUND`/not-found response from that connection check as the
 > same setup state. Query Wix-only GBP locations once to answer what the site
 > already has, report the result, explain the connect → account selection →
-> unimported-location selection → bulk-create flow, and stop. Do not call a
-> Google-backed location method or make further API probes or documentation
+> unimported-location selection → bulk-create flow, and stop — after that one
+> query the **next action is the final response**, with no other tool call. Do
+> not call a Google-backed location method, probe for Business Profile
+> accounts, guess an endpoint, or make further API probes or documentation
 > searches until the connection is `VALID`. A `403` or `PERMISSION_DENIED` is
 > terminal: the **next action is the final response** explaining it. Stop
 > without the Wix-only query, documentation search, or any other tool call.
@@ -51,11 +53,13 @@ Make **Get Connection** first, then branch before making any other call:
   another endpoint.
 - `NEVER_CONNECTED`, `NEEDS_RECONNECT`, or `CONNECTION_NOT_FOUND` — make one
   **Query GBP Locations** call, report the Wix-stored result, explain the future
-  import steps, and stop.
+  import steps, and stop. The next action is the final response.
 - `VALID` — proceed with the requested Google-backed flow.
 
-Do not call List GBP Accounts or another Google-backed method until the
-connection is `VALID`.
+Do not call **List GBP Accounts** or another Google-backed method until the
+connection is `VALID` — account discovery requires the connection, and its
+request shape is not the locations query. Never guess an endpoint that is not
+in the table above or in the loaded reference.
 
 ## Check the connection first
 

--- a/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+++ b/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
@@ -8,11 +8,11 @@ description: Import Google Business Profile locations into the authenticated Wix
 Use the public **Google Business Profile Locations API** to manage the
 authenticated Wix site's Business Profile locations — the entries that decide
 how the business appears on Google Search and Maps. The REST requests do not
-contain a site ID, but the MCP still needs a site selected so it can set the
-authorization context. Use a site already supplied by the environment. If none
-is supplied, call **ListWixSites** once: auto-select the only site, or ask the
-user to choose by site name when several are available. Never invent a site ID
-or ask the user to type one.
+contain a site ID — the site comes from the caller's authorization context.
+Use the site the environment already supplies; if no site is selected, list
+the user's sites once and auto-select the only one, or ask the user to choose
+by site name when several are available. Never invent a site ID or ask the
+user to type one.
 
 > **Unconnected-site fast path — read first.** Read the connection once. Treat
 > `NEVER_CONNECTED`, `NEEDS_RECONNECT`, or a single

--- a/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+++ b/skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
@@ -43,10 +43,19 @@ calling them.
 { "query": { "paging": { "limit": 100 } } }
 ```
 
-On a fresh, unconnected site, make exactly those two calls: read the connection
-once, query the Wix-stored locations once, then report the empty result and the
-future import steps. Do not call List GBP Accounts or any other Google-backed
-method until the connection is `VALID`.
+Make **Get Connection** first, then branch before making any other call:
+
+- `403` or `PERMISSION_DENIED` — stop. The next action is the final response;
+  explain that the current Wix identity cannot inspect the site's GBP state.
+  Do not query locations, inspect installed apps, search documentation, or try
+  another endpoint.
+- `NEVER_CONNECTED`, `NEEDS_RECONNECT`, or `CONNECTION_NOT_FOUND` — make one
+  **Query GBP Locations** call, report the Wix-stored result, explain the future
+  import steps, and stop.
+- `VALID` — proceed with the requested Google-backed flow.
+
+Do not call List GBP Accounts or another Google-backed method until the
+connection is `VALID`.
 
 ## Check the connection first
 

--- a/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
+++ b/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
@@ -44,11 +44,13 @@ assertions:
       Rate how smoothly the Wix MCP let the agent fulfill the connect request. Examine the tool-call
       trace. Score 0-10 (10 = direct: one status read, one connect-URL request, then either a clear
       handoff to the user or a typed error explained per its meaning, with no wasted calls). A typed
-      connect-URL error handled correctly is not a friction. Penalize and list any duplicate
-      connect-URL request, extended status polling (more than two or three reads when no human can
-      authorize), attempt to fetch the connect URL, guessed request shape, redundant probing call,
-      or recovered non-2xx error that clearer docs would avoid. For each problem, name the likely
-      skill, MCP, or docs gap.
+      connect-URL error handled correctly is not a friction. A single 403 or PERMISSION_DENIED from
+      the status or connect-URL call is also an expected authorization blocker, not a friction, if
+      the agent explains it and stops. Penalize and list any call or documentation search after that
+      terminal denial, duplicate connect-URL request, extended status polling (more than two or
+      three reads when no human can authorize), attempt to fetch the connect URL, guessed request
+      shape, redundant probing call, or other recovered non-2xx error that clearer docs would avoid.
+      For each problem, name the likely skill, MCP, or docs gap.
       Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
 siteSetup:
   mode: template

--- a/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
+++ b/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
@@ -1,0 +1,55 @@
+name: google-business-profile/connect-google-business-profile
+description: >-
+  Verifies that the agent checks the site's Google Business Profile connection status before
+  anything else, requests exactly one connect URL for a never-connected site, hands that URL to the
+  site owner to authorize in their own browser, and never fetches the URL itself or claims the site
+  is connected without the status saying so.
+triggerPrompt: >-
+  Connect my Wix site to Google Business Profile so I can manage my business locations from Wix.
+tags: [aria, seo]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/connection-v1/skills/connect-a-wix-site-to-google-business-profile
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked to connect their Wix site to Google Business Profile. The site is freshly
+      provisioned, so its connection status is NEVER_CONNECTED and no human is available to complete
+      Google's browser authorization during this run.
+
+      In every passing run the agent reads the connection status first and treats NEVER_CONNECTED
+      as a setup step, not an error. From there, two outcomes of requesting the connect URL are
+      both passable:
+
+      - **A connect URL is returned.** Pass if the agent requested exactly one connect URL,
+        presents it to the user as a link to open in their own browser (explaining that they sign
+        in to Google there and that the URL is single-use and expires in about 15 minutes), and
+        explains that completion is confirmed by re-reading the connection status until it is
+        VALID, rather than by the URL having been returned.
+      - **The request fails with a typed error.** Pass if the agent handles it per its meaning:
+        the temporary owner-lookup failure may be retried; a non-resolvable connecting user or a
+        permission denial means stopping with a clear explanation of the blocker instead of trying
+        other request shapes.
+
+      Fail if the agent fetches or opens the connect URL itself, requests more than one connect URL
+      without the first attempt having failed or expired, claims the site is connected without the
+      status reporting VALID, automatically retries the connect-URL call after a timeout or
+      ambiguous response, asks the user for a site ID, or calls Disconnect.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how smoothly the Wix MCP let the agent fulfill the connect request. Examine the tool-call
+      trace. Score 0-10 (10 = direct: one status read, one connect-URL request, then either a clear
+      handoff to the user or a typed error explained per its meaning, with no wasted calls). A typed
+      connect-URL error handled correctly is not a friction. Penalize and list any duplicate
+      connect-URL request, extended status polling (more than two or three reads when no human can
+      authorize), attempt to fetch the connect URL, guessed request shape, redundant probing call,
+      or recovered non-2xx error that clearer docs would avoid. For each problem, name the likely
+      skill, MCP, or docs gap.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor

--- a/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
+++ b/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
@@ -6,11 +6,11 @@ description: >-
   is connected without the status saying so.
 triggerPrompt: >-
   Connect my Wix site to Google Business Profile so I can manage my business locations from Wix.
-tags: [aria, seo]
+tags: [seo]
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/connection-v1/skills/connect-a-wix-site-to-google-business-profile
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/skills/connect-a-wix-site-to-google-business-profile
   - type: llm_judge
     minScore: 7
     maxTokens: 2048

--- a/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
+++ b/yaml/wix-manage-evals/google-business-profile/connect-google-business-profile.yml
@@ -19,6 +19,11 @@ assertions:
       provisioned, so its connection status is NEVER_CONNECTED and no human is available to complete
       Google's browser authorization during this run.
 
+      The REST methods take no siteId field, but the MCP may require a selected site for its
+      authorization context. If no valid site is already in context, listing sites once and
+      auto-selecting the only available site is correct and is not a failure. The agent must never
+      invent a site ID or ask the user to type one.
+
       In every passing run the agent reads the connection status first and treats NEVER_CONNECTED
       as a setup step, not an error. From there, two outcomes of requesting the connect URL are
       both passable:
@@ -43,8 +48,10 @@ assertions:
     prompt: |
       Rate how smoothly the Wix MCP let the agent fulfill the connect request. Examine the tool-call
       trace. Score 0-10 (10 = direct: one status read, one connect-URL request, then either a clear
-      handoff to the user or a typed error explained per its meaning, with no wasted calls). A typed
-      connect-URL error handled correctly is not a friction. A single 403 or PERMISSION_DENIED from
+      handoff to the user or a typed error explained per its meaning, with no wasted calls). A
+      site-list call used once to resolve genuinely missing site context is necessary setup, not
+      friction. A typed connect-URL error handled correctly is not a friction. A single 403 or
+      PERMISSION_DENIED from
       the status or connect-URL call is also an expected authorization blocker, not a friction, if
       the agent explains it and stops. Penalize and list any call or documentation search after that
       terminal denial, duplicate connect-URL request, extended status polling (more than two or

--- a/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
+++ b/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
@@ -1,0 +1,54 @@
+name: google-business-profile/manage-google-business-profile-locations
+description: >-
+  Verifies that the agent checks the site's Google connection before Google-backed location work,
+  reports a never-connected site as a setup step with the connect flow offered rather than an
+  error, uses Wix-only reads where they still work, and never retries connection-gated calls or
+  invents account or location IDs.
+triggerPrompt: >-
+  Import my Google Business Profile locations into my Wix site, and show me which locations the
+  site already has.
+tags: [aria, seo]
+assertions:
+  - tool: ReadFullDocsArticle
+    params:
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/gbplocation-v1/skills/manage-google-business-profile-locations-for-a-wix-site
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      The user asked to import their Google Business Profile locations into their Wix site and to
+      see which locations the site already has. The site is freshly provisioned, so it has no
+      Google connection (status NEVER_CONNECTED) and no imported locations, and no human is
+      available to complete Google's browser authorization during this run.
+
+      Pass if the agent:
+      - establishes the connection state up front — either by reading the connection status or by
+        correctly interpreting a connection-not-found precondition failure on the first
+        Google-backed call,
+      - reports the missing connection as a setup step, not a failure, and offers the connect flow
+        (presenting a connect URL for the owner to open in their own browser is acceptable and
+        good),
+      - answers the "which locations does the site already have" part with a Wix-only location
+        query, correctly reporting that none are imported yet, and
+      - explains what the import flow will look like once connected: choose a Business Profile
+        account, review unimported locations, confirm, then bulk create with per-item results.
+
+      Fail if the agent retries connection-gated calls after a connection-not-found failure,
+      invents or hardcodes a Business Profile account ID or location ID, claims any location was
+      imported, treats the missing connection as an unrecoverable error, asks the user for a site
+      ID, or presents the never-connected state as if the import partially succeeded.
+  - type: llm_judge
+    minScore: 7
+    maxTokens: 2048
+    prompt: |
+      Rate how smoothly the Wix MCP let the agent fulfill the location-import request. Examine the
+      tool-call trace. Score 0-10 (10 = direct: connection state established once, one Wix-only
+      location query for the existing-locations answer, a clear setup handoff, no wasted calls or
+      errors). Penalize and list any repeated call into a connection-not-found failure, guessed
+      account or location ID, redundant probing call, guessed request shape, or recovered non-2xx
+      error that clearer docs would avoid. For each problem, name the likely skill, MCP, or docs
+      gap.
+      Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
+siteSetup:
+  mode: template
+  templateId: blank-editor

--- a/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
+++ b/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
@@ -7,11 +7,11 @@ description: >-
 triggerPrompt: >-
   Import my Google Business Profile locations into my Wix site, and show me which locations the
   site already has.
-tags: [aria, seo]
+tags: [seo]
 assertions:
   - tool: ReadFullDocsArticle
     params:
-      articleUrl: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/gbplocation-v1/skills/manage-google-business-profile-locations-for-a-wix-site
+      articleUrl: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/skills/manage-google-business-profile-locations-for-a-wix-site
   - type: llm_judge
     minScore: 7
     maxTokens: 2048

--- a/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
+++ b/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
@@ -21,6 +21,11 @@ assertions:
       Google connection (status NEVER_CONNECTED) and no imported locations, and no human is
       available to complete Google's browser authorization during this run.
 
+      The REST methods take no siteId field, but the MCP may require a selected site for its
+      authorization context. If no valid site is already in context, listing sites once and
+      auto-selecting the only available site is correct and is not a failure. The agent must never
+      invent a site ID or ask the user to type one.
+
       Pass if the agent:
       - establishes the connection state up front — either by reading the connection status or by
         correctly interpreting a connection-not-found precondition failure on the first
@@ -44,6 +49,8 @@ assertions:
       Rate how smoothly the Wix MCP let the agent fulfill the location-import request. Examine the
       tool-call trace. Score 0-10 (10 = direct: connection state established once, one Wix-only
       location query for the existing-locations answer, a clear setup handoff, and no wasted calls).
+      A site-list call used once to resolve genuinely missing site context is necessary setup, not
+      friction.
       On this fresh site, a single CONNECTION_NOT_FOUND or equivalent not-found response used to
       establish the expected unconnected state is not a friction if the agent does not retry that
       call. Penalize and list any repeated call into that failure, Google-backed location call or

--- a/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
+++ b/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
@@ -26,37 +26,42 @@ assertions:
       auto-selecting the only available site is correct and is not a failure. The agent must never
       invent a site ID or ask the user to type one.
 
-      Pass if the agent:
-      - establishes the connection state up front — either by reading the connection status or by
-        correctly interpreting a connection-not-found precondition failure on the first
-        Google-backed call,
-      - reports the missing connection as a setup step, not a failure, and offers the connect flow
-        (presenting a connect URL for the owner to open in their own browser is acceptable and
-        good),
-      - answers the "which locations does the site already have" part with a Wix-only location
-        query, correctly reporting that none are imported yet, and
-      - explains what the import flow will look like once connected: choose a Business Profile
-        account, review unimported locations, confirm, then bulk create with per-item results.
+      Two outcomes are passable, depending on whether the provisioned site's GBP APIs are available
+      to the current Wix identity:
+
+      - **The connection state is readable.** Pass if the agent establishes the connection state up
+        front, reports NEVER_CONNECTED (or a connection-not-found response) as a setup step, answers
+        the "which locations" part with one Wix-only location query, correctly reports that none are
+        imported, and explains the later import flow: choose an account, review unimported
+        locations, confirm, then bulk create with per-item results.
+      - **The status or Wix-only location query returns 403/PERMISSION_DENIED.** Pass if the agent
+        treats that as a terminal authorization blocker, clearly explains that it cannot inspect the
+        site's GBP state with the current Wix identity, and stops immediately. In this branch it
+        must not claim the site has no locations, because the read did not succeed.
 
       Fail if the agent retries connection-gated calls after a connection-not-found failure,
       invents or hardcodes a Business Profile account ID or location ID, claims any location was
       imported, treats the missing connection as an unrecoverable error, asks the user for a site
-      ID, or presents the never-connected state as if the import partially succeeded.
+      ID, presents the never-connected state as if the import partially succeeded, or makes any
+      tool call after a 403/PERMISSION_DENIED result.
   - type: llm_judge
     minScore: 7
     maxTokens: 2048
     prompt: |
       Rate how smoothly the Wix MCP let the agent fulfill the location-import request. Examine the
-      tool-call trace. Score 0-10 (10 = direct: connection state established once, one Wix-only
-      location query for the existing-locations answer, a clear setup handoff, and no wasted calls).
+      tool-call trace. Score 0-10 (10 = either a direct readable-state path — connection state once,
+      one Wix-only location query, clear setup handoff — or one 403/PERMISSION_DENIED followed by a
+      clear blocker explanation and no further tool calls).
       A site-list call used once to resolve genuinely missing site context is necessary setup, not
-      friction.
+      friction. A single 403/PERMISSION_DENIED from the status or Wix-only location query is an
+      expected authorization blocker, not friction, only when the agent explains it and stops.
       On this fresh site, a single CONNECTION_NOT_FOUND or equivalent not-found response used to
       establish the expected unconnected state is not a friction if the agent does not retry that
-      call. Penalize and list any repeated call into that failure, Google-backed location call or
-      documentation search after the unconnected state is known, guessed account or location ID,
-      redundant probing call, guessed request shape, or other recovered non-2xx error that clearer
-      docs would avoid. For each problem, name the likely skill, MCP, or docs gap.
+      call. Penalize and list any call or documentation search after a terminal denial, repeated call
+      into a connection-not-found failure, Google-backed location call or documentation search after
+      the unconnected state is known, guessed account or location ID, redundant probing call, guessed
+      request shape, or other recovered non-2xx error that clearer docs would avoid. For each
+      problem, name the likely skill, MCP, or docs gap.
       Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
 siteSetup:
   mode: template

--- a/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
+++ b/yaml/wix-manage-evals/google-business-profile/manage-google-business-profile-locations.yml
@@ -43,11 +43,13 @@ assertions:
     prompt: |
       Rate how smoothly the Wix MCP let the agent fulfill the location-import request. Examine the
       tool-call trace. Score 0-10 (10 = direct: connection state established once, one Wix-only
-      location query for the existing-locations answer, a clear setup handoff, no wasted calls or
-      errors). Penalize and list any repeated call into a connection-not-found failure, guessed
-      account or location ID, redundant probing call, guessed request shape, or recovered non-2xx
-      error that clearer docs would avoid. For each problem, name the likely skill, MCP, or docs
-      gap.
+      location query for the existing-locations answer, a clear setup handoff, and no wasted calls).
+      On this fresh site, a single CONNECTION_NOT_FOUND or equivalent not-found response used to
+      establish the expected unconnected state is not a friction if the agent does not retry that
+      call. Penalize and list any repeated call into that failure, Google-backed location call or
+      documentation search after the unconnected state is known, guessed account or location ID,
+      redundant probing call, guessed request shape, or other recovered non-2xx error that clearer
+      docs would avoid. For each problem, name the likely skill, MCP, or docs gap.
       Return ONLY {"score":<0-10>,"reason":"<terse list of frictions and suspected gap, or 'clean path' if none>"}.
 siteSetup:
   mode: template

--- a/yaml/wix-manage/google-business-profile/documentation.yaml
+++ b/yaml/wix-manage/google-business-profile/documentation.yaml
@@ -1,0 +1,12 @@
+apiDoc:
+  title: Wix Google Business Profile Management Recipes
+
+  docs:
+    - file: ../../../skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
+      title: Connect a Wix Site to Google Business Profile
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/connection-v1
+      tags: [aria, seo]
+    - file: ../../../skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
+      title: Manage Google Business Profile Locations for a Wix Site
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/gbplocation-v1
+      tags: [aria, seo]

--- a/yaml/wix-manage/google-business-profile/documentation.yaml
+++ b/yaml/wix-manage/google-business-profile/documentation.yaml
@@ -4,9 +4,9 @@ apiDoc:
   docs:
     - file: ../../../skills/wix-manage/references/google-business-profile/connect-google-business-profile.md
       title: Connect a Wix Site to Google Business Profile
-      docsEntry: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/connection-v1
-      tags: [aria, seo]
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/google-business-profile
+      tags: [seo]
     - file: ../../../skills/wix-manage/references/google-business-profile/manage-google-business-profile-locations.md
       title: Manage Google Business Profile Locations for a Wix Site
-      docsEntry: https://dev.wix.com/docs/api-reference/business-management/google-business-profile/gbplocation-v1
-      tags: [aria, seo]
+      docsEntry: https://dev.wix.com/docs/api-reference/business-management/google-business-profile
+      tags: [seo]


### PR DESCRIPTION
Adds Business Manager Aria recipes for the public **Google Business Profile** APIs [WIXSEO-3914], following the pattern of the accessibility recipe (#834).

## What

Two recipes under a new `google-business-profile` area:

- **Connect a Wix Site to Google Business Profile** — connection status check (`NEVER_CONNECTED` / `VALID` / `NEEDS_RECONNECT`), the connect flow through a single-use 15-minute connect URL the site owner opens in their own browser, the warnings before any reconnect that permanently removes imported locations, and disconnect. Grounded in the [Connection API docs](https://dev.wix.com/docs/rest/business-management/google-business-profile/connection-v1).
- **Manage Google Business Profile Locations for a Wix Site** — connection precondition, the import flow (accounts → unimported locations → bulk create with per-item results), Wix-only vs Google-hydrated reads, routing each write to the correct side (Wix row vs Google listing), the two different deletes, Voice of Merchant, and Google's shared ~10-edits/min budget. Grounded in the [Locations API docs](https://dev.wix.com/docs/rest/business-management/google-business-profile/gbplocation-v1).

Both APIs are `PUBLIC` + `BETA` and live on dev.wix.com (all referenced method pages verified returning 200). The recipes deliberately exclude the bulk media-upload queue — its doc pages are not published yet.

## Files (per the contribution guide)

- `skills/wix-manage/references/google-business-profile/*.md` — the two recipes
- `skills/wix-manage/SKILL.md` — new **Google Business Profile** section + `google-business-profile` added to the routes list
- `yaml/wix-manage/google-business-profile/documentation.yaml` — registration, `tags: [aria, seo]`
- `yaml/wix-manage-evals/google-business-profile/*.yml` — one EvalForge scenario per recipe (fresh `blank-editor` site each, so the never-connected branch is deterministic; no human can complete Google OAuth in an eval, so the scenarios assert the correct handoff behavior)

## Notes for reviewers

- Tags: used existing EvalForge tags `[aria, seo]` (the tag gate rejects unregistered tags). If a dedicated `google-business-profile` tag gets registered in EvalForge, happy to switch.
- The connect eval intentionally penalizes an agent that polls the connection status indefinitely or fetches the connect URL itself — the URL is single-use and for a human browser.
