### PR TITLE
fix: wix-headless-fast — fast-path detaches the seed (foreground ~25s flat)

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -56,13 +56,14 @@ re-litigate them.
    node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json
    ```
 
-   It emits one JSON event per line: **scaffolds** the project, **deploys** the shipped code
-   (patching `package.json` with every dependency the code imports, and placing the
-   pre-resolved lockfile), **starts** `npm ci --ignore-scripts || npm install --ignore-scripts`
-   detached in the background (its log and completion marker are in the events), and **seeds**
-   from the plan. The final `ready_for_brand_layer` event carries the project dir, siteId, and
-   ready-made dashboard links. Takes ~1 min; relay notable events. On an `error` event, recover
-   just that step via the manual path below, then continue.
+   It emits one JSON event per line and returns in **~35s**: **scaffolds** the project,
+   **deploys** the shipped code (patching `package.json` with every dependency the code
+   imports, and placing the pre-resolved lockfile), then **starts two detached background
+   jobs** — the dependency install (`npm ci --ignore-scripts || npm install --ignore-scripts`)
+   and the **seed** — whose logs and completion markers are in the events. The final
+   `ready_for_brand_layer` event carries the project dir, siteId, ready-made dashboard links,
+   and both markers. Relay notable events. On an `error` event, recover just that step via the
+   manual path below, then continue.
 
    **Connect/iterate runs (a project already on disk): never scaffold — use the manual path:**
    `CI=1 npm create @wix/new@latest init` in place if there is no `wix.config.json` yet; then
@@ -76,8 +77,11 @@ re-litigate them.
    `ready_for_brand_layer` event, per the vertical's `INSTRUCTIONS.md`: the home page, the
    layout's header/footer/tokens, and the copy — composing the shipped pieces. Read the
    INSTRUCTIONS first, and don't open the shipped files themselves.
-5. **When the install has completed** (its marker file, `node_modules/.package-lock.json`,
-   exists)**, build & release once** (managed):
+5. **When both background jobs have completed** — the install's marker
+   (`node_modules/.package-lock.json`) and the seed's (`.seed-exit`) both exist — **verify the
+   seed succeeded** (`.seed-exit` contains `0`; `seed-result.json` has the created counts for
+   your summary — if non-zero, read `seed.log` and re-run the seed module manually). Then
+   **build & release once** (managed):
    `npx @wix/cli@latest build` then `npx @wix/cli@latest release` (if the install failed, run
    it once more and then build). Don't build+release mid-flow; backend content is fetched at
    runtime, so a re-release never "refreshes" seeded data. The run is complete only when the

--- a/skills/wix-headless-fast/install/fast-path.mjs
+++ b/skills/wix-headless-fast/install/fast-path.mjs
@@ -6,14 +6,15 @@
 //   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json \
 //        [--vertical storefront] [--stack astro] [--folder-name <npm-safe-name>]
 //
-// It emits ONE JSON event per line and exits after seeding, with the dependency install
-// still running detached in the background (log + completion marker reported in the final
-// event). Steps: scaffold (Wix CLI; requires a logged-in session) → deploy shipped code +
-// deps + lockfile → start `npm ci || npm install` detached → seed from the plan.
+// It emits ONE JSON event per line and exits in ~35s with BOTH long steps — the dependency
+// install AND the seed — running detached in the background (logs + completion markers
+// reported in the final event), so the caller can build the brand layer while they finish.
+// Steps: scaffold (Wix CLI; requires a logged-in session) → deploy shipped code + deps +
+// lockfile → start `npm ci || npm install` detached → start the seed detached.
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, openSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const SKILL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -90,25 +91,26 @@ const install = spawn("sh", ["-c", "npm ci --ignore-scripts || npm install --ign
 install.unref();
 emit("install_started", { log: installLog, doneMarker: "node_modules/.package-lock.json" });
 
-// ---- 4 · seed from the plan ----------------------------------------------------------------------
+// ---- 4 · start the seed, detached ----------------------------------------------------------------
+// The seed includes a Wix-side provisioning wait of unpredictable length (10-80s); running it
+// in the caller's foreground would idle the agent for exactly that long. Detach it like the
+// install: result JSON + exit-code marker land as files the caller syncs on before release.
 const seedDir = join(SKILL_ROOT, "references", vertical, "seed");
 const seedFile = existsSync(join(seedDir, "seed-store.mjs"))
   ? join(seedDir, "seed-store.mjs")
   : null;
 if (!seedFile) fail("seed", `no seed module found under ${seedDir}`);
-emit("seeding", { vertical });
-try {
-  const seed = await import(pathToFileURL(seedFile).href);
-  const ctx = seed.makeCtx({ cwd: projectDir });
-  const result = await seed.setupStore(ctx, plan);
-  emit("seeded", {
-    products: result.products?.length ?? 0,
-    categories: result.categories?.length ?? 0,
-    imagesAttached: result.imagesAttached ?? 0,
-  });
-} catch (e) {
-  fail("seed", e.message);
-}
+const seedResultFile = join(projectDir, "seed-result.json");
+const seedLog = join(projectDir, "seed.log");
+const seedDoneMarker = join(projectDir, ".seed-exit");
+const planAbs = resolve(planPath);
+const seedChild = spawn(
+  "sh",
+  ["-c", `node "${seedFile}" "${planAbs}" > seed-result.json 2> seed.log; echo $? > .seed-exit`],
+  { cwd: projectDir, detached: true, stdio: "ignore" },
+);
+seedChild.unref();
+emit("seeding_started", { vertical, resultFile: seedResultFile, log: seedLog, doneMarker: seedDoneMarker });
 
 // ---- done ----------------------------------------------------------------------------------------
 emit("ready_for_brand_layer", {
@@ -118,5 +120,6 @@ emit("ready_for_brand_layer", {
   productsUrl: deployResult.productsUrl,
   categoriesUrl: deployResult.categoriesUrl,
   install: { log: installLog, doneMarker: "node_modules/.package-lock.json" },
-  next: "theme SiteLayout + write the home page; then wait for the install marker, build, release",
+  seed: { resultFile: "seed-result.json", log: "seed.log", doneMarker: ".seed-exit", success: "file contains 0" },
+  next: "theme SiteLayout + write the home page; then wait for BOTH done markers, verify .seed-exit is 0 (else read seed.log and re-run the seed module), build, release",
 });


### PR DESCRIPTION
Fast-path n=3 showed the orchestrator's foreground call ranging **40s–1.8m**, entirely driven by the seed's Wix-side provisioning wait — the agent idled through it (run 22: 5.8m total) even though the brand layer needs only the deployed files, ready seconds in.

**Fix:** the seed now spawns **detached**, exactly like the install — stdout → `seed-result.json`, stderr → `seed.log`, exit code → `.seed-exit` — and fast-path exits right after launching both background jobs. SKILL.md's pre-release barrier waits on **both** markers and checks `.seed-exit` is `0` (non-zero → read `seed.log`, re-run the seed module manually); `seed-result.json` supplies the counts for the closing summary.

**Live-verified:** foreground call **25.5s** (was 40s–1.8m); the detached seed completed after the script exited (exit 0, 3 products + 2 categories on a real site); the detached install completed too (391 packages).

Effect: provisioning variance leaves the critical path — the agent themes/writes while both jobs run behind it. Expected distribution **~3.3–4.2m**, bounded by model pacing only (from 3.4–5.8m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)