### PR TITLE
fix: wix-headless-fast — foreground install re-run as the build sync barrier

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -62,8 +62,8 @@ re-litigate them.
    it fills in missing files/deps, never overwrites edits.
 4. **Start ONE dependency install in the background and keep working:** launch
    `npm install --ignore-scripts` as a background task **now**, and do step 5 while it runs —
-   don't sit and wait on it, don't poll it, and never run a second install. It's the longest
-   step (~2 min); everything in step 5 is independent of `node_modules`.
+   don't sit polling it. It's the longest step (~2 min); everything in step 5 is independent of
+   `node_modules`.
 5. **While the install runs — seed and build the brand layer:**
    - **Seed** per the vertical's `seed/SEED.md`: write a plain-data plan from the brief and run
      the seed script (it needs no `node_modules`; it installs the vertical's Wix app itself).
@@ -72,10 +72,14 @@ re-litigate them.
    - **Brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
      header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
      first, and don't open the shipped files themselves.
-6. **When the install finishes: build & release once** (managed): `npx @wix/cli@latest build`
-   then `npx @wix/cli@latest release`. Don't build+release mid-flow; backend content is fetched
-   at runtime, so a re-release never "refreshes" seeded data. Close with the live URL and the
-   dashboard link `https://manage.wix.com/dashboard/<siteId>`.
+6. **Sync on the install, then build & release once** (managed). When step 5 is done, run
+   `npm install --ignore-scripts` again **in the foreground** — this is the sync barrier: it
+   returns in seconds if the background install finished, and completes the work itself if it
+   didn't (npm is idempotent). **Never end the run while an install is pending or before the
+   release has happened — the deliverable is the released site, not prepared work.** Then
+   `npx @wix/cli@latest build` and `npx @wix/cli@latest release`. Don't build+release mid-flow;
+   backend content is fetched at runtime, so a re-release never "refreshes" seeded data. Close
+   with the live URL and the dashboard link `https://manage.wix.com/dashboard/<siteId>`.
 
 Don't smoke-test with a dev server unless the user explicitly asks to verify — correctness
 comes from the shipped code, and real errors surface at build/release.


### PR DESCRIPTION
Run 2 with v1.1 validated the pipelining (deploy→deps patched cleanly, background install, seed+theme in parallel, **24 turns / 3.6 min / \$1.30 of agent work, zero errors**) — and then exposed a print-mode pitfall: the agent ended its turn "waiting for npm install", which in `claude -p` terminates the process and kills the background install with it. No build, no release.

Fix (SKILL.md only):
- Step 4 drops the "don't sit and wait / never run a second install" phrasing that caused it.
- Step 6 now begins with a **harness-agnostic sync barrier**: re-run `npm install --ignore-scripts` in the foreground — near-instant when the background install finished, completes the work itself when it didn't — plus an explicit "never end the run while an install is pending or before the release has happened."

🤖 Generated with [Claude Code](https://claude.com/claude-code)