### PR TITLE
feat: wix-headless-fast — shipped-code skill for SDK storefronts (stores v1)

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: wix-headless-fast
+description: "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from recipes. Each Wix business vertical ships a typed, framework-agnostic React core (data layer returning plain DTOs, hooks, headless components) plus an Astro overlay (SSR pages with owner-editable SEO pre-wired) and a build-time REST seed script — the agent scaffolds via the Wix CLI, deploys the shipped code, seeds the backend, builds only the brand layer (home, layout, theme, copy), and releases to Wix hosting. Works on Wix-managed Astro (ambient auth, the default) and on any React-based project (Vite, non-Astro) over the public OAuth client id. Verticals: stores/storefront (products, categories, variants, cart, hosted checkout). Triggers: build me a store fast, storefront with shipped components, wix headless fast, connect Wix Stores with ready-made SDK code."
+---
+
+# Wix Headless Fast
+
+Build a Wix Headless site by **deploying shipped code, not authoring it**. Where `wix-headless`
+hands the agent recipes to code from, this skill ships the integration itself — a typed data
+layer, hooks, components, pages, and a seed script that are already correct — and the agent's
+job narrows to brand, layout, copy, and wiring. The decisions live in the code; don't
+re-litigate them.
+
+## Relationship to sibling skills
+
+| Skill | Use when |
+|---|---|
+| **wix-headless-fast** (this) | A supported vertical fits the request and the frontend is Astro or React — the fast path. |
+| `wix-headless` | A vertical this skill doesn't ship yet, a non-React frontend, backend-only runs, or stripe/self-managed project types. |
+| `wix-vibe-headless` | Client-only REST over a `WIX_CLIENT_ID` inside a vibe platform (Base44 etc.) — no SDK, no CLI. |
+
+## The model
+
+- **Shipped code is the implementation.** Every vertical ships under `references/<vertical>/`:
+  - `app/` — the framework-agnostic core (TypeScript): a data layer that returns **plain,
+    serializable DTOs** (images resolved to https URLs, prices pre-formatted), React hooks, and
+    routing-free headless components. Works in Astro islands, Vite SPAs, and Next.
+  - `app-astro/` — a thin Astro overlay: SSR pages that fetch via the core and pass DTOs to
+    islands, with owner-editable item-page SEO pre-wired.
+  - `seed/` — a build-time REST seed script (plain-data plan in, created content out) plus its
+    `SEED.md` contract.
+  - `INSTRUCTIONS.md` — the vertical's playbook: file map, what you build, hard rules, verify.
+- **One auth seam.** All shipped code calls Wix through `src/wix/sdk.ts`: on Wix-managed Astro
+  auth is ambient (no client, no id); on any other React setup the same file runs a manual
+  visitor client off the public client id in `src/wix/config.ts`. The deploy step configures
+  this — nothing to wire by hand.
+- **Copy as-is; extend by calling.** Wire the exported hooks/components/functions; never
+  rewrite their internals, re-route them through API routes, or re-derive a request shape. For
+  a genuine gap, add a new function in the data layer (or consult the `wix-docs` skill for the
+  API contract) — never edit the shipped ones.
+- **Never mock, fail loudly, purchases via Wix.** Live data or an honest empty state; surfaced
+  errors, not swallowed ones; checkout/purchase always through the Wix redirect session.
+
+## The run
+
+1. **Resolve the stack.** Default is **Wix-managed Astro** — take it unless the user names a
+   different React framework or the directory already holds a non-Astro React project. A
+   non-React frontend is out of scope → `wix-headless`.
+2. **Scaffold / connect (managed).** Requires Node ≥ 20.11 and a logged-in Wix CLI
+   (`npx @wix/cli@latest whoami`; login via the device-code flow — surface the URL+code, never
+   read tokens into context). Then:
+   - empty directory → `CI=1 npm create @wix/new@latest -- headless --folder-name <name>
+     --business-name "<Brand>" --site-template --skip-install --no-publish`, then work inside
+     the created folder (install deps with `npm install --ignore-scripts`);
+   - existing project not yet on Wix → `CI=1 npm create @wix/new@latest init` in place;
+   - already has `wix.config.json` → neither; it's an iterate run.
+3. **Deploy the shipped code** (from the project root):
+   `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` (react stack: add
+   `--client-id` if there is no `wix.config.json` to read the public id from). Re-running is
+   safe — it fills in missing files, never overwrites edits.
+4. **Seed the backend** per the vertical's `seed/SEED.md` — write a plain-data plan from the
+   brief and run the seed script. It installs the vertical's Wix app itself. Seeding is
+   **additive**: never delete or overwrite existing content; if a cleanup seems needed, ask.
+5. **Build the brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
+   header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
+   before touching any shipped file.
+6. **Release once, at the very end** (managed): `npx @wix/cli@latest build` then
+   `npx @wix/cli@latest release`. Don't build+release mid-flow; backend content is fetched at
+   runtime, so a re-release never "refreshes" seeded data. Close with the live URL and the
+   dashboard link `https://manage.wix.com/dashboard/<siteId>`.
+
+Don't smoke-test with a dev server unless the user explicitly asks to verify — correctness
+comes from the shipped code, and real errors surface at build/release.
+
+## Verticals
+
+| The user wants… | Vertical | Playbook |
+|---|---|---|
+| Online store: products, categories, variants, cart, checkout | **storefront** | `references/storefront/INSTRUCTIONS.md` |
+
+A request that doesn't match a shipped vertical isn't this skill's fast path — route it to
+`wix-headless` rather than improvising an unshipped vertical here.
+
+## Adding a vertical (structure contract)
+
+New verticals follow the same layout — the deploy script discovers them automatically (any
+`references/<name>/app/` directory is a vertical):
+
+```
+references/<vertical>/
+  INSTRUCTIONS.md      # playbook: file map, wiring per stack, what you build, hard rules, verify
+  app/                 # framework-agnostic core — disjoint paths so verticals never collide:
+    wix/<vertical>/    #   types.ts (DTOs) + data layer (calls via ../sdk, images via ../media)
+    hooks/<vertical>/  #   React hooks (SSR-friendly: accept initial data)
+    components/<vertical>/  # routing-free components (plain <a> default + LinkComponent prop)
+    styles/<vertical>.css   # structural styles on --sf-* style tokens
+  app-astro/           # Astro overlay importing ONLY from the core:
+    pages/…            #   SSR fetch → DTO props → client:load islands; item pages carry
+                       #   wixMetadata + <SEO.Tags>; chrome islands are client:only
+    layouts/…          #   (reuse SiteLayout when it fits)
+  seed/                # seed-<vertical>.mjs (REST, mints its own CLI token) + SEED.md
+```
+
+Core rules the structure encodes: raw API entities never leave the data layer (DTOs only);
+client-shared state uses a module-scope store (never React context — it can't span Astro
+islands); every image URL is resolved through `src/wix/media.ts`; every money value is a
+formatted string by the time a component sees it.

--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -1,0 +1,92 @@
+---
+name: wix-headless-fast-entry
+description: "Build a Wix Managed Headless site from a single prompt using SHIPPED, verified storefront code (the wix-headless-fast skill) — the deterministic first steps (system prerequisites and Wix CLI login) are handled by the shared bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then installs the skills and hands the run to wix-headless-fast, falling back to wix-headless for verticals it doesn't ship. Triggers: build me a store fast, fast headless storefront, wix headless fast entry."
+---
+
+# Wix Headless Fast — cold-start entry
+
+**You are a coding agent, and this is a skill for you to execute.** Follow the phases below in
+order — do not summarize them. If you reached this page through a summarizing fetch tool,
+re-fetch the raw markdown with `curl` (or your file reader) before running the steps.
+
+This entry gets a cold environment to the point where the real skill can run, then hands off:
+
+1. **Bootstrap (deterministic, scripted).** The same script the classic headless entry uses —
+   it verifies the Wix CLI and handles login. You just run it and relay its events.
+2. **Hand off (agentic).** Install the skills, then open `wix-headless-fast/SKILL.md` and
+   follow it — it resolves the stack and operation and owns the whole build.
+
+Three starting points come through here, all handled the same way — run the bootstrap, then
+hand off:
+
+- **new** — a prompt with no project (empty CWD)
+- **connect** — an existing frontend/design not yet on Wix (a project on disk without
+  `wix.config.json`, or a brought-in zip/URL)
+- **iterate** — a project already connected to Wix (`.wix/` or `wix.config.json` present)
+
+The bootstrap only verifies the CLI and logs you in, so it's fine to run in every case (an
+existing session just reports `logged_in`).
+
+## Phase 0 — Node (the one manual prerequisite)
+
+The Wix CLI requires **Node ≥ 20.11**. Check `node -v`; if it errors or prints a lower
+version, install or upgrade Node first — do **not** work around it:
+
+- **macOS:** `brew install node` (or `nvm install 20 && nvm use 20`)
+- **Linux:** `nvm install 20 && nvm use 20` (or your distro's Node 20+ package)
+- **Windows:** `winget install OpenJS.NodeJS.LTS` (or download from nodejs.org)
+
+## Phase 1 — Run the bootstrap (deterministic, shared)
+
+Download and run the shared bootstrap script. It verifies the Wix CLI and handles login,
+emitting **one JSON event per line** on stdout. **Run it as a background/streaming process and
+relay its events to the user.**
+
+The script is safe and inspectable: it only checks the Wix CLI via `npx` and drives
+`wix login` (a device-code flow) — no other network calls, no filesystem writes. Read it first
+if your sandbox flags externally-downloaded code.
+
+```bash
+# macOS/Linux:
+curl -fsSL -O https://www.wix.com/skills/headless/entry/bootstrap.mjs
+# Windows PowerShell:
+iwr https://www.wix.com/skills/headless/entry/bootstrap.mjs -OutFile bootstrap.mjs
+
+node bootstrap.mjs
+```
+
+### Relay these events
+
+| Event | What to do |
+|---|---|
+| `cli_ok` | Wix CLI reachable — continue. |
+| `awaiting_user` (`verificationUri`, `userCode`) | Show the URL and code in plain prose; wait for the user to finish the login in their browser. |
+| `logged_in` / `success` | Login done — continue. |
+| `cli_unreachable` / `login_failed` (with `detail`) | Stop and show the user the `detail`. **Do not** improvise a parallel setup by hand. |
+
+## Phase 2 — Install the skills and hand off
+
+Install the Wix skills (`CI=1` forces plain non-interactive CLI output — keep it on every Wix
+CLI command):
+
+```bash
+CI=1 npx skills@latest add wix/skills --yes
+```
+
+The skills land in `.agents/skills/` — including both `wix-headless-fast` and `wix-headless`.
+
+Then route by what the request needs:
+
+- The request matches a vertical `wix-headless-fast` ships (see its SKILL.md § Verticals —
+  currently **storefront**: products, categories, variants, cart, checkout) → **open
+  `wix-headless-fast/SKILL.md` and follow it.** It owns the rest of the run: resolve the stack,
+  scaffold, deploy the shipped code, seed, build the brand layer, release.
+- The request needs a vertical it doesn't ship, or a non-React frontend → **open
+  `wix-headless/SKILL.md` instead** and follow that skill's full flow.
+
+Either way:
+
+- **Don't** scaffold, install apps, or seed by hand here — the skill you hand off to does all
+  of that. This entry stops at *logged in*.
+- You're already authenticated from Phase 1, so the skill's CLI auth step will pass without
+  prompting again.

--- a/skills/wix-headless-fast/install/deploy.mjs
+++ b/skills/wix-headless-fast/install/deploy.mjs
@@ -1,0 +1,93 @@
+// Deploy the shipped code into the project. Run from the PROJECT ROOT:
+//
+//   node <SKILL_ROOT>/install/deploy.mjs <vertical> [<vertical> …] --stack astro|react [--client-id <id>]
+//
+//   --stack astro  (default) — copies each vertical's framework-agnostic core (app/) AND its
+//                  Astro overlay (app-astro/: pages, layouts) into src/. Ambient auth: no
+//                  client id is needed or written.
+//   --stack react  — copies only the core (app/) into src/, and writes the public OAuth
+//                  client id into src/wix/config.ts (pass --client-id, or it's read from
+//                  wix.config.json's appId when present).
+//
+// ONE mechanism: recursive copy with force:false — only files that AREN'T there yet are
+// written, so a re-run restores missing files without clobbering edits, and a later call can
+// add a vertical safely. Verticals ship at disjoint paths (src/wix/<vertical>/,
+// src/components/<vertical>/, …), so they never collide with each other.
+import { cpSync, existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SKILL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REF = join(SKILL_ROOT, "references");
+const PROJECT = process.cwd();
+const SRC = join(PROJECT, "src");
+const CONFIG_TS = join(SRC, "wix", "config.ts");
+
+// The vertical registry: every directory under references/ that ships an app/ is a vertical.
+const VERTICALS = readdirSync(REF, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && existsSync(join(REF, d.name, "app")) && d.name !== "shared")
+  .map((d) => d.name);
+
+const COPY = { recursive: true, force: false, errorOnExist: false };
+
+// ---- args ---------------------------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i !== -1 && argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[i + 1] : null;
+};
+const stack = flag("stack") ?? "astro";
+const clientIdFlag = flag("client-id");
+const flagArgs = new Set(["--stack", "--client-id", stack, clientIdFlag].filter(Boolean));
+const requested = [...new Set(argv.filter((a) => !flagArgs.has(a)))];
+
+const result = { stack, verticals: [], skillRoot: SKILL_ROOT };
+
+if (!["astro", "react"].includes(stack)) {
+  console.log(JSON.stringify({ error: `unknown --stack "${stack}" — expected astro|react` }));
+  process.exit(1);
+}
+
+// ---- copy ---------------------------------------------------------------------------------------
+// Shared core — always.
+cpSync(join(REF, "shared", "app"), SRC, COPY);
+
+const unknown = requested.filter((v) => !VERTICALS.includes(v));
+for (const vertical of requested.filter((v) => VERTICALS.includes(v))) {
+  cpSync(join(REF, vertical, "app"), SRC, COPY);
+  if (stack === "astro" && existsSync(join(REF, vertical, "app-astro"))) {
+    cpSync(join(REF, vertical, "app-astro"), SRC, COPY);
+  }
+  result.verticals.push(vertical);
+}
+
+if (unknown.length) {
+  result.error = `unknown vertical(s) ${unknown.map((v) => `"${v}"`).join(", ")} — available: ${VERTICALS.join(", ")}`;
+}
+if (!requested.length) {
+  result.note = `no vertical given — deployed the shared core only. Available: ${VERTICALS.join(", ")}`;
+}
+
+// ---- client id (react stack only) ---------------------------------------------------------------
+// On astro the ambient integration authenticates — WIX_CLIENT_ID stays null.
+if (stack === "react") {
+  let clientId = clientIdFlag;
+  if (!clientId && existsSync(join(PROJECT, "wix.config.json"))) {
+    // On a Wix-managed project the public OAuth client id IS the appId.
+    clientId = JSON.parse(readFileSync(join(PROJECT, "wix.config.json"), "utf8")).appId ?? null;
+  }
+  if (clientId) {
+    const current = readFileSync(CONFIG_TS, "utf8");
+    // A non-null id already set wins; only fill the shipped null placeholder.
+    if (/WIX_CLIENT_ID:\s*string\s*\|\s*null\s*=\s*null/.test(current)) {
+      writeFileSync(CONFIG_TS, current.replace(/WIX_CLIENT_ID:\s*string\s*\|\s*null\s*=\s*null/, `WIX_CLIENT_ID: string | null = "${clientId}"`));
+      result.clientId = "written";
+    } else {
+      result.clientId = "already_set";
+    }
+  } else {
+    result.clientId = "missing — pass --client-id (react stack needs the public OAuth client id)";
+  }
+}
+
+console.log(JSON.stringify(result, null, 2));

--- a/skills/wix-headless-fast/references/shared/app/wix/config.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/config.ts
@@ -1,0 +1,9 @@
+// Wix connection config — written by the skill's deploy step (install/deploy.mjs).
+//
+// WIX_CLIENT_ID = null  → ambient auth (a Wix-managed Astro project: `@wix/astro` authenticates
+//                         every SDK call automatically; there is no client and nothing to set).
+// WIX_CLIENT_ID = "..." → manual visitor client (any other React setup): the public OAuth client id.
+//                         It is NOT a secret — it only mints anonymous visitor tokens — so
+//                         hardcoding and committing it is fine. On a Wix-managed non-Astro project
+//                         it equals the `appId` in wix.config.json.
+export const WIX_CLIENT_ID: string | null = null;

--- a/skills/wix-headless-fast/references/shared/app/wix/media.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/media.ts
@@ -1,0 +1,26 @@
+// Wix media resolution — define once, use on EVERY image render path. Copy as-is.
+//
+// SDK media fields come back either as an already-absolute https URL, or as a
+// `wix:image://v1/<hash>/<file>#originWidth=…` identifier that a browser cannot load
+// (ERR_UNKNOWN_URL_SCHEME). The wix:image:// form must go through the SDK media module;
+// never hand-build a static.wixstatic.com URL (wrong format → 403).
+import { media } from "@wix/sdk";
+
+type MediaLike =
+  | string
+  | null
+  | undefined
+  | { image?: string | null; url?: string | null };
+
+/** Resolve any Wix media value to a browser-loadable URL ("" when absent). */
+export function imgSrc(value: MediaLike, width = 600, height = 600): string {
+  const v =
+    typeof value === "object" && value !== null
+      ? (value.image ?? value.url ?? "")
+      : (value ?? "");
+  if (!v) return "";
+  if (typeof v === "string" && v.startsWith("wix:image://")) {
+    return media.getScaledToFillImageUrl(v, width, height, {});
+  }
+  return typeof v === "string" ? v : "";
+}

--- a/skills/wix-headless-fast/references/shared/app/wix/money.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/money.ts
@@ -1,0 +1,24 @@
+// Money formatting for API amounts that carry no formatted string. Copy as-is.
+//
+// Catalog prices come with a ready `formattedAmount` — use that directly. But eCom Cart V2
+// amounts are ConvertedMoney `{ amount, convertedAmount }` with NO formatted string, and the
+// currency lives on the cart, not on the money object. Never hardcode "$" or assume USD.
+export interface ConvertedMoneyLike {
+  amount?: string | null;
+  convertedAmount?: string | null;
+}
+
+/** Format a ConvertedMoney in the given currency, using the visitor's locale. */
+export function formatMoney(
+  money: ConvertedMoneyLike | null | undefined,
+  currencyCode: string | null | undefined,
+): string {
+  const value = money?.convertedAmount ?? money?.amount;
+  if (value == null || value === "") return "";
+  const currency = currencyCode || "USD";
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(Number(value));
+  } catch {
+    return `${value} ${currency}`;
+  }
+}

