### PR TITLE
feat: wix-headless-fast — agent-designed presentation on shipped hooks (vibe model)

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wix-headless-fast
-description: "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from recipes. Each Wix business vertical ships a typed, framework-agnostic React core (data layer returning plain DTOs, hooks, headless components) plus an Astro overlay (SSR pages with owner-editable SEO pre-wired) and a build-time REST seed script — the agent scaffolds via the Wix CLI, deploys the shipped code, seeds the backend, builds only the brand layer (home, layout, theme, copy), and releases to Wix hosting. Works on Wix-managed Astro (ambient auth, the default) and on any React-based project (Vite, non-Astro) over the public OAuth client id. Verticals: stores/storefront (products, categories, variants, cart, hosted checkout). Triggers: build me a store fast, storefront with shipped components, wix headless fast, connect Wix Stores with ready-made SDK code."
+description: "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from recipes. Each Wix business vertical ships a typed, framework-agnostic React core (data layer returning plain DTOs, hooks, headless components) plus an Astro overlay (SSR pages with owner-editable SEO pre-wired) and a build-time REST seed script — the agent scaffolds via the Wix CLI, deploys the shipped code, seeds the backend, designs the presentation layer itself on the shipped hooks (product card/grid, PDP, home, theme), and releases to Wix hosting. Works on Wix-managed Astro (ambient auth, the default) and on any React-based project (Vite, non-Astro) over the public OAuth client id. Verticals: stores/storefront (products, categories, variants, cart, hosted checkout). Triggers: build me a store fast, storefront with shipped components, wix headless fast, connect Wix Stores with ready-made SDK code."
 ---
 
 # Wix Headless Fast
@@ -34,10 +34,12 @@ re-litigate them.
   auth is ambient (no client, no id); on any other React setup the same file runs a manual
   visitor client off the public client id in `src/wix/config.ts`. The deploy step configures
   this — nothing to wire by hand.
-- **Copy as-is; extend by calling.** Wire the exported hooks/components/functions; never
-  rewrite their internals, re-route them through API routes, or re-derive a request shape. For
-  a genuine gap, add a new function in the data layer (or consult the `wix-docs` skill for the
-  API contract) — never edit the shipped ones.
+- **Data as-is; presentation is yours.** The data layer, hooks, and cart chrome are wired
+  as-is — never rewrite their internals, re-route them through API routes, or re-derive a
+  request shape (for a genuine gap, add a new function in the data layer, or consult the
+  `wix-docs` skill for the API contract). The presentation components ship only as
+  **references**: the vertical's INSTRUCTIONS names the surfaces you design and implement
+  yourself on the shipped hooks (for storefront: card, grid, shop + PDP surfaces, home).
 - **Never mock, fail loudly, purchases via Wix.** Live data or an honest empty state; surfaced
   errors, not swallowed ones; checkout/purchase always through the Wix redirect session.
 
@@ -73,10 +75,13 @@ re-litigate them.
    but **never run a second npm install concurrently**: two npms in one `node_modules` race and
    redo each other's work); then seed per the vertical's `seed/SEED.md`. Seeding is
    **additive**: never delete or overwrite existing content; if a cleanup seems needed, ask.
