### PR TITLE
fix: wix-headless-fast — seed default 3; verbatim URL; deploy links; single-skill entry

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -84,7 +84,9 @@ re-litigate them.
    it once more and then build). Don't build+release mid-flow; backend content is fetched at
    runtime, so a re-release never "refreshes" seeded data. The run is complete only when the
    site is released — close with the live URL and the dashboard link
-   `https://manage.wix.com/dashboard/<siteId>`.
+   `https://manage.wix.com/dashboard/<siteId>`. **Copy the live URL verbatim from the
+   `wix release` output — never retype it from memory** (a mistyped subdomain hands the user
+   a 404).
 
 Don't smoke-test with a dev server unless the user explicitly asks to verify — correctness
 comes from the shipped code, and real errors surface at build/release.

--- a/skills/wix-headless-fast/entry/skill.md
+++ b/skills/wix-headless-fast/entry/skill.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless-fast-entry
-description: "Build a Wix Managed Headless site from a single prompt using SHIPPED, verified storefront code (the wix-headless-fast skill) — the deterministic first steps (system prerequisites and Wix CLI login) are handled by the shared bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then installs the skills and hands the run to wix-headless-fast, falling back to wix-headless for verticals it doesn't ship. Triggers: build me a store fast, fast headless storefront, wix headless fast entry."
+description: "Build a Wix Managed Headless site from a single prompt using SHIPPED, verified storefront code (the wix-headless-fast skill) — the deterministic first steps (system prerequisites and Wix CLI login) are handled by the shared bootstrap script (`https://www.wix.com/skills/headless/entry/bootstrap.mjs`); the agent then installs the skill and hands it the run. Triggers: build me a store fast, fast headless storefront, wix headless fast entry."
 ---
 
 # Wix Headless Fast — cold-start entry
@@ -67,29 +67,22 @@ node bootstrap.mjs
 | `logged_in` / `success` | Login done — continue. |
 | `cli_unreachable` / `login_failed` (with `detail`) | Stop and show the user the `detail`. **Do not** improvise a parallel setup by hand. |
 
-## Phase 2 — Install the skills and hand off
+## Phase 2 — Install the skill and hand off
 
-Install the Wix skills (`CI=1` forces plain non-interactive CLI output — keep it on every Wix
-CLI command):
+Install the skill (`CI=1` forces plain non-interactive CLI output — keep it on every Wix CLI
+command):
 
 ```bash
-CI=1 npx skills@latest add wix/skills --yes
+CI=1 npx skills@latest add wix/skills/skills/wix-headless-fast --yes
 ```
 
-The skills land in `.agents/skills/` — including both `wix-headless-fast` and `wix-headless`.
+It lands at `.agents/skills/wix-headless-fast/`. Then **open
+`.agents/skills/wix-headless-fast/SKILL.md` and follow it** — it owns the rest of the run:
+resolve the stack, scaffold, deploy the shipped code, seed, build the brand layer, release.
+(If the request needs a vertical the skill doesn't ship yet — see its SKILL.md § Verticals —
+say so plainly and point the user at the `wix-headless` skill instead of improvising.)
 
-Then route by what the request needs:
-
-- The request matches a vertical `wix-headless-fast` ships (see its SKILL.md § Verticals —
-  currently **storefront**: products, categories, variants, cart, checkout) → **open
-  `wix-headless-fast/SKILL.md` and follow it.** It owns the rest of the run: resolve the stack,
-  scaffold, deploy the shipped code, seed, build the brand layer, release.
-- The request needs a vertical it doesn't ship, or a non-React frontend → **open
-  `wix-headless/SKILL.md` instead** and follow that skill's full flow.
-
-Either way:
-
-- **Don't** scaffold, install apps, or seed by hand here — the skill you hand off to does all
-  of that. This entry stops at *logged in*.
+- **Don't** scaffold, install apps, or seed by hand here — the skill does all of that. This
+  entry stops at *logged in*.
 - You're already authenticated from Phase 1, so the skill's CLI auth step will pass without
   prompting again.