--- a/skills/wix-headless-fast/references/shared/app/wix/sdk.ts
+++ b/skills/wix-headless-fast/references/shared/app/wix/sdk.ts
@@ -1,0 +1,58 @@
+// The one auth seam for every Wix SDK call in this app. Copy as-is; do not rewrite.
+//
+// Two modes, switched by WIX_CLIENT_ID in ./config:
+//   null (ambient)  — a Wix-managed Astro project: `@wix/astro` authenticates raw SDK module
+//                     calls automatically, server-side AND in client islands. `wixModule()`
+//                     returns the module untouched.
+//   string (manual) — any other React setup (Vite SPA, non-Astro): one shared client is built
+//                     with OAuthStrategy, and `wixModule()` returns the module bound to it.
+//                     The strategy self-manages visitor tokens on every call (mints on first
+//                     use, renews on expiry) and persists them through the storage below.
+//
+// The visitor token IS the identity of the current cart / member session, so in manual mode
+// tokens persist to localStorage — never re-minted per load (a fresh anonymous mint is a NEW
+// visitor and silently empties the cart).
+import { createClient, OAuthStrategy, EMPTY_TOKENS } from "@wix/sdk";
+import type { TokenStorage, Tokens } from "@wix/sdk";
+import { WIX_CLIENT_ID } from "./config";
+
+const STORAGE_KEY = `wix-session-${WIX_CLIENT_ID ?? "ambient"}`;
+
+function browserTokenStorage(): TokenStorage {
+  return {
+    getTokens(): Tokens {
+      if (typeof window !== "undefined") {
+        try {
+          const raw = window.localStorage.getItem(STORAGE_KEY);
+          if (raw) return JSON.parse(raw) as Tokens;
+        } catch {
+          /* disabled/corrupt storage — fall through to empty */
+        }
+      }
+      return EMPTY_TOKENS;
+    },
+    setTokens(tokens: Tokens): void {
+      if (typeof window === "undefined") return;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens));
+      } catch {
+        /* storage full/disabled — the session just won't survive a reload */
+      }
+    },
+  };
+}
+
+const client = WIX_CLIENT_ID
+  ? createClient({ auth: OAuthStrategy({ clientId: WIX_CLIENT_ID, tokenStorage: browserTokenStorage() }) })
+  : null;
+
+/**
+ * Bind an SDK module to this app's auth. Usage (identical in both modes):
+ *   import { productsV3 } from "@wix/stores";
+ *   const products = wixModule(productsV3);
+ *   await products.queryProducts(...)
+ */
+export function wixModule<T>(module: T): T {
+  // The cast bridges the SDK's internal Descriptors constraint; the in/out type is identical.
+  return client ? (client.use(module as unknown as Record<string, unknown>) as unknown as T) : module;
+}

--- a/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
@@ -1,0 +1,114 @@
+# Storefront — playbook
+
+A complete Wix Stores storefront ships as files: catalog + variants + cart + Wix-hosted
+checkout, typed end-to-end. You wire routes and build the brand layer; you don't write
+commerce code.
+
+## The file map (deployed into `src/` — you don't need to open these)
+
+| file | what it is |
+|---|---|
+| `wix/config.ts` · `wix/sdk.ts` | shared auth seam (deploy configures it — nothing to set by hand) |
+| `wix/media.ts` · `wix/money.ts` | `imgSrc()` / `formatMoney()` — already used by everything shipped |
+| `wix/storefront/types.ts` | the DTOs: `ProductSummary`, `ProductDetail`, `Cart`, `Category`… — the shapes your own UI consumes |
+| `wix/storefront/catalog.ts` | `fetchProducts`, `fetchProductsByCategory`, `fetchProductBySlug`, `fetchCategories`, `resolveVariant` |
+| `wix/storefront/cart.ts` | `addToCart`, `fetchCart`, `updateQuantity`, `removeLine`, `checkoutUrl` (Cart V2) |
+| `wix/storefront/cart-store.ts` | shared cart state (module store — spans Astro islands) |
+| `hooks/storefront/useCart.ts` | cart state + actions for any React component |
+| `hooks/storefront/useShop.ts` | listing + live category filter (accepts SSR `initial` data) |
+| `hooks/storefront/useProductDetail.ts` | option selection → variant resolution → add-to-cart |
+| `components/storefront/ShopView.tsx` | full listing surface: category bar + grid — mount as-is |
+| `components/storefront/ProductDetailView.tsx` | full PDP surface: gallery, picker, qty, add — mount as-is |
+| `components/storefront/CartButton.tsx` · `CartDrawer.tsx` | header badge + slide-over cart — mount as-is (drawer once per page) |
+| `components/storefront/VariantPicker.tsx` | swatches/pills/modifiers — used by ProductDetailView |
+| `components/storefront/ProductCard.tsx` · `ProductGrid.tsx` | **reference** tile + grid — correct as-is; designing your own on the same DTOs is encouraged (pass `CardComponent` to ShopView/ProductGrid) |
+| `styles/storefront.css` | structural styles for the above, themed by `--sf-*` tokens |
+
+Astro stack additionally gets:
+
+| file | what it is |
+|---|---|
+| `layouts/SiteLayout.astro` | the site chrome — **this is yours to theme**: tokens, header, footer. Keep the `<slot name="seo-tags" />`, the css import, and the CartButton/CartDrawer mounts |
+| `pages/shop.astro` | SSR listing → ShopView island — wire as-is |
+| `pages/products/[slug].astro` | SSR PDP with owner-editable SEO (`wixMetadata` + `<SEO.Tags>`) — wire as-is |
+
+## What you build
+
+The **home page**, the **layout/branding** (tokens in `SiteLayout.astro`, header, footer), and
+the **copy** — composing shipped pieces. A featured strip on home is `fetchProducts()` in
+frontmatter + `<ProductGrid client:load products={…} />`; nav is a link to `/shop` plus the
+shipped `CartButton`. Style everything you add from the same tokens.
+
+### Wiring — Astro (default)
+
+Deploy already placed pages, layout, and islands. Remaining work: build `pages/index.astro`
+(home) on `SiteLayout`, theme the tokens/header/footer, adjust copy. Every island mounts with
+`client:load` when it renders primary content with SSR props, `client:only="react"` when it
+reads browser-only state (the shipped mounts already do this correctly).
+
+### Wiring — React SPA (Vite etc.)
+
+No pages ship — write thin route wrappers in the project's router:
+
+```tsx
+import "./styles/storefront.css";           // once, at the app entry
+import ShopView from "./components/storefront/ShopView";
+import ProductDetailView from "./components/storefront/ProductDetailView";
+import CartButton from "./components/storefront/CartButton";
+import CartDrawer from "./components/storefront/CartDrawer";
+import { Link, useParams } from "react-router-dom";
+
+const AppLink = ({ href, className, children }) => <Link to={href} className={className}>{children}</Link>;
+
+// routes: /shop → <ShopView LinkComponent={AppLink} />
+//         /products/:slug → <ProductDetailView slug={useParams().slug!} />
+// layout: <CartButton /> in the header; <CartDrawer /> mounted once.
+```
+
+Components fetch client-side when no `initial` props are passed. The deploy step wrote the
+public client id into `wix/config.ts`; nothing else to configure.
+
+## Hard rules
+
+- Wire the shipped exports as-is; never rewrite their internals or re-derive a request shape.
+  Extend by calling the exports or adding a new function in `wix/storefront/` for a genuine gap
+  (API contracts: the `wix-docs` skill).
+- Don't wrap shipped calls in your own API routes — they run client-side by design. A backend
+  route is only for a genuinely privileged (elevated) read, which nothing here needs.
+- Theme via the tokens (`SiteLayout` / `--sf-*`), never by restyling shipped component markup
+  or adding a parallel theme file.
+- Checkout only through the shipped cart (`checkout()` / `checkoutUrl()`) — never a hand-built
+  checkout URL.
+- Live data or the shipped empty state — never mock products, prices, reviews, or counts.
+- On the PDP, selection→cart goes through `useProductDetail` — never add a product with
+  options by picking `variants[0]`.
+
+## Point the user to their dashboard
+
+Content editing happens in the Wix dashboard — give the owner these links (substitute the
+`siteId` from `wix.config.json`):
+
+- Products — `https://manage.wix.com/dashboard/{siteId}/wix-stores/products`
+- Categories — `https://manage.wix.com/dashboard/{siteId}/wix-stores/categories/list`
+
+Real payments additionally need a premium plan + a connected payment method (dashboard) —
+mention it, don't treat it as a code failure.
+
+## Seeding
+
+Per `seed/SEED.md` — a plain-data `plan.json` into `seed-store.mjs`, run from the project
+root. Independent of the frontend work; seed a catalog that exercises the UI (≥1 product with
+a color option, ≥1 on sale) unless the brief says otherwise.
+
+## Verify (before declaring done)
+
+- [ ] `/shop` renders live products SSR (view-source shows product names) with the category
+      bar when categories exist; empty catalog shows the shipped empty state.
+- [ ] A product with options: choices render (color = swatches), add is disabled until every
+      option is picked, and the resolved variant's price shows.
+- [ ] Cart: add / quantity ± / remove work; badge count is live; subtotal shows; cart survives
+      a reload (same visitor token).
+- [ ] Checkout button redirects to Wix-hosted checkout.
+- [ ] PDP view-source carries the SEO tags (Astro) and a sale product shows the strikethrough.
+- [ ] Home/header/footer are yours, themed via tokens; shipped files unedited.
+- [ ] Dashboard links handed to the owner.

