### PR TITLE
fix: wix-headless-fast — cart line images via catalog join; seed images required+verified

### DIFF
--- a/skills/wix-headless-fast/references/storefront/app/styles/storefront.css
+++ b/skills/wix-headless-fast/references/storefront/app/styles/storefront.css
@@ -74,6 +74,6 @@
 .sf-qty { display: inline-flex; align-items: center; gap: 10px; border: 1px solid var(--sf-border); border-radius: 999px; padding: 2px 8px; margin-top: 8px; }
 .sf-qty button { background: none; border: none; cursor: pointer; font-size: 16px; color: var(--sf-text); padding: 2px 6px; }
 .sf-qty button:disabled { opacity: 0.4; cursor: not-allowed; }
-.sf-remove { background: none; border: none; color: var(--sf-muted); font-size: 12px; cursor: pointer; text-decoration: underline; margin-top: 6px; padding: 0; }
+.sf-remove { background: none; border: none; color: var(--sf-muted); font-size: 12px; cursor: pointer; text-decoration: underline; margin: 6px 0 0 12px; padding: 0; }
 .sf-drawer-foot { border-top: 1px solid var(--sf-border); padding: 20px 24px; }
 .sf-subtotal { display: flex; justify-content: space-between; font-size: 15px; margin-bottom: 14px; }

--- a/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart.ts
+++ b/skills/wix-headless-fast/references/storefront/app/wix/storefront/cart.ts
@@ -7,6 +7,7 @@
 // missing required selection — surface the message to the buyer, don't swallow it.
 import { currentCartV2 } from "@wix/ecom";
 import { redirects as redirectsModule } from "@wix/redirects";
+import { productsV3 } from "@wix/stores";
 import { wixModule } from "../sdk";
 import { imgSrc } from "../media";
 import { formatMoney } from "../money";
@@ -14,6 +15,41 @@ import type { Cart, CartLine } from "./types";
 
 const cartApi = wixModule(currentCartV2);
 const redirects = wixModule(redirectsModule);
+const productsApi = wixModule(productsV3);
+
+// The V2 cart does NOT return line-item images (attributes.image is typed but comes back
+// absent — verified against a live cart), so images are joined from the catalog by the
+// line's catalogItemId and cached for the session.
+const lineImageCache = new Map<string, string>();
+
+async function fillLineImages(lines: CartLine[], raws: RawCart[]): Promise<void> {
+  const wanted = new Map<string, number[]>(); // productId -> line indexes
+  raws.forEach((raw, i) => {
+    if (lines[i].imageUrl) return;
+    const pid = raw.source?.catalogReference?.catalogItemId;
+    if (!pid) return;
+    const cached = lineImageCache.get(pid);
+    if (cached !== undefined) {
+      lines[i].imageUrl = cached;
+      return;
+    }
+    wanted.set(pid, [...(wanted.get(pid) ?? []), i]);
+  });
+  if (!wanted.size) return;
+  try {
+    const res = await productsApi
+      .queryProducts()
+      .in("_id", [...wanted.keys()])
+      .find();
+    for (const p of (res.items ?? []) as RawCart[]) {
+      const url = imgSrc(p.media?.main, 300, 300);
+      lineImageCache.set(p._id, url);
+      for (const i of wanted.get(p._id) ?? []) lines[i].imageUrl = url;
+    }
+  } catch {
+    /* images are a nicety — the cart stays correct without them */
+  }
+}
 
 // Public app id of the Wix Stores catalog — required inside every catalogReference.
 const WIX_STORES_APP_ID = "215238eb-22a5-4c36-9e7b-e7c08025e04e";
@@ -66,7 +102,9 @@ async function readCartWithSubtotal(raw: RawCart | null): Promise<Cart> {
   } catch {
     /* estimate is a display nicety — the cart itself is still valid */
   }
-  return toCart(raw, subtotal);
+  const cart = toCart(raw, subtotal);
+  await fillLineImages(cart.lines, raw.lineItems as RawCart[]);
+  return cart;
 }
 
 /** Read the visitor's current cart. An empty Cart (not an error) when none exists yet. */

--- a/skills/wix-headless-fast/references/storefront/seed/SEED.md
+++ b/skills/wix-headless-fast/references/storefront/seed/SEED.md
@@ -36,7 +36,10 @@ node <SKILL_ROOT>/references/storefront/seed/seed-store.mjs plan.json
   carrying the product's price/compareAtPrice/quantity) — keep option counts small.
 - `compareAtPrice` (> `price`) — the "was" price: strikethrough on the PDP, sale badge data on
   the tile.
-- `imageUrl` — a real, fetchable https URL; Wix re-hosts it server-side. Omit to seed text-only.
+- `imageUrl` — **include one for every product** (a store without product images looks broken:
+  gray boxes on tiles, PDP, and cart). It must be a real, fetchable https URL — **verify each
+  resolves (e.g. a quick `curl -sI` → 200) before seeding**; a guessed URL seeds a broken
+  image. Wix re-hosts it server-side. Seed text-only only when the user explicitly asks.
 - `categories` — category name → product NAMES. Omit when the brief names none.
 
 **Default to 3 products** unless the brief asks for a specific catalog — the seed shows the


### PR DESCRIPTION
User-reported: the cart drawer shows a gray box instead of the product image.

**Diagnosis (empirical, live cart):** Cart V2 returns line `attributes` **without `image`** at runtime — `{descriptionLines, url, policies, itemType, physicalProperties, membersOnly}` — even though the SDK type declares `image?: string`. No client rendering could show what's never sent. Separately, some runs seeded **fully imageless stores** because SEED.md made `imageUrl` read as optional.

**Fixes:**
- `cart.ts`: backfill line images from the catalog — one `queryProducts().in("_id", ids)` keyed by `source.catalogReference.catalogItemId`, session-cached, failure-tolerant. Join query + `wix:image://` resolution verified against a live store; strict tsc passes.
- `storefront.css`: un-glue the Remove link from the qty stepper (screenshot nit).
- `SEED.md`: an `imageUrl` per product is now the expectation, with "verify each URL resolves before seeding" (agents have seeded hallucinated URLs); text-only only on explicit user request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)