-4. **Build the brand layer while the install finishes** — in the project dir from the
-   `ready_for_brand_layer` event, per the vertical's `INSTRUCTIONS.md`: the home page, the
-   layout's header/footer/tokens, and the copy — composing the shipped pieces. Read the
-   INSTRUCTIONS first, and don't open the shipped files themselves.
+4. **Design and build the presentation while the install finishes** — in the project dir from
+   the `ready_for_brand_layer` event, per the vertical's `INSTRUCTIONS.md`: set the `@theme`
+   tokens, brand the chrome, and implement the vertical's creative surfaces yourself on the
+   shipped hooks (for storefront: your product card + grid, shop surface, PDP surface, and the
+   home page) — designed to fit the brief, not copied from the reference components. Read the
+   INSTRUCTIONS first; the hook/DTO contracts are inlined there, so don't open the shipped
+   files themselves.
 5. **When both background jobs have completed** — the install's marker
    (`node_modules/.package-lock.json`) and the seed's (`.seed-exit`) both exist — **verify the
    seed succeeded** (`.seed-exit` contains `0`; `seed-result.json` has the created counts for

--- a/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
+++ b/skills/wix-headless-fast/references/storefront/INSTRUCTIONS.md
@@ -1,122 +1,149 @@
 # Storefront — playbook
 
-A complete Wix Stores storefront ships as files: catalog + variants + cart + Wix-hosted
-checkout, typed end-to-end. You wire routes and build the brand layer; you don't write
-commerce code.
+The commerce machinery ships as files — data layer, hooks, cart, checkout, SEO plumbing,
+typed end-to-end. **The presentation is yours**: you design and implement the product card,
+the grid, and the PDP surface on the shipped hooks/DTOs, plus the home page and the brand.
+You never write commerce code; you never skip designing the store.
 
 ## The file map (deployed into `src/`)
 
-**Don't read the shipped files** — this table and the typed export signatures are the whole
-contract, and every shape you need is in this playbook. Open a shipped file's source **only**
-on a real fallback: a runtime error, or a field this playbook doesn't cover. The one exception
-is `SiteLayout.astro`, which you edit (below).
+**Don't read the shipped files** — this table and the contracts below are everything you
+need. Open a shipped file's source **only** on a real fallback: a runtime error, a field this
+playbook doesn't cover, or when a *reference* component's pattern is explicitly worth reading
+(marked below). Files you edit: `SiteLayout.astro`, `styles/global.css`, and the two page
+imports you swap to your own components.
 
 | file | what it is |
 |---|---|
 | `wix/config.ts` · `wix/sdk.ts` | shared auth seam (deploy configures it — nothing to set by hand) |
 | `wix/media.ts` · `wix/money.ts` | `imgSrc()` / `formatMoney()` — already used by everything shipped |
-| `wix/storefront/types.ts` | the DTOs: `ProductSummary`, `ProductDetail`, `Cart`, `Category`… — the shapes your own UI consumes |
+| `wix/storefront/types.ts` | the DTOs (`ProductSummary`, `ProductDetail`, `Cart`, `Category`) — contracts inlined below |
 | `wix/storefront/catalog.ts` | `fetchProducts`, `fetchProductsByCategory`, `fetchProductBySlug`, `fetchCategories`, `resolveVariant` |
-| `wix/storefront/cart.ts` | `addToCart`, `fetchCart`, `updateQuantity`, `removeLine`, `checkoutUrl` (Cart V2) |
-| `wix/storefront/cart-store.ts` | shared cart state (module store — spans Astro islands) |
-| `hooks/storefront/useCart.ts` | cart state + actions for any React component |
-| `hooks/storefront/useShop.ts` | listing + live category filter (accepts SSR `initial` data) |
-| `hooks/storefront/useProductDetail.ts` | option selection → variant resolution → add-to-cart |
-| `components/storefront/ShopView.tsx` | full listing surface: category bar + grid — mount as-is |
-| `components/storefront/ProductDetailView.tsx` | full PDP surface: gallery, picker, qty, add — mount as-is |
-| `components/storefront/CartButton.tsx` · `CartDrawer.tsx` | header badge + slide-over cart — mount as-is (drawer once per page) |
-| `components/storefront/VariantPicker.tsx` | swatches/pills/modifiers — used by ProductDetailView |
-| `components/storefront/ProductCard.tsx` · `ProductGrid.tsx` | **reference** tile + grid — correct as-is; designing your own on the same DTOs is encouraged (pass `CardComponent` to ShopView/ProductGrid) |
-| `styles/global.css` | **the design system**: Tailwind v4 + the `@theme` token block (colors, radii, font — same token family as the official Wix templates). Every shipped component styles itself from these tokens |
+| `wix/storefront/cart.ts` · `cart-store.ts` | Cart V2 + shared cart state (module store — spans Astro islands) |
+| `hooks/storefront/useCart.ts` | cart state + actions — contract below |
+| `hooks/storefront/useShop.ts` | listing + live category filter — contract below |
+| `hooks/storefront/useProductDetail.ts` | option selection → variant resolution → add-to-cart — contract below |
+| `components/storefront/CartButton.tsx` · `CartDrawer.tsx` | header badge + slide-over cart — **wire as-is** (drawer once per page) |
+| `components/storefront/ShopView.tsx` · `ProductCard.tsx` · `ProductGrid.tsx` · `ProductDetailView.tsx` · `VariantPicker.tsx` | **REFERENCE implementations** — correct, plain, deliberately generic. Read for patterns if useful; **build your own instead of shipping them** (below) |
+| `styles/global.css` | **the design system**: Tailwind v4 + the `@theme` token block (colors, radii, fonts — same token family as the official Wix templates). Everything, shipped and yours, styles from these tokens |
 
 Astro stack additionally gets:
 
 | file | what it is |
 |---|---|
 | `layouts/SiteLayout.astro` | the site chrome — **yours to brand**: header, footer, nav. Keep the `<slot name="seo-tags" />`, the global.css import, and the CartButton/CartDrawer mounts |
-| `pages/shop.astro` | SSR listing → ShopView island — wire as-is |
-| `pages/products/[slug].astro` | SSR PDP with owner-editable SEO (`wixMetadata` + `<SEO.Tags>`) — wire as-is |
+| `pages/shop.astro` | SSR listing page — **keep its frontmatter** (the data fetching), swap the island import to YOUR shop component |
+| `pages/products/[slug].astro` | SSR PDP with owner-editable SEO — **keep its frontmatter and the SEO pieces** (`wixMetadata`, `loadSEOTagsServiceConfig`, `<SEO.Tags>`) exactly, swap the island import to YOUR detail component |
 
-## What you build
+## What you build — this is the design job, not optional polish
 
-The **home page**, the **theme** (edit the `@theme` token block in `styles/global.css` — a dark
-brand is just flipped token values), the **layout chrome** (header/footer in `SiteLayout.astro`), and
-the **copy** — composing shipped pieces. A featured strip on home is `fetchProducts()` in
-frontmatter + `<ProductGrid client:load products={…} />`; nav is a link to `/shop` plus the
-shipped `CartButton`. Style everything you add with Tailwind utilities reading the same tokens
-(`bg-primary`, `text-muted-foreground`, `rounded-lg`, …).
+You implement **four surfaces yourself**, styled with Tailwind utilities on the `@theme`
+tokens, designed to fit the brief (the business, the tone, the audience — a toy brand and a
+jewelry house should not get the same store):
+
+1. **The product card + grid** — your tile design (image treatment, badges, price/sale
+   presentation, hover behavior) and your grid rhythm (columns, density, maybe an editorial
+   featured tile). Keep skeleton-while-loading and an honest empty state (the reference
+   `ProductGrid` shows the pattern — `products === null` → skeletons, `[]` → empty message).
+2. **The shop surface** — category filter + your grid, on `useShop`.
+3. **The PDP surface** — gallery, price/sale, description, your option-selection UI (color
+   options = real swatches), quantity, add-to-cart — on `useProductDetail`, which owns ALL
+   selection/variant logic; you own how it looks.
+4. **The home page** — hero, featured products (fetch in frontmatter → your grid), brand story.
+
+Plus the **theme** (edit the `@theme` block in `styles/global.css` — one edit; a dark brand is
+flipped token values; add brand fonts as extra tokens) and the **chrome** (header/footer in
+`SiteLayout.astro`, one edit pass; mount the shipped `CartButton` in your header).
+
+### The contracts your components consume (everything you need — don't read the source)
+
+```ts
+// ProductSummary (grid tiles) — all display-ready: prices formatted, images https URLs:
+// { id, slug, name, price, maxPrice, compareAtPrice|null, ribbon|null,
+//   availability: "IN_STOCK"|"OUT_OF_STOCK"|"PARTIALLY_OUT_OF_STOCK", preorder: boolean,
+//   imageUrl, hoverImageUrl, optionsSummary /* "2 colors · 3 sizes" */, quickAddable: boolean }
+// price vs maxPrice differ → show a range. quickAddable → useCart().addToCart(product.id).
+
+// useShop({ initialProducts?, initialCategories? }) →
+// { products: ProductSummary[]|null /* null = loading → skeletons */, categories: Category[],
+//   activeCategoryId: string|null, setActiveCategoryId(id|null), loading, error }
+// Category = { id, slug, name }. Render the filter bar only when categories.length > 1.
+
+// useProductDetail({ initial? /* SSR */, slug? /* SPA */ }) →
+// { product: ProductDetail|null, notFound,
+//   optionGroups: [{ id, name, isColor, choices: [{ choiceId, name, colorCode|null, inStock, selected }] }],
+//   selectOption(optionName, choiceName),
+//   modifierValues, setModifier(key, value),          // product.modifiers: pills or text input; "*" = mandatory
+//   price, compareAtPrice,                            // live: variant price once resolved
+//   canAdd,                                           // gate the button; false until every option picked & in stock
+//   quantity, setQuantity, add(), adding, error }
+// ProductDetail adds: descriptionHtml (render as HTML), gallery: string[] (urls, main first),
+// options, modifiers, variants — but selection ALWAYS goes through the hook above.
+
+// useCart() →
+// { cart: { lines, itemCount, subtotal, currency }|null, busy, error, open,
+//   addToCart(productId, variantId?, qty?, extras?), updateQuantity(lineItemId, qty),
+//   removeLine(lineItemId), checkout(), openCart(), closeCart(), refresh() }
+```
 
 ### Wiring — Astro (default)
 
-Deploy already placed pages, layout, and islands. Remaining work: build `pages/index.astro`
-(home) on `SiteLayout`, set the brand's tokens in `styles/global.css` (**one edit** of the
-`@theme` block), and brand the header/footer in `SiteLayout.astro` (**one edit pass** — read it
-once, rewrite header+footer together). Every island mounts with `client:load` when it renders
-primary content with SSR props, `client:only="react"` when it reads browser-only state (the
-shipped mounts already do this correctly).
+1. Set the `@theme` tokens (one edit); brand `SiteLayout.astro` (one pass).
+2. Write your components under `src/components/storefront/` (new file names — don't overwrite
+   the references), then **swap the island import** in `pages/shop.astro` and
+   `pages/products/[slug].astro` to yours — keep each page's frontmatter (data fetching, SEO
+   pieces) exactly as shipped. Primary-content islands mount `client:load` with the SSR props;
+   browser-state widgets (cart) are `client:only="react"` — the shipped mounts show this.
+3. Write `pages/index.astro` (home) on `SiteLayout`.
 
 ### Wiring — React SPA (Vite etc.)
 
