### PR TITLE
rework: wix-headless-fast — strip harness-specific waiting mitigations; plan-before-scaffold

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -43,6 +43,14 @@ re-litigate them.
 
 ## The run
 
+> **The waiting rule (applies to every step below):** the ONLY way to wait for anything — a
+> scaffold, an install, a seed, a build — is a **foreground blocking command**: the process
+> itself run in the foreground, or a single `until <completion check>; do sleep 5; done` call
+> with a generous tool timeout. **Never wait by ending your turn**, arming a watcher and
+> stopping, or "pausing until it finishes" — in a non-interactive run, ending the turn kills
+> every background task you started and the run itself. Runs have died exactly this way, on
+> three different steps.
+
 1. **Resolve the stack.** Default is **Wix-managed Astro** — take it unless the user names a
    different React framework or the directory already holds a non-Astro React project. A
    non-React frontend is out of scope → `wix-headless`.
@@ -55,8 +63,9 @@ re-litigate them.
    - existing project not yet on Wix → `CI=1 npm create @wix/new@latest init` in place;
    - already has `wix.config.json` → neither; it's an iterate run.
 
-   The scaffold takes ~30s to provision the site — **write the seed plan (the vertical's
-   `SEED.md` plan file) while it runs** instead of waiting; the plan depends only on the brief.
+   **Draft the seed plan (the vertical's `SEED.md` plan file) BEFORE scaffolding** — it depends
+   only on the brief — then run the scaffold in the **foreground** (~30s). Don't background the
+   scaffold; everything after this step needs its output.
 3. **Deploy the shipped code — BEFORE installing dependencies** (from the project root):
    `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` (react stack: add
    `--client-id` if there is no `wix.config.json` to read the public id from). Besides copying

--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -43,14 +43,6 @@ re-litigate them.
 
 ## The run
 
-> **The waiting rule (applies to every step below):** the ONLY way to wait for anything — a
-> scaffold, an install, a seed, a build — is a **foreground blocking command**: the process
-> itself run in the foreground, or a single `until <completion check>; do sleep 5; done` call
-> with a generous tool timeout. **Never wait by ending your turn**, arming a watcher and
-> stopping, or "pausing until it finishes" — in a non-interactive run, ending the turn kills
-> every background task you started and the run itself. Runs have died exactly this way, on
-> three different steps.
-
 1. **Resolve the stack.** Default is **Wix-managed Astro** — take it unless the user names a
    different React framework or the directory already holds a non-Astro React project. A
    non-React frontend is out of scope → `wix-headless`.
@@ -63,50 +55,35 @@ re-litigate them.
    - existing project not yet on Wix → `CI=1 npm create @wix/new@latest init` in place;
    - already has `wix.config.json` → neither; it's an iterate run.
 
-   **Draft the seed plan (the vertical's `SEED.md` plan file) BEFORE scaffolding** — it depends
-   only on the brief — then run the scaffold in the **foreground** (~30s). Don't background the
-   scaffold; everything after this step needs its output.
+   **Draft the seed plan (the vertical's `SEED.md` plan file) before scaffolding** — it depends
+   only on the brief — then run the scaffold (~30s); everything after this step needs its
+   output.
 3. **Deploy the shipped code — BEFORE installing dependencies** (from the project root):
    `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` (react stack: add
    `--client-id` if there is no `wix.config.json` to read the public id from). Besides copying
    the files, it **patches `package.json` with every dependency the shipped code imports**
    (fill-only), so the single install in the next step covers everything. Re-running is safe —
    it fills in missing files/deps, never overwrites edits.
-4. **Start ONE dependency install and keep working:** launch
-   `npm ci --ignore-scripts || npm install --ignore-scripts` as a **tracked** background task
-   (the kind your environment notifies you about on completion) and do step 5 while it runs.
-   Deploy placed a pre-resolved `package-lock.json`, so `npm ci` usually finishes in seconds to
-   ~1 min; the `|| npm install` fallback covers a stale/out-of-sync lock. Everything in step 5
-   is independent of `node_modules`. If your environment has no tracked background tasks (a
-   plain shell `&` is NOT tracked — it dies with your turn), don't background it: run the
-   single install command in the foreground after the seed is launched.
+4. **Run ONE dependency install:**
+   `npm ci --ignore-scripts || npm install --ignore-scripts`. Deploy placed a pre-resolved
+   `package-lock.json`, so `npm ci` usually finishes in seconds to ~1 min; the `|| npm install`
+   fallback covers a stale/out-of-sync lock. It can run in the background while you do step 5 —
+   everything there is independent of `node_modules`. **Never run a second `npm install`
+   concurrently with the first** — two npms in one `node_modules` race and redo each other's
+   work.
 5. **While the install runs — seed and build the brand layer:**
-   - **Seed** per the vertical's `seed/SEED.md`: run the seed script with the plan from step 2,
-     in the **foreground** — it takes ~20s, needs no `node_modules`, and installs the
-     vertical's Wix app itself. Seeding is **additive**: never delete or overwrite existing
-     content; if a cleanup seems needed, ask.
+   - **Seed** per the vertical's `seed/SEED.md`: run the seed script with the plan from step 2
+     — it takes ~20s, needs no `node_modules`, and installs the vertical's Wix app itself.
+     Seeding is **additive**: never delete or overwrite existing content; if a cleanup seems
+     needed, ask.
    - **Brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
      header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
      first, and don't open the shipped files themselves.
-6. **Sync on the install with ONE foreground blocking command, then build & release once**
-   (managed). When step 5 is done, run — as a normal foreground call with a generous tool
-   timeout (10 min):
-
-   ```bash
-   until [ -f node_modules/.package-lock.json ]; do sleep 5; done
-   ```
-
-   (`node_modules/.package-lock.json` is npm's completion artifact.) **This is the only valid
-   way to wait.** Never wait by ending your turn, going idle, or arming a watcher and stopping
-   — in a non-interactive run, ending the turn kills your background tasks and the run; runs
-   have died exactly this way. Two more hard rules: **never start a second `npm install` while
-   one may still be running** (two npms in one `node_modules` race and redo each other's work),
-   and **never end the run before the release has happened — the deliverable is the released
-   site, not prepared work.** If the wait times out, check the install task's output; only if
-   it demonstrably died, run `npm install --ignore-scripts` once in the foreground as recovery.
-   Then `npx @wix/cli@latest build` and `npx @wix/cli@latest release`. Don't build+release
-   mid-flow; backend content is fetched at runtime, so a re-release never "refreshes" seeded
-   data. Close with the live URL and the dashboard link
+6. **When the install has completed, build & release once** (managed):
+   `npx @wix/cli@latest build` then `npx @wix/cli@latest release` (if the install failed, run
+   it once more and then build). Don't build+release mid-flow; backend content is fetched at
+   runtime, so a re-release never "refreshes" seeded data. The run is complete only when the
+   site is released — close with the live URL and the dashboard link
    `https://manage.wix.com/dashboard/<siteId>`.
 
 Don't smoke-test with a dev server unless the user explicitly asks to verify — correctness

--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -40,12 +40,10 @@ version, install or upgrade Node first — do **not** work around it:
 ## Phase 1 — Run the bootstrap (deterministic, shared)
 
 Download and run the shared bootstrap script. It verifies the Wix CLI and handles login,
-emitting **one JSON event per line** on stdout. **Run it in the FOREGROUND and relay its
-events** — it exits on its own once the CLI is verified and a session exists (seconds, when
-already logged in). Only when a login is actually needed does it pause on `awaiting_user`;
-surface the URL + code and keep the process in the foreground until it completes. **Never end
-your turn/run while the bootstrap — or any process you started — is still running: a
-non-interactive run is never resumed, so ending the turn kills the work.**
+emitting **one JSON event per line** on stdout. **Run it and relay its events** — it exits on
+its own once the CLI is verified and a session exists (seconds, when already logged in). Only
+when a login is actually needed does it pause on `awaiting_user`; surface the URL + code and
+let it keep running until the login completes.
 
 The script is safe and inspectable: it only checks the Wix CLI via `npx` and drives
 `wix login` (a device-code flow) — no other network calls, no filesystem writes. Read it first


### PR DESCRIPTION
Direction change from review: the turn-end-kills-background-tasks failure (runs 2/4/6) is a property of the **invocation** (`claude -p` print mode), not of the flow — so the skill must not carry mitigations for it. Interactive harnesses wake on task notifications and none of this applies to them.

**Removed from the skill** (added across #1126–#1128 and this branch's first commit): the global waiting rule, the foreground `until`-loop barrier prescription, "the only valid way to wait", and every "never end your turn/run while X is pending" clause (SKILL.md steps 4–6, entry Phase 1).

**Kept**, because they're flow/tool facts true for any agent: exactly one install, never two concurrent npms (npm behavior), draft the seed plan before scaffolding, build after the install completes, release once, "the run is complete only when the site is released".

**Where the mitigation lives now:** the invocation layer — a short suffix appended to the `-p` prompt ("this is a non-interactive run; wait with blocking commands; your final message comes after release"), and/or the runner resuming the session (`claude -p --resume <id> "continue"`) when it exits before the deliverable. That harness lives with the experiment runner, not in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)