--- a/skills/wix-headless-fast/install/deploy.mjs
+++ b/skills/wix-headless-fast/install/deploy.mjs
@@ -122,6 +122,22 @@ if (result.verticals.length === 1 && existsSync(PKG_JSON) && !existsSync(PROJECT
   }
 }
 
+// ---- ready-made links -----------------------------------------------------------------------------
+// Emit the siteId and the dashboard deep links so nothing downstream re-derives or retypes them.
+const WIX_CONFIG = join(PROJECT, "wix.config.json");
+if (existsSync(WIX_CONFIG)) {
+  const config = JSON.parse(readFileSync(WIX_CONFIG, "utf8"));
+  const siteId = config.siteId ?? config.projectId;
+  if (siteId) {
+    result.siteId = siteId;
+    result.dashboardUrl = `https://manage.wix.com/dashboard/${siteId}`;
+    if (result.verticals.includes("storefront")) {
+      result.productsUrl = `https://manage.wix.com/dashboard/${siteId}/wix-stores/products`;
+      result.categoriesUrl = `https://manage.wix.com/dashboard/${siteId}/wix-stores/categories/list`;
+    }
+  }
+}
+
 if (unknown.length) {
   result.error = `unknown vertical(s) ${unknown.map((v) => `"${v}"`).join(", ")} — available: ${VERTICALS.join(", ")}`;
 }

--- a/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
@@ -92,11 +92,9 @@ public client id into `wix/config.ts`; nothing else to configure.
 
 ## Point the user to their dashboard
 
-Content editing happens in the Wix dashboard — give the owner these links (substitute the
-`siteId` from `wix.config.json`):
-
-- Products — `https://manage.wix.com/dashboard/{siteId}/wix-stores/products`
-- Categories — `https://manage.wix.com/dashboard/{siteId}/wix-stores/categories/list`
+Content editing happens in the Wix dashboard — give the owner the dashboard, products, and
+categories links. **The deploy step's JSON output already printed them ready-made**
+(`dashboardUrl`, `productsUrl`, `categoriesUrl`) — copy them from there, don't re-derive.
 
 Real payments additionally need a premium plan + a connected payment method (dashboard) —
 mention it, don't treat it as a code failure.

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -39,9 +39,10 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
 - `imageUrl` — a real, fetchable https URL; Wix re-hosts it server-side. Omit to seed text-only.
 - `categories` — category name → product NAMES. Omit when the brief names none.
 
-**Seed a catalog that exercises the shipped UI**: unless the brief says otherwise, give at
-least one product a color option and put one product on sale — truthfully to the business (a
-ceramics studio has glaze colors; a bakery doesn't).
+**Default to 3 products** unless the brief asks for a specific catalog — the seed shows the
+shape, not a full inventory; the owner adds the rest in the dashboard. **Make those 3 exercise
+the shipped UI**: give at least one product a color option and put one product on sale —
+truthfully to the business (a ceramics studio has glaze colors; a bakery doesn't).
 
 **Seeding is additive — never delete or overwrite existing content.** No cleanup, no removing
 "sample" data, no resets. If a cleanup genuinely seems needed, ask the user first.


### PR DESCRIPTION
Two findings from the sonnet consistency batch (runs 12–15, all released):

1. **Seed size drift** — sonnet agents seeded ~18-product catalogs (opus: 6–8). `SEED.md` now defaults to **3 products** unless the brief asks otherwise — the seed shows the shape, the owner adds inventory in the dashboard — while keeping the exercise-the-UI rule (≥1 color option, ≥1 on sale).
2. **Misreported deliverable** — run 15's final message carried a typo'd live URL (`-1006` vs the real `-1306`; the site was fine, the report wasn't). Step 6 now requires **copying the live URL verbatim from the `wix release` output**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)