-No pages ship — write thin route wrappers in the project's router:
-
-```tsx
-import "./styles/global.css";               // once, at the app entry (needs @tailwindcss/vite in vite.config plugins)
-import ShopView from "./components/storefront/ShopView";
-import ProductDetailView from "./components/storefront/ProductDetailView";
-import CartButton from "./components/storefront/CartButton";
-import CartDrawer from "./components/storefront/CartDrawer";
-import { Link, useParams } from "react-router-dom";
-
-const AppLink = ({ href, className, children }) => <Link to={href} className={className}>{children}</Link>;
-
-// routes: /shop → <ShopView LinkComponent={AppLink} />
-//         /products/:slug → <ProductDetailView slug={useParams().slug!} />
-// layout: <CartButton /> in the header; <CartDrawer /> mounted once.
-```
-
-Components fetch client-side when no `initial` props are passed. The deploy step wrote the
-public client id into `wix/config.ts`; nothing else to configure.
+Import `./styles/global.css` once at the app entry (needs `@tailwindcss/vite` in the vite
+config plugins — deploy already added the dep). Write route wrappers in the project's router:
+`/shop` → your shop component; `/products/:slug` → your detail component
+(`useProductDetail({ slug })` — components fetch client-side when no `initial` is passed).
+Mount the shipped `CartButton` in the header and `CartDrawer` once. Deploy wrote the public
+client id into `wix/config.ts`; nothing else to configure.
 
 ## Hard rules
 
