### PR TITLE
fix: wix-headless-fast — deploy patches deps; parallel install; fewer turns

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -51,22 +51,30 @@ re-litigate them.
    read tokens into context). Then:
    - empty directory → `CI=1 npm create @wix/new@latest -- headless --folder-name <name>
      --business-name "<Brand>" --site-template --skip-install --no-publish`, then work inside
-     the created folder (install deps with `npm install --ignore-scripts`);
+     the created folder;
    - existing project not yet on Wix → `CI=1 npm create @wix/new@latest init` in place;
    - already has `wix.config.json` → neither; it's an iterate run.
-3. **Deploy the shipped code** (from the project root):
+3. **Deploy the shipped code — BEFORE installing dependencies** (from the project root):
    `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` (react stack: add
-   `--client-id` if there is no `wix.config.json` to read the public id from). Re-running is
-   safe — it fills in missing files, never overwrites edits.
-4. **Seed the backend** per the vertical's `seed/SEED.md` — write a plain-data plan from the
-   brief and run the seed script. It installs the vertical's Wix app itself. Seeding is
-   **additive**: never delete or overwrite existing content; if a cleanup seems needed, ask.
-5. **Build the brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
-   header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
-   before touching any shipped file.
-6. **Release once, at the very end** (managed): `npx @wix/cli@latest build` then
-   `npx @wix/cli@latest release`. Don't build+release mid-flow; backend content is fetched at
-   runtime, so a re-release never "refreshes" seeded data. Close with the live URL and the
+   `--client-id` if there is no `wix.config.json` to read the public id from). Besides copying
+   the files, it **patches `package.json` with every dependency the shipped code imports**
+   (fill-only), so the single install in the next step covers everything. Re-running is safe —
+   it fills in missing files/deps, never overwrites edits.
+4. **Start ONE dependency install in the background and keep working:** launch
+   `npm install --ignore-scripts` as a background task **now**, and do step 5 while it runs —
+   don't sit and wait on it, don't poll it, and never run a second install. It's the longest
+   step (~2 min); everything in step 5 is independent of `node_modules`.
+5. **While the install runs — seed and build the brand layer:**
+   - **Seed** per the vertical's `seed/SEED.md`: write a plain-data plan from the brief and run
+     the seed script (it needs no `node_modules`; it installs the vertical's Wix app itself).
+     Seeding is **additive**: never delete or overwrite existing content; if a cleanup seems
+     needed, ask.
+   - **Brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
+     header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
+     first, and don't open the shipped files themselves.
+6. **When the install finishes: build & release once** (managed): `npx @wix/cli@latest build`
+   then `npx @wix/cli@latest release`. Don't build+release mid-flow; backend content is fetched
+   at runtime, so a re-release never "refreshes" seeded data. Close with the live URL and the
    dashboard link `https://manage.wix.com/dashboard/<siteId>`.
 
 Don't smoke-test with a dev server unless the user explicitly asks to verify — correctness

--- a/skills/wix-headless-fast/install/deploy.mjs
+++ b/skills/wix-headless-fast/install/deploy.mjs
@@ -9,10 +9,16 @@
 //                  client id into src/wix/config.ts (pass --client-id, or it's read from
 //                  wix.config.json's appId when present).
 //
-// ONE mechanism: recursive copy with force:false — only files that AREN'T there yet are
-// written, so a re-run restores missing files without clobbering edits, and a later call can
-// add a vertical safely. Verticals ship at disjoint paths (src/wix/<vertical>/,
-// src/components/<vertical>/, …), so they never collide with each other.
+// TWO mechanisms, driven by the same vertical arguments:
+// 1. Recursive file copy with force:false — only files that AREN'T there yet are written, so
+//    a re-run restores missing files without clobbering edits, and a later call can add a
+//    vertical safely. Verticals ship at disjoint paths (src/wix/<vertical>/,
+//    src/components/<vertical>/, …), so they never collide with each other.
+// 2. package.json dependency patch — after the copy, any dependency the copied code imports
+//    that is absent from BOTH dependencies and devDependencies is added to dependencies
+//    (fill-only: an existing version range always wins). The script never runs npm install —
+//    it only makes package.json truthful about what src/ imports; installing is the caller's
+//    one command afterwards.
 import { cpSync, existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,11 +28,31 @@ const REF = join(SKILL_ROOT, "references");
 const PROJECT = process.cwd();
 const SRC = join(PROJECT, "src");
 const CONFIG_TS = join(SRC, "wix", "config.ts");
+const PKG_JSON = join(PROJECT, "package.json");
 
 // The vertical registry: every directory under references/ that ships an app/ is a vertical.
 const VERTICALS = readdirSync(REF, { withFileTypes: true })
   .filter((d) => d.isDirectory() && existsSync(join(REF, d.name, "app")) && d.name !== "shared")
   .map((d) => d.name);
+
+// What the shipped code imports, declared per layer (version ranges are the ones the shipped
+// code was verified against). react/astro/typescript/@wix/astro* are scaffold-owned — never
+// listed here. A new vertical adds its own entry; the patch logic below never changes.
+const SHARED_DEPS = { "@wix/sdk": "^1.21.5" };
+const VERTICAL_DEPS = {
+  storefront: {
+    core: {
+      "@wix/stores": "^1.0.888",
+      "@wix/categories": "^1.0.220",
+      "@wix/ecom": "^1.0.2451",
+      "@wix/redirects": "^1.0.125",
+    },
+    astro: {
+      "@wix/seo": "^1.0.79",
+      "@wix/essentials": "^1.0.6",
+    },
+  },
+};
 
 const COPY = { recursive: true, force: false, errorOnExist: false };
 
@@ -53,12 +79,30 @@ if (!["astro", "react"].includes(stack)) {
 cpSync(join(REF, "shared", "app"), SRC, COPY);
 
 const unknown = requested.filter((v) => !VERTICALS.includes(v));
+const wantedDeps = { ...SHARED_DEPS };
 for (const vertical of requested.filter((v) => VERTICALS.includes(v))) {
   cpSync(join(REF, vertical, "app"), SRC, COPY);
   if (stack === "astro" && existsSync(join(REF, vertical, "app-astro"))) {
     cpSync(join(REF, vertical, "app-astro"), SRC, COPY);
   }
+  const deps = VERTICAL_DEPS[vertical] ?? {};
+  Object.assign(wantedDeps, deps.core, stack === "astro" ? deps.astro : undefined);
   result.verticals.push(vertical);
+}
+
+// ---- dependency patch (fill-only) ----------------------------------------------------------------
+if (result.verticals.length && existsSync(PKG_JSON)) {
+  const pkg = JSON.parse(readFileSync(PKG_JSON, "utf8"));
+  pkg.dependencies ??= {};
+  const present = { ...pkg.devDependencies, ...pkg.dependencies };
+  const added = Object.entries(wantedDeps).filter(([name]) => !(name in present));
+  for (const [name, range] of added) pkg.dependencies[name] = range;
+  if (added.length) writeFileSync(PKG_JSON, JSON.stringify(pkg, null, 2) + "\n");
+  result.depsAdded = added.map(([name]) => name);
+  if (added.length) result.note = [result.note, "run `npm install --ignore-scripts` to pick up depsAdded"].filter(Boolean).join("; ");
+} else if (result.verticals.length) {
+  result.depsAdded = [];
+  result.note = [result.note, "no package.json here — run deploy from the project root"].filter(Boolean).join("; ");
 }
 
 if (unknown.length) {

--- a/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
@@ -4,7 +4,12 @@ A complete Wix Stores storefront ships as files: catalog + variants + cart + Wix
 checkout, typed end-to-end. You wire routes and build the brand layer; you don't write
 commerce code.
 
-## The file map (deployed into `src/` — you don't need to open these)
+## The file map (deployed into `src/`)
+
+**Don't read the shipped files** — this table and the typed export signatures are the whole
+contract, and every shape you need is in this playbook. Open a shipped file's source **only**
+on a real fallback: a runtime error, or a field this playbook doesn't cover. The one exception
+is `SiteLayout.astro`, which you edit (below).
 
 | file | what it is |
 |---|---|
@@ -42,9 +47,11 @@ shipped `CartButton`. Style everything you add from the same tokens.
 ### Wiring — Astro (default)
 
 Deploy already placed pages, layout, and islands. Remaining work: build `pages/index.astro`
-(home) on `SiteLayout`, theme the tokens/header/footer, adjust copy. Every island mounts with
-`client:load` when it renders primary content with SSR props, `client:only="react"` when it
-reads browser-only state (the shipped mounts already do this correctly).
+(home) on `SiteLayout`, theme the tokens/header/footer, adjust copy. **Theme `SiteLayout.astro`
+in ONE edit pass** — read it once, then rewrite the token block + header + footer together in a
+single Write/Edit, not token-by-token. Every island mounts with `client:load` when it renders
+primary content with SSR props, `client:only="react"` when it reads browser-only state (the
+shipped mounts already do this correctly).
 
 ### Wiring — React SPA (Vite etc.)
 


### PR DESCRIPTION
## Why

First fully-autonomous e2e run (`claude -p`, opus-4-6, cold entry URL → live store) succeeded in **11.2 min / \$1.89 / 46 turns** — target is ~5 min. Friction analysis of the transcript:

| bucket | time | fix here |
|---|---|---|
| `npm install` ran twice, foreground (2.0m timeout + 2.1m rerun) | ~4.1m | background it once, overlap with seed/theming |
| dep-gap rework (2 failed builds → grep imports → 2 more installs) | ~1.6m | deploy patches package.json upfront |
| avoidable turns (5 shipped-file reads, 4-pass layout theming, node_modules polling) | ~1–1.5m | INSTRUCTIONS tightenings |

The run also validated the design: every shipped file remained **byte-identical** to the references; the agent only themed `SiteLayout` and wrote `index.astro` + `plan.json`. Live variants/SEO/categories all work.

## What

- **`install/deploy.mjs`** — new per-vertical dependency registry (`core` + `astro`-overlay maps, versions the code was verified against). After copying files it adds any missing entry to `dependencies` (fill-only — existing ranges win, both dep sections checked), reports `depsAdded`, and never runs npm itself. Same vertical arguments drive files and deps, so they can't disagree. Idempotent (re-run → `depsAdded: []`), tested.
- **`SKILL.md`** — run reorder: scaffold → **deploy → ONE background `npm install --ignore-scripts`** → seed + brand layer while it runs → build → release.
- **`references/storefront/INSTRUCTIONS.md`** — vibe-style "don't read the shipped files" rule (SiteLayout excepted) and "theme SiteLayout in ONE edit pass".

Expected effect: install (~2.1m) hides behind ~2m of seed/theming work, rework disappears, ~1m fewer gen turns → **~4.5–5.5m** for the same prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)