### PR TITLE
fix: wix-headless-fast — fast-path requires an explicit --vertical

### DIFF
--- a/skills/wix-headless-fast/SKILL.md
+++ b/skills/wix-headless-fast/SKILL.md
@@ -55,8 +55,11 @@ re-litigate them.
 3. **Create runs (empty directory): run the fast path** — one deterministic call:
 
    ```bash
-   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json
+   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json --vertical <storefront|bookings>
    ```
+
+   `--vertical` is required and picks which shipped code deploys AND which seed runs — use
+   the vertical you resolved from the Verticals table.
 
    It emits one JSON event per line and returns in **~35s**: **scaffolds** the project,
    **deploys** the shipped code (patching `package.json` with every dependency the code

--- a/skills/wix-headless-fast/install/fast-path.mjs
+++ b/skills/wix-headless-fast/install/fast-path.mjs
@@ -4,7 +4,7 @@
 // or for connect/iterate runs (which must NOT scaffold and don't use this script).
 //
 //   node <SKILL_ROOT>/install/fast-path.mjs --business-name "<Brand>" --plan plan.json \
-//        [--vertical storefront] [--stack astro] [--folder-name <npm-safe-name>]
+//        --vertical <storefront|bookings|…> [--stack astro] [--folder-name <npm-safe-name>]
 //
 // It emits ONE JSON event per line and exits in ~35s with BOTH long steps — the dependency
 // install AND the seed — running detached in the background (logs + completion markers
@@ -32,10 +32,18 @@ const flag = (name) => {
 };
 const businessName = flag("business-name");
 const planPath = flag("plan");
-const vertical = flag("vertical") ?? "storefront";
+const vertical = flag("vertical");
 const stack = flag("stack") ?? "astro";
-if (!businessName || !planPath) {
-  fail("args", 'usage: fast-path.mjs --business-name "<Brand>" --plan plan.json [--vertical storefront] [--stack astro]');
+// --vertical is REQUIRED: a defaulted vertical deploys the wrong code and runs the wrong
+// seed against the plan — fail loudly with the discovered choices instead.
+const knownVerticals = readdirSync(join(SKILL_ROOT, "references"), { withFileTypes: true })
+  .filter((d) => d.isDirectory() && d.name !== "shared" && existsSync(join(SKILL_ROOT, "references", d.name, "app")))
+  .map((d) => d.name);
+if (!businessName || !planPath || !vertical) {
+  fail("args", `usage: fast-path.mjs --business-name "<Brand>" --plan plan.json --vertical <${knownVerticals.join("|")}> [--stack astro]`);
+}
+if (!knownVerticals.includes(vertical)) {
+  fail("args", `unknown vertical "${vertical}" — shipped verticals: ${knownVerticals.join(", ")}`);
 }
 if (!existsSync(planPath)) fail("args", `plan file not found: ${planPath}`);
 const plan = JSON.parse(readFileSync(planPath, "utf8"));


### PR DESCRIPTION
The first cold-prompt bookings e2e (run32) omitted `--vertical` and the silent `storefront` default did maximum quiet damage: wrong shipped code deployed, the pre-resolved lockfile skipped, and the **storefront seed ran against a bookings plan** — `products must not be empty`, seed exit 1. The agent recovered by hand (ran the bookings seed itself, patched deps, reinstalled) and still released a working site in 6.8m, but that's ~2 minutes and the lockfile win lost to a defaulted flag.

- `fast-path.mjs`: `--vertical` is now **required** and validated against the verticals discovered under `references/` (any `<name>/app`, `shared` excluded). Both failure modes emit an `error` event that lists the shipped choices.
- `SKILL.md`: the fast-path invocation shows `--vertical <storefront|bookings>` with one line tying it to the Verticals table.

Verified: missing flag → usage listing `bookings|storefront`; unknown value → "unknown vertical" with the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)