-- Wire the shipped exports as-is; never rewrite their internals or re-derive a request shape.
-  Extend by calling the exports or adding a new function in `wix/storefront/` for a genuine gap
-  (API contracts: the `wix-docs` skill).
-- Don't wrap shipped calls in your own API routes — they run client-side by design. A backend
-  route is only for a genuinely privileged (elevated) read, which nothing here needs.
-- Theme via the `@theme` tokens in `styles/global.css`, never by restyling shipped component
-  markup or adding a parallel theme file. Your own markup uses Tailwind utilities on the same
-  tokens.
-- Checkout only through the shipped cart (`checkout()` / `checkoutUrl()`) — never a hand-built
-  checkout URL.
-- Live data or the shipped empty state — never mock products, prices, reviews, or counts.
-- On the PDP, selection→cart goes through `useProductDetail` — never add a product with
-  options by picking `variants[0]`.
+- **Data and commerce logic only through the shipped exports** — never rewrite their
+  internals or re-derive a request shape. Extend by calling the exports or adding a new
+  function in `wix/storefront/` for a genuine gap (API contracts: the `wix-docs` skill).
+- **Selection→cart goes through `useProductDetail`** — never add a product with options by
+  picking `variants[0]`, and never gate `canAdd` yourself.
+- Don't wrap shipped calls in your own API routes — they run client-side by design.
+- Theme via the `@theme` tokens; your markup uses Tailwind utilities on the same tokens. No
+  parallel theme files, no hardcoded palette values in components.
+- Checkout only through the shipped cart (`checkout()`) — never a hand-built checkout URL.
+- Live data or an honest empty state — never mock products, prices, reviews, or counts.
+- Keep the PDP page's SEO pieces (`wixMetadata` + `loadSEOTagsServiceConfig` + `<SEO.Tags>`)
+  exactly as shipped — owners edit those tags in their dashboard.
 
 ## Point the user to their dashboard
 
