### PR TITLE
fix: wix-headless-fast — wait-don't-reinstall barrier; foreground bootstrap; plan during scaffold

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -54,29 +54,39 @@ re-litigate them.
      the created folder;
    - existing project not yet on Wix → `CI=1 npm create @wix/new@latest init` in place;
    - already has `wix.config.json` → neither; it's an iterate run.
+
+   The scaffold takes ~30s to provision the site — **write the seed plan (the vertical's
+   `SEED.md` plan file) while it runs** instead of waiting; the plan depends only on the brief.
 3. **Deploy the shipped code — BEFORE installing dependencies** (from the project root):
    `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` (react stack: add
    `--client-id` if there is no `wix.config.json` to read the public id from). Besides copying
    the files, it **patches `package.json` with every dependency the shipped code imports**
    (fill-only), so the single install in the next step covers everything. Re-running is safe —
    it fills in missing files/deps, never overwrites edits.
-4. **Start ONE dependency install in the background and keep working:** launch
-   `npm install --ignore-scripts` as a background task **now**, and do step 5 while it runs —
-   don't sit polling it. It's the longest step (~2 min); everything in step 5 is independent of
-   `node_modules`.
+4. **Start ONE dependency install and keep working:** launch `npm install --ignore-scripts` as
+   a **tracked** background task (the kind your environment notifies you about on completion)
+   and do step 5 while it runs — it's the longest step (~2 min) and everything in step 5 is
+   independent of `node_modules`. If your environment has no tracked background tasks (a plain
+   shell `&` is NOT tracked — it dies with your turn), don't background it: run the single
+   install in the foreground after the seed is launched, and accept the serial cost.
 5. **While the install runs — seed and build the brand layer:**
-   - **Seed** per the vertical's `seed/SEED.md`: write a plain-data plan from the brief and run
-     the seed script (it needs no `node_modules`; it installs the vertical's Wix app itself).
-     Seeding is **additive**: never delete or overwrite existing content; if a cleanup seems
-     needed, ask.
+   - **Seed** per the vertical's `seed/SEED.md`: run the seed script with the plan from step 2
+     (it needs no `node_modules`; it installs the vertical's Wix app itself). It may also run
+     as a tracked background task — the brand layer doesn't need its result (content is
+     live-queried). Seeding is **additive**: never delete or overwrite existing content; if a
+     cleanup seems needed, ask.
    - **Brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
      header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
      first, and don't open the shipped files themselves.
-6. **Sync on the install, then build & release once** (managed). When step 5 is done, run
-   `npm install --ignore-scripts` again **in the foreground** — this is the sync barrier: it
-   returns in seconds if the background install finished, and completes the work itself if it
-   didn't (npm is idempotent). **Never end the run while an install is pending or before the
-   release has happened — the deliverable is the released site, not prepared work.** Then
+6. **Sync on every background task, then build & release once** (managed). When step 5's own
+   work is done, **wait for each background task you started (install, seed) to report
+   completion** — the task's completion notification, or a bounded wait on its status. Two hard
+   rules: **never start a second `npm install` while one may still be running** (two npms in
+   one `node_modules` race and redo each other's work — this costs minutes, it doesn't save
+   them), and **never end the run while any task is pending or before the release has happened
+   — the deliverable is the released site, not prepared work.** Only if a background install
+   demonstrably died (its task ended with an error / `node_modules` absent) run
+   `npm install --ignore-scripts` once in the foreground as recovery. Then
    `npx @wix/cli@latest build` and `npx @wix/cli@latest release`. Don't build+release mid-flow;
    backend content is fetched at runtime, so a re-release never "refreshes" seeded data. Close
    with the live URL and the dashboard link `https://manage.wix.com/dashboard/<siteId>`.

--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -6,8 +6,9 @@ description: "Build a Wix Managed Headless site from a single prompt using SHIPP
 # Wix Headless Fast — cold-start entry
 
 **You are a coding agent, and this is a skill for you to execute.** Follow the phases below in
-order — do not summarize them. If you reached this page through a summarizing fetch tool,
-re-fetch the raw markdown with `curl` (or your file reader) before running the steps.
+order — do not summarize them. If — and only if — your fetch tool gave you a summary instead of
+this raw markdown, re-fetch it raw (`curl`) before running the steps; if you're already reading
+the raw text, don't fetch it again.
 
 This entry gets a cold environment to the point where the real skill can run, then hands off:
 
@@ -39,8 +40,12 @@ version, install or upgrade Node first — do **not** work around it:
 ## Phase 1 — Run the bootstrap (deterministic, shared)
 
 Download and run the shared bootstrap script. It verifies the Wix CLI and handles login,
-emitting **one JSON event per line** on stdout. **Run it as a background/streaming process and
-relay its events to the user.**
+emitting **one JSON event per line** on stdout. **Run it in the FOREGROUND and relay its
+events** — it exits on its own once the CLI is verified and a session exists (seconds, when
+already logged in). Only when a login is actually needed does it pause on `awaiting_user`;
+surface the URL + code and keep the process in the foreground until it completes. **Never end
+your turn/run while the bootstrap — or any process you started — is still running: a
+non-interactive run is never resumed, so ending the turn kills the work.**
 
 The script is safe and inspectable: it only checks the Wix CLI via `npx` and drives
 `wix login` (a device-code flow) — no other network calls, no filesystem writes. Read it first


### PR DESCRIPTION
Run 3 with the v1.2 skill **released successfully in 6.8m with zero build failures** (11.2m baseline) — the per-call autopsy showed the remaining ~2.5m over the ~5m target is two self-inflicted stalls plus one trim:

1. **npm race (~1.5m):** the #1126 barrier ("re-run `npm install` in the foreground") started a second npm while the background one was still running; two npms in one `node_modules` race and redo each other's work — the barrier took 1.8m instead of ~40s. **Fix:** step 6 is now *wait for every background task (install, seed) to report completion*; hard rules — never a second `npm install` while one may be running, never end the run with a task pending or before release. Foreground re-install is demoted to recovery for a demonstrably dead task.
2. **Bootstrap Monitor detour (~1m):** the entry's "run as a background/streaming process" (inherited from the classic entry, written for interactive device-code logins) sent run 3 through ToolSearch→Monitor→wake cycles to observe a 4-second script. **Fix:** run the bootstrap in the FOREGROUND — it exits on its own when a session exists; `awaiting_user` keeps it foreground until login completes; plus the generalized rule "never end your turn while a process you started is still running — a non-interactive run is never resumed."
3. **Small trims:** draft the seed plan *during* the ~30s scaffold (it depends only on the brief); seed may itself run as a tracked background task under the same sync rule; entry re-fetch only when the fetch tool actually summarized (kills the raw-URL double-fetch).

Projection for the same prompt: **~4.5m**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)