### PR TITLE
feat: wix-headless-fast — fast-path.mjs orchestrator (plan → brand layer in one call)

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -46,40 +46,38 @@ re-litigate them.
 1. **Resolve the stack.** Default is **Wix-managed Astro** — take it unless the user names a
    different React framework or the directory already holds a non-Astro React project. A
    non-React frontend is out of scope → `wix-headless`.
-2. **Scaffold / connect (managed).** Requires Node ≥ 20.11 and a logged-in Wix CLI
+2. **Draft the seed plan** (the vertical's `SEED.md` plan file) — it depends only on the
+   brief. Requires from here on: Node ≥ 20.11 and a logged-in Wix CLI
    (`npx @wix/cli@latest whoami`; login via the device-code flow — surface the URL+code, never
-   read tokens into context). Then:
-   - empty directory → `CI=1 npm create @wix/new@latest -- headless --folder-name <name>
-     --business-name "<Brand>" --site-template --skip-install --no-publish`, then work inside
-     the created folder;
-   - existing project not yet on Wix → `CI=1 npm create @wix/new@latest init` in place;
-   - already has `wix.config.json` → neither; it's an iterate run.
+   read tokens into context).
+3. **Create runs (empty directory): run the fast path** — one deterministic call:
 
-   **Draft the seed plan (the vertical's `SEED.md` plan file) before scaffolding** — it depends
-   only on the brief — then run the scaffold (~30s); everything after this step needs its
-   output.
-3. **Deploy the shipped code — BEFORE installing dependencies** (from the project root):
-   `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` (react stack: add
-   `--client-id` if there is no `wix.config.json` to read the public id from). Besides copying
-   the files, it **patches `package.json` with every dependency the shipped code imports**
-   (fill-only), so the single install in the next step covers everything. Re-running is safe —
-   it fills in missing files/deps, never overwrites edits.
-4. **Run ONE dependency install:**
-   `npm ci --ignore-scripts || npm install --ignore-scripts`. Deploy placed a pre-resolved
-   `package-lock.json`, so `npm ci` usually finishes in seconds to ~1 min; the `|| npm install`
-   fallback covers a stale/out-of-sync lock. It can run in the background while you do step 5 —
-   everything there is independent of `node_modules`. **Never run a second `npm install`
-   concurrently with the first** — two npms in one `node_modules` race and redo each other's
-   work.
-5. **While the install runs — seed and build the brand layer:**
-   - **Seed** per the vertical's `seed/SEED.md`: run the seed script with the plan from step 2
-     — it takes ~20s, needs no `node_modules`, and installs the vertical's Wix app itself.
-     Seeding is **additive**: never delete or overwrite existing content; if a cleanup seems
-     needed, ask.
-   - **Brand layer** per the vertical's `INSTRUCTIONS.md`: the home page, the layout's
-     header/footer/tokens, and the copy — composing the shipped pieces. Read the INSTRUCTIONS
-     first, and don't open the shipped files themselves.
-6. **When the install has completed, build & release once** (managed):
+   ```bash
+   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json
+   ```
+
+   It emits one JSON event per line: **scaffolds** the project, **deploys** the shipped code
+   (patching `package.json` with every dependency the code imports, and placing the
+   pre-resolved lockfile), **starts** `npm ci --ignore-scripts || npm install --ignore-scripts`
+   detached in the background (its log and completion marker are in the events), and **seeds**
+   from the plan. The final `ready_for_brand_layer` event carries the project dir, siteId, and
+   ready-made dashboard links. Takes ~1 min; relay notable events. On an `error` event, recover
+   just that step via the manual path below, then continue.
+
+   **Connect/iterate runs (a project already on disk): never scaffold — use the manual path:**
+   `CI=1 npm create @wix/new@latest init` in place if there is no `wix.config.json` yet; then
+   `node <SKILL_ROOT>/install/deploy.mjs <vertical…> --stack astro|react` from the project root
+   (react stack: add `--client-id` if there is no `wix.config.json` to read the public id
+   from); then ONE `npm ci --ignore-scripts || npm install --ignore-scripts` (backgroundable —
+   but **never run a second npm install concurrently**: two npms in one `node_modules` race and
+   redo each other's work); then seed per the vertical's `seed/SEED.md`. Seeding is
+   **additive**: never delete or overwrite existing content; if a cleanup seems needed, ask.
+4. **Build the brand layer while the install finishes** — in the project dir from the
+   `ready_for_brand_layer` event, per the vertical's `INSTRUCTIONS.md`: the home page, the
+   layout's header/footer/tokens, and the copy — composing the shipped pieces. Read the
+   INSTRUCTIONS first, and don't open the shipped files themselves.
+5. **When the install has completed** (its marker file, `node_modules/.package-lock.json`,
+   exists)**, build & release once** (managed):
    `npx @wix/cli@latest build` then `npx @wix/cli@latest release` (if the install failed, run
    it once more and then build). Don't build+release mid-flow; backend content is fetched at
    runtime, so a re-release never "refreshes" seeded data. The run is complete only when the

--- a/skills/wix-headless-fast/install/fast-path.mjs
+++ b/skills/wix-headless-fast/install/fast-path.mjs
@@ -1,0 +1,122 @@
+// Fast path for a managed CREATE run — one deterministic call from "plan exists" to
+// "brand layer can start". Composes the pieces that also remain individually runnable
+// (deploy.mjs, the vertical's seed module); use those directly to recover a failed step,
+// or for connect/iterate runs (which must NOT scaffold and don't use this script).
+//
+//   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json \
+//        [--vertical storefront] [--stack astro] [--folder-name <npm-safe-name>]
+//
+// It emits ONE JSON event per line and exits after seeding, with the dependency install
+// still running detached in the background (log + completion marker reported in the final
+// event). Steps: scaffold (Wix CLI; requires a logged-in session) → deploy shipped code +
+// deps + lockfile → start `npm ci || npm install` detached → seed from the plan.
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, openSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SKILL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const emit = (event, extra = {}) => console.log(JSON.stringify({ event, ...extra }));
+const fail = (step, detail) => {
+  emit("error", { step, detail: String(detail).slice(0, 600) });
+  process.exit(1);
+};
+
+// ---- args ---------------------------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i !== -1 && argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[i + 1] : null;
+};
+const businessName = flag("business-name");
+const planPath = flag("plan");
+const vertical = flag("vertical") ?? "storefront";
+const stack = flag("stack") ?? "astro";
+if (!businessName || !planPath) {
+  fail("args", 'usage: fast-path.mjs --business-name "<Brand>" --plan plan.json [--vertical storefront] [--stack astro]');
+}
+if (!existsSync(planPath)) fail("args", `plan file not found: ${planPath}`);
+const plan = JSON.parse(readFileSync(planPath, "utf8"));
+
+const folderName =
+  flag("folder-name") ??
+  businessName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
+const projectDir = resolve(process.cwd(), folderName);
+
+// ---- 1 · scaffold -------------------------------------------------------------------------------
+if (existsSync(join(process.cwd(), "wix.config.json"))) {
+  fail("scaffold", "the current directory is already a Wix project — this script is for CREATE runs only; use deploy.mjs + the seed module directly");
+}
+if (existsSync(join(projectDir, "wix.config.json"))) {
+  emit("scaffold_skipped", { reason: "project already exists", folder: folderName });
+} else {
+  emit("scaffolding", { folder: folderName });
+  const scaffold = spawnSync(
+    "npm",
+    ["create", "@wix/new@latest", "--", "headless",
+     "--folder-name", folderName, "--business-name", businessName,
+     "--site-template", "--skip-install", "--no-publish"],
+    { env: { ...process.env, CI: "1" }, encoding: "utf8", timeout: 300_000 },
+  );
+  if (scaffold.status !== 0 || !existsSync(join(projectDir, "wix.config.json"))) {
+    fail("scaffold", (scaffold.stderr || scaffold.stdout || "scaffold produced no wix.config.json — is the Wix CLI logged in? (npx @wix/cli@latest whoami)").slice(-600));
+  }
+}
+const wixConfig = JSON.parse(readFileSync(join(projectDir, "wix.config.json"), "utf8"));
+const siteId = wixConfig.siteId ?? wixConfig.projectId;
+emit("scaffolded", { folder: folderName, siteId });
+
+// ---- 2 · deploy shipped code + deps + lockfile ---------------------------------------------------
+const deploy = spawnSync(
+  "node",
+  [join(SKILL_ROOT, "install", "deploy.mjs"), vertical, "--stack", stack],
+  { cwd: projectDir, encoding: "utf8", timeout: 60_000 },
+);
+if (deploy.status !== 0) fail("deploy", deploy.stderr || deploy.stdout);
+let deployResult = {};
+try { deployResult = JSON.parse(deploy.stdout); } catch { /* keep going with raw output below */ }
+if (deployResult.error) fail("deploy", deployResult.error);
+emit("deployed", deployResult);
+
+// ---- 3 · start the dependency install, detached --------------------------------------------------
+const installLog = join(projectDir, "npm-install.log");
+const logFd = openSync(installLog, "a");
+const install = spawn("sh", ["-c", "npm ci --ignore-scripts || npm install --ignore-scripts"], {
+  cwd: projectDir,
+  detached: true,
+  stdio: ["ignore", logFd, logFd],
+});
+install.unref();
+emit("install_started", { log: installLog, doneMarker: "node_modules/.package-lock.json" });
+
+// ---- 4 · seed from the plan ----------------------------------------------------------------------
+const seedDir = join(SKILL_ROOT, "references", vertical, "seed");
+const seedFile = existsSync(join(seedDir, "seed-store.mjs"))
+  ? join(seedDir, "seed-store.mjs")
+  : null;
+if (!seedFile) fail("seed", `no seed module found under ${seedDir}`);
+emit("seeding", { vertical });
+try {
+  const seed = await import(pathToFileURL(seedFile).href);
+  const ctx = seed.makeCtx({ cwd: projectDir });
+  const result = await seed.setupStore(ctx, plan);
+  emit("seeded", {
+    products: result.products?.length ?? 0,
+    categories: result.categories?.length ?? 0,
+    imagesAttached: result.imagesAttached ?? 0,
+  });
+} catch (e) {
+  fail("seed", e.message);
+}
+
+// ---- done ----------------------------------------------------------------------------------------
+emit("ready_for_brand_layer", {
+  projectDir,
+  siteId,
+  dashboardUrl: deployResult.dashboardUrl,
+  productsUrl: deployResult.productsUrl,
+  categoriesUrl: deployResult.categoriesUrl,
+  install: { log: installLog, doneMarker: "node_modules/.package-lock.json" },
+  next: "theme SiteLayout + write the home page; then wait for the install marker, build, release",
+});


### PR DESCRIPTION
## Why

After the earlier trims, ~60% of remaining wall-clock is model gen; the biggest reducible chunk is the mechanical middle of a create run — scaffold → deploy → install → seed — which has a fixed order and zero creative content but cost ~6 agent turns and produced the observed run-to-run variance (cwd retries, plan placement, opus/sonnet phrasing differences).

## What

**`install/fast-path.mjs`** — a bootstrap-style orchestrator, one call, one JSON event per line:

```
scaffolding → scaffolded{siteId} → deployed{depsAdded,lockDeployed,links} →
install_started{log,doneMarker} (npm ci||install spawned DETACHED) →
seeding → seeded{products,categories} → ready_for_brand_layer{projectDir,siteId,links,install}
```

- Composes the existing pieces (runs `deploy.mjs` as a child in the project dir; imports the vertical's seed module and calls `setupStore` with the parsed plan) — they all stay individually runnable for per-step recovery and for **connect/iterate runs, which must not scaffold and keep the manual path in SKILL.md**.
- Guards: refuses to run inside an existing Wix project; skips scaffold if the target folder already has `wix.config.json`; any step failure emits `{"event":"error","step",…}` and exits 1.
- **SKILL.md**: the run collapses 6 steps → 5; create = plan → one fast-path call → brand layer while the detached install finishes → marker-wait → build → release.

## Verified live (real site)

Full run in a scratch dir: scaffolded, deployed (5 deps patched, lock placed), install detached, **3 products + 2 categories seeded**, `ready_for_brand_layer` emitted — then the detached install **survived the script exiting** and completed (391 packages, marker written), and `wix build` passed on the result.

Expected effect: ~23 → ~14 turns, mean ~4.4m → ~3.5m, and the mechanical middle becomes order-of-execution-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)