--- a/skills/wix-headless-fast/references/storefront/app-astro/layouts/SiteLayout.astro
+++ b/skills/wix-headless-fast/references/storefront/app-astro/layouts/SiteLayout.astro
@@ -1,0 +1,84 @@
+---
+// The site chrome for every storefront page — THIS is the file you theme and brand.
+// Replace the token values, the header, and the footer with the site's own design; keep:
+//   - the <slot name="seo-tags" /> in <head> (the product page's owner-editable SEO lands there)
+//   - the storefront.css import (shipped component styles, themed by the tokens below)
+//   - one <CartButton> in the header and one <CartDrawer> per page (both client:only —
+//     they read browser cart state and must not server-render)
+import CartButton from "../components/storefront/CartButton";
+import CartDrawer from "../components/storefront/CartDrawer";
+import "../styles/storefront.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+const { title, description } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <slot name="seo-tags" />
+    <style is:global>
+      /* Design tokens — theme the whole store here (shipped components read the --sf-* set,
+         which defaults to these). */
+      :root {
+        --surface: #ffffff;
+        --text: #16181d;
+        --muted: #6b7280;
+        --border: #e5e7eb;
+        --primary: #16181d;
+        --on-primary: #ffffff;
+        --radius: 8px;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: system-ui, sans-serif;
+        background: var(--surface);
+        color: var(--text);
+      }
+      a { color: inherit; }
+      .site-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--border);
+        position: sticky;
+        top: 0;
+        background: var(--surface);
+        z-index: 100;
+      }
+      .site-nav { display: flex; gap: 20px; align-items: center; font-size: 14px; }
+      .site-main { max-width: 1280px; margin: 0 auto; padding: 32px 24px 96px; }
+      .site-footer {
+        border-top: 1px solid var(--border);
+        padding: 32px 24px;
+        color: var(--muted);
+        font-size: 13px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <a href="/" style="font-weight: 700; text-decoration: none;">Brand Name</a>
+      <nav class="site-nav">
+        <a href="/shop">Shop</a>
+        <CartButton client:only="react" />
+      </nav>
+    </header>
+    <main class="site-main">
+      <slot />
+    </main>
+    <footer class="site-footer">© Brand Name</footer>
+    <CartDrawer client:only="react" />
+  </body>
+</html>

--- a/skills/wix-headless-fast/references/storefront/app-astro/pages/products/[slug].astro
+++ b/skills/wix-headless-fast/references/storefront/app-astro/pages/products/[slug].astro
@@ -1,0 +1,56 @@
+---
+// Product detail page — wire as-is; theme via SiteLayout's tokens.
+//
+// This is a Wix ITEM PAGE: the wixMetadata export + <SEO.Tags> below are what let the site
+// owner edit this page's title/description/OG in the dashboard, and register the route in
+// the sitemap. Keep all three SEO pieces when editing this file.
+import SiteLayout from "../../layouts/SiteLayout.astro";
+import ProductDetailView from "../../components/storefront/ProductDetailView";
+import { fetchProductBySlug } from "../../wix/storefront/catalog";
+import { WIX_APPS } from "@wix/essentials";
+import { SEO } from "@wix/seo/components";
+import { loadSEOTagsServiceConfig } from "@wix/seo/services";
+import { seoTags } from "@wix/seo";
+
+export const wixMetadata = {
+  appDefId: WIX_APPS.checkoutAndOrders.id,
+  pageIdentifier: WIX_APPS.checkoutAndOrders.productPageMetadata.pageIdentifier,
+  identifiers: {
+    slug: WIX_APPS.checkoutAndOrders.productPageMetadata.identifiers.handle,
+  },
+};
+
+const slug = Astro.params.slug!;
+
+// Behind Wix's proxy the request URL is the internal one — the real public page URL
+// arrives on x-wix-forwarded-url. The SEO service needs the public URL.
+const forwardedUrl = Astro.request.headers.get("x-wix-forwarded-url");
+const pageUrl =
+  forwardedUrl && URL.canParse(forwardedUrl) && /^https?:$/.test(new URL(forwardedUrl).protocol)
+    ? forwardedUrl
+    : Astro.url.href;
+
+let product = null;
+let seoTagsServiceConfig = null;
+try {
+  [product, seoTagsServiceConfig] = await Promise.all([
+    fetchProductBySlug(slug),
+    loadSEOTagsServiceConfig({
+      pageUrl,
+      itemType: seoTags.ItemType.STORES_PRODUCT,
+      itemData: { slug },
+    }),
+  ]);
+} catch {
+  // Guarded: an unhandled SSR throw truncates the response mid-stream.
+}
+
+if (!product) {
+  return new Response(null, { status: 404 });
+}
+---
+
+<SiteLayout title={product.name}>
+  <SEO.Tags seoTagsServiceConfig={seoTagsServiceConfig} slot="seo-tags" />
+  <ProductDetailView client:load initial={product} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/storefront/app-astro/pages/shop.astro
+++ b/skills/wix-headless-fast/references/storefront/app-astro/pages/shop.astro
@@ -1,0 +1,23 @@
+---
+// Shop listing — products and categories are fetched SERVER-SIDE (SEO) and handed to the
+// island as serialized DTO props; category switches then filter live on the client.
+// Wire as-is; theme via SiteLayout's tokens.
+import SiteLayout from "../layouts/SiteLayout.astro";
+import ShopView from "../components/storefront/ShopView";
+import { fetchProducts, fetchCategories } from "../wix/storefront/catalog";
+import type { Category, ProductSummary } from "../wix/storefront/types";
+
+let products: ProductSummary[] = [];
+let categories: Category[] = [];
+try {
+  [products, categories] = await Promise.all([fetchProducts(), fetchCategories()]);
+} catch {
+  // An unguarded SSR throw truncates the response mid-stream; the island renders the
+  // shipped empty state instead.
+}
+---
+
+<SiteLayout title="Shop">
+  <h1>Shop</h1>
+  <ShopView client:load initialProducts={products} initialCategories={categories} />
+</SiteLayout>

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/CartButton.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/CartButton.tsx
@@ -1,0 +1,17 @@
+// Header cart icon with a live count badge — mount once in your header, as-is.
+// Opens the CartDrawer (mount that once too, anywhere in the page).
+import { useCart } from "../../hooks/storefront/useCart";
+
+export default function CartButton() {
+  const { itemCount, openCart } = useCart();
+  return (
+    <button type="button" className="sf-cart-btn" aria-label={`Cart, ${itemCount} items`} onClick={openCart}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <path d="M16 10a4 4 0 01-8 0" />
+      </svg>
+      {itemCount > 0 && <span className="sf-cart-count">{itemCount}</span>}
+    </button>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/CartDrawer.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/CartDrawer.tsx
@@ -1,0 +1,94 @@
+// Slide-over cart with quantity stepper, remove, live subtotal, and Wix-hosted checkout.
+// Mount ONCE per page, as-is; opens via useCart().openCart() / CartButton.
+import { useCart } from "../../hooks/storefront/useCart";
+
+export default function CartDrawer() {
+  const { cart, open, closeCart, busy, error, updateQuantity, removeLine, checkout } = useCart();
+  if (!open) return null;
+  const lines = cart?.lines ?? [];
+
+  return (
+    <div className="sf-overlay" onClick={closeCart}>
+      <aside className="sf-drawer" role="dialog" aria-label="Cart" onClick={(e) => e.stopPropagation()}>
+        <div className="sf-drawer-head">
+          <span>Cart{cart && cart.itemCount > 0 ? ` (${cart.itemCount})` : ""}</span>
+          <button type="button" className="sf-drawer-close" aria-label="Close cart" onClick={closeCart}>
+            ×
+          </button>
+        </div>
+
+        <div className="sf-drawer-items">
+          {lines.length === 0 && <p className="sf-empty">Your cart is empty.</p>}
+          {lines.map((line) => (
+            <div className="sf-line" key={line.lineItemId}>
+              {line.imageUrl ? (
+                <img className="sf-line-img" src={line.imageUrl} alt="" loading="lazy" />
+              ) : (
+                <div className="sf-line-img" aria-hidden="true" />
+              )}
+              <div className="sf-line-body">
+                <p className="sf-line-name">{line.productName}</p>
+                {line.descriptionLines.map((d) => (
+                  <p className="sf-line-desc" key={d}>
+                    {d}
+                  </p>
+                ))}
+                {line.status !== "IN_STOCK" && (
+                  <p className="sf-line-warn">No longer available at this quantity</p>
+                )}
+                <div className="sf-qty">
+                  <button
+                    type="button"
+                    aria-label="Decrease quantity"
+                    disabled={busy || line.quantity <= 1}
+                    onClick={() => updateQuantity(line.lineItemId, line.quantity - 1).catch(() => {})}
+                  >
+                    −
+                  </button>
+                  <span>{line.quantity}</span>
+                  <button
+                    type="button"
+                    aria-label="Increase quantity"
+                    disabled={busy}
+                    onClick={() => updateQuantity(line.lineItemId, line.quantity + 1).catch(() => {})}
+                  >
+                    +
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  className="sf-remove"
+                  disabled={busy}
+                  onClick={() => removeLine(line.lineItemId).catch(() => {})}
+                >
+                  Remove
+                </button>
+              </div>
+              <p className="sf-line-price">{line.linePrice}</p>
+            </div>
+          ))}
+        </div>
+
+        {lines.length > 0 && (
+          <div className="sf-drawer-foot">
+            {cart?.subtotal && (
+              <div className="sf-subtotal">
+                <span>Subtotal</span>
+                <strong>{cart.subtotal}</strong>
+              </div>
+            )}
+            {error && <p className="sf-error">{error}</p>}
+            <button
+              type="button"
+              className="sf-btn sf-btn-full"
+              disabled={busy}
+              onClick={() => checkout().catch(() => {})}
+            >
+              {busy ? "One moment…" : "Checkout"}
+            </button>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/ProductCard.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/ProductCard.tsx
@@ -1,0 +1,72 @@
+// Grid tile — a REFERENCE implementation over the ProductSummary DTO. It's correct and
+// complete (badges, sale price, hover image, quick-add), but the layout is deliberately
+// plain: designing your own card that fits the brand is encouraged — build it on the same
+// ProductSummary fields and keep quick-add wired through useCart().
+import type { ComponentType, ReactNode } from "react";
+import type { ProductSummary } from "../../wix/storefront/types";
+import { useCart } from "../../hooks/storefront/useCart";
+
+export interface LinkLikeProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+export interface ProductCardProps {
+  product: ProductSummary;
+  /** Route pattern for detail pages; default matches the shipped /products/[slug] page. */
+  productHref?: (slug: string) => string;
+  /** Router-specific link (react-router Link, next/link); defaults to a plain <a>. */
+  LinkComponent?: ComponentType<LinkLikeProps>;
+}
+
+const PlainLink = ({ href, className, children }: LinkLikeProps) => (
+  <a href={href} className={className}>
+    {children}
+  </a>
+);
+
+export default function ProductCard({
+  product,
+  productHref = (slug) => `/products/${slug}`,
+  LinkComponent = PlainLink,
+}: ProductCardProps) {
+  const { addToCart, busy } = useCart();
+  const soldOut = product.availability === "OUT_OF_STOCK" && !product.preorder;
+  const priceLabel =
+    product.maxPrice && product.maxPrice !== product.price
+      ? `${product.price} – ${product.maxPrice}`
+      : product.price;
+
+  return (
+    <div className="sf-card">
+      <LinkComponent href={productHref(product.slug)}>
+        <div className="sf-card-media">
+          {product.imageUrl && <img src={product.imageUrl} alt={product.name} loading="lazy" />}
+          {product.hoverImageUrl && (
+            <img className="sf-hover" src={product.hoverImageUrl} alt="" loading="lazy" aria-hidden="true" />
+          )}
+          {product.ribbon && <span className="sf-badge">{product.ribbon}</span>}
+          {soldOut && <span className="sf-badge sf-badge-right">Sold out</span>}
+          {product.preorder && <span className="sf-badge sf-badge-right">Pre-order</span>}
+        </div>
+        <p className="sf-card-name">{product.name}</p>
+        <p className="sf-card-price">
+          <span>{priceLabel}</span>
+          {product.compareAtPrice && <span className="sf-compare">{product.compareAtPrice}</span>}
+        </p>
+        {product.optionsSummary && <p className="sf-card-options">{product.optionsSummary}</p>}
+      </LinkComponent>
+      {product.quickAddable && (
+        <button
+          type="button"
+          className="sf-chip"
+          disabled={busy}
+          onClick={() => addToCart(product.id).catch(() => {})}
+        >
+          Add to cart
+        </button>
+      )}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/ProductDetailView.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/ProductDetailView.tsx
@@ -1,0 +1,106 @@
+// The full product detail surface: gallery, price, option/modifier picker, quantity,
+// add-to-cart. Mount as-is (Astro: an island with the server-fetched `initial` product;
+// SPA: pass the `slug`). All selection→variant logic lives in useProductDetail — never
+// bypass it to add a product with options.
+import { useState } from "react";
+import { useProductDetail } from "../../hooks/storefront/useProductDetail";
+import type { ProductDetail } from "../../wix/storefront/types";
+import VariantPicker from "./VariantPicker";
+
+export interface ProductDetailViewProps {
+  /** Server-fetched product (Astro/Next SSR). */
+  initial?: ProductDetail | null;
+  /** SPA alternative: fetch by slug on mount. */
+  slug?: string;
+}
+
+export default function ProductDetailView({ initial, slug }: ProductDetailViewProps) {
+  const {
+    product,
+    notFound,
+    optionGroups,
+    selectOption,
+    modifierValues,
+    setModifier,
+    price,
+    compareAtPrice,
+    canAdd,
+    quantity,
+    setQuantity,
+    add,
+    adding,
+    error,
+  } = useProductDetail({ initial, slug });
+  const [imageIndex, setImageIndex] = useState(0);
+
+  if (notFound) return <p className="sf-empty">This product doesn't exist (anymore).</p>;
+  if (!product) return <div className="sf-skeleton" style={{ maxWidth: 480 }} />;
+
+  const soldOut = product.availability === "OUT_OF_STOCK" && !product.preorder;
+  const mainImage = product.gallery[imageIndex] ?? product.imageUrl;
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: 40 }}>
+      <div>
+        <div className="sf-card-media">
+          {mainImage && <img src={mainImage} alt={product.name} />}
+        </div>
+        {product.gallery.length > 1 && (
+          <div className="sf-chips" style={{ marginTop: 12 }}>
+            {product.gallery.map((url, i) => (
+              <button
+                key={url}
+                type="button"
+                className={i === imageIndex ? "sf-swatch sf-on" : "sf-swatch"}
+                style={{ backgroundImage: `url(${url})`, backgroundSize: "cover", width: 56, height: 56, borderRadius: 8 }}
+                aria-label={`Image ${i + 1}`}
+                onClick={() => setImageIndex(i)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h1 style={{ marginTop: 0 }}>{product.name}</h1>
+        <p className="sf-card-price" style={{ fontSize: 20 }}>
+          <span>{price}</span>
+          {compareAtPrice && <span className="sf-compare">{compareAtPrice}</span>}
+        </p>
+        {soldOut && <p className="sf-error">Out of stock</p>}
+        {product.preorder && <p className="sf-card-options">Available for pre-order</p>}
+
+        {product.descriptionHtml && (
+          // plainDescription is HTML (despite the name) — render it, don't print it.
+          <div dangerouslySetInnerHTML={{ __html: product.descriptionHtml }} />
+        )}
+
+        <VariantPicker
+          optionGroups={optionGroups}
+          selectOption={selectOption}
+          modifiers={product.modifiers}
+          modifierValues={modifierValues}
+          setModifier={setModifier}
+        />
+
+        {!soldOut && (
+          <div style={{ display: "flex", gap: 12, alignItems: "center", marginTop: 8 }}>
+            <div className="sf-qty">
+              <button type="button" aria-label="Decrease quantity" disabled={quantity <= 1} onClick={() => setQuantity(quantity - 1)}>
+                −
+              </button>
+              <span>{quantity}</span>
+              <button type="button" aria-label="Increase quantity" onClick={() => setQuantity(quantity + 1)}>
+                +
+              </button>
+            </div>
+            <button type="button" className="sf-btn" disabled={!canAdd || adding} onClick={() => add().catch(() => {})}>
+              {adding ? "Adding…" : canAdd ? "Add to cart" : "Select options"}
+            </button>
+          </div>
+        )}
+        {error && <p className="sf-error">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/ProductGrid.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/ProductGrid.tsx
@@ -1,0 +1,44 @@
+// Listing grid with loading skeletons and an honest empty state — a REFERENCE layout.
+// Keep the states (they're correct); choosing a grid arrangement that fits the brand is
+// encouraged. Never mock products: empty catalog → the empty state.
+import type { ComponentType } from "react";
+import type { ProductSummary } from "../../wix/storefront/types";
+import ProductCard, { type ProductCardProps } from "./ProductCard";
+
+export interface ProductGridProps {
+  /** null → loading skeletons; [] → the empty state. */
+  products: ProductSummary[] | null;
+  emptyMessage?: string;
+  productHref?: ProductCardProps["productHref"];
+  LinkComponent?: ProductCardProps["LinkComponent"];
+  /** Swap in your own tile (built on ProductSummary) without re-doing the states. */
+  CardComponent?: ComponentType<ProductCardProps>;
+}
+
+export default function ProductGrid({
+  products,
+  emptyMessage = "No products yet — check back soon.",
+  productHref,
+  LinkComponent,
+  CardComponent = ProductCard,
+}: ProductGridProps) {
+  if (products === null) {
+    return (
+      <div className="sf-grid" aria-busy="true">
+        {Array.from({ length: 8 }, (_, i) => (
+          <div className="sf-skeleton" key={i} />
+        ))}
+      </div>
+    );
+  }
+  if (products.length === 0) {
+    return <p className="sf-empty">{emptyMessage}</p>;
+  }
+  return (
+    <div className="sf-grid">
+      {products.map((p) => (
+        <CardComponent key={p.id} product={p} productHref={productHref} LinkComponent={LinkComponent} />
+      ))}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/ShopView.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/ShopView.tsx
@@ -1,0 +1,63 @@
+// The full shop surface: live category filter bar + product grid. Mount as-is (Astro:
+// one island with server-fetched initial data; SPA: no props needed).
+import { useShop } from "../../hooks/storefront/useShop";
+import type { Category, ProductSummary } from "../../wix/storefront/types";
+import ProductGrid, { type ProductGridProps } from "./ProductGrid";
+
+export interface ShopViewProps {
+  /** Server-fetched data (Astro/Next SSR) — omit in a SPA and it fetches client-side. */
+  initialProducts?: ProductSummary[];
+  initialCategories?: Category[];
+  emptyMessage?: string;
+  productHref?: ProductGridProps["productHref"];
+  LinkComponent?: ProductGridProps["LinkComponent"];
+  CardComponent?: ProductGridProps["CardComponent"];
+}
+
+export default function ShopView({
+  initialProducts,
+  initialCategories,
+  emptyMessage,
+  productHref,
+  LinkComponent,
+  CardComponent,
+}: ShopViewProps) {
+  const { products, categories, activeCategoryId, setActiveCategoryId, loading, error } = useShop({
+    initialProducts,
+    initialCategories,
+  });
+
+  return (
+    <div>
+      {categories.length > 1 && (
+        <div className="sf-cats" role="group" aria-label="Categories">
+          <button
+            type="button"
+            className={activeCategoryId === null ? "sf-cat sf-on" : "sf-cat"}
+            onClick={() => setActiveCategoryId(null)}
+          >
+            All
+          </button>
+          {categories.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              className={activeCategoryId === c.id ? "sf-cat sf-on" : "sf-cat"}
+              onClick={() => setActiveCategoryId(c.id)}
+            >
+              {c.name}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <p className="sf-error">{error}</p>}
+      <ProductGrid
+        products={loading ? null : products}
+        emptyMessage={emptyMessage}
+        productHref={productHref}
+        LinkComponent={LinkComponent}
+        CardComponent={CardComponent}
+      />
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/components/storefront/VariantPicker.tsx
+++ b/skills/wix-headless-fast/references/storefront/app/components/storefront/VariantPicker.tsx
@@ -1,0 +1,90 @@
+// Option/modifier selector — wire as-is on the PDP (color options render as swatches, text
+// options as pills, modifiers as pills or a text input). Restyle via the --sf-* tokens.
+import type { ProductModifier } from "../../wix/storefront/types";
+import type { OptionGroupView } from "../../hooks/storefront/useProductDetail";
+
+export interface VariantPickerProps {
+  optionGroups: OptionGroupView[];
+  selectOption: (optionName: string, choiceName: string) => void;
+  modifiers?: ProductModifier[];
+  modifierValues?: Record<string, string>;
+  setModifier?: (key: string, value: string) => void;
+}
+
+export default function VariantPicker({
+  optionGroups,
+  selectOption,
+  modifiers = [],
+  modifierValues = {},
+  setModifier,
+}: VariantPickerProps) {
+  return (
+    <div>
+      {optionGroups.map((group) => (
+        <div className="sf-opt" key={group.id || group.name}>
+          <p className="sf-opt-label">{group.name}</p>
+          <div className="sf-chips">
+            {group.choices.map((choice) =>
+              group.isColor && choice.colorCode ? (
+                <button
+                  key={choice.choiceId || choice.name}
+                  type="button"
+                  className={choice.selected ? "sf-swatch sf-on" : "sf-swatch"}
+                  style={{ background: choice.colorCode }}
+                  title={choice.name}
+                  aria-label={`${group.name}: ${choice.name}`}
+                  aria-pressed={choice.selected}
+                  disabled={!choice.inStock}
+                  onClick={() => selectOption(group.name, choice.name)}
+                />
+              ) : (
+                <button
+                  key={choice.choiceId || choice.name}
+                  type="button"
+                  className={choice.selected ? "sf-chip sf-on" : "sf-chip"}
+                  aria-pressed={choice.selected}
+                  disabled={!choice.inStock}
+                  onClick={() => selectOption(group.name, choice.name)}
+                >
+                  {choice.name}
+                </button>
+              ),
+            )}
+          </div>
+        </div>
+      ))}
+
+      {modifiers.map((m) => (
+        <div className="sf-opt" key={m.key}>
+          <p className="sf-opt-label">
+            {m.name}
+            {m.mandatory ? " *" : ""}
+          </p>
+          {m.type === "text" ? (
+            <input
+              className="sf-modifier-input"
+              type="text"
+              value={modifierValues[m.key] ?? ""}
+              onChange={(e) => setModifier?.(m.key, e.target.value)}
+              aria-label={m.name}
+            />
+          ) : (
+            <div className="sf-chips">
+              {m.choices.map((c) => (
+                <button
+                  key={c.key}
+                  type="button"
+                  className={modifierValues[m.key] === c.key ? "sf-chip sf-on" : "sf-chip"}
+                  aria-pressed={modifierValues[m.key] === c.key}
+                  onClick={() => setModifier?.(m.key, c.key)}
+                >
+                  {c.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/hooks/storefront/useCart.ts
+++ b/skills/wix-headless-fast/references/storefront/app/hooks/storefront/useCart.ts
@@ -1,0 +1,48 @@
+// React binding for the cart store. Works in any React root — Astro islands (several on one
+// page share the same store) and SPAs alike.
+import { useSyncExternalStore } from "react";
+import {
+  addLine,
+  getCartState,
+  goToCheckout,
+  refreshCart,
+  removeCartLine,
+  setCartOpen,
+  subscribeCart,
+  updateLineQuantity,
+  type CartState,
+} from "../../wix/storefront/cart-store";
+import type { AddToCartExtras } from "../../wix/storefront/cart";
+
+const SERVER_STATE = getCartState();
+
+export interface UseCart extends CartState {
+  itemCount: number;
+  addToCart: (
+    productId: string,
+    variantId?: string | null,
+    quantity?: number,
+    extras?: AddToCartExtras,
+  ) => Promise<void>;
+  updateQuantity: (lineItemId: string, quantity: number) => Promise<void>;
+  removeLine: (lineItemId: string) => Promise<void>;
+  checkout: () => Promise<void>;
+  openCart: () => void;
+  closeCart: () => void;
+  refresh: () => Promise<void>;
+}
+
+export function useCart(): UseCart {
+  const state = useSyncExternalStore(subscribeCart, getCartState, () => SERVER_STATE);
+  return {
+    ...state,
+    itemCount: state.cart?.itemCount ?? 0,
+    addToCart: addLine,
+    updateQuantity: updateLineQuantity,
+    removeLine: removeCartLine,
+    checkout: goToCheckout,
+    openCart: () => setCartOpen(true),
+    closeCart: () => setCartOpen(false),
+    refresh: refreshCart,
+  };
+}

--- a/skills/wix-headless-fast/references/storefront/app/hooks/storefront/useProductDetail.ts
+++ b/skills/wix-headless-fast/references/storefront/app/hooks/storefront/useProductDetail.ts
@@ -1,0 +1,140 @@
+// Product detail state: option selection → variant resolution → add-to-cart, plus modifier
+// inputs. This is the logic the turtle-run class of bugs comes from (adding variants[0]
+// regardless of the buyer's choice) — always drive a PDP through this hook.
+//
+// SSR-friendly: pass the server-fetched ProductDetail as `initial` (Astro/Next); in a SPA
+// pass the slug and it fetches on mount.
+import { useEffect, useMemo, useState } from "react";
+import { fetchProductBySlug, resolveVariant } from "../../wix/storefront/catalog";
+import type { ProductDetail, ProductOption, ProductVariant } from "../../wix/storefront/types";
+import { useCart } from "./useCart";
+
+export interface UseProductDetailOptions {
+  initial?: ProductDetail | null;
+  slug?: string;
+}
+
+export interface OptionGroupView extends ProductOption {
+  choices: (ProductOption["choices"][number] & { selected: boolean })[];
+}
+
+export interface UseProductDetail {
+  /** null while loading (or when the slug doesn't resolve — check notFound). */
+  product: ProductDetail | null;
+  notFound: boolean;
+  /** Option groups with per-choice `selected`, ready to render as pills/swatches. */
+  optionGroups: OptionGroupView[];
+  selectOption: (optionName: string, choiceName: string) => void;
+  /** Modifier inputs keyed by modifier key. */
+  modifierValues: Record<string, string>;
+  setModifier: (key: string, value: string) => void;
+  /** The resolved variant; null while the selection is incomplete. */
+  variant: ProductVariant | null;
+  /** Price to display right now (variant price once resolved, else the product range). */
+  price: string;
+  compareAtPrice: string | null;
+  /** False until every option is selected (and the resolved variant is in stock). */
+  canAdd: boolean;
+  quantity: number;
+  setQuantity: (n: number) => void;
+  /** Adds the resolved variant to the cart (opens the drawer). Throws on refusal. */
+  add: () => Promise<void>;
+  adding: boolean;
+  error: string | null;
+}
+
+export function useProductDetail({ initial, slug }: UseProductDetailOptions): UseProductDetail {
+  const [product, setProduct] = useState<ProductDetail | null>(initial ?? null);
+  const [notFound, setNotFound] = useState(false);
+  const [selections, setSelections] = useState<Record<string, string>>({});
+  const [modifierValues, setModifierValues] = useState<Record<string, string>>({});
+  const [quantity, setQuantity] = useState(1);
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { addToCart } = useCart();
+
+  useEffect(() => {
+    if (initial || !slug) return;
+    let alive = true;
+    fetchProductBySlug(slug)
+      .then((p) => {
+        if (!alive) return;
+        setProduct(p);
+        setNotFound(p === null);
+      })
+      .catch(() => alive && setNotFound(true));
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
+
+  const variant = useMemo(
+    () => (product ? resolveVariant(product, selections) : null),
+    [product, selections],
+  );
+
+  const optionGroups: OptionGroupView[] = useMemo(
+    () =>
+      (product?.options ?? []).map((o) => ({
+        ...o,
+        choices: o.choices.map((c) => ({ ...c, selected: selections[o.name] === c.name })),
+      })),
+    [product, selections],
+  );
+
+  const mandatoryModifiersFilled = (product?.modifiers ?? [])
+    .filter((m) => m.mandatory)
+    .every((m) => (modifierValues[m.key] ?? "").length > 0);
+
+  const canAdd =
+    !!product &&
+    product.availability !== "OUT_OF_STOCK" &&
+    variant !== null &&
+    variant.inStock &&
+    mandatoryModifiersFilled;
+
+  async function add(): Promise<void> {
+    if (!product || !variant) return;
+    setAdding(true);
+    setError(null);
+    try {
+      const choiceModifiers: Record<string, string> = {};
+      const textModifiers: Record<string, string> = {};
+      for (const m of product.modifiers) {
+        const value = modifierValues[m.key];
+        if (!value) continue;
+        if (m.type === "text") textModifiers[m.key] = value;
+        else choiceModifiers[m.key] = value;
+      }
+      await addToCart(product.id, variant.variantId, quantity, {
+        modifierChoices: choiceModifiers,
+        customTextFields: textModifiers,
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      throw e;
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  return {
+    product,
+    notFound,
+    optionGroups,
+    selectOption: (optionName, choiceName) =>
+      setSelections((s) => ({ ...s, [optionName]: choiceName })),
+    modifierValues,
+    setModifier: (key, value) => setModifierValues((v) => ({ ...v, [key]: value })),
+    variant,
+    price: variant?.price || product?.price || "",
+    compareAtPrice: variant ? variant.compareAtPrice : (product?.compareAtPrice ?? null),
+    canAdd,
+    quantity,
+    setQuantity,
+    add,
+    adding,
+    error,
+  };
+}

--- a/skills/wix-headless-fast/references/storefront/app/hooks/storefront/useShop.ts
+++ b/skills/wix-headless-fast/references/storefront/app/hooks/storefront/useShop.ts
@@ -1,0 +1,80 @@
+// Catalog listing + category filter for a shop/listing surface.
+//
+// SSR-friendly: when the host fetched the data already (Astro frontmatter, a server
+// component), pass it as `initial` and no client fetch happens for it. In a pure SPA,
+// pass nothing and the hook fetches on mount. Category switches always fetch live
+// (server-side-filtered by the category id).
+import { useEffect, useState } from "react";
+import {
+  fetchCategories,
+  fetchProducts,
+  fetchProductsByCategory,
+} from "../../wix/storefront/catalog";
+import type { Category, ProductSummary } from "../../wix/storefront/types";
+
+export interface UseShopOptions {
+  initialProducts?: ProductSummary[];
+  initialCategories?: Category[];
+  limit?: number;
+}
+
+export interface UseShop {
+  /** null while the first load is in flight — render skeletons, not an empty state. */
+  products: ProductSummary[] | null;
+  categories: Category[];
+  /** null = "all products". */
+  activeCategoryId: string | null;
+  setActiveCategoryId: (id: string | null) => void;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useShop({ initialProducts, initialCategories, limit = 100 }: UseShopOptions = {}): UseShop {
+  const [products, setProducts] = useState<ProductSummary[] | null>(initialProducts ?? null);
+  const [categories, setCategories] = useState<Category[]>(initialCategories ?? []);
+  const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialCategories) return;
+    let alive = true;
+    fetchCategories().then((c) => alive && setCategories(c));
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // The initial all-products data may have come from the server; only fetch when it
+    // didn't, or when the buyer picked a category.
+    if (activeCategoryId === null && initialProducts) {
+      setProducts(initialProducts);
+      return;
+    }
+    let alive = true;
+    setLoading(true);
+    setError(null);
+    const load = activeCategoryId
+      ? fetchProductsByCategory(activeCategoryId, { limit })
+      : fetchProducts({ limit });
+    load
+      .then((items) => {
+        if (!alive) return;
+        setProducts(items);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setProducts([]);
+        setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeCategoryId, limit]);
+
+  return { products, categories, activeCategoryId, setActiveCategoryId, loading, error };
+}

--- a/skills/wix-headless-fast/references/storefront/app/styles/storefront.css
+++ b/skills/wix-headless-fast/references/storefront/app/styles/storefront.css
@@ -1,0 +1,79 @@
+/* Shipped storefront component styles — structural only, themed entirely by the tokens
+   below. Theme the store by overriding the --sf-* tokens (in your global stylesheet or
+   Layout), not by editing component markup or this file's rules. */
+:root {
+  --sf-surface: var(--surface, #ffffff);
+  --sf-text: var(--text, #16181d);
+  --sf-muted: var(--muted, #6b7280);
+  --sf-border: var(--border, #e5e7eb);
+  --sf-primary: var(--primary, #16181d);
+  --sf-on-primary: var(--on-primary, #ffffff);
+  --sf-danger: #c0392b;
+  --sf-radius: var(--radius, 8px);
+}
+
+/* Product card (reference) */
+.sf-card { display: block; color: inherit; text-decoration: none; }
+.sf-card-media { position: relative; aspect-ratio: 1; overflow: hidden; border-radius: var(--sf-radius); background: var(--sf-border); }
+.sf-card-media img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.sf-card-media .sf-hover { position: absolute; inset: 0; opacity: 0; transition: opacity 0.2s; }
+.sf-card:hover .sf-hover { opacity: 1; }
+.sf-badge { position: absolute; top: 10px; left: 10px; background: var(--sf-surface); color: var(--sf-text); font-size: 12px; font-weight: 600; padding: 4px 10px; border-radius: 999px; }
+.sf-badge.sf-badge-right { left: auto; right: 10px; }
+.sf-card-name { margin: 10px 0 2px; font-size: 14px; font-weight: 600; }
+.sf-card-price { font-size: 14px; color: var(--sf-muted); display: flex; gap: 8px; align-items: baseline; }
+.sf-card-price .sf-compare { text-decoration: line-through; opacity: 0.6; }
+.sf-card-options { font-size: 12px; color: var(--sf-muted); margin-top: 2px; }
+
+/* Grid (reference) */
+.sf-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 24px; }
+.sf-skeleton { aspect-ratio: 1; border-radius: var(--sf-radius); background: var(--sf-border); animation: sf-pulse 1.4s ease-in-out infinite; }
+@keyframes sf-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
+.sf-empty { padding: 64px 0; text-align: center; color: var(--sf-muted); }
+
+/* Category bar */
+.sf-cats { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 24px; }
+.sf-cat { border: 1px solid var(--sf-border); background: none; color: var(--sf-text); border-radius: 999px; padding: 8px 18px; font-size: 14px; cursor: pointer; }
+.sf-cat.sf-on { background: var(--sf-primary); color: var(--sf-on-primary); border-color: var(--sf-primary); }
+
+/* Variant picker */
+.sf-opt { margin-bottom: 18px; }
+.sf-opt-label { font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--sf-muted); margin-bottom: 8px; }
+.sf-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.sf-chip { border: 1px solid var(--sf-border); background: none; color: var(--sf-text); border-radius: 999px; padding: 8px 16px; font-size: 14px; cursor: pointer; }
+.sf-chip.sf-on { background: var(--sf-primary); color: var(--sf-on-primary); border-color: var(--sf-primary); }
+.sf-chip:disabled { opacity: 0.4; cursor: not-allowed; text-decoration: line-through; }
+.sf-swatch { width: 32px; height: 32px; border-radius: 50%; border: 2px solid var(--sf-border); cursor: pointer; padding: 0; }
+.sf-swatch.sf-on { border-color: var(--sf-primary); box-shadow: 0 0 0 2px var(--sf-surface), 0 0 0 4px var(--sf-primary); }
+.sf-swatch:disabled { opacity: 0.35; cursor: not-allowed; }
+.sf-modifier-input { width: 100%; border: 1px solid var(--sf-border); border-radius: var(--sf-radius); background: var(--sf-surface); color: var(--sf-text); padding: 10px 12px; font-size: 14px; }
+
+/* Buttons */
+.sf-btn { background: var(--sf-primary); color: var(--sf-on-primary); border: none; border-radius: 999px; padding: 14px 32px; font-size: 15px; font-weight: 600; cursor: pointer; }
+.sf-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.sf-btn-full { width: 100%; }
+.sf-error { color: var(--sf-danger); font-size: 13px; margin-top: 8px; }
+
+/* Cart button */
+.sf-cart-btn { position: relative; background: none; border: none; color: inherit; cursor: pointer; display: inline-flex; align-items: center; padding: 6px; }
+.sf-cart-count { position: absolute; top: -2px; right: -4px; min-width: 18px; height: 18px; border-radius: 999px; background: var(--sf-primary); color: var(--sf-on-primary); font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; padding: 0 4px; }
+
+/* Cart drawer */
+.sf-overlay { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.45); z-index: 200; display: flex; justify-content: flex-end; }
+.sf-drawer { width: min(400px, 100vw); height: 100%; background: var(--sf-surface); color: var(--sf-text); display: flex; flex-direction: column; }
+.sf-drawer-head { display: flex; justify-content: space-between; align-items: center; padding: 20px 24px; border-bottom: 1px solid var(--sf-border); font-weight: 700; }
+.sf-drawer-close { background: none; border: none; font-size: 22px; cursor: pointer; color: var(--sf-muted); }
+.sf-drawer-items { flex: 1; overflow-y: auto; padding: 20px 24px; }
+.sf-line { display: flex; gap: 14px; margin-bottom: 20px; }
+.sf-line-img { width: 64px; height: 64px; border-radius: var(--sf-radius); object-fit: cover; background: var(--sf-border); flex-shrink: 0; }
+.sf-line-body { flex: 1; min-width: 0; }
+.sf-line-name { font-size: 14px; font-weight: 600; }
+.sf-line-desc { font-size: 12px; color: var(--sf-muted); margin-top: 2px; }
+.sf-line-price { font-size: 14px; font-weight: 600; white-space: nowrap; }
+.sf-line-warn { font-size: 12px; color: var(--sf-danger); margin-top: 4px; }
+.sf-qty { display: inline-flex; align-items: center; gap: 10px; border: 1px solid var(--sf-border); border-radius: 999px; padding: 2px 8px; margin-top: 8px; }
+.sf-qty button { background: none; border: none; cursor: pointer; font-size: 16px; color: var(--sf-text); padding: 2px 6px; }
+.sf-qty button:disabled { opacity: 0.4; cursor: not-allowed; }
+.sf-remove { background: none; border: none; color: var(--sf-muted); font-size: 12px; cursor: pointer; text-decoration: underline; margin-top: 6px; padding: 0; }
+.sf-drawer-foot { border-top: 1px solid var(--sf-border); padding: 20px 24px; }
+.sf-subtotal { display: flex; justify-content: space-between; font-size: 15px; margin-bottom: 14px; }

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart-store.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart-store.ts
@@ -1,0 +1,101 @@
+// Client-side cart state — a module-scope store, deliberately NOT a React context.
+// A context can't span Astro islands (each island is its own React root); a module
+// singleton is shared by every island in the page bundle, and works identically in a
+// single-root SPA. Consume it through useCart() (hooks/), or subscribe directly.
+import type { Cart } from "./types";
+import {
+  addToCart as apiAdd,
+  fetchCart,
+  removeLine as apiRemove,
+  updateQuantity as apiUpdate,
+  checkoutUrl,
+  type AddToCartExtras,
+} from "./cart";
+
+export interface CartState {
+  cart: Cart | null;
+  /** True while any cart operation is in flight. */
+  busy: boolean;
+  /** Last failed operation's message — render it; a new operation clears it. */
+  error: string | null;
+  /** Cart drawer visibility (CartButton opens it, CartDrawer renders by it). */
+  open: boolean;
+}
+
+const EMPTY: CartState = { cart: null, busy: false, error: null, open: false };
+
+let state: CartState = EMPTY;
+const listeners = new Set<() => void>();
+let loaded = false;
+
+function setState(patch: Partial<CartState>): void {
+  state = { ...state, ...patch };
+  for (const l of listeners) l();
+}
+
+export function getCartState(): CartState {
+  return state;
+}
+
+export function subscribeCart(listener: () => void): () => void {
+  listeners.add(listener);
+  // First subscriber triggers the initial load (browser only — SSR renders the empty state).
+  if (!loaded && typeof window !== "undefined") {
+    loaded = true;
+    void refreshCart();
+  }
+  return () => listeners.delete(listener);
+}
+
+async function run(op: () => Promise<Cart>): Promise<void> {
+  setState({ busy: true, error: null });
+  try {
+    setState({ cart: await op(), busy: false });
+  } catch (e) {
+    setState({ busy: false, error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}
+
+export async function refreshCart(): Promise<void> {
+  try {
+    setState({ cart: await fetchCart() });
+  } catch {
+    /* no cart yet — leave the empty state */
+  }
+}
+
+/** Add to cart and open the drawer. Throws (and sets .error) on refusal. */
+export async function addLine(
+  productId: string,
+  variantId?: string | null,
+  quantity = 1,
+  extras?: AddToCartExtras,
+): Promise<void> {
+  await run(() => apiAdd(productId, variantId, quantity, extras));
+  setState({ open: true });
+}
+
+export async function updateLineQuantity(lineItemId: string, quantity: number): Promise<void> {
+  await run(() => apiUpdate(lineItemId, quantity));
+}
+
+export async function removeCartLine(lineItemId: string): Promise<void> {
+  await run(() => apiRemove(lineItemId));
+}
+
+/** Navigate to the Wix-hosted checkout. Never hand-build a checkout URL. */
+export async function goToCheckout(): Promise<void> {
+  setState({ busy: true, error: null });
+  try {
+    const url = await checkoutUrl();
+    window.location.href = url;
+  } catch (e) {
+    setState({ busy: false, error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}
+
+export function setCartOpen(open: boolean): void {
+  setState({ open });
+}

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart.ts
@@ -1,0 +1,178 @@
+// Cart + checkout (Wix eCom Cart V2) — the only file that touches raw cart entities.
+// Copy as-is; extend by calling these exports, never by editing them. The request shapes are
+// exact (catalogItems wrapper, options.variantId, the redirect-session body) and rewriting
+// them is how carts break.
+//
+// Failures are loud: these throw on out-of-stock lines, an empty cart at checkout, and a
+// missing required selection — surface the message to the buyer, don't swallow it.
+import { currentCartV2 } from "@wix/ecom";
+import { redirects as redirectsModule } from "@wix/redirects";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import { formatMoney } from "../money";
+import type { Cart, CartLine } from "./types";
+
+const cartApi = wixModule(currentCartV2);
+const redirects = wixModule(redirectsModule);
+
+// Public app id of the Wix Stores catalog — required inside every catalogReference.
+const WIX_STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
+
+type RawCart = Record<string, any>;
+
+function cartCurrency(raw: RawCart | null): string {
+  return raw?.customerInfo?.currencyCode ?? raw?.businessInfo?.currencyCode ?? "";
+}
+
+function toLine(raw: RawCart, currency: string): CartLine {
+  const descriptionLines: string[] = (raw.attributes?.descriptionLines ?? [])
+    .map((d: RawCart) => {
+      const label = d.name?.original ?? "";
+      const value = d.plainText?.original ?? d.colorInfo?.original ?? "";
+      return label && value ? `${label}: ${value}` : value || label;
+    })
+    .filter(Boolean);
+  return {
+    lineItemId: raw._id ?? "",
+    productName: raw.name?.original ?? "",
+    quantity: raw.quantityInfo?.confirmedQuantity ?? 0,
+    unitPrice: formatMoney(raw.pricing?.unitPrice, currency),
+    linePrice: formatMoney(raw.pricing?.totalPrice, currency),
+    imageUrl: imgSrc(raw.attributes?.image, 300, 300),
+    descriptionLines,
+    status: raw.status ?? "IN_STOCK",
+  };
+}
+
+function toCart(raw: RawCart | null, subtotal: string): Cart {
+  const currency = cartCurrency(raw);
+  const lines = (raw?.lineItems ?? []).map((l: RawCart) => toLine(l, currency));
+  return {
+    lines,
+    itemCount: lines.reduce((sum: number, l: CartLine) => sum + l.quantity, 0),
+    subtotal,
+    currency,
+  };
+}
+
+async function readCartWithSubtotal(raw: RawCart | null): Promise<Cart> {
+  if (!raw?.lineItems?.length) return toCart(raw, "");
+  // The authoritative after-discount subtotal comes from the cart estimate, never from
+  // hand-summing line items (tax and shipping resolve at checkout).
+  let subtotal = "";
+  try {
+    const estimate: RawCart = await cartApi.estimateCurrentCart();
+    subtotal = formatMoney(estimate?.summary?.priceSummary?.subtotal, cartCurrency(raw));
+  } catch {
+    /* estimate is a display nicety — the cart itself is still valid */
+  }
+  return toCart(raw, subtotal);
+}
+
+/** Read the visitor's current cart. An empty Cart (not an error) when none exists yet. */
+export async function fetchCart(): Promise<Cart> {
+  try {
+    const { cart } = await cartApi.getCurrentCart();
+    return readCartWithSubtotal(cart as RawCart);
+  } catch {
+    return toCart(null, "");
+  }
+}
+
+export interface AddToCartExtras {
+  /** TEXT_CHOICES modifier selections: modifier key -> choice key. */
+  modifierChoices?: Record<string, string>;
+  /** FREE_TEXT modifier inputs: freeTextSettings key -> the buyer's text. */
+  customTextFields?: Record<string, string>;
+}
+
+/**
+ * Add a product to the current cart.
+ * For a product WITH options, `variantId` is mandatory — resolve it with
+ * `resolveVariant()` from ./catalog first. Mandatory modifiers must be included.
+ */
+export async function addToCart(
+  productId: string,
+  variantId?: string | null,
+  quantity = 1,
+  { modifierChoices, customTextFields }: AddToCartExtras = {},
+): Promise<Cart> {
+  const options: Record<string, unknown> = {};
+  if (variantId) options.variantId = variantId;
+  if (modifierChoices && Object.keys(modifierChoices).length) options.options = modifierChoices;
+  if (customTextFields && Object.keys(customTextFields).length) options.customTextFields = customTextFields;
+
+  const { cart } = await cartApi.addLineItemsToCurrentCart({
+    catalogItems: [
+      {
+        quantity,
+        catalogReference: {
+          catalogItemId: productId,
+          appId: WIX_STORES_APP_ID,
+          ...(Object.keys(options).length ? { options } : {}),
+        },
+      },
+    ],
+  });
+
+  const line = ((cart as RawCart)?.lineItems ?? []).find(
+    (l: RawCart) =>
+      l.source?.catalogReference?.catalogItemId === productId &&
+      (!variantId || l.source?.catalogReference?.options?.variantId === variantId),
+  );
+  if (line?.status && line.status !== "IN_STOCK") {
+    throw new Error(`This item isn't available right now (${line.status.toLowerCase().replace(/_/g, " ")}).`);
+  }
+  if (!line || line.quantityInfo?.confirmedQuantity === 0) {
+    throw new Error(
+      "The item couldn't be added. Make sure every required selection was made " +
+        "(options for a product with variants, and all mandatory customizations).",
+    );
+  }
+  return readCartWithSubtotal(cart as RawCart);
+}
+
+/** Change a line's quantity. `lineItemId` is CartLine.lineItemId, never the product id. */
+export async function updateQuantity(lineItemId: string, quantity: number): Promise<Cart> {
+  const { cart } = await cartApi.updateLineItemsInCurrentCart({
+    lineItems: [{ lineItemId, quantity: { newQuantity: quantity } }],
+  });
+  return readCartWithSubtotal(cart as RawCart);
+}
+
+/** Remove a line from the cart by CartLine.lineItemId. */
+export async function removeLine(lineItemId: string): Promise<Cart> {
+  const { cart } = await cartApi.removeLineItemsFromCurrentCart([lineItemId]);
+  return readCartWithSubtotal(cart as RawCart);
+}
+
+/**
+ * Start the Wix-hosted checkout for the current cart and return the URL to navigate to.
+ * The cart's id IS the checkout id — no separate checkout-creation call.
+ * Call from the browser: the return origin must be the site's real https origin
+ * (window.location.origin), never a server-derived request origin.
+ */
+export async function checkoutUrl(): Promise<string> {
+  const { cart } = await cartApi.getCurrentCart();
+  const raw = cart as RawCart;
+  const lines: RawCart[] = raw?.lineItems ?? [];
+  if (!lines.length) throw new Error("Your cart is empty.");
+  const unavailable = lines.filter((l) => l.status && l.status !== "IN_STOCK");
+  if (unavailable.length) {
+    const names = unavailable.map((l) => l.name?.original).filter(Boolean).join(", ");
+    throw new Error(`Some items are no longer available: ${names}.`);
+  }
+  if (!raw?._id) throw new Error("Checkout couldn't start: the cart has no id.");
+
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const session = await redirects.createRedirectSession({
+    ecomCheckout: { checkoutId: raw._id },
+    callbacks: {
+      postFlowUrl: origin ? `${origin}/` : undefined,
+      thankYouPageUrl: origin ? `${origin}/` : undefined,
+    },
+  });
+  const url = session?.redirectSession?.fullUrl;
+  if (!url) throw new Error("Checkout couldn't start: no redirect URL returned.");
+  return url;
+}

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/catalog.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/catalog.ts
@@ -1,0 +1,212 @@
+// Catalog reads (Wix Stores Catalog V3) — the only file that touches raw catalog entities.
+// Everything it returns is a plain DTO from ./types: images resolved, prices formatted,
+// variants normalized. Copy as-is; extend by adding functions, not by editing these.
+import { productsV3 } from "@wix/stores";
+import { categories as categoriesModule } from "@wix/categories";
+import { wixModule } from "../sdk";
+import { imgSrc } from "../media";
+import type {
+  Category,
+  ProductDetail,
+  ProductOption,
+  ProductModifier,
+  ProductSummary,
+  ProductVariant,
+  Availability,
+} from "./types";
+
+const products = wixModule(productsV3);
+const categories = wixModule(categoriesModule);
+
+// Requested on every product read. CURRENCY populates formattedAmount (without it, prices render
+// as bare unlocalized numbers); MEDIA_ITEMS_INFO populates the gallery; the detail read adds
+// PLAIN_DESCRIPTION and VARIANT_OPTION_CHOICE_NAMES (which populates variantsInfo.variants).
+const LIST_FIELDS = ["CURRENCY", "MEDIA_ITEMS_INFO"];
+const DETAIL_FIELDS = [...LIST_FIELDS, "PLAIN_DESCRIPTION", "VARIANT_OPTION_CHOICE_NAMES"];
+
+type RawProduct = Record<string, any>;
+
+function toAvailability(raw: RawProduct): Availability {
+  const status = raw.inventory?.availabilityStatus;
+  return status === "OUT_OF_STOCK" || status === "PARTIALLY_OUT_OF_STOCK"
+    ? status
+    : "IN_STOCK";
+}
+
+function toSummary(raw: RawProduct): ProductSummary {
+  const options: RawProduct[] = raw.options ?? [];
+  const galleryItems: RawProduct[] = raw.media?.itemsInfo?.items ?? [];
+  const mainUrl = imgSrc(raw.media?.main, 800, 800);
+  const hover = galleryItems
+    .map((m) => imgSrc(m.image ?? m, 800, 800))
+    .filter((u) => u && u !== mainUrl);
+  const availability = toAvailability(raw);
+  const preorder = raw.inventory?.preorderStatus === "ENABLED" && availability === "OUT_OF_STOCK";
+  const optionsSummary = options
+    .map((o) => {
+      const visible = (o.choicesSettings?.choices ?? []).filter((c: RawProduct) => c.visible !== false);
+      return `${visible.length} ${String(o.name ?? "").toLowerCase()}${visible.length === 1 ? "" : "s"}`;
+    })
+    .join(" · ");
+  return {
+    id: raw._id ?? "",
+    slug: raw.slug ?? "",
+    name: raw.name ?? "",
+    price: raw.actualPriceRange?.minValue?.formattedAmount ?? "",
+    maxPrice: raw.actualPriceRange?.maxValue?.formattedAmount ?? "",
+    compareAtPrice: raw.compareAtPriceRange?.minValue?.formattedAmount ?? null,
+    ribbon: raw.ribbon?.name ?? null,
+    availability,
+    preorder,
+    imageUrl: mainUrl,
+    hoverImageUrl: hover[0] ?? "",
+    optionsSummary,
+    quickAddable: options.length === 0 && availability === "IN_STOCK",
+  };
+}
+
+function toOptions(raw: RawProduct): ProductOption[] {
+  return (raw.options ?? []).map((o: RawProduct) => {
+    const isColor = o.optionRenderType === "SWATCH_CHOICES" || o.optionRenderType === "COLOR_CHOICES";
+    return {
+      id: o._id ?? o.id ?? o.name ?? "",
+      name: o.name ?? "",
+      isColor,
+      choices: (o.choicesSettings?.choices ?? [])
+        .filter((c: RawProduct) => c.visible !== false)
+        .map((c: RawProduct) => ({
+          choiceId: c.choiceId ?? "",
+          name: c.name ?? "",
+          colorCode: c.colorCode ?? null,
+          inStock: c.inStock !== false,
+        })),
+    };
+  });
+}
+
+function toModifiers(raw: RawProduct): ProductModifier[] {
+  return (raw.modifiers ?? []).map((m: RawProduct) => ({
+    key: m.key ?? m.freeTextSettings?.key ?? m.name ?? "",
+    name: m.name ?? "",
+    mandatory: m.mandatory === true,
+    type: m.modifierRenderType === "FREE_TEXT" ? ("text" as const) : ("choices" as const),
+    choices: (m.choicesSettings?.choices ?? []).map((c: RawProduct) => ({
+      key: c.key ?? c.name ?? "",
+      name: c.name ?? "",
+    })),
+  }));
+}
+
+function toVariants(raw: RawProduct): ProductVariant[] {
+  return (raw.variantsInfo?.variants ?? []).map((v: RawProduct) => {
+    const choices: Record<string, string> = {};
+    for (const c of v.choices ?? []) {
+      const names = c.optionChoiceNames;
+      if (names?.optionName) choices[names.optionName] = names.choiceName ?? "";
+    }
+    return {
+      variantId: v._id ?? v.variantId ?? "",
+      choices,
+      price: v.price?.actualPrice?.formattedAmount ?? "",
+      compareAtPrice: v.price?.compareAtPrice?.formattedAmount ?? null,
+      inStock: v.inventoryStatus?.inStock !== false,
+    };
+  });
+}
+
+function toDetail(raw: RawProduct): ProductDetail {
+  const summary = toSummary(raw);
+  const gallery = [
+    summary.imageUrl,
+    ...(raw.media?.itemsInfo?.items ?? []).map((m: RawProduct) => imgSrc(m.image ?? m, 1200, 1200)),
+  ].filter((u, i, arr) => u && arr.indexOf(u) === i);
+  return {
+    ...summary,
+    descriptionHtml: raw.plainDescription ?? "",
+    gallery,
+    options: toOptions(raw),
+    modifiers: toModifiers(raw),
+    variants: toVariants(raw),
+  };
+}
+
+/** List visible products (newest catalog order), mapped to grid-ready DTOs. */
+export async function fetchProducts({ limit = 100 } = {}): Promise<ProductSummary[]> {
+  const res = await products
+    .queryProducts({ fields: LIST_FIELDS as any })
+    .limit(limit)
+    .find();
+  return (res.items ?? []).map((p) => toSummary(p as RawProduct));
+}
+
+/**
+ * List visible products in a category, server-side-filtered by the live category id.
+ * Category filtering MUST go through searchProducts (the field is not filterable in
+ * queryProducts) with the $matchItems operator — this is encoded here so callers never
+ * reconstruct it.
+ */
+export async function fetchProductsByCategory(
+  categoryId: string,
+  { limit = 100 } = {},
+): Promise<ProductSummary[]> {
+  const res: RawProduct = await products.searchProducts(
+    {
+      filter: { "allCategoriesInfo.categories": { $matchItems: [{ id: categoryId }] } },
+      cursorPaging: { limit },
+    },
+    { fields: LIST_FIELDS as any },
+  );
+  return (res.products ?? []).map((p: RawProduct) => toSummary(p));
+}
+
+/** Fetch one product by its URL slug, with options/modifiers/variants. Null when not found. */
+export async function fetchProductBySlug(slug: string): Promise<ProductDetail | null> {
+  try {
+    const res = await products.getProductBySlug(slug, { fields: DETAIL_FIELDS as any });
+    return res.product ? toDetail(res.product as RawProduct) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List the store's categories for nav/filter UI, minus Wix's auto-created "all-products"
+ * system category. The query must carry a filter condition (`.exists("name", true)` — a
+ * tautology): a bare .find() serializes an empty filter that the API rejects on the
+ * visitor-client path. Treat a failure as "no category nav", not a fatal error.
+ */
+export async function fetchCategories(): Promise<Category[]> {
+  try {
+    const res = await categories
+      .queryCategories({ treeReference: { appNamespace: "@wix/stores" } })
+      .exists("name", true)
+      .find();
+    return (res.items ?? [])
+      .map((c) => ({
+        id: (c as RawProduct)._id ?? "",
+        slug: (c as RawProduct).slug ?? "",
+        name: (c as RawProduct).name ?? "",
+      }))
+      .filter((c) => c.slug !== "all-products");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve the variant for the buyer's selections (optionName -> choiceName).
+ * A product with no options resolves to its single variant; with options, every option
+ * must be selected and match. Returns null while the selection is incomplete.
+ */
+export function resolveVariant(
+  detail: ProductDetail,
+  selections: Record<string, string>,
+): ProductVariant | null {
+  if (detail.options.length === 0) return detail.variants[0] ?? null;
+  if (!detail.options.every((o) => selections[o.name])) return null;
+  return (
+    detail.variants.find((v) =>
+      detail.options.every((o) => v.choices[o.name] === selections[o.name]),
+    ) ?? null
+  );
+}

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/types.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/types.ts
@@ -1,0 +1,109 @@
+// Storefront DTOs — the serializable shapes every hook, component, and page consumes.
+// These are plain JSON: safe to pass as Astro island props or across a server/client
+// boundary. Image values are already-resolved https URLs (never wix:image://), and every
+// displayable price is a ready formatted string.
+
+export type Availability = "IN_STOCK" | "OUT_OF_STOCK" | "PARTIALLY_OUT_OF_STOCK";
+
+/** A product as a listing/grid tile needs it. */
+export interface ProductSummary {
+  id: string;
+  slug: string;
+  name: string;
+  /** Lowest price, formatted with currency symbol (e.g. "€34.99"). */
+  price: string;
+  /** Highest price, formatted — differs from `price` when variants are priced differently. */
+  maxPrice: string;
+  /** Strikethrough "was" price, formatted; null when not on sale. */
+  compareAtPrice: string | null;
+  /** Merchant-set badge ("New", "Best Seller"); null when none. */
+  ribbon: string | null;
+  availability: Availability;
+  /** OUT_OF_STOCK but pre-orderable — label "Pre-order", not "Sold out". */
+  preorder: boolean;
+  /** Resolved https URL of the main image ("" when the product has none). */
+  imageUrl: string;
+  /** Resolved https URL of the second gallery image ("" when there is only one). */
+  hoverImageUrl: string;
+  /** e.g. "2 colors · 3 sizes"; "" for a single-variant product. */
+  optionsSummary: string;
+  /** True when the product can be added to the cart with no choices (single variant, in stock). */
+  quickAddable: boolean;
+}
+
+export interface OptionChoice {
+  choiceId: string;
+  name: string;
+  /** Hex color for swatch rendering; null for text choices. */
+  colorCode: string | null;
+  inStock: boolean;
+}
+
+export interface ProductOption {
+  id: string;
+  name: string;
+  /** Render choices as color swatches (true) or text pills (false). */
+  isColor: boolean;
+  choices: OptionChoice[];
+}
+
+export interface ProductModifier {
+  key: string;
+  name: string;
+  mandatory: boolean;
+  /** "choices" renders pills; "text" renders a free-text input. */
+  type: "choices" | "text";
+  choices: { key: string; name: string }[];
+}
+
+export interface ProductVariant {
+  variantId: string;
+  /** The option selections this variant answers to: optionName -> choiceName. */
+  choices: Record<string, string>;
+  price: string;
+  compareAtPrice: string | null;
+  inStock: boolean;
+}
+
+/** A product as the detail page needs it. */
+export interface ProductDetail extends ProductSummary {
+  /** Product description as an HTML string — render with innerHTML, not as text. */
+  descriptionHtml: string;
+  /** Every gallery image as a resolved https URL, main image first, de-duplicated. */
+  gallery: string[];
+  options: ProductOption[];
+  modifiers: ProductModifier[];
+  variants: ProductVariant[];
+}
+
+export interface Category {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+export interface CartLine {
+  /** The cart line id — what update/remove take (NOT the product id). */
+  lineItemId: string;
+  productName: string;
+  quantity: number;
+  /** Per-unit price, formatted. */
+  unitPrice: string;
+  /** Line total, formatted. */
+  linePrice: string;
+  /** Resolved https URL ("" when none). */
+  imageUrl: string;
+  /** Human-readable option/modifier labels, e.g. ["Color: Ink", "Size: M"]. */
+  descriptionLines: string[];
+  /** Not IN_STOCK → the line can't be checked out as-is. */
+  status: string;
+}
+
+export interface Cart {
+  lines: CartLine[];
+  /** Sum of line quantities. */
+  itemCount: number;
+  /** Formatted subtotal (after discounts) — from the cart estimate, not hand-summed. */
+  subtotal: string;
+  currency: string;
+}

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -1,0 +1,67 @@
+# Storefront — seeding
+
+Seed the Wix Stores catalog by **running `seed-store.mjs` with a plan file** — don't hand-write
+the REST calls. The script mints its own site token via the Wix CLI (requires a logged-in CLI
+session and a `wix.config.json` in the working directory), installs the Stores app if needed,
+waits for the V3 catalog, and creates everything in the right order.
+
+```bash
+# from the project root (where wix.config.json lives):
+node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
+```
+
+`plan.json` is plain data — write it from the brief:
+
+```json
+{
+  "products": [
+    { "name": "The Glam Rocker", "description": "Sequin-studded velvet legend…",
+      "price": 49.99, "quantity": 12, "imageUrl": "https://…" },
+    { "name": "The Understudy", "description": "…", "price": 245, "quantity": 8,
+      "options": [{ "name": "Color", "type": "color",
+                    "choices": [{ "name": "Ink", "colorCode": "#1B1B2F" },
+                                { "name": "Bone", "colorCode": "#EDE6D6" }] }] },
+    { "name": "Encore Jacket", "description": "…", "price": 68, "compareAtPrice": 129,
+      "quantity": 5 }
+  ],
+  "categories": { "Legends": ["The Glam Rocker"], "Rising Stars": [] }
+}
+```
+
+- `description` — plain text or simple HTML (`<p>`, `<br/>`, `<strong>`, `<em>`); converted to
+  Wix rich text so the storefront renders paragraphs and bold, not tag text.
+- `options` — ONLY things the buyer selects-and-buys (Size, Color); they become variants.
+  `type: "color"` renders as real swatches (give every color choice a `colorCode`); anything
+  else renders as text pills. Variants are expanded automatically (full cross-product, each
+  carrying the product's price/compareAtPrice/quantity) — keep option counts small.
+- `compareAtPrice` (> `price`) — the "was" price: strikethrough on the PDP, sale badge data on
+  the tile.
+- `imageUrl` — a real, fetchable https URL; Wix re-hosts it server-side. Omit to seed text-only.
+- `categories` — category name → product NAMES. Omit when the brief names none.
+
+**Seed a catalog that exercises the shipped UI**: unless the brief says otherwise, give at
+least one product a color option and put one product on sale — truthfully to the business (a
+ceramics studio has glaze colors; a bakery doesn't).
+
+**Seeding is additive — never delete or overwrite existing content.** No cleanup, no removing
+"sample" data, no resets. If a cleanup genuinely seems needed, ask the user first.
+
+Two things this module does not seed (dashboard-only — tell the merchant):
+**ribbons** ("New", "Best Seller") and **per-choice linked media** (color choice → gallery photo).
+
+## Escape hatch — individual functions
+
+`setupStore` is built from exported steps; import them only for a partial re-seed or custom
+ordering: `installStoresApp`, `bulkCreateProducts`, `createCategories`,
+`addProductsToCategories`, `attachProductImages` — plus `makeCtx()` for the auth context.
+
+## Reference
+
+If a call returns an unexpected shape or you need an operation this module doesn't cover, read
+the live Wix API reference — never guess. The authoritative source recipe is
+`wix-headless/references/inline-recipes/setup-online-store.md`. Key pages:
+
+- Bulk Create Products With Inventory: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-create-products-with-inventory.md
+- Create Category: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/create-category.md
+- Bulk Add Items To Category: https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/categories/bulk-add-items-to-category.md
+- Bulk Update Products (image attach): https://dev.wix.com/docs/api-reference/business-solutions/stores/catalog-v3/products-v3/bulk-update-products.md

--- a/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
+++ b/skills/wix-headless-fast/references/storefront/seed/seed-store.mjs
@@ -1,0 +1,327 @@
+// Storefront seed — a BUILD-TIME script, never shipped in the app. Run it from the project
+// root (where wix.config.json lives) with a plan file:
+//
+//   node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
+//
+// It mints its own site token via the Wix CLI (the token never leaves this process), installs
+// the Wix Stores app if needed, waits for the V3 catalog, bulk-creates products (variants
+// expanded, descriptions converted to rich text), creates categories (serially — the shared
+// tree 409s on concurrent creates), assigns products, and attaches images. Prints a JSON
+// result to stdout.
+//
+// Plan shape (see SEED.md):
+//   { "products": [{ "name", "description", "price", "compareAtPrice"?, "quantity",
+//                    "options"?: [{ "name", "type"?: "text"|"color",
+//                                   "choices": ["S","M"] | [{ "name", "colorCode" }] }],
+//                    "imageUrl"?, "altText"? }],
+//     "categories"?: { "<category name>": ["<product name>", ...] } }
+//
+// Seeding is ADDITIVE — this script never deletes or overwrites existing content.
+// If a call fails with an unexpected shape, read the live API reference (the authoritative
+// source recipe is wix-headless/references/inline-recipes/setup-online-store.md) — never guess.
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const API = "https://www.wixapis.com";
+const STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
+
+// ---- auth: siteId from wix.config.json, token minted by the Wix CLI ----------------------------
+
+export function makeCtx({ cwd = process.cwd() } = {}) {
+  const config = JSON.parse(readFileSync(`${cwd}/wix.config.json`, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (!siteId) throw new Error("wix.config.json has no siteId — is this a Wix CLI project?");
+  // The CLI returns a byte-identical token within a run — mint once, reuse.
+  const token = execFileSync("npx", ["@wix/cli@latest", "token", "--site", siteId], {
+    encoding: "utf8",
+    cwd,
+  }).trim();
+  if (!token) throw new Error("The Wix CLI returned no token — run `npx @wix/cli@latest login` first.");
+  return { token, siteId };
+}
+
+// ---- transport ----------------------------------------------------------------------------------
+
+async function req(ctx, path, { method = "POST", body } = {}) {
+  // Retry while the catalog is still provisioning: right after a fresh Stores install the V3
+  // WRITE path becomes usable later than the read path, so the first bulk-create can 428 even
+  // after the read probe clears. Wait it out (~80s budget); other errors throw immediately.
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(API + path, {
+      method,
+      headers: {
+        Authorization: `Bearer ${ctx.token}`,
+        "wix-site-id": ctx.siteId,
+        "Content-Type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const json = await res.json().catch(() => ({}));
+    if (res.ok) return json;
+    if (isProvisioning(res.status, json) && attempt < 40) {
+      await sleep(2000);
+      continue;
+    }
+    throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(json).slice(0, 400)}`);
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A freshly installed catalog signals "not writable yet" with a 428 under (at least) two codes.
+const PROVISIONING_CODES = new Set(["CATALOG_V1_SITE_CALLING_CATALOG_V3_API", "CATALOG_V3_SITE_PROVISIONING"]);
+
+function isProvisioning(status, json) {
+  if (PROVISIONING_CODES.has(json?.details?.applicationError?.code)) return true;
+  return status === 428 && /provision/i.test(json?.message || "");
+}
+
+async function waitForCatalogV3(ctx, { attempts = 40, delayMs = 2000 } = {}) {
+  for (let i = 0; i < attempts; i++) {
+    const res = await fetch(`${API}/stores/v3/products/query`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ctx.token}`, "wix-site-id": ctx.siteId, "Content-Type": "application/json" },
+      body: JSON.stringify({ query: { paging: { limit: 1 } } }),
+    });
+    if (res.ok) return;
+    const json = await res.json().catch(() => ({}));
+    if (!isProvisioning(res.status, json)) return;
+    await sleep(delayMs);
+  }
+}
+
+// ---- description string -> Wix rich-text nodes --------------------------------------------------
+// Descriptions arrive as HTML as often as not. The writable field is `description` (Ricos
+// nodes) — the HTML `plainDescription` the storefront renders is derived from them, so markup
+// dropped into a TEXT node comes back escaped and the PDP shows literal tags. Convert the tags
+// a model actually emits; a tag-free string stays one paragraph.
+
+const HTML_ENTITIES = { "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;": "'", "&nbsp;": " " };
+
+function decodeEntities(s) {
+  return s.replace(/&(?:amp|lt|gt|quot|#39|nbsp);/g, (m) => HTML_ENTITIES[m] ?? m);
+}
+
+function mkTextNodes(html) {
+  const nodes = [];
+  let bold = 0, italic = 0, last = 0, m;
+  const tag = /<(\/?)(strong|b|em|i)\s*\/?>/gi;
+  const push = (raw) => {
+    const text = decodeEntities(raw.replace(/<[^>]*>/g, ""));
+    if (!text) return;
+    const decorations = [];
+    if (bold > 0) decorations.push({ type: "BOLD" });
+    if (italic > 0) decorations.push({ type: "ITALIC" });
+    nodes.push({ type: "TEXT", textData: { text, decorations } });
+  };
+  while ((m = tag.exec(html)) !== null) {
+    push(html.slice(last, m.index));
+    const step = m[1] ? -1 : 1;
+    if (/^(strong|b)$/i.test(m[2])) bold = Math.max(0, bold + step);
+    else italic = Math.max(0, italic + step);
+    last = tag.lastIndex;
+  }
+  push(html.slice(last));
+  return nodes.length ? nodes : [{ type: "TEXT", textData: { text: "", decorations: [] } }];
+}
+
+function mkDesc(text, i) {
+  const blocks = String(text ?? "").split(/<\/p\s*>|<br\s*\/?>/i).map((b) => b.trim()).filter(Boolean);
+  return {
+    nodes: (blocks.length ? blocks : [""]).map((block, n) => ({
+      type: "PARAGRAPH", id: `desc-${i}-${n}`,
+      nodes: mkTextNodes(block),
+      paragraphData: { textStyle: { textAlignment: "AUTO" } },
+    })),
+    metadata: { version: 1, id: `desc-meta-${i}` },
+  };
+}
+
+// ---- options / variants -------------------------------------------------------------------------
+
+function buildOptions(options = []) {
+  return options.map((o) => {
+    const color = o.type === "color";
+    return {
+      name: o.name,
+      optionRenderType: color ? "SWATCH_CHOICES" : "TEXT_CHOICES",
+      choicesSettings: {
+        choices: o.choices.map((c) =>
+          color
+            ? { choiceType: "ONE_COLOR", name: c.name, colorCode: c.colorCode }
+            : { choiceType: "CHOICE_TEXT", name: typeof c === "string" ? c : c.name }),
+      },
+    };
+  });
+}
+
+// Full Cartesian product, each variant priced/stocked from the product; visible:true baked in.
+function expandVariants(options = [], { price, compareAtPrice, quantity }) {
+  const base = {
+    price: {
+      actualPrice: { amount: String(price) },
+      ...(compareAtPrice ? { compareAtPrice: { amount: String(compareAtPrice) } } : {}),
+    },
+    visible: true,
+    physicalProperties: {},
+    inventoryItem: { quantity: quantity ?? 0, preorderInfo: { enabled: false } },
+  };
+  if (!options.length) return [base];
+  let combos = [[]];
+  for (const o of options) {
+    const rt = o.type === "color" ? "SWATCH_CHOICES" : "TEXT_CHOICES";
+    const names = o.choices.map((c) => (typeof c === "string" ? c : c.name));
+    combos = combos.flatMap((combo) =>
+      names.map((choiceName) => [...combo, { optionChoiceNames: { optionName: o.name, choiceName, renderType: rt } }]));
+  }
+  return combos.map((choices) => ({ ...base, choices }));
+}
+
+// ---- operations ---------------------------------------------------------------------------------
+
+export async function installStoresApp(ctx) {
+  try {
+    await req(ctx, "/apps-installer-service/v1/app-instance/install", { body: {
+      tenant: { tenantType: "SITE", id: ctx.siteId },
+      appInstance: { appDefId: STORES_APP_ID, enabled: true },
+    } });
+  } catch {
+    // already installed is fine — the readiness wait below still confirms the V3 catalog is live
+  }
+  await waitForCatalogV3(ctx);
+}
+
+export async function bulkCreateProducts(ctx, products) {
+  const body = {
+    returnEntity: true,
+    products: products.map((p, i) => ({
+      name: p.name,
+      productType: "PHYSICAL",
+      physicalProperties: {},
+      visible: true,
+      visibleInPos: true,
+      description: mkDesc(p.description, i),
+      options: buildOptions(p.options),
+      variantsInfo: { variants: expandVariants(p.options, p) },
+    })),
+  };
+  const r = await req(ctx, "/stores/v3/bulk/products-with-inventory/create", { body });
+  // NB: results nest under productResults.results[].item — NOT a top-level `results`.
+  const created = (r.productResults?.results ?? []).map((x, i) => ({
+    id: x.item?.id, slug: x.item?.slug, revision: x.item?.revision,
+    variantId: x.item?.variantsInfo?.variants?.[0]?.id,
+    hasOptions: (products[i]?.options?.length ?? 0) > 0,
+    quantity: products[i]?.quantity ?? 0,
+  }));
+  await stockOptionlessProducts(ctx, created);
+  return created.map((p) => ({ id: p.id, slug: p.slug, revision: p.revision }));
+}
+
+// The bulk create stocks a variant via its choices; an OPTION-LESS product's single default
+// variant is NOT stocked by it and lands OUT_OF_STOCK — stock those explicitly.
+async function stockOptionlessProducts(ctx, created) {
+  const need = created.filter((p) => !p.hasOptions && p.id);
+  if (!need.length) return;
+  const missing = need.filter((p) => !p.variantId).map((p) => p.id);
+  if (missing.length) {
+    const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: missing } }, paging: { limit: missing.length } } } });
+    const vById = new Map((q.products ?? []).map((p) => [p.id, p.variantsInfo?.variants?.[0]?.id]));
+    need.forEach((p) => { if (!p.variantId) p.variantId = vById.get(p.id); });
+  }
+  const inventoryItems = need
+    .filter((p) => p.variantId)
+    .map((p) => ({ productId: p.id, variantId: p.variantId, quantity: p.quantity }));
+  if (inventoryItems.length) {
+    await req(ctx, "/stores/v3/bulk/inventory-items/create", { body: { inventoryItems } });
+  }
+}
+
+// Categories share the @wix/stores tree revision — concurrent creates 409, so: sequential.
+export async function createCategories(ctx, names) {
+  const out = [];
+  for (const name of names) {
+    const r = await req(ctx, "/categories/v1/categories", {
+      body: { category: { name, visible: true }, treeReference: { appNamespace: "@wix/stores", treeKey: null } },
+    });
+    out.push({ id: r.category?.id, name });
+  }
+  return out;
+}
+
+export async function addProductsToCategories(ctx, mapping) {
+  for (const [categoryId, productIds] of Object.entries(mapping)) {
+    await req(ctx, `/categories/v1/bulk/categories/${categoryId}/add-items`, {
+      body: {
+        items: productIds.map((catalogItemId) => ({ catalogItemId, appId: STORES_APP_ID })),
+        treeReference: { appNamespace: "@wix/stores", treeKey: null },
+      },
+    });
+  }
+}
+
+// Bulk image attach in ONE call. items: [{ id, url, altText }] — no revision to pass: the
+// current revision is read right before the update, so attach any number of times, any pass.
+// Wix re-hosts each url server-side; the media can take a little while to appear on read-back
+// (propagation) — normal, not a failure.
+export async function attachProductImages(ctx, items) {
+  if (!items?.length) return;
+  const ids = items.map((it) => it.id);
+  const q = await req(ctx, "/stores/v3/products/query", { body: { query: { filter: { id: { $in: ids } }, paging: { limit: ids.length } } } });
+  const revById = new Map((q.products ?? []).map((p) => [p.id, p.revision]));
+  return req(ctx, "/stores/v3/bulk/products/update", {
+    body: {
+      products: items.map((it) => ({
+        product: { id: it.id, revision: revById.get(it.id), media: { itemsInfo: { items: [{ url: it.url, altText: it.altText }] } } },
+      })),
+    },
+  });
+}
+
+/**
+ * ONE-CALL seed: install → create products → categories → attach images, ids threaded in
+ * memory. This is the default path — call it once instead of the individual functions.
+ */
+export async function setupStore(ctx, { products = [], categories = {} } = {}) {
+  await installStoresApp(ctx);
+
+  const created = await bulkCreateProducts(ctx, products);
+  const withNames = created.map((p, i) => ({ ...p, name: products[i]?.name }));
+  const idByName = new Map(withNames.map((p) => [p.name, p.id]));
+
+  const names = Object.keys(categories);
+  const cats = names.length ? await createCategories(ctx, names) : [];
+  if (cats.length) {
+    const mapping = {};
+    for (const c of cats) {
+      const ids = (categories[c.name] || []).map((n) => idByName.get(n)).filter(Boolean);
+      if (ids.length) mapping[c.id] = ids;
+    }
+    if (Object.keys(mapping).length) await addProductsToCategories(ctx, mapping);
+  }
+
+  const imageItems = withNames
+    .map((p, i) => ({ id: p.id, url: products[i]?.imageUrl, altText: products[i]?.altText ?? p.slug }))
+    .filter((it) => it.url);
+  if (imageItems.length) await attachProductImages(ctx, imageItems);
+
+  return { products: withNames, categories: cats, imagesAttached: imageItems.length };
+}
+
+// ---- CLI entry ----------------------------------------------------------------------------------
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (invokedDirectly) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error("usage: node seed-store.mjs <plan.json>   (run from the project root)");
+    process.exit(1);
+  }
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  const ctx = makeCtx();
+  setupStore(ctx, plan)
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((e) => {
+      console.error(e.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## What

A new top-level skill, **`wix-headless-fast`**: `wix-vibe-headless`'s mechanics (correct integration code **ships as files**; the agent themes, wires, and composes) aimed at `wix-headless`'s audience (coding agents like Claude Code/Codex, the Wix CLI, `@wix/sdk`, managed hosting). First vertical: **storefront** (Stores Catalog V3 + eCom Cart V2), with the structure contract for adding more.

## Why

Even a fully recipe-compliant `wix-headless` run produces systematic gaps (observed in a real run): no variant-selection UI (`variants[0]` added regardless of the buyer's choice), `any`-typed code in a strict-TS scaffold, `imgSrc` copy-pasted per page, a read-only cart with no quantity/remove/badge, no categories. This skill ships that hard 80% as verified code so the agent's effort goes to brand, layout, and copy.

## Shape

```
skills/wix-headless-fast/
  SKILL.md                 # full-run spine (managed-Astro default, react path), vertical registry + add-a-vertical contract
  entry/skill.md           # cold-start funnel — reuses the SHARED hosted bootstrap.mjs; routes unshipped verticals to wix-headless
  install/deploy.mjs       # stack-aware, vertical-discovering, force:false (never clobbers agent edits)
  references/
    shared/app/wix/        # config-switched auth seam (ambient managed-Astro / OAuthStrategy+tokenStorage), imgSrc, formatMoney
    storefront/
      app/                 # framework-agnostic React core, strict TS: DTO data layer, module-scope cart store
                           # (spans Astro islands — deliberately not React context), SSR-friendly hooks,
                           # routing-free components themed by --sf-* tokens
      app-astro/           # SiteLayout + shop + products/[slug] with item-page SEO (wixMetadata + <SEO.Tags>) pre-wired
      seed/                # seed-store.mjs (build-time REST, mints its own CLI token) + SEED.md
      INSTRUCTIONS.md      # file map, per-stack wiring, hard rules, verify checklist
```

Key design points:
- **DTOs at the boundary**: raw SDK entities never leave the data layer — images resolved (no `wix:image://` reaches components), prices pre-formatted, everything island-prop/server-component serializable.
- **One auth seam** (`wix/sdk.ts`): `WIX_CLIENT_ID = null` → ambient (managed Astro); a string → one shared `OAuthStrategy` client with localStorage `tokenStorage` (the SDK self-manages mint/renew/persist — visitor identity survives reloads, carts don't empty).
- **Cart V2 throughout** (`addLineItemsToCurrentCart`/`updateLineItemsInCurrentCart`/`estimateCurrentCart`; cart `_id` = checkout id).
- Decisions live in the code; INSTRUCTIONS carries only the map + prohibitions.

## Verified

- **Strict `tsc` passes** against the published `@wix/sdk` / `@wix/stores` / `@wix/ecom` / `@wix/redirects` / `@wix/categories` — four API shapes were corrected from the real `.d.ts` during this pass (`estimateCurrentCart`, `updateLineItemsInCurrentCart`, two-arg `searchProducts`, `getProductBySlug`).
- `install/deploy.mjs` exercised on both stacks (astro: core+overlay; react: core + client id written from `wix.config.json`).
- Both `.mjs` scripts pass `node --check`; seed internals are `wix-vibe-headless`'s production-proven module, converted to ESM with CLI-token self-minting.

## Not yet verified (before GA)

- Live e2e on a provisioned commerce site (ambient island Cart V2 calls, `VARIANT_OPTION_CHOICE_NAMES` populating `variantsInfo`, category search on the visitor path, SPA token persistence, seed run, `wix build` over the overlay).
- wix.com hosting for `entry/skill.md` (the entry reuses the already-live shared `bootstrap.mjs`).
- Docs-registry/eval-scenario wiring if this skill should join those gates (the current gates cover wix-manage/wix-app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)