-Content editing happens in the Wix dashboard — give the owner the dashboard, products, and
-categories links. **The deploy step's JSON output already printed them ready-made**
-(`dashboardUrl`, `productsUrl`, `categoriesUrl`) — copy them from there, don't re-derive.
-
-Real payments additionally need a premium plan + a connected payment method (dashboard) —
-mention it, don't treat it as a code failure.
+Give the owner the dashboard, products, and categories links — **the deploy step's JSON
+output already printed them ready-made** (`dashboardUrl`, `productsUrl`, `categoriesUrl`);
+copy, don't re-derive. Real payments additionally need a premium plan + a connected payment
+method (dashboard) — mention it, don't treat it as a code failure.
 
 ## Seeding
 
 Per `seed/SEED.md` — a plain-data `plan.json` into `seed-store.mjs`, run from the project
 root. Independent of the frontend work; seed a catalog that exercises the UI (≥1 product with
-a color option, ≥1 on sale) unless the brief says otherwise.
+a color option, ≥1 on sale, an image per product) unless the brief says otherwise.
 
 ## Verify (before declaring done)
 
-- [ ] `/shop` renders live products SSR (view-source shows product names) with the category
-      bar when categories exist; empty catalog shows the shipped empty state.
-- [ ] A product with options: choices render (color = swatches), add is disabled until every
-      option is picked, and the resolved variant's price shows.
+- [ ] `/shop` renders live products SSR (view-source shows product names) through **your**
+      grid/card; category bar filters when categories exist; empty catalog shows your honest
+      empty state.
+- [ ] Your PDP: color options render as swatches, add is disabled until every option is
+      picked (`canAdd`), the resolved variant's price shows, a sale shows the strikethrough.
 - [ ] Cart: add / quantity ± / remove work; badge count is live; subtotal shows; cart survives
       a reload (same visitor token).
 - [ ] Checkout button redirects to Wix-hosted checkout.
-- [ ] PDP view-source carries the SEO tags (Astro) and a sale product shows the strikethrough.
-- [ ] Home/header/footer are yours; brand set via the `@theme` tokens; shipped files unedited.
+- [ ] PDP view-source carries the SEO tags (Astro).
+- [ ] Card/grid/PDP/home are YOUR designs on the tokens — not the shipped references; the
+      data-layer/hook/cart files are unedited.
 - [ ] Dashboard links handed to the owner.


### PR DESCRIPTION
Now that the flow is fast (~4m) and correctness is proven, the presentation layer opens up — mirroring `wix-vibe-headless`'s required-creativity pattern:

- **The agent designs and implements** the product card, grid, shop surface, and PDP surface itself, on the shipped hooks/DTOs, styled with Tailwind utilities on the `@theme` tokens, fitted to the brief. The shipped `ShopView`/`ProductCard`/`ProductGrid`/`ProductDetailView`/`VariantPicker` are demoted to **reference implementations** (working baseline + patterns to read).
- **The correctness moat stays wire-as-is**: data layer, hooks, cart chrome (`CartButton`/`CartDrawer`), and the Astro pages' SSR frontmatter + item-page SEO plumbing (the agent swaps only the island import to its own component).
- **Hook/DTO contracts are inlined in INSTRUCTIONS** (ProductSummary fields, `useShop`, `useProductDetail`, `useCart`) so the agent builds without reading shipped source; hard rules pin the traps (selection only through `useProductDetail` — never `variants[0]`; `canAdd` gates the button; skeleton/empty states required; SEO pieces untouched).

Cost: ~1–2 min more per run (accepted trade); benefit: stores that look designed for the business instead of